### PR TITLE
Fix register compaction regression in VM

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -276,9 +276,12 @@ func Optimize(fn *Function) {
 		}
 	}
 	// Compact registers to reduce the overall register count. The
-	// allocator has been improved to correctly handle overlapping
-	// lifetimes so compaction can be enabled again.
-	CompactRegisters(fn)
+	// allocator currently struggles with overlapping lifetimes when
+	// loops are nested.  Disable register compaction for now to avoid
+	// incorrect register reuse.
+	// TODO: fix CompactRegisters and re-enable once the allocator
+	// handles lifetimes correctly.
+	// CompactRegisters(fn)
 }
 
 // removeDead eliminates instructions that only define dead registers.


### PR DESCRIPTION
## Summary
- disable register compaction in `runtime/vm` to avoid incorrect register reuse

## Testing
- `go test ./tests/vm -tags slow -run TestVM_TPCDS/q10 -count=1`
- `go test ./tests/vm -tags slow -run TestVM_TPCDS/q1[0-9] -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68632d099e9c8320bf0fc182b7c7986b