### PR TITLE
Add fuzz tool for vm package

### DIFF
--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -1,0 +1,16 @@
+# Fuzzing the Mochi VM
+
+This directory provides a Go fuzzing harness for the `runtime/vm`
+package. A small generator enumerates valid Mochi programs covering a
+wide range of AST nodes. These programs are added to the fuzzing corpus
+and mutated by Go's built in engine. Invalid programs are skipped while
+panics or crashes are reported by the engine.
+
+Run fuzzing with Go 1.18+ using:
+
+```bash
+go test ./tools/fuzz -fuzz FuzzVM
+```
+
+Use the `-fuzztime` flag to control how long to fuzz.
+

--- a/tools/fuzz/fuzz_test.go
+++ b/tools/fuzz/fuzz_test.go
@@ -1,0 +1,41 @@
+package fuzz
+
+import (
+	"io"
+	"testing"
+
+	"mochi/parser"
+	vm "mochi/runtime/vm"
+	"mochi/types"
+)
+
+// FuzzVM compiles and executes arbitrary Mochi programs. Invalid
+// programs are skipped. Any panic or crash inside the VM will be
+// surfaced by the Go fuzzing engine.
+func FuzzVM(f *testing.F) {
+	gen := NewGenerator()
+	for {
+		src, ok := gen.Next()
+		if !ok {
+			break
+		}
+		f.Add(src)
+	}
+
+	f.Fuzz(func(t *testing.T, src string) {
+		prog, err := parser.ParseString(src)
+		if err != nil {
+			t.Skip()
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Skip()
+		}
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			t.Skip()
+		}
+		m := vm.New(p, io.Discard)
+		_ = m.Run()
+	})
+}

--- a/tools/fuzz/generator.go
+++ b/tools/fuzz/generator.go
@@ -1,0 +1,72 @@
+package fuzz
+
+// Generator provides example Mochi programs covering
+// a wide portion of the AST. It can be used as a seed
+// corpus for fuzzing the VM.
+type Generator struct {
+	idx      int
+	programs []string
+}
+
+// NewGenerator returns a generator pre-populated with
+// programs exercising different statement and expression
+// forms. Each program is small but syntactically valid.
+func NewGenerator() *Generator {
+	return &Generator{programs: []string{
+		// Declarations
+		"let x = 1",
+		"var y: int = 2",
+		"x = x + 1",
+		"fun add(a: int, b: int): int { return a + b }",
+		"return 1",
+		"type Pair { a: int, b: int }",
+		"extern type Ext",
+		"extern var math.pi: float",
+		"extern fun math.sin(x: float): float",
+		"extern object JS",
+		"stream Data { value: int }",
+		"model Person { name: \"\" }",
+		"import \"math\" as math",
+		// Control flow
+		"if true { let z = 1 } else { var w = 2 }",
+		"while false { break }",
+		"for i in 0..3 { continue }",
+		// Expressions
+		"let l = [1, 2, 3]",
+		"let m = { a: 1, b: 2 }",
+		"let s = Point{ x: 1, y: 2 }",
+		"let call = add(1, 2)",
+		"let sel = s.x",
+		"let unary = -1",
+		"let binary = 1 + 2",
+		"let idx = l[0]",
+		"let slice = l[1:2]",
+		"let cast = 1 as int",
+		"let q = from x in l select x",
+		"let mt = match 1 { 1 => 2 }",
+		"let g = generate Person { name: \"bob\" }",
+		"fetch \"https://example.com\" into resp",
+		"load \"file.txt\" as int",
+		"save 1 to \"out.txt\"",
+		"emit Data { value: 1 }",
+		// Agent DSL
+		"agent Bot { on Data as d { print(d.value) } intent greet(u: string): string { return \"hi\" + u } }",
+		// Logic DSL
+		"fact parent(\"a\", \"b\")",
+		"rule ancestor(a,b) :- parent(a,b)",
+		// Testing
+		"expect 1 == 1",
+		"test \"t\" { expect 2 == 2 }",
+	}}
+}
+
+// Next returns the next program source. ok is false when
+// all programs have been exhausted.
+func (g *Generator) Next() (src string, ok bool) {
+	if g.idx >= len(g.programs) {
+		return "", false
+	}
+	src = g.programs[g.idx]
+	g.idx++
+	return src, true
+}


### PR DESCRIPTION
## Summary
- add `tools/fuzz` with a Go fuzzing harness
- document how to run fuzzing for the VM
- create a generator that systematically enumerates Mochi AST programs for fuzzing

## Testing
- `go test ./tools/fuzz -run FuzzVM -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6862f4dc21148320b9e9573e626198bb