### PR TITLE
Add slow build tag for fuzz tests

### DIFF
--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -1,0 +1,21 @@
+# Fuzzing the Mochi VM
+
+This directory provides a Go fuzzing harness for the `runtime/vm`
+package. A small generator walks the Mochi grammar to enumerate valid
+programs covering a wide range of AST nodes. These programs are added
+to the fuzzing corpus
+and mutated by Go's built in engine. Invalid programs are skipped while
+panics or crashes are reported by the engine.
+
+Another generator enumerates dataset query expressions. The `FuzzQueries`
+test parses these expressions, executes them against sample in-memory
+datasets using the interpreter, and checks for crashes.
+
+Run fuzzing with Go 1.18+ using the `slow` build tag:
+
+```bash
+go test ./tools/fuzz -fuzz FuzzVM -tags slow
+```
+
+Use the `-fuzztime` flag to control how long to fuzz.
+

--- a/tools/fuzz/data_gen.go
+++ b/tools/fuzz/data_gen.go
@@ -1,0 +1,21 @@
+package fuzz
+
+import (
+	"fmt"
+	"mochi/types"
+)
+
+// newDatasetEnv creates an environment with several datasets bound to
+// sequential identifier names (v1, v2, ...). Each dataset is a slice of
+// maps so queries have something to operate on.
+func newDatasetEnv() *types.Env {
+	env := types.NewEnv(nil)
+	sample := []any{
+		map[string]any{"a": 1, "b": 2},
+		map[string]any{"a": 2, "b": 3},
+	}
+	for i := 1; i <= 10; i++ {
+		env.SetValue(fmt.Sprintf("v%d", i), sample, true)
+	}
+	return env
+}

--- a/tools/fuzz/fuzz_test.go
+++ b/tools/fuzz/fuzz_test.go
@@ -1,0 +1,94 @@
+//go:build slow
+
+package fuzz
+
+import (
+	"io"
+	"testing"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/data"
+	vm "mochi/runtime/vm"
+	"mochi/types"
+)
+
+var queryParser = participle.MustBuild[parser.QueryExpr](
+	participle.Lexer(lexer.MustSimple([]lexer.SimpleRule{
+		{Name: "Comment", Pattern: `//[^\n]*|/\*([^*]|\*+[^*/])*\*/`},
+		{Name: "Bool", Pattern: `\b(true|false)\b`},
+		{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|import|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch|load|save|package|export|fact|rule|all|null)\b`},
+		{Name: "Ident", Pattern: `[\p{L}\p{So}_][\p{L}\p{So}\p{N}_]*`},
+		{Name: "Float", Pattern: `\d+\.\d+`},
+		{Name: "Int", Pattern: `\d+`},
+		{Name: "String", Pattern: `"(?:\\.|[^"])*"`},
+		{Name: "Punct", Pattern: `==|!=|<=|>=|&&|\|\||=>|:-|\.\.|[-+*/%=<>!|{}\[\](),.:]`},
+		{Name: "Whitespace", Pattern: `[ \t\n\r]+`},
+	})),
+	participle.Elide("Whitespace", "Comment"),
+	participle.Unquote("String"),
+	participle.UseLookahead(999),
+)
+
+// FuzzVM compiles and executes arbitrary Mochi programs. Invalid
+// programs are skipped. Any panic or crash inside the VM will be
+// surfaced by the Go fuzzing engine.
+func FuzzVM(f *testing.F) {
+	gen := NewGenerator()
+	for {
+		src, ok := gen.Next()
+		if !ok {
+			break
+		}
+		f.Add(src)
+	}
+
+	f.Fuzz(func(t *testing.T, src string) {
+		prog, err := parser.ParseString(src)
+		if err != nil {
+			t.Skip()
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Skip()
+		}
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			t.Skip()
+		}
+		m := vm.New(p, io.Discard)
+		_ = m.Run()
+	})
+}
+
+// FuzzQueries executes randomly generated dataset queries using the interpreter
+// and in-memory engine. Invalid queries are skipped.
+func FuzzQueries(f *testing.F) {
+	gen := NewQueryGenerator()
+	for {
+		q, ok := gen.Next()
+		if !ok {
+			break
+		}
+		f.Add(q)
+	}
+
+	f.Fuzz(func(t *testing.T, q string) {
+		query, err := queryParser.ParseString("", q)
+		if err != nil {
+			t.Skip()
+		}
+		env := newDatasetEnv()
+		eval := func(e *types.Env, ex *parser.Expr) (any, error) {
+			interp := interpreter.New(&parser.Program{}, e, "")
+			interp.SetDataPlan("memory")
+			return interp.EvalExpr(ex)
+		}
+		_, err = data.RunQuery(query, env, data.MemoryEngine{}, eval)
+		if err != nil {
+			t.Skip()
+		}
+	})
+}

--- a/tools/fuzz/generator.go
+++ b/tools/fuzz/generator.go
@@ -1,0 +1,176 @@
+package fuzz
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	part "github.com/alecthomas/participle/v2/ebnf"
+	"mochi/parser"
+)
+
+// Generator systematically enumerates small Mochi programs by
+// walking the parser grammar. Each call to Next returns the source
+// for one program until exhaustion.
+type Generator struct {
+	programs []string
+	idx      int
+}
+
+// NewGenerator parses the Mochi grammar and expands the Statement rule
+// to produce a corpus of example programs covering most AST nodes.
+func NewGenerator() *Generator {
+	g := &grammarGen{rules: loadGrammar()}
+	stmts := g.expandRule("Statement", 0)
+	programs := make([]string, len(stmts))
+	for i, s := range stmts {
+		programs[i] = strings.TrimSpace(s)
+	}
+	return &Generator{programs: programs}
+}
+
+// QueryGenerator enumerates query expressions using the parser grammar.
+// Each item returned is a standalone query expression string.
+type QueryGenerator struct {
+	queries []string
+	idx     int
+}
+
+// NewQueryGenerator expands the `QueryExpr` rule from the grammar to build
+// a corpus of query strings.
+func NewQueryGenerator() *QueryGenerator {
+	g := &grammarGen{rules: loadGrammar()}
+	qs := g.expandRule("QueryExpr", 0)
+	out := make([]string, len(qs))
+	for i, q := range qs {
+		out[i] = strings.TrimSpace(q)
+	}
+	return &QueryGenerator{queries: out}
+}
+
+// Next returns the next query string. ok is false once exhausted.
+func (q *QueryGenerator) Next() (string, bool) {
+	if q.idx >= len(q.queries) {
+		return "", false
+	}
+	s := q.queries[q.idx]
+	q.idx++
+	return s, true
+}
+
+// Next returns the next program source. ok is false when all programs
+// have been exhausted.
+func (g *Generator) Next() (src string, ok bool) {
+	if g.idx >= len(g.programs) {
+		return "", false
+	}
+	src = g.programs[g.idx]
+	g.idx++
+	return src, true
+}
+
+// --- grammar based generation ---
+
+// grammarGen recursively expands EBNF productions.
+type grammarGen struct {
+	rules map[string]*part.Expression
+	ident int
+	num   int
+}
+
+func loadGrammar() map[string]*part.Expression {
+	eb, _ := part.ParseString(parser.Parser.String())
+	m := map[string]*part.Expression{}
+	for _, p := range eb.Productions {
+		m[p.Production] = p.Expression
+	}
+	return m
+}
+
+func (g *grammarGen) expandRule(name string, depth int) []string {
+	expr := g.rules[name]
+	if expr == nil || depth > 3 {
+		return []string{""}
+	}
+	return g.expandExpr(expr, depth)
+}
+
+func (g *grammarGen) expandExpr(expr *part.Expression, depth int) []string {
+	var out []string
+	for _, seq := range expr.Alternatives {
+		out = append(out, g.expandSeq(seq, depth+1)...)
+	}
+	return out
+}
+
+func (g *grammarGen) expandSeq(seq *part.Sequence, depth int) []string {
+	res := []string{""}
+	for _, term := range seq.Terms {
+		t := g.expandTerm(term, depth+1)
+		res = cross(res, t)
+	}
+	return res
+}
+
+func (g *grammarGen) expandTerm(term *part.Term, depth int) []string {
+	base := []string{""}
+	switch {
+	case term.Name != "":
+		base = g.expandRule(term.Name, depth+1)
+	case term.Literal != "":
+		base = []string{term.Literal}
+	case term.Token != "":
+		tok := strings.Trim(term.Token, "<>")
+		base = []string{g.token(tok)}
+	case term.Group != nil:
+		base = g.expandExpr(term.Group.Expr, depth+1)
+	}
+
+	switch term.Repetition {
+	case "?":
+		return append(base, "")
+	case "*":
+		return append([]string{""}, base...)
+	default:
+		return base
+	}
+}
+
+func (g *grammarGen) token(tok string) string {
+	switch tok {
+	case "ident":
+		g.ident++
+		return fmt.Sprintf("v%d", g.ident)
+	case "int":
+		g.num++
+		return strconv.Itoa(g.num)
+	case "float":
+		return "1.0"
+	case "string":
+		g.ident++
+		return fmt.Sprintf("\"s%d\"", g.ident)
+	default:
+		return tok
+	}
+}
+
+func cross(a, b []string) []string {
+	var out []string
+	for _, x := range a {
+		for _, y := range b {
+			xs := strings.TrimSpace(x)
+			ys := strings.TrimSpace(y)
+			switch {
+			case xs == "" && ys == "":
+				out = append(out, "")
+			case xs == "":
+				out = append(out, ys)
+			case ys == "":
+				out = append(out, xs)
+			default:
+				out = append(out, xs+" "+ys)
+			}
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- mark FuzzVM tests with the `slow` build tag
- update fuzzing instructions to include `-tags slow`
- add QueryGenerator and fuzzing harness for dataset queries

## Testing
- `go test ./tools/fuzz -run FuzzVM -count=1 -tags slow`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6862f4dc21148320b9e9573e626198bb