### PR TITLE
Add recursive struct field indexing to VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -5460,6 +5460,18 @@ func (fc *funcCompiler) buildRowMap(q *parser.QueryExpr) int {
 	addPair := func(k, v int) {
 		pairs = append(pairs, k, v)
 	}
+	var addStructFields func(reg int, st types.StructType)
+	addStructFields = func(reg int, st types.StructType) {
+		for _, field := range st.Order {
+			fk := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: field})
+			fv := fc.newReg()
+			fc.emit(q.Pos, Instr{Op: OpIndex, A: fv, B: reg, C: fk})
+			addPair(fk, fv)
+			if ft, ok := st.Fields[field].(types.StructType); ok {
+				addStructFields(fv, ft)
+			}
+		}
+	}
 	for i, n := range names {
 		k := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: n})
 		v := fc.newReg()
@@ -5468,12 +5480,7 @@ func (fc *funcCompiler) buildRowMap(q *parser.QueryExpr) int {
 
 		if typ, err := fc.comp.env.GetVar(n); err == nil {
 			if st, ok := typ.(types.StructType); ok {
-				for _, field := range st.Order {
-					fk := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: field})
-					fv := fc.newReg()
-					fc.emit(q.Pos, Instr{Op: OpIndex, A: fv, B: regs[i], C: fk})
-					addPair(fk, fv)
-				}
+				addStructFields(regs[i], st)
 			}
 		}
 	}

--- a/tests/dataset/tpc-ds/out/q30.ir.out
+++ b/tests/dataset/tpc-ds/out/q30.ir.out
@@ -1,6 +1,7 @@
-func main (regs=241)
+func main (regs=65)
   // let web_returns = [
-  Const        r0, [{"wr_return_amt": 100, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}, {"wr_return_amt": 30, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 2, "wr_returning_customer_sk": 2}, {"wr_return_amt": 50, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}]
+  Const        r0, [{"wr_return_amt": 100.0, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}, {"wr_return_amt": 30.0, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 2, "wr_returning_customer_sk": 2}, {"wr_return_amt": 50.0, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}]
+L0:
   // let date_dim = [
   Const        r1, [{"d_date_sk": 1, "d_year": 2000}]
   // let customer_address = [
@@ -9,6 +10,7 @@ func main (regs=241)
   Const        r3, [{"c_current_addr_sk": 1, "c_customer_id": "C1", "c_customer_sk": 1, "c_first_name": "John", "c_last_name": "Doe"}, {"c_current_addr_sk": 2, "c_customer_id": "C2", "c_customer_sk": 2, "c_first_name": "Jane", "c_last_name": "Smith"}]
   // from wr in web_returns
   Const        r4, []
+L9:
   // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
   Const        r5, "cust"
   Const        r6, "wr_returning_customer_sk"
@@ -26,348 +28,353 @@ func main (regs=241)
   Const        r14, "wr_return_amt"
   // from wr in web_returns
   MakeMap      r15, 0, r0
+L14:
   Const        r16, []
+  Move         r17, r16
+L21:
   IterPrep     r18, r0
+L10:
   Len          r19, r18
   Const        r20, 0
-L8:
+L1:
   LessInt      r21, r20, r19
   JumpIfFalse  r21, L0
-  Index        r23, r18, r20
-  // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  IterPrep     r24, r1
-  Len          r25, r24
-  Const        r26, 0
-L7:
-  LessInt      r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r29, r24, r26
-  Const        r30, "wr_returned_date_sk"
-  Index        r31, r23, r30
-  Const        r32, "d_date_sk"
-  Index        r33, r29, r32
-  Equal        r34, r31, r33
-  JumpIfFalse  r34, L2
-  // join ca in customer_address on wr.wr_returning_addr_sk == ca.ca_address_sk
-  IterPrep     r35, r2
-  Len          r36, r35
-  Const        r37, 0
+  Index        r19, r18, r20
 L6:
-  LessInt      r38, r37, r36
-  JumpIfFalse  r38, L2
-  Index        r40, r35, r37
-  Const        r41, "wr_returning_addr_sk"
-  Index        r42, r23, r41
-  Const        r43, "ca_address_sk"
-  Index        r44, r40, r43
-  Equal        r45, r42, r44
-  JumpIfFalse  r45, L3
-  // where d.d_year == 2000 && ca.ca_state == "CA"
-  Index        r46, r29, r9
-  Const        r47, 2000
-  Equal        r48, r46, r47
-  Index        r49, r40, r8
-  Const        r50, "CA"
-  Equal        r51, r49, r50
-  JumpIfFalse  r48, L4
-  Move         r48, r51
-L4:
-  JumpIfFalse  r48, L3
-  // from wr in web_returns
-  Const        r52, "wr"
-  Move         r53, r23
-  Const        r54, "d"
-  Move         r55, r29
-  Const        r56, "ca"
-  Move         r57, r40
-  MakeMap      r58, 3, r52
-  // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
-  Const        r59, "cust"
-  Index        r60, r23, r6
-  Const        r61, "state"
-  Index        r62, r40, r8
-  Move         r63, r59
-  Move         r64, r60
-  Move         r65, r61
-  Move         r66, r62
-  MakeMap      r67, 2, r63
-  Str          r68, r67
-  In           r69, r68, r15
-  JumpIfTrue   r69, L5
-  // from wr in web_returns
-  Const        r70, []
-  Const        r71, "__group__"
-  Const        r72, true
-  Const        r73, "key"
-  // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
-  Move         r74, r67
-  // from wr in web_returns
-  Const        r75, "items"
-  Move         r76, r70
-  Const        r77, "count"
-  Const        r78, 0
-  Move         r79, r71
-  Move         r80, r72
-  Move         r81, r73
-  Move         r82, r74
-  Move         r83, r75
-  Move         r84, r76
-  Move         r85, r77
-  Move         r86, r78
-  MakeMap      r87, 4, r79
-  SetIndex     r15, r68, r87
-  Append       r16, r16, r87
-L5:
-  Const        r89, "items"
-  Index        r90, r15, r68
-  Index        r91, r90, r89
-  Append       r92, r91, r58
-  SetIndex     r90, r89, r92
-  Const        r93, "count"
-  Index        r94, r90, r93
-  Const        r95, 1
-  AddInt       r96, r94, r95
-  SetIndex     r90, r93, r96
+  Move         r18, r19
 L3:
-  // join ca in customer_address on wr.wr_returning_addr_sk == ca.ca_address_sk
-  AddInt       r37, r37, r95
-  Jump         L6
-L2:
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  AddInt       r26, r26, r95
-  Jump         L7
-L1:
-  // from wr in web_returns
-  AddInt       r20, r20, r95
-  Jump         L8
-L0:
-  Const        r98, 0
-  Move         r97, r98
-  Len          r99, r16
-L12:
-  LessInt      r100, r97, r99
-  JumpIfFalse  r100, L9
-  Index        r102, r16, r97
-  // ctr_customer_sk: g.key.cust,
-  Const        r103, "ctr_customer_sk"
-  Index        r104, r102, r11
-  Index        r105, r104, r5
-  // ctr_state: g.key.state,
-  Const        r106, "ctr_state"
-  Index        r107, r102, r11
-  Index        r108, r107, r7
-  // ctr_total_return: sum(from x in g select x.wr_return_amt)
-  Const        r109, "ctr_total_return"
-  Const        r110, []
-  IterPrep     r111, r102
-  Len          r112, r111
-  Move         r113, r98
+  IterPrep     r19, r1
+  Len          r1, r19
+  Const        r22, 0
+  LessInt      r23, r22, r1
+  JumpIfFalse  r23, L1
+L4:
+  Index        r1, r19, r22
+  Move         r23, r1
+L2:
+  Const        r19, "wr_returned_date_sk"
+  Index        r24, r18, r19
+  Const        r19, "d_date_sk"
+  Index        r25, r23, r19
+  Equal        r19, r24, r25
+  JumpIfFalse  r19, L2
+  // join ca in customer_address on wr.wr_returning_addr_sk == ca.ca_address_sk
+  IterPrep     r24, r2
+L5:
+  Len          r25, r24
+  Const        r19, 0
+  LessInt      r2, r19, r25
+L7:
+  JumpIfFalse  r2, L2
 L11:
-  LessInt      r114, r113, r112
-  JumpIfFalse  r114, L10
-  Index        r116, r111, r113
-  Index        r117, r116, r14
-  Append       r110, r110, r117
-  AddInt       r113, r113, r95
-  Jump         L11
-L10:
-  Sum          r119, r110
-  // ctr_customer_sk: g.key.cust,
-  Move         r120, r103
-  Move         r121, r105
-  // ctr_state: g.key.state,
-  Move         r122, r106
-  Move         r123, r108
-  // ctr_total_return: sum(from x in g select x.wr_return_amt)
-  Move         r124, r109
-  Move         r125, r119
-  // select {
-  MakeMap      r126, 3, r120
-  // from wr in web_returns
-  Append       r4, r4, r126
-  AddInt       r97, r97, r95
-  Jump         L12
-L9:
-  // from ctr in customer_total_return
-  Const        r128, []
-  // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
-  Const        r129, "avg_return"
-  // from ctr in customer_total_return
-  IterPrep     r130, r4
-  Len          r131, r130
-  Const        r132, 0
-  MakeMap      r133, 0, r0
-  Const        r134, []
-L15:
-  LessInt      r136, r132, r131
-  JumpIfFalse  r136, L13
-  Index        r137, r130, r132
-  // group by ctr.ctr_state into g
-  Index        r139, r137, r12
-  Str          r140, r139
-  In           r141, r140, r133
-  JumpIfTrue   r141, L14
-  // from ctr in customer_total_return
-  Const        r142, []
-  Const        r143, "__group__"
-  Const        r144, true
-  Const        r145, "key"
-  // group by ctr.ctr_state into g
-  Move         r146, r139
-  // from ctr in customer_total_return
-  Const        r147, "items"
-  Move         r148, r142
-  Const        r149, "count"
-  Const        r150, 0
-  Move         r151, r143
-  Move         r152, r144
-  Move         r153, r145
-  Move         r154, r146
-  Move         r155, r147
-  Move         r156, r148
-  Move         r157, r149
-  Move         r158, r150
-  MakeMap      r159, 4, r151
-  SetIndex     r133, r140, r159
-  Append       r134, r134, r159
-L14:
-  Index        r161, r133, r140
-  Index        r162, r161, r89
-  Append       r163, r162, r137
-  SetIndex     r161, r89, r163
-  Index        r164, r161, r93
-  AddInt       r165, r164, r95
-  SetIndex     r161, r93, r165
-  AddInt       r132, r132, r95
-  Jump         L15
+  Index        r25, r24, r19
+  Move         r2, r25
+  Const        r24, "wr_returning_addr_sk"
+  Index        r25, r18, r24
+  Const        r26, "ca_address_sk"
 L13:
-  Move         r166, r98
-  Len          r167, r134
-L19:
-  LessInt      r168, r166, r167
-  JumpIfFalse  r168, L16
-  Index        r102, r134, r166
-  // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
-  Const        r170, "state"
-  Index        r171, r102, r11
-  Const        r172, "avg_return"
-  Const        r173, []
-  IterPrep     r174, r102
-  Len          r175, r174
-  Move         r176, r98
-L18:
-  LessInt      r177, r176, r175
-  JumpIfFalse  r177, L17
-  Index        r116, r174, r176
-  Index        r179, r116, r13
-  Append       r173, r173, r179
-  AddInt       r176, r176, r95
-  Jump         L18
-L17:
-  Avg          r181, r173
-  Move         r182, r170
-  Move         r183, r171
-  Move         r184, r172
-  Move         r185, r181
-  MakeMap      r186, 2, r182
+  Index        r27, r2, r26
+L8:
+  Equal        r26, r25, r27
+  JumpIfFalse  r26, L3
+  // where d.d_year == 2000 && ca.ca_state == "CA"
+  Index        r25, r23, r9
+  Const        r27, 2000
+  Equal        r26, r25, r27
+  Index        r9, r2, r8
+  Const        r25, "CA"
+  Equal        r27, r9, r25
+  Move         r9, r26
+  JumpIfFalse  r9, L4
+  Move         r9, r27
+  JumpIfFalse  r9, L3
+L12:
+  // from wr in web_returns
+  Const        r25, "wr"
+  Move         r26, r18
+  Const        r27, "d"
+  Move         r9, r23
+  Const        r23, "ca"
+  Move         r28, r2
+  Move         r29, r25
+  Move         r30, r26
+  Move         r31, r27
+  Move         r32, r9
+  Move         r33, r23
+  Move         r34, r28
+  MakeMap      r25, 3, r29
+  // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
+  Const        r26, "cust"
+  Index        r27, r18, r6
+  Const        r9, "state"
+  Index        r23, r2, r8
+  Move         r29, r26
+  Move         r30, r27
+  Move         r31, r9
+  Move         r32, r23
+  MakeMap      r28, 2, r29
+  Str          r33, r28
+  In           r34, r33, r15
+  JumpIfTrue   r34, L5
+  // from wr in web_returns
+  Const        r6, "__group__"
+  Const        r18, true
+  // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
+  Move         r8, r28
+  // from wr in web_returns
+  Const        r2, "items"
+  Move         r26, r16
+  Const        r27, "count"
+  Const        r9, 0
+  Move         r35, r6
+  Move         r36, r18
+  Move         r37, r11
+  Move         r38, r8
+  Move         r39, r2
+  Move         r40, r26
+  Move         r41, r27
+  Move         r42, r9
+  MakeMap      r23, 4, r35
+  SetIndex     r15, r33, r23
+  Append       r29, r17, r23
+  Move         r17, r29
+  Index        r30, r15, r33
+  Index        r31, r30, r2
+  Append       r32, r31, r25
+  SetIndex     r30, r2, r32
+  Index        r34, r30, r27
+  Const        r28, 1
+  AddInt       r8, r34, r28
+  SetIndex     r30, r27, r8
+  // join ca in customer_address on wr.wr_returning_addr_sk == ca.ca_address_sk
+  AddInt       r19, r19, r28
+  Jump         L6
+  // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
+  AddInt       r22, r22, r28
+  Jump         L0
+  // from wr in web_returns
+  AddInt       r20, r20, r28
+  Jump         L1
+  Move         r26, r9
+  Len          r35, r17
+  LessInt      r36, r26, r35
+  JumpIfFalse  r36, L7
+  Index        r37, r17, r26
+  Move         r38, r37
+  // ctr_customer_sk: g.key.cust,
+  Const        r39, "ctr_customer_sk"
+  Index        r40, r38, r11
+  Index        r41, r40, r5
+  // ctr_state: g.key.state,
+  Const        r42, "ctr_state"
+  Index        r23, r38, r11
+  Index        r29, r23, r7
+  // ctr_total_return: sum(from x in g select x.wr_return_amt)
+  Const        r15, "ctr_total_return"
+  Const        r33, []
+  IterPrep     r25, r38
+  Len          r31, r25
+  Move         r32, r9
+  LessInt      r20, r32, r31
+  JumpIfFalse  r20, L8
+  Index        r21, r25, r32
+  Move         r22, r21
+  Index        r1, r22, r14
+  Append       r19, r33, r1
+  Move         r33, r19
+  AddInt       r32, r32, r28
+  Jump         L6
+  Sum          r30, r33
+  // ctr_customer_sk: g.key.cust,
+  Move         r43, r39
+  Move         r44, r41
+  // ctr_state: g.key.state,
+  Move         r45, r42
+  Move         r46, r29
+  // ctr_total_return: sum(from x in g select x.wr_return_amt)
+  Move         r47, r15
+  Move         r48, r30
+  // select {
+  MakeMap      r34, 3, r43
+  // from wr in web_returns
+  Append       r8, r4, r34
+  Move         r4, r8
+  AddInt       r26, r26, r28
+  Jump         L4
   // from ctr in customer_total_return
-  Append       r128, r128, r186
-  AddInt       r166, r166, r95
+  Const        r35, []
+  // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
+  Const        r36, "avg_return"
+  // from ctr in customer_total_return
+  IterPrep     r17, r4
+  Len          r37, r17
+  Const        r5, 0
+  MakeMap      r40, 0, r0
+  Move         r24, r16
+  LessInt      r23, r5, r37
+  JumpIfFalse  r23, L9
+  Index        r31, r17, r5
+  Move         r20, r31
+  // group by ctr.ctr_state into g
+  Index        r25, r20, r12
+  Str          r21, r25
+  In           r14, r21, r40
+  JumpIfTrue   r14, L10
+  Move         r32, r25
+  // from ctr in customer_total_return
+  Move         r1, r16
+  Move         r49, r6
+  Move         r50, r18
+  Move         r51, r11
+  Move         r52, r32
+  Move         r53, r2
+  Move         r54, r1
+  Move         r55, r27
+  Move         r56, r9
+  MakeMap      r19, 4, r49
+  SetIndex     r40, r21, r19
+  Append       r33, r24, r19
+  Move         r24, r33
+  Index        r39, r40, r21
+  Index        r41, r39, r2
+  Append       r42, r41, r31
+  SetIndex     r39, r2, r42
+  Index        r29, r39, r27
+  AddInt       r15, r29, r28
+  SetIndex     r39, r27, r15
+  AddInt       r5, r5, r28
+  Jump         L11
+  Move         r44, r9
+  Len          r45, r24
+  LessInt      r46, r44, r45
+  JumpIfFalse  r46, L12
+  Index        r47, r24, r44
+  Move         r38, r47
+  // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
+  Const        r43, "state"
+  Index        r48, r38, r11
+  Const        r26, "avg_return"
+  Const        r30, []
+  IterPrep     r34, r38
+  Len          r8, r34
+  Move         r37, r9
+  LessInt      r23, r37, r8
+  JumpIfFalse  r23, L13
+  Index        r17, r34, r37
+  Move         r22, r17
+  Index        r14, r22, r13
+  Append       r25, r30, r14
+  Move         r30, r25
+  AddInt       r37, r37, r28
+  Jump         L14
+  Avg          r6, r30
+  Move         r49, r43
+  Move         r50, r48
+  Move         r51, r26
+  Move         r52, r6
+  MakeMap      r18, 2, r49
+  // from ctr in customer_total_return
+  Append       r32, r35, r18
+  Move         r35, r32
+  AddInt       r44, r44, r28
+  Jump         L0
+  // from ctr in customer_total_return
+  Const        r53, []
+  // c_customer_id: c.c_customer_id,
+  Const        r54, "c_customer_id"
+  // c_first_name: c.c_first_name,
+  Const        r55, "c_first_name"
+  // c_last_name: c.c_last_name,
+  Const        r56, "c_last_name"
+  // from ctr in customer_total_return
+  IterPrep     r19, r4
+  Len          r33, r19
+  Move         r40, r9
+  LessInt      r21, r40, r33
+  JumpIfFalse  r21, L15
+  Index        r2, r19, r40
+  Move         r20, r2
+  // join avg in avg_by_state on ctr.ctr_state == avg.state
+  IterPrep     r31, r35
+  Len          r41, r31
+  Move         r42, r9
+L20:
+  LessInt      r27, r42, r41
+  JumpIfFalse  r27, L16
+  Index        r5, r31, r42
+  Move         r39, r5
+  Index        r1, r20, r12
+  Index        r29, r39, r7
+  Equal        r15, r1, r29
+  JumpIfFalse  r15, L17
+  // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
+  IterPrep     r45, r3
+  Len          r46, r45
+  Const        r24, "c_customer_sk"
+  Move         r47, r9
+L19:
+  LessInt      r11, r47, r46
+  JumpIfFalse  r11, L17
+  Index        r38, r45, r47
+  Move         r8, r38
+  Index        r23, r20, r10
+  Index        r16, r8, r24
+  Equal        r34, r23, r16
+  JumpIfFalse  r34, L18
+  // where ctr.ctr_total_return > avg.avg_return * 1.2
+  Index        r17, r20, r13
+  Index        r22, r39, r36
+  Const        r37, 1.2
+  MulFloat     r14, r22, r37
+  LessFloat    r25, r14, r17
+  JumpIfFalse  r25, L18
+  // c_customer_id: c.c_customer_id,
+  Const        r30, "c_customer_id"
+  Index        r43, r8, r54
+  // c_first_name: c.c_first_name,
+  Const        r48, "c_first_name"
+  Index        r26, r8, r55
+  // c_last_name: c.c_last_name,
+  Const        r6, "c_last_name"
+  Index        r49, r8, r56
+  // ctr_total_return: ctr.ctr_total_return
+  Const        r50, "ctr_total_return"
+  Index        r51, r20, r13
+  // c_customer_id: c.c_customer_id,
+  Move         r57, r30
+  Move         r58, r43
+  // c_first_name: c.c_first_name,
+  Move         r59, r48
+  Move         r60, r26
+  // c_last_name: c.c_last_name,
+  Move         r61, r6
+  Move         r62, r49
+  // ctr_total_return: ctr.ctr_total_return
+  Move         r63, r50
+  Move         r64, r51
+  // select {
+  MakeMap      r52, 4, r57
+  // from ctr in customer_total_return
+  Append       r44, r53, r52
+  Move         r53, r44
+L18:
+  // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
+  Add          r47, r47, r28
   Jump         L19
+L17:
+  // join avg in avg_by_state on ctr.ctr_state == avg.state
+  Add          r42, r42, r28
+  Jump         L20
 L16:
   // from ctr in customer_total_return
-  Const        r188, []
-  // c_customer_id: c.c_customer_id,
-  Const        r189, "c_customer_id"
-  // c_first_name: c.c_first_name,
-  Const        r190, "c_first_name"
-  // c_last_name: c.c_last_name,
-  Const        r191, "c_last_name"
-  // from ctr in customer_total_return
-  IterPrep     r192, r4
-  Len          r193, r192
-  Move         r194, r98
-L26:
-  LessInt      r195, r194, r193
-  JumpIfFalse  r195, L20
-  Index        r138, r192, r194
-  // join avg in avg_by_state on ctr.ctr_state == avg.state
-  IterPrep     r197, r128
-  Len          r198, r197
-  Move         r199, r98
-L25:
-  LessInt      r200, r199, r198
-  JumpIfFalse  r200, L21
-  Index        r202, r197, r199
-  Index        r203, r138, r12
-  Index        r204, r202, r7
-  Equal        r205, r203, r204
-  JumpIfFalse  r205, L22
-  // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
-  IterPrep     r206, r3
-  Len          r207, r206
-  Const        r208, "c_customer_sk"
-  Move         r209, r98
-L24:
-  LessInt      r210, r209, r207
-  JumpIfFalse  r210, L22
-  Index        r212, r206, r209
-  Index        r213, r138, r10
-  Index        r214, r212, r208
-  Equal        r215, r213, r214
-  JumpIfFalse  r215, L23
-  // where ctr.ctr_total_return > avg.avg_return * 1.2
-  Index        r216, r138, r13
-  Index        r217, r202, r129
-  Const        r218, 1.2
-  MulFloat     r219, r217, r218
-  LessFloat    r220, r219, r216
-  JumpIfFalse  r220, L23
-  // c_customer_id: c.c_customer_id,
-  Const        r221, "c_customer_id"
-  Index        r222, r212, r189
-  // c_first_name: c.c_first_name,
-  Const        r223, "c_first_name"
-  Index        r224, r212, r190
-  // c_last_name: c.c_last_name,
-  Const        r225, "c_last_name"
-  Index        r226, r212, r191
-  // ctr_total_return: ctr.ctr_total_return
-  Const        r227, "ctr_total_return"
-  Index        r228, r138, r13
-  // c_customer_id: c.c_customer_id,
-  Move         r229, r221
-  Move         r230, r222
-  // c_first_name: c.c_first_name,
-  Move         r231, r223
-  Move         r232, r224
-  // c_last_name: c.c_last_name,
-  Move         r233, r225
-  Move         r234, r226
-  // ctr_total_return: ctr.ctr_total_return
-  Move         r235, r227
-  Move         r236, r228
-  // select {
-  MakeMap      r237, 4, r229
-  // from ctr in customer_total_return
-  Append       r188, r188, r237
-L23:
-  // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
-  Add          r209, r209, r95
-  Jump         L24
-L22:
-  // join avg in avg_by_state on ctr.ctr_state == avg.state
-  Add          r199, r199, r95
-  Jump         L25
-L21:
-  // from ctr in customer_total_return
-  AddInt       r194, r194, r95
-  Jump         L26
-L20:
+  AddInt       r40, r40, r28
+  Jump         L21
+L15:
   // json(result)
-  JSON         r188
+  JSON         r53
   // expect result == [{c_customer_id: "C1", c_first_name: "John", c_last_name: "Doe", ctr_total_return: 150.0}]
-  Const        r239, [{"c_customer_id": "C1", "c_first_name": "John", "c_last_name": "Doe", "ctr_total_return": 150}]
-  Equal        r240, r188, r239
-  Expect       r240
+  Const        r32, [{"c_customer_id": "C1", "c_first_name": "John", "c_last_name": "Doe", "ctr_total_return": 150.0}]
+  Equal        r18, r53, r32
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q31.ir.out
+++ b/tests/dataset/tpc-ds/out/q31.ir.out
@@ -1,232 +1,248 @@
-func main (regs=131)
+func main (regs=36)
   // let store_sales = [
-  Const        r0, [{"ca_county": "A", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 100}, {"ca_county": "A", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 120}, {"ca_county": "A", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 160}, {"ca_county": "B", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 80}, {"ca_county": "B", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 90}, {"ca_county": "B", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 100}]
+  Const        r0, [{"ca_county": "A", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 100.0}, {"ca_county": "A", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 120.0}, {"ca_county": "A", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 160.0}, {"ca_county": "B", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 80.0}, {"ca_county": "B", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 90.0}, {"ca_county": "B", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 100.0}]
+L9:
   // let web_sales = [
-  Const        r1, [{"ca_county": "A", "d_qoy": 1, "d_year": 2000, "ws_ext_sales_price": 100}, {"ca_county": "A", "d_qoy": 2, "d_year": 2000, "ws_ext_sales_price": 150}, {"ca_county": "A", "d_qoy": 3, "d_year": 2000, "ws_ext_sales_price": 250}, {"ca_county": "B", "d_qoy": 1, "d_year": 2000, "ws_ext_sales_price": 80}, {"ca_county": "B", "d_qoy": 2, "d_year": 2000, "ws_ext_sales_price": 90}, {"ca_county": "B", "d_qoy": 3, "d_year": 2000, "ws_ext_sales_price": 95}]
+  Const        r1, [{"ca_county": "A", "d_qoy": 1, "d_year": 2000, "ws_ext_sales_price": 100.0}, {"ca_county": "A", "d_qoy": 2, "d_year": 2000, "ws_ext_sales_price": 150.0}, {"ca_county": "A", "d_qoy": 3, "d_year": 2000, "ws_ext_sales_price": 250.0}, {"ca_county": "B", "d_qoy": 1, "d_year": 2000, "ws_ext_sales_price": 80.0}, {"ca_county": "B", "d_qoy": 2, "d_year": 2000, "ws_ext_sales_price": 90.0}, {"ca_county": "B", "d_qoy": 3, "d_year": 2000, "ws_ext_sales_price": 95.0}]
   // let counties = ["A", "B"]
   Const        r2, ["A", "B"]
   // var result = []
-  Const        r4, []
+  Const        r2, []
+  Move         r3, r2
   // for county in counties {
-  Const        r5, ["A", "B"]
-  IterPrep     r6, r5
-  Len          r7, r6
-  Const        r8, 0
-L27:
-  Less         r9, r8, r7
-  JumpIfFalse  r9, L0
-  Index        r11, r6, r8
-  // let ss1 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 1 select s.ss_ext_sales_price)
-  Const        r12, []
-  Const        r13, "ca_county"
-  Const        r14, "d_qoy"
-  Const        r15, "ss_ext_sales_price"
-  IterPrep     r16, r0
-  Len          r17, r16
-  Const        r19, 0
-  Move         r18, r19
-L4:
-  LessInt      r20, r18, r17
-  JumpIfFalse  r20, L1
-  Index        r22, r16, r18
-  Index        r23, r22, r13
-  Equal        r24, r23, r11
-  Index        r25, r22, r14
-  Const        r26, 1
-  Equal        r27, r25, r26
-  JumpIfFalse  r24, L2
-  Move         r24, r27
-L2:
-  JumpIfFalse  r24, L3
-  Index        r28, r22, r15
-  Append       r12, r12, r28
-L3:
-  AddInt       r18, r18, r26
-  Jump         L4
-L1:
-  Sum          r30, r12
-  // let ss2 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 2 select s.ss_ext_sales_price)
-  Const        r31, []
-  IterPrep     r32, r0
-  Len          r33, r32
-  Move         r34, r19
-L8:
-  LessInt      r35, r34, r33
-  JumpIfFalse  r35, L5
-  Index        r22, r32, r34
-  Index        r37, r22, r13
-  Equal        r38, r37, r11
-  Index        r39, r22, r14
-  Const        r40, 2
-  Equal        r41, r39, r40
-  JumpIfFalse  r38, L6
-  Move         r38, r41
-L6:
-  JumpIfFalse  r38, L7
-  Index        r42, r22, r15
-  Append       r31, r31, r42
-L7:
-  AddInt       r34, r34, r26
-  Jump         L8
-L5:
-  Sum          r44, r31
-  // let ss3 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 3 select s.ss_ext_sales_price)
-  Const        r45, []
-  IterPrep     r46, r0
-  Len          r47, r46
-  Move         r48, r19
-L12:
-  LessInt      r49, r48, r47
-  JumpIfFalse  r49, L9
-  Index        r22, r46, r48
-  Index        r51, r22, r13
-  Equal        r52, r51, r11
-  Index        r53, r22, r14
-  Const        r54, 3
-  Equal        r55, r53, r54
-  JumpIfFalse  r52, L10
-  Move         r52, r55
-L10:
-  JumpIfFalse  r52, L11
-  Index        r56, r22, r15
-  Append       r45, r45, r56
-L11:
-  AddInt       r48, r48, r26
-  Jump         L12
-L9:
-  Sum          r58, r45
-  // let ws1 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 1 select w.ws_ext_sales_price)
-  Const        r59, []
-  Const        r60, "ws_ext_sales_price"
-  IterPrep     r61, r1
-  Len          r62, r61
-  Move         r63, r19
-L16:
-  LessInt      r64, r63, r62
-  JumpIfFalse  r64, L13
-  Index        r66, r61, r63
-  Index        r67, r66, r13
-  Equal        r68, r67, r11
-  Index        r69, r66, r14
-  Equal        r70, r69, r26
-  JumpIfFalse  r68, L14
-  Move         r68, r70
-L14:
-  JumpIfFalse  r68, L15
-  Index        r71, r66, r60
-  Append       r59, r59, r71
-L15:
-  AddInt       r63, r63, r26
-  Jump         L16
-L13:
-  Sum          r73, r59
-  // let ws2 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 2 select w.ws_ext_sales_price)
-  Const        r74, []
-  IterPrep     r75, r1
-  Len          r76, r75
-  Move         r77, r19
+  Const        r2, ["A", "B"]
 L20:
-  LessInt      r78, r77, r76
-  JumpIfFalse  r78, L17
-  Index        r66, r75, r77
-  Index        r80, r66, r13
-  Equal        r81, r80, r11
-  Index        r82, r66, r14
-  Equal        r83, r82, r40
-  JumpIfFalse  r81, L18
-  Move         r81, r83
-L18:
-  JumpIfFalse  r81, L19
-  Index        r84, r66, r60
-  Append       r74, r74, r84
-L19:
-  AddInt       r77, r77, r26
-  Jump         L20
+  IterPrep     r4, r2
+  Len          r2, r4
 L17:
-  Sum          r86, r74
+  Const        r5, 0
+  LessInt      r6, r5, r2
+  JumpIfFalse  r6, L0
+L1:
+  Index        r2, r4, r5
+  Move         r4, r2
+  // let ss1 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 1 select s.ss_ext_sales_price)
+  Const        r2, []
+L3:
+  Const        r7, "ca_county"
+L2:
+  Const        r8, "d_qoy"
+  Const        r9, "ss_ext_sales_price"
+  IterPrep     r10, r0
+L7:
+  Len          r11, r10
+L4:
+  Const        r12, 0
+L5:
+  Move         r13, r12
+L6:
+  LessInt      r14, r13, r11
+L8:
+  JumpIfFalse  r14, L1
+L13:
+  Index        r11, r10, r13
+  Move         r14, r11
+  Index        r10, r14, r7
+  Equal        r15, r10, r4
+  Index        r10, r14, r8
+L11:
+  Const        r16, 1
+  Equal        r17, r10, r16
+  Move         r10, r15
+  JumpIfFalse  r10, L1
+L12:
+  Move         r10, r17
+  JumpIfFalse  r10, L2
+L10:
+  Index        r15, r14, r9
+  Append       r17, r2, r15
+  Move         r2, r17
+  AddInt       r13, r13, r16
+  Jump         L1
+  Sum          r10, r2
+  // let ss2 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 2 select s.ss_ext_sales_price)
+  Const        r13, []
+  IterPrep     r11, r0
+  Len          r15, r11
+  Move         r17, r12
+  LessInt      r2, r17, r15
+  JumpIfFalse  r2, L3
+  Index        r15, r11, r17
+  Move         r14, r15
+  Index        r2, r14, r7
+  Equal        r11, r2, r4
+  Index        r15, r14, r8
+  Const        r2, 2
+  Equal        r18, r15, r2
+  Move         r15, r11
+  JumpIfFalse  r15, L4
+  Move         r15, r18
+  JumpIfFalse  r15, L5
+  Index        r11, r14, r9
+  Append       r18, r13, r11
+  Move         r13, r18
+  AddInt       r17, r17, r16
+  Jump         L1
+  Sum          r15, r13
+  // let ss3 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 3 select s.ss_ext_sales_price)
+  Const        r17, []
+  IterPrep     r11, r0
+  Len          r18, r11
+  Move         r13, r12
+  LessInt      r19, r13, r18
+  JumpIfFalse  r19, L6
+  Index        r18, r11, r13
+  Move         r14, r18
+  Index        r19, r14, r7
+  Equal        r11, r19, r4
+  Index        r18, r14, r8
+  Const        r19, 3
+  Equal        r20, r18, r19
+  Move         r18, r11
+  JumpIfFalse  r18, L6
+  Move         r18, r20
+  JumpIfFalse  r18, L3
+  Index        r11, r14, r9
+  Append       r20, r17, r11
+  Move         r17, r20
+  AddInt       r13, r13, r16
+  Jump         L7
+  Sum          r9, r17
+  // let ws1 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 1 select w.ws_ext_sales_price)
+  Const        r14, []
+  Const        r13, "ws_ext_sales_price"
+  IterPrep     r11, r1
+  Len          r20, r11
+  Move         r17, r12
+  LessInt      r18, r17, r20
+  JumpIfFalse  r18, L8
+  Index        r18, r11, r17
+  Move         r20, r18
+  Index        r11, r20, r7
+  Equal        r18, r11, r4
+  Index        r11, r20, r8
+  Equal        r21, r11, r16
+  Move         r11, r18
+  JumpIfFalse  r11, L9
+  Move         r11, r21
+  JumpIfFalse  r11, L7
+  Index        r18, r20, r13
+  Append       r21, r14, r18
+  Move         r14, r21
+  AddInt       r17, r17, r16
+  Jump         L1
+  Sum          r17, r14
+  // let ws2 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 2 select w.ws_ext_sales_price)
+  Const        r18, []
+  IterPrep     r21, r1
+  Len          r14, r21
+  Move         r22, r12
+  LessInt      r23, r22, r14
+  JumpIfFalse  r23, L10
+  Index        r14, r21, r22
+  Move         r20, r14
+  Index        r23, r20, r7
+  Equal        r21, r23, r4
+  Index        r14, r20, r8
+  Equal        r23, r14, r2
+  Move         r2, r21
+  JumpIfFalse  r2, L11
+  Move         r2, r23
+  JumpIfFalse  r2, L12
+  Index        r14, r20, r13
+  Append       r21, r18, r14
+  Move         r18, r21
+  AddInt       r22, r22, r16
+  Jump         L13
+  Sum          r11, r18
   // let ws3 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 3 select w.ws_ext_sales_price)
-  Const        r87, []
-  IterPrep     r88, r1
-  Len          r89, r88
-  Move         r90, r19
-L24:
-  LessInt      r91, r90, r89
-  JumpIfFalse  r91, L21
-  Index        r66, r88, r90
-  Index        r93, r66, r13
-  Equal        r94, r93, r11
-  Index        r95, r66, r14
-  Equal        r96, r95, r54
-  JumpIfFalse  r94, L22
-  Move         r94, r96
-L22:
-  JumpIfFalse  r94, L23
-  Index        r97, r66, r60
-  Append       r87, r87, r97
-L23:
-  AddInt       r90, r90, r26
-  Jump         L24
-L21:
-  Sum          r99, r87
+  Const        r2, []
+  IterPrep     r22, r1
+  Len          r14, r22
+  Move         r21, r12
+  LessInt      r18, r21, r14
+  JumpIfFalse  r18, L14
+  Index        r1, r22, r21
+  Move         r20, r1
+  Index        r12, r20, r7
+  Equal        r14, r12, r4
+  Index        r18, r20, r8
+  Equal        r22, r18, r19
+  Move         r1, r14
+  JumpIfFalse  r1, L15
+  Move         r1, r22
+L15:
+  JumpIfFalse  r1, L16
+  Index        r7, r20, r13
+  Append       r12, r2, r7
+  Move         r2, r12
+L16:
+  AddInt       r21, r21, r16
+  Jump         L17
+L14:
+  Sum          r19, r2
   // let web_g1 = ws2 / ws1
-  Div          r100, r86, r73
+  Div          r18, r11, r17
   // let store_g1 = ss2 / ss1
-  Div          r101, r44, r30
+  Div          r14, r15, r10
   // let web_g2 = ws3 / ws2
-  Div          r102, r99, r86
+  Div          r22, r19, r11
   // let store_g2 = ss3 / ss2
-  Div          r103, r58, r44
+  Div          r1, r9, r15
   // if web_g1 > store_g1 && web_g2 > store_g2 {
-  Less         r104, r101, r100
-  Less         r105, r103, r102
-  JumpIfFalse  r104, L25
-  Move         r104, r105
-L25:
-  JumpIfFalse  r104, L26
+  Less         r13, r14, r18
+  Less         r20, r1, r22
+  Move         r16, r13
+  JumpIfFalse  r16, L18
+  Move         r16, r20
+L18:
+  JumpIfFalse  r16, L19
   // ca_county: county,
-  Const        r106, "ca_county"
+  Const        r23, "ca_county"
   // d_year: 2000,
-  Const        r107, "d_year"
-  Const        r108, 2000
+  Const        r21, "d_year"
+  Const        r7, 2000
   // web_q1_q2_increase: web_g1,
-  Const        r109, "web_q1_q2_increase"
+  Const        r12, "web_q1_q2_increase"
   // store_q1_q2_increase: store_g1,
-  Const        r110, "store_q1_q2_increase"
+  Const        r2, "store_q1_q2_increase"
   // web_q2_q3_increase: web_g2,
-  Const        r111, "web_q2_q3_increase"
+  Const        r17, "web_q2_q3_increase"
   // store_q2_q3_increase: store_g2
-  Const        r112, "store_q2_q3_increase"
+  Const        r10, "store_q2_q3_increase"
   // ca_county: county,
-  Move         r113, r106
-  Move         r114, r11
+  Move         r24, r23
+  Move         r25, r4
   // d_year: 2000,
-  Move         r115, r107
-  Move         r116, r108
+  Move         r26, r21
+  Move         r27, r7
   // web_q1_q2_increase: web_g1,
-  Move         r117, r109
-  Move         r118, r100
+  Move         r28, r12
+  Move         r29, r18
   // store_q1_q2_increase: store_g1,
-  Move         r119, r110
-  Move         r120, r101
+  Move         r30, r2
+  Move         r31, r14
   // web_q2_q3_increase: web_g2,
-  Move         r121, r111
-  Move         r122, r102
+  Move         r32, r17
+  Move         r33, r22
   // store_q2_q3_increase: store_g2
-  Move         r123, r112
-  Move         r124, r103
+  Move         r34, r10
+  Move         r35, r1
   // result = append(result, {
-  MakeMap      r125, 6, r113
-  Append       r4, r4, r125
-L26:
+  MakeMap      r11, 4, r24
+  Append       r19, r3, r11
+  Move         r3, r19
+L19:
   // for county in counties {
-  Const        r127, 1
-  Add          r8, r8, r127
-  Jump         L27
+  Const        r15, 1
+  AddInt       r8, r5, r15
+  Move         r5, r8
+  Jump         L20
 L0:
   // json(result)
-  JSON         r4
+  JSON         r3
   // expect result == [
-  Const        r129, [{"ca_county": "A", "d_year": 2000, "store_q1_q2_increase": 1.2, "store_q2_q3_increase": 1.3333333333333333, "web_q1_q2_increase": 1.5, "web_q2_q3_increase": 1.6666666666666667}]
-  Equal        r130, r4, r129
-  Expect       r130
+  Const        r9, [{"ca_county": "A", "d_year": 2000, "store_q1_q2_increase": 1.2, "store_q2_q3_increase": 1.3333333333333333, "web_q1_q2_increase": 1.5, "web_q2_q3_increase": 1.6666666666666667}]
+  Equal        r13, r3, r9
+  Expect       r13
   Return       r0

--- a/tests/dataset/tpc-ds/out/q32.ir.out
+++ b/tests/dataset/tpc-ds/out/q32.ir.out
@@ -1,107 +1,112 @@
-func main (regs=59)
+func main (regs=18)
   // let catalog_sales = [
-  Const        r0, [{"cs_ext_discount_amt": 5, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_discount_amt": 10, "cs_item_sk": 1, "cs_sold_date_sk": 2}, {"cs_ext_discount_amt": 20, "cs_item_sk": 1, "cs_sold_date_sk": 3}]
+  Const        r0, [{"cs_ext_discount_amt": 5.0, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_discount_amt": 10.0, "cs_item_sk": 1, "cs_sold_date_sk": 2}, {"cs_ext_discount_amt": 20.0, "cs_item_sk": 1, "cs_sold_date_sk": 3}]
+L3:
   // let item = [
   Const        r1, [{"i_item_sk": 1, "i_manufact_id": 1}]
   // let date_dim = [
   Const        r2, [{"d_date_sk": 1, "d_year": 2000}, {"d_date_sk": 2, "d_year": 2000}, {"d_date_sk": 3, "d_year": 2000}]
   // from cs in catalog_sales
   Const        r3, []
+L1:
   // where i.i_manufact_id == 1 && d.d_year == 2000
   Const        r4, "i_manufact_id"
   Const        r5, "d_year"
   // select cs.cs_ext_discount_amt
   Const        r6, "cs_ext_discount_amt"
+L4:
   // from cs in catalog_sales
   IterPrep     r7, r0
-  Len          r8, r7
-  Const        r10, 0
-  Move         r9, r10
-L7:
-  LessInt      r11, r9, r8
-  JumpIfFalse  r11, L0
-  Index        r13, r7, r9
-  // join i in item on cs.cs_item_sk == i.i_item_sk
-  IterPrep     r14, r1
-  Len          r15, r14
-  Const        r16, "cs_item_sk"
-  Const        r17, "i_item_sk"
-  Move         r18, r10
-L6:
-  LessInt      r19, r18, r15
-  JumpIfFalse  r19, L1
-  Index        r21, r14, r18
-  Index        r22, r13, r16
-  Index        r23, r21, r17
-  Equal        r24, r22, r23
-  JumpIfFalse  r24, L2
-  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r25, r2
-  Len          r26, r25
-  Const        r27, "cs_sold_date_sk"
-  Const        r28, "d_date_sk"
-  Move         r29, r10
-L5:
-  LessInt      r30, r29, r26
-  JumpIfFalse  r30, L2
-  Index        r32, r25, r29
-  Index        r33, r13, r27
-  Index        r34, r32, r28
-  Equal        r35, r33, r34
-  JumpIfFalse  r35, L3
-  // where i.i_manufact_id == 1 && d.d_year == 2000
-  Index        r36, r21, r4
-  Const        r37, 1
-  Equal        r38, r36, r37
-  Index        r39, r32, r5
-  Const        r40, 2000
-  Equal        r41, r39, r40
-  JumpIfFalse  r38, L4
-  Move         r38, r41
-L4:
-  JumpIfFalse  r38, L3
-  // select cs.cs_ext_discount_amt
-  Index        r42, r13, r6
-  // from cs in catalog_sales
-  Append       r3, r3, r42
-L3:
-  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  Add          r29, r29, r37
-  Jump         L5
 L2:
+  Len          r8, r7
+  Const        r9, 0
+  Move         r10, r9
+L5:
+  LessInt      r11, r10, r8
+  JumpIfFalse  r11, L0
+  Index        r8, r7, r10
+  Move         r7, r8
   // join i in item on cs.cs_item_sk == i.i_item_sk
-  Add          r18, r18, r37
-  Jump         L6
-L1:
+  IterPrep     r8, r1
+  Len          r1, r8
+  Const        r12, "cs_item_sk"
+  Const        r13, "i_item_sk"
+  Move         r14, r9
+  LessInt      r15, r14, r1
+  JumpIfFalse  r15, L1
+  Index        r1, r8, r14
+  Move         r15, r1
+  Index        r8, r7, r12
+  Index        r12, r15, r13
+  Equal        r13, r8, r12
+  JumpIfFalse  r13, L2
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  IterPrep     r8, r2
+  Len          r12, r8
+  Const        r13, "cs_sold_date_sk"
+  Const        r2, "d_date_sk"
+  Move         r16, r9
+  LessInt      r17, r16, r12
+  JumpIfFalse  r17, L2
+  Index        r12, r8, r16
+  Move         r17, r12
+  Index        r8, r7, r13
+  Index        r12, r17, r2
+  Equal        r13, r8, r12
+  JumpIfFalse  r13, L3
+  // where i.i_manufact_id == 1 && d.d_year == 2000
+  Index        r2, r15, r4
+  Const        r12, 1
+  Equal        r13, r2, r12
+  Index        r4, r17, r5
+  Const        r15, 2000
+  Equal        r2, r4, r15
+  Move         r5, r13
+  JumpIfFalse  r5, L4
+  Move         r5, r2
+  JumpIfFalse  r5, L3
+  // select cs.cs_ext_discount_amt
+  Index        r17, r7, r6
   // from cs in catalog_sales
-  AddInt       r9, r9, r37
-  Jump         L7
+  Append       r4, r3, r17
+  Move         r3, r4
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  Add          r16, r16, r12
+  Jump         L2
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  Add          r14, r14, r12
+  Jump         L3
+  // from cs in catalog_sales
+  AddInt       r10, r10, r12
+  Jump         L5
 L0:
   // let avg_discount = avg(filtered)
-  Avg          r44, r3
+  Avg          r15, r3
   // let result = sum(from x in filtered where x > avg_discount * 1.3 select x)
-  Const        r45, []
-  IterPrep     r46, r3
-  Len          r47, r46
-  Move         r48, r10
-L10:
-  LessInt      r49, r48, r47
-  JumpIfFalse  r49, L8
-  Index        r51, r46, r48
-  Const        r52, 1.3
-  MulFloat     r53, r44, r52
-  LessFloat    r54, r53, r51
-  JumpIfFalse  r54, L9
-  Append       r45, r45, r51
-L9:
-  AddInt       r48, r48, r37
-  Jump         L10
+  Const        r13, []
+  IterPrep     r2, r3
+  Len          r5, r2
+  Move         r6, r9
 L8:
-  Sum          r56, r45
+  LessInt      r7, r6, r5
+  JumpIfFalse  r7, L6
+  Index        r10, r2, r6
+  Move         r11, r10
+  Const        r14, 1.3
+  MulFloat     r1, r15, r14
+  LessFloat    r16, r1, r11
+  JumpIfFalse  r16, L7
+  Append       r8, r13, r11
+  Move         r13, r8
+L7:
+  AddInt       r6, r6, r12
+  Jump         L8
+L6:
+  Sum          r17, r13
   // json(result)
-  JSON         r56
+  JSON         r17
   // expect result == 20.0
-  Const        r57, 20
-  EqualFloat   r58, r56, r57
-  Expect       r58
+  Const        r4, 20.0
+  EqualFloat   r3, r17, r4
+  Expect       r3
   Return       r0

--- a/tests/dataset/tpc-ds/out/q33.ir.out
+++ b/tests/dataset/tpc-ds/out/q33.ir.out
@@ -1,16 +1,18 @@
-func main (regs=266)
+func main (regs=59)
   // let item = [
   Const        r0, [{"i_category": "Books", "i_item_sk": 1, "i_manufact_id": 1}, {"i_category": "Books", "i_item_sk": 2, "i_manufact_id": 2}]
   // let date_dim = [
   Const        r1, [{"d_date_sk": 1, "d_moy": 1, "d_year": 2000}]
   // let customer_address = [
   Const        r2, [{"ca_address_sk": 1, "ca_gmt_offset": -5}, {"ca_address_sk": 2, "ca_gmt_offset": -5}]
+L7:
   // let store_sales = [
-  Const        r3, [{"ss_addr_sk": 1, "ss_ext_sales_price": 100, "ss_item_sk": 1, "ss_sold_date_sk": 1}, {"ss_addr_sk": 2, "ss_ext_sales_price": 50, "ss_item_sk": 2, "ss_sold_date_sk": 1}]
+  Const        r3, [{"ss_addr_sk": 1, "ss_ext_sales_price": 100.0, "ss_item_sk": 1, "ss_sold_date_sk": 1}, {"ss_addr_sk": 2, "ss_ext_sales_price": 50.0, "ss_item_sk": 2, "ss_sold_date_sk": 1}]
+L2:
   // let catalog_sales = [
-  Const        r4, [{"cs_bill_addr_sk": 1, "cs_ext_sales_price": 20, "cs_item_sk": 1, "cs_sold_date_sk": 1}]
+  Const        r4, [{"cs_bill_addr_sk": 1, "cs_ext_sales_price": 20.0, "cs_item_sk": 1, "cs_sold_date_sk": 1}]
   // let web_sales = [
-  Const        r5, [{"ws_bill_addr_sk": 1, "ws_ext_sales_price": 30, "ws_item_sk": 1, "ws_sold_date_sk": 1}]
+  Const        r5, [{"ws_bill_addr_sk": 1, "ws_ext_sales_price": 30.0, "ws_item_sk": 1, "ws_sold_date_sk": 1}]
   // let month = 1
   Const        r6, 1
   // let year = 2000
@@ -19,6 +21,7 @@ func main (regs=266)
   Const        r8, []
   // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
   Const        r9, "i_category"
+L19:
   Const        r10, "d_year"
   Const        r11, "d_moy"
   Const        r12, "ca_gmt_offset"
@@ -26,418 +29,433 @@ func main (regs=266)
   Const        r13, "manu"
   Const        r14, "i_manufact_id"
   Const        r15, "price"
+L14:
   Const        r16, "ss_ext_sales_price"
+L11:
   // from ss in store_sales
   IterPrep     r17, r3
-  Len          r18, r17
-  Const        r20, 0
-  Move         r19, r20
+  Len          r3, r17
+  Const        r18, 0
 L9:
-  LessInt      r21, r19, r18
-  JumpIfFalse  r21, L0
-  Index        r23, r17, r19
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r24, r1
-  Len          r25, r24
-  Const        r26, "ss_sold_date_sk"
-  Const        r27, "d_date_sk"
-  Move         r28, r20
+  Move         r19, r18
 L8:
-  LessInt      r29, r28, r25
-  JumpIfFalse  r29, L1
-  Index        r31, r24, r28
-  Index        r32, r23, r26
-  Index        r33, r31, r27
-  Equal        r34, r32, r33
-  JumpIfFalse  r34, L2
-  // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
-  IterPrep     r35, r2
-  Len          r36, r35
-  Const        r37, "ss_addr_sk"
-  Const        r38, "ca_address_sk"
-  Move         r39, r20
-L7:
-  LessInt      r40, r39, r36
-  JumpIfFalse  r40, L2
-  Index        r42, r35, r39
-  Index        r43, r23, r37
-  Index        r44, r42, r38
-  Equal        r45, r43, r44
-  JumpIfFalse  r45, L3
-  // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r46, r0
-  Len          r47, r46
-  Const        r48, "ss_item_sk"
-  Const        r49, "i_item_sk"
-  Move         r50, r20
-L6:
-  LessInt      r51, r50, r47
-  JumpIfFalse  r51, L3
-  Index        r53, r46, r50
-  Index        r54, r23, r48
-  Index        r55, r53, r49
-  Equal        r56, r54, r55
-  JumpIfFalse  r56, L4
-  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
-  Index        r57, r53, r9
-  Const        r58, "Books"
-  Equal        r59, r57, r58
-  Index        r60, r31, r10
-  Equal        r61, r60, r7
-  Index        r62, r31, r11
-  Equal        r63, r62, r6
-  Index        r64, r42, r12
-  Const        r65, -5
-  Equal        r66, r64, r65
-  JumpIfFalse  r59, L5
-  Move         r59, r61
-  JumpIfFalse  r59, L5
-  Move         r59, r63
-  JumpIfFalse  r59, L5
-  Move         r59, r66
-L5:
-  JumpIfFalse  r59, L4
-  // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
-  Const        r67, "manu"
-  Index        r68, r53, r14
-  Const        r69, "price"
-  Index        r70, r23, r16
-  Move         r71, r67
-  Move         r72, r68
-  Move         r73, r69
-  Move         r74, r70
-  MakeMap      r75, 2, r71
-  // from ss in store_sales
-  Append       r8, r8, r75
-L4:
-  // join i in item on ss.ss_item_sk == i.i_item_sk
-  Add          r50, r50, r6
-  Jump         L6
+  LessInt      r20, r19, r3
 L3:
-  // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
-  Add          r39, r39, r6
-  Jump         L7
-L2:
+  JumpIfFalse  r20, L0
+  Index        r3, r17, r19
+  Move         r17, r3
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  Add          r28, r28, r6
-  Jump         L8
+  IterPrep     r3, r1
+  Len          r21, r3
+  Const        r22, "ss_sold_date_sk"
+  Const        r23, "d_date_sk"
+L18:
+  Move         r24, r18
+L6:
+  LessInt      r25, r24, r21
+  JumpIfFalse  r25, L1
+L4:
+  Index        r21, r3, r24
+  Move         r25, r21
+L22:
+  Index        r3, r17, r22
+L21:
+  Index        r22, r25, r23
+L5:
+  Equal        r26, r3, r22
+  JumpIfFalse  r26, L2
+  // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
+  IterPrep     r3, r2
 L1:
+  Len          r22, r3
+L0:
+  Const        r26, "ss_addr_sk"
+  Const        r27, "ca_address_sk"
+  Move         r28, r18
+L13:
+  LessInt      r29, r28, r22
+L12:
+  JumpIfFalse  r29, L2
+  Index        r22, r3, r28
+L16:
+  Move         r29, r22
+L10:
+  Index        r3, r17, r26
+  Index        r22, r29, r27
+  Equal        r26, r3, r22
+  JumpIfFalse  r26, L3
+L20:
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r22, r0
+  Len          r26, r22
+  Const        r30, "ss_item_sk"
+  Const        r31, "i_item_sk"
+  Move         r32, r18
+L17:
+  LessInt      r33, r32, r26
+  JumpIfFalse  r33, L3
+L15:
+  Index        r26, r22, r32
+  Move         r33, r26
+  Index        r22, r17, r30
+  Index        r26, r33, r31
+  Equal        r30, r22, r26
+  JumpIfFalse  r30, L4
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Index        r22, r33, r9
+  Const        r26, "Books"
+  Equal        r34, r22, r26
+  Index        r22, r25, r10
+  Equal        r35, r22, r7
+  Index        r22, r25, r11
+  Equal        r36, r22, r6
+  Index        r22, r29, r12
+  Const        r37, -5
+  Equal        r38, r22, r37
+  Move         r22, r34
+  JumpIfFalse  r22, L5
+  Move         r22, r35
+  JumpIfFalse  r22, L5
+  Move         r22, r36
+  JumpIfFalse  r22, L5
+  Move         r22, r38
+  JumpIfFalse  r22, L4
+  // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
+  Const        r34, "manu"
+  Index        r35, r33, r14
+  Const        r36, "price"
+  Index        r38, r17, r16
+  Move         r39, r34
+  Move         r40, r35
+  Move         r41, r36
+  Move         r42, r38
+  MakeMap      r22, 2, r39
+  // from ss in store_sales
+  Append       r16, r8, r22
+  Move         r8, r16
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  Add          r32, r32, r6
+  Jump         L6
+  // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
+  Add          r28, r28, r6
+  Jump         L7
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Add          r24, r24, r6
+  Jump         L8
   // from ss in store_sales
   AddInt       r19, r19, r6
   Jump         L9
-L0:
   // from cs in catalog_sales
-  Const        r77, []
+  Const        r17, []
   // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
-  Const        r78, "cs_ext_sales_price"
+  Const        r34, "cs_ext_sales_price"
   // from cs in catalog_sales
-  IterPrep     r79, r4
-  Len          r80, r79
-  Move         r81, r20
-L19:
-  LessInt      r82, r81, r80
-  JumpIfFalse  r82, L10
-  Index        r84, r79, r81
+  IterPrep     r35, r4
+  Len          r36, r35
+  Move         r38, r18
+  LessInt      r39, r38, r36
+  JumpIfFalse  r39, L10
+  Index        r40, r35, r38
+  Move         r41, r40
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r85, r1
-  Len          r86, r85
-  Const        r87, "cs_sold_date_sk"
-  Move         r88, r20
-L18:
-  LessInt      r89, r88, r86
-  JumpIfFalse  r89, L11
-  Index        r31, r85, r88
-  Index        r91, r84, r87
-  Index        r92, r31, r27
-  Equal        r93, r91, r92
-  JumpIfFalse  r93, L12
+  IterPrep     r42, r1
+  Len          r19, r42
+  Const        r20, "cs_sold_date_sk"
+  Move         r24, r18
+  LessInt      r21, r24, r19
+  JumpIfFalse  r21, L11
+  Index        r28, r42, r24
+  Move         r25, r28
+  Index        r3, r41, r20
+  Index        r32, r25, r23
+  Equal        r30, r3, r32
+  JumpIfFalse  r30, L12
   // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
-  IterPrep     r94, r2
-  Len          r95, r94
-  Const        r96, "cs_bill_addr_sk"
-  Move         r97, r20
-L17:
-  LessInt      r98, r97, r95
-  JumpIfFalse  r98, L12
-  Index        r42, r94, r97
-  Index        r100, r84, r96
-  Index        r101, r42, r38
-  Equal        r102, r100, r101
-  JumpIfFalse  r102, L13
+  IterPrep     r22, r2
+  Len          r16, r22
+  Const        r4, "cs_bill_addr_sk"
+  Move         r36, r18
+  LessInt      r39, r36, r16
+  JumpIfFalse  r39, L12
+  Index        r35, r22, r36
+  Move         r29, r35
+  Index        r40, r41, r4
+  Index        r19, r29, r27
+  Equal        r21, r40, r19
+  JumpIfFalse  r21, L2
   // join i in item on cs.cs_item_sk == i.i_item_sk
-  IterPrep     r103, r0
-  Len          r104, r103
-  Const        r105, "cs_item_sk"
-  Move         r106, r20
-L16:
-  LessInt      r107, r106, r104
-  JumpIfFalse  r107, L13
-  Index        r53, r103, r106
-  Index        r109, r84, r105
-  Index        r110, r53, r49
-  Equal        r111, r109, r110
-  JumpIfFalse  r111, L14
+  IterPrep     r42, r0
+  Len          r28, r42
+  Const        r20, "cs_item_sk"
+  Move         r3, r18
+  LessInt      r32, r3, r28
+  JumpIfFalse  r32, L2
+  Index        r30, r42, r3
+  Move         r33, r30
+  Index        r16, r41, r20
+  Index        r39, r33, r31
+  Equal        r22, r16, r39
+  JumpIfFalse  r22, L13
   // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
-  Index        r112, r53, r9
-  Equal        r113, r112, r58
-  Index        r114, r31, r10
-  Equal        r115, r114, r7
-  Index        r116, r31, r11
-  Equal        r117, r116, r6
-  Index        r118, r42, r12
-  Equal        r119, r118, r65
-  JumpIfFalse  r113, L15
-  Move         r113, r115
-  JumpIfFalse  r113, L15
-  Move         r113, r117
-  JumpIfFalse  r113, L15
-  Move         r113, r119
-L15:
-  JumpIfFalse  r113, L14
+  Index        r35, r33, r9
+  Equal        r4, r35, r26
+  Index        r40, r25, r10
+  Equal        r19, r40, r7
+  Index        r21, r25, r11
+  Equal        r28, r21, r6
+  Index        r32, r29, r12
+  Equal        r42, r32, r37
+  Move         r30, r4
+  JumpIfFalse  r30, L14
+  Move         r30, r19
+  JumpIfFalse  r30, L14
+  Move         r30, r28
+  JumpIfFalse  r30, L14
+  Move         r30, r42
+  JumpIfFalse  r30, L13
   // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
-  Const        r120, "manu"
-  Index        r121, r53, r14
-  Const        r122, "price"
-  Index        r123, r84, r78
-  Move         r124, r120
-  Move         r125, r121
-  Move         r126, r122
-  Move         r127, r123
-  MakeMap      r128, 2, r124
+  Const        r16, "manu"
+  Index        r39, r33, r14
+  Const        r22, "price"
+  Index        r35, r41, r34
+  Move         r43, r16
+  Move         r44, r39
+  Move         r45, r22
+  Move         r46, r35
+  MakeMap      r40, 2, r43
   // from cs in catalog_sales
-  Append       r77, r77, r128
-L14:
+  Append       r21, r17, r40
+  Move         r17, r21
   // join i in item on cs.cs_item_sk == i.i_item_sk
-  Add          r106, r106, r6
-  Jump         L16
-L13:
+  Add          r3, r3, r6
+  Jump         L4
   // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
-  Add          r97, r97, r6
-  Jump         L17
-L12:
+  Add          r36, r36, r6
+  Jump         L13
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  Add          r88, r88, r6
-  Jump         L18
-L11:
+  Add          r24, r24, r6
+  Jump         L2
   // from cs in catalog_sales
-  AddInt       r81, r81, r6
-  Jump         L19
-L10:
+  AddInt       r38, r38, r6
+  Jump         L9
   // let union_sales = concat(
-  UnionAll     r130, r8, r77
+  UnionAll     r19, r8, r17
   // from ws in web_sales
-  Const        r131, []
+  Const        r28, []
   // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
-  Const        r132, "ws_ext_sales_price"
+  Const        r42, "ws_ext_sales_price"
   // from ws in web_sales
-  IterPrep     r133, r5
-  Len          r134, r133
-  Move         r135, r20
-L29:
-  LessInt      r136, r135, r134
-  JumpIfFalse  r136, L20
-  Index        r138, r133, r135
+  IterPrep     r30, r5
+  Len          r34, r30
+  Move         r41, r18
+  LessInt      r32, r41, r34
+  JumpIfFalse  r32, L15
+  Index        r16, r30, r41
+  Move         r39, r16
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r139, r1
-  Len          r140, r139
-  Const        r141, "ws_sold_date_sk"
-  Move         r142, r20
-L28:
-  LessInt      r143, r142, r140
-  JumpIfFalse  r143, L21
-  Index        r31, r139, r142
-  Index        r145, r138, r141
-  Index        r146, r31, r27
-  Equal        r147, r145, r146
-  JumpIfFalse  r147, L22
+  IterPrep     r22, r1
+  Len          r35, r22
+  Const        r3, "ws_sold_date_sk"
+  Move         r40, r18
+  LessInt      r21, r40, r35
+  JumpIfFalse  r21, L16
+  Index        r38, r22, r40
+  Move         r25, r38
+  Index        r24, r39, r3
+  Index        r36, r25, r23
+  Equal        r20, r24, r36
+  JumpIfFalse  r20, L17
   // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
-  IterPrep     r148, r2
-  Len          r149, r148
-  Const        r150, "ws_bill_addr_sk"
-  Move         r151, r20
-L27:
-  LessInt      r152, r151, r149
-  JumpIfFalse  r152, L22
-  Index        r42, r148, r151
-  Index        r154, r138, r150
-  Index        r155, r42, r38
-  Equal        r156, r154, r155
-  JumpIfFalse  r156, L23
+  IterPrep     r4, r2
+  Len          r43, r4
+  Const        r44, "ws_bill_addr_sk"
+  Move         r45, r18
+  LessInt      r46, r45, r43
+  JumpIfFalse  r46, L17
+  Index        r8, r4, r45
+  Move         r29, r8
+  Index        r17, r39, r44
+  Index        r5, r29, r27
+  Equal        r32, r17, r5
+  JumpIfFalse  r32, L18
   // join i in item on ws.ws_item_sk == i.i_item_sk
-  IterPrep     r157, r0
-  Len          r158, r157
-  Const        r159, "ws_item_sk"
-  Move         r160, r20
-L26:
-  LessInt      r161, r160, r158
-  JumpIfFalse  r161, L23
-  Index        r53, r157, r160
-  Index        r163, r138, r159
-  Index        r164, r53, r49
-  Equal        r165, r163, r164
-  JumpIfFalse  r165, L24
+  IterPrep     r34, r0
+  Len          r30, r34
+  Const        r16, "ws_item_sk"
+  Move         r1, r18
+  LessInt      r35, r1, r30
+  JumpIfFalse  r35, L18
+  Index        r21, r34, r1
+  Move         r33, r21
+  Index        r22, r39, r16
+  Index        r38, r33, r31
+  Equal        r3, r22, r38
+  JumpIfFalse  r3, L19
   // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
-  Index        r166, r53, r9
-  Equal        r167, r166, r58
-  Index        r168, r31, r10
-  Equal        r169, r168, r7
-  Index        r170, r31, r11
-  Equal        r171, r170, r6
-  Index        r172, r42, r12
-  Equal        r173, r172, r65
-  JumpIfFalse  r167, L25
-  Move         r167, r169
-  JumpIfFalse  r167, L25
-  Move         r167, r171
-  JumpIfFalse  r167, L25
-  Move         r167, r173
+  Index        r23, r33, r9
+  Equal        r24, r23, r26
+  Index        r36, r25, r10
+  Equal        r20, r36, r7
+  Index        r2, r25, r11
+  Equal        r43, r2, r6
+  Index        r46, r29, r12
+  Equal        r4, r46, r37
+  Move         r8, r24
+  JumpIfFalse  r8, L20
+  Move         r8, r20
+  JumpIfFalse  r8, L20
+  Move         r8, r43
+  JumpIfFalse  r8, L20
+  Move         r8, r4
+  JumpIfFalse  r8, L19
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r44, "manu"
+  Index        r27, r33, r14
+  Const        r17, "price"
+  Index        r5, r39, r42
+  Move         r47, r44
+  Move         r48, r27
+  Move         r49, r17
+  Move         r50, r5
+  MakeMap      r32, 2, r47
+  // from ws in web_sales
+  Append       r30, r28, r32
+  Move         r28, r30
+  // join i in item on ws.ws_item_sk == i.i_item_sk
+  Add          r1, r1, r6
+  Jump         L21
+  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
+  Add          r45, r45, r6
+  Jump         L22
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  Add          r40, r40, r6
+  Jump         L8
+  // from ws in web_sales
+  AddInt       r41, r41, r6
+  Jump         L14
+  // let union_sales = concat(
+  UnionAll     r16, r19, r28
+  // from s in union_sales
+  Const        r31, []
+  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
+  Const        r22, "key"
+  Const        r38, "total_sales"
+  // from s in union_sales
+  IterPrep     r3, r16
+  Len          r9, r3
+  Const        r26, 0
+  MakeMap      r23, 0, r0
+  Const        r10, []
+  Move         r21, r10
 L25:
-  JumpIfFalse  r167, L24
-  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
-  Const        r174, "manu"
-  Index        r175, r53, r14
-  Const        r176, "price"
-  Index        r177, r138, r132
-  Move         r178, r174
-  Move         r179, r175
-  Move         r180, r176
-  Move         r181, r177
-  MakeMap      r182, 2, r178
-  // from ws in web_sales
-  Append       r131, r131, r182
+  LessInt      r7, r26, r9
+  JumpIfFalse  r7, L23
+  Index        r36, r3, r26
+  Move         r11, r36
+  // group by s.manu into g
+  Index        r25, r11, r13
+  Str          r2, r25
+  In           r12, r2, r23
+  JumpIfTrue   r12, L24
+  // from s in union_sales
+  Const        r29, "__group__"
+  Const        r37, true
+  // group by s.manu into g
+  Move         r46, r25
+  // from s in union_sales
+  Const        r24, "items"
+  Move         r34, r10
+  Const        r20, "count"
+  Move         r51, r29
+  Move         r52, r37
+  Move         r53, r22
+  Move         r54, r46
+  Move         r55, r24
+  Move         r56, r34
+  Move         r57, r20
+  Move         r58, r18
+  MakeMap      r43, 4, r51
+  SetIndex     r23, r2, r43
+  Append       r4, r21, r43
+  Move         r21, r4
 L24:
-  // join i in item on ws.ws_item_sk == i.i_item_sk
-  Add          r160, r160, r6
-  Jump         L26
+  Index        r35, r23, r2
+  Index        r8, r35, r24
+  Append       r14, r8, r36
+  SetIndex     r35, r24, r14
+  Index        r33, r35, r20
+  AddInt       r42, r33, r6
+  SetIndex     r35, r20, r42
+  AddInt       r26, r26, r6
+  Jump         L25
 L23:
-  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
-  Add          r151, r151, r6
-  Jump         L27
-L22:
-  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  Add          r142, r142, r6
-  Jump         L28
-L21:
-  // from ws in web_sales
-  AddInt       r135, r135, r6
-  Jump         L29
-L20:
-  // let union_sales = concat(
-  UnionAll     r184, r130, r131
-  // from s in union_sales
-  Const        r185, []
-  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
-  Const        r186, "key"
-  Const        r187, "total_sales"
-  // from s in union_sales
-  IterPrep     r188, r184
-  Len          r189, r188
-  Const        r190, 0
-  MakeMap      r191, 0, r0
-  Const        r192, []
-L32:
-  LessInt      r194, r190, r189
-  JumpIfFalse  r194, L30
-  Index        r195, r188, r190
-  // group by s.manu into g
-  Index        r197, r195, r13
-  Str          r198, r197
-  In           r199, r198, r191
-  JumpIfTrue   r199, L31
-  // from s in union_sales
-  Const        r200, []
-  Const        r201, "__group__"
-  Const        r202, true
-  Const        r203, "key"
-  // group by s.manu into g
-  Move         r204, r197
-  // from s in union_sales
-  Const        r205, "items"
-  Move         r206, r200
-  Const        r207, "count"
-  Const        r208, 0
-  Move         r209, r201
-  Move         r210, r202
-  Move         r211, r203
-  Move         r212, r204
-  Move         r213, r205
-  Move         r214, r206
-  Move         r215, r207
-  Move         r216, r208
-  MakeMap      r217, 4, r209
-  SetIndex     r191, r198, r217
-  Append       r192, r192, r217
+  Move         r39, r18
+  Len          r44, r21
 L31:
-  Const        r219, "items"
-  Index        r220, r191, r198
-  Index        r221, r220, r219
-  Append       r222, r221, r195
-  SetIndex     r220, r219, r222
-  Const        r223, "count"
-  Index        r224, r220, r223
-  AddInt       r225, r224, r6
-  SetIndex     r220, r223, r225
-  AddInt       r190, r190, r6
-  Jump         L32
-L30:
-  Move         r226, r20
-  Len          r227, r192
-L38:
-  LessInt      r228, r226, r227
-  JumpIfFalse  r228, L33
-  Index        r230, r192, r226
+  LessInt      r27, r39, r44
+  JumpIfFalse  r27, L26
+  Index        r17, r21, r39
+  Move         r5, r17
   // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
-  Const        r231, "i_manufact_id"
-  Index        r232, r230, r186
-  Const        r233, "total_sales"
-  Const        r234, []
-  IterPrep     r235, r230
-  Len          r236, r235
-  Move         r237, r20
-L35:
-  LessInt      r238, r237, r236
-  JumpIfFalse  r238, L34
-  Index        r240, r235, r237
-  Index        r241, r240, r15
-  Append       r234, r234, r241
-  AddInt       r237, r237, r6
-  Jump         L35
-L34:
-  Sum          r243, r234
-  Move         r244, r231
-  Move         r245, r232
-  Move         r246, r233
-  Move         r247, r243
-  MakeMap      r248, 2, r244
+  Const        r47, "i_manufact_id"
+  Index        r48, r5, r22
+  Const        r49, "total_sales"
+  Const        r50, []
+  IterPrep     r1, r5
+  Len          r32, r1
+  Move         r30, r18
+L28:
+  LessInt      r45, r30, r32
+  JumpIfFalse  r45, L27
+  Index        r40, r1, r30
+  Move         r41, r40
+  Index        r19, r41, r15
+  Append       r28, r50, r19
+  Move         r50, r28
+  AddInt       r30, r30, r6
+  Jump         L28
+L27:
+  Sum          r38, r50
+  Move         r51, r47
+  Move         r52, r48
+  Move         r53, r49
+  Move         r54, r38
+  MakeMap      r16, 2, r51
   // sort by -sum(from x in g select x.price)
-  Const        r249, []
-  IterPrep     r250, r230
-  Len          r251, r250
-  Move         r252, r20
-L37:
-  LessInt      r253, r252, r251
-  JumpIfFalse  r253, L36
-  Index        r240, r250, r252
-  Index        r255, r240, r15
-  Append       r249, r249, r255
-  AddInt       r252, r252, r6
-  Jump         L37
-L36:
-  Sum          r257, r249
-  Neg          r259, r257
+  Const        r9, []
+  IterPrep     r7, r5
+  Len          r3, r7
+  Move         r13, r18
+L30:
+  LessInt      r11, r13, r3
+  JumpIfFalse  r11, L29
+  Index        r12, r7, r13
+  Move         r41, r12
+  Index        r25, r41, r15
+  Append       r10, r9, r25
+  Move         r9, r10
+  AddInt       r13, r13, r6
+  Jump         L30
+L29:
+  Sum          r34, r9
+  Neg          r29, r34
+  Move         r55, r29
   // from s in union_sales
-  Move         r260, r248
-  MakeList     r261, 2, r259
-  Append       r185, r185, r261
-  AddInt       r226, r226, r6
-  Jump         L38
-L33:
+  Move         r56, r16
+  MakeList     r37, 2, r55
+  Append       r46, r31, r37
+  Move         r31, r46
+  AddInt       r39, r39, r6
+  Jump         L31
+L26:
   // sort by -sum(from x in g select x.price)
-  Sort         r185, r185
+  Sort         r57, r31
+  // from s in union_sales
+  Move         r31, r57
   // json(result)
-  JSON         r185
+  JSON         r31
   // expect result == [
-  Const        r264, [{"i_manufact_id": 1, "total_sales": 150}, {"i_manufact_id": 2, "total_sales": 50}]
-  Equal        r265, r185, r264
-  Expect       r265
+  Const        r58, [{"i_manufact_id": 1, "total_sales": 150.0}, {"i_manufact_id": 2, "total_sales": 50.0}]
+  Equal        r23, r31, r58
+  Expect       r23
   Return       r0

--- a/tests/dataset/tpc-ds/out/q34.ir.out
+++ b/tests/dataset/tpc-ds/out/q34.ir.out
@@ -1,10 +1,12 @@
-func main (regs=210)
+func main (regs=68)
   // let store_sales = [
   Const        r0, [{"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}]
+L9:
   // let date_dim = [
   Const        r1, [{"d_date_sk": 1, "d_dom": 2, "d_year": 2000}]
   // let store = [
   Const        r2, [{"s_county": "A", "s_store_sk": 1}]
+L2:
   // let household_demographics = [
   Const        r3, [{"hd_buy_potential": ">10000", "hd_demo_sk": 1, "hd_dep_count": 3, "hd_vehicle_count": 2}, {"hd_buy_potential": ">10000", "hd_demo_sk": 2, "hd_dep_count": 1, "hd_vehicle_count": 2}]
   // let customer = [
@@ -16,6 +18,7 @@ func main (regs=210)
   Const        r7, "ss_ticket_number"
   Const        r8, "cust"
   Const        r9, "ss_customer_sk"
+L5:
   // where (d.d_dom >= 1 && d.d_dom <= 3) && hd.hd_buy_potential == ">10000" && hd.hd_vehicle_count > 0 && (hd.hd_dep_count / hd.hd_vehicle_count) > 1.2 && d.d_year == 2000 && s.s_county == "A"
   Const        r10, "d_dom"
   Const        r11, "hd_buy_potential"
@@ -26,284 +29,300 @@ func main (regs=210)
   // select {ss_ticket_number: g.key.ticket, ss_customer_sk: g.key.cust, cnt: count(g)}
   Const        r16, "key"
   Const        r17, "cnt"
+L4:
   // from ss in store_sales
   MakeMap      r18, 0, r0
   Const        r19, []
+  Move         r20, r19
   IterPrep     r21, r0
   Len          r22, r21
-  Const        r23, 0
-L11:
-  LessInt      r24, r23, r22
-  JumpIfFalse  r24, L0
-  Index        r26, r21, r23
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r27, r1
-  Len          r28, r27
-  Const        r29, 0
-L10:
-  LessInt      r30, r29, r28
-  JumpIfFalse  r30, L1
-  Index        r32, r27, r29
-  Const        r33, "ss_sold_date_sk"
-  Index        r34, r26, r33
-  Const        r35, "d_date_sk"
-  Index        r36, r32, r35
-  Equal        r37, r34, r36
-  JumpIfFalse  r37, L2
-  // join s in store on ss.ss_store_sk == s.s_store_sk
-  IterPrep     r38, r2
-  Len          r39, r38
-  Const        r40, 0
-L9:
-  LessInt      r41, r40, r39
-  JumpIfFalse  r41, L2
-  Index        r43, r38, r40
-  Const        r44, "ss_store_sk"
-  Index        r45, r26, r44
-  Const        r46, "s_store_sk"
-  Index        r47, r43, r46
-  Equal        r48, r45, r47
-  JumpIfFalse  r48, L3
-  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
-  IterPrep     r49, r3
-  Len          r50, r49
-  Const        r51, 0
-L8:
-  LessInt      r52, r51, r50
-  JumpIfFalse  r52, L3
-  Index        r54, r49, r51
-  Const        r55, "ss_hdemo_sk"
-  Index        r56, r26, r55
-  Const        r57, "hd_demo_sk"
-  Index        r58, r54, r57
-  Equal        r59, r56, r58
-  JumpIfFalse  r59, L4
-  // where (d.d_dom >= 1 && d.d_dom <= 3) && hd.hd_buy_potential == ">10000" && hd.hd_vehicle_count > 0 && (hd.hd_dep_count / hd.hd_vehicle_count) > 1.2 && d.d_year == 2000 && s.s_county == "A"
-  Index        r60, r32, r10
-  Const        r61, 1
-  LessEq       r62, r61, r60
-  Index        r63, r32, r10
-  Const        r64, 3
-  LessEq       r65, r63, r64
-  JumpIfFalse  r62, L5
-  Move         r62, r65
-L5:
-  Index        r66, r54, r12
-  Const        r67, 0
-  Less         r68, r67, r66
-  Index        r69, r54, r13
-  Index        r70, r54, r12
-  Div          r71, r69, r70
-  Const        r72, 1.2
-  LessFloat    r73, r72, r71
-  Index        r74, r54, r11
-  Const        r75, ">10000"
-  Equal        r76, r74, r75
-  Index        r77, r32, r14
-  Const        r78, 2000
-  Equal        r79, r77, r78
-  Index        r80, r43, r15
-  Const        r81, "A"
-  Equal        r82, r80, r81
-  JumpIfFalse  r62, L6
-  Move         r62, r76
-  JumpIfFalse  r62, L6
-  Move         r62, r68
-  JumpIfFalse  r62, L6
-  Move         r62, r73
-  JumpIfFalse  r62, L6
-  Move         r62, r79
-  JumpIfFalse  r62, L6
-  Move         r62, r82
-L6:
-  JumpIfFalse  r62, L4
-  // from ss in store_sales
-  Const        r83, "ss"
-  Move         r84, r26
-  Const        r85, "d"
-  Move         r86, r32
-  Const        r87, "s"
-  Move         r88, r43
-  Const        r89, "hd"
-  Move         r90, r54
-  MakeMap      r91, 4, r83
-  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
-  Const        r92, "ticket"
-  Index        r93, r26, r7
-  Const        r94, "cust"
-  Index        r95, r26, r9
-  Move         r96, r92
-  Move         r97, r93
-  Move         r98, r94
-  Move         r99, r95
-  MakeMap      r100, 2, r96
-  Str          r101, r100
-  In           r102, r101, r18
-  JumpIfTrue   r102, L7
-  // from ss in store_sales
-  Const        r103, []
-  Const        r104, "__group__"
-  Const        r105, true
-  Const        r106, "key"
-  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
-  Move         r107, r100
-  // from ss in store_sales
-  Const        r108, "items"
-  Move         r109, r103
-  Const        r110, "count"
-  Const        r111, 0
-  Move         r112, r104
-  Move         r113, r105
-  Move         r114, r106
-  Move         r115, r107
-  Move         r116, r108
-  Move         r117, r109
-  Move         r118, r110
-  Move         r119, r111
-  MakeMap      r120, 4, r112
-  SetIndex     r18, r101, r120
-  Append       r19, r19, r120
-L7:
-  Const        r122, "items"
-  Index        r123, r18, r101
-  Index        r124, r123, r122
-  Append       r125, r124, r91
-  SetIndex     r123, r122, r125
-  Const        r126, "count"
-  Index        r127, r123, r126
-  AddInt       r128, r127, r61
-  SetIndex     r123, r126, r128
-L4:
-  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
-  AddInt       r51, r51, r61
-  Jump         L8
-L3:
-  // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r40, r40, r61
-  Jump         L9
-L2:
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r29, r29, r61
-  Jump         L10
 L1:
-  // from ss in store_sales
-  AddInt       r23, r23, r61
-  Jump         L11
+  Const        r23, 0
+L10:
+  LessInt      r24, r23, r22
 L0:
-  Move         r129, r67
-  Len          r130, r19
-L13:
-  LessInt      r131, r129, r130
-  JumpIfFalse  r131, L12
-  Index        r133, r19, r129
-  // select {ss_ticket_number: g.key.ticket, ss_customer_sk: g.key.cust, cnt: count(g)}
-  Const        r134, "ss_ticket_number"
-  Index        r135, r133, r16
-  Index        r136, r135, r6
-  Const        r137, "ss_customer_sk"
-  Index        r138, r133, r16
-  Index        r139, r138, r8
-  Const        r140, "cnt"
-  Index        r141, r133, r126
-  Move         r142, r134
-  Move         r143, r136
-  Move         r144, r137
-  Move         r145, r139
-  Move         r146, r140
-  Move         r147, r141
-  MakeMap      r148, 3, r142
-  // from ss in store_sales
-  Append       r5, r5, r148
-  AddInt       r129, r129, r61
-  Jump         L13
+  JumpIfFalse  r24, L0
+L3:
+  Index        r22, r21, r23
+L8:
+  Move         r21, r22
+L7:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r22, r1
+  Len          r1, r22
+  Const        r25, 0
+  LessInt      r26, r25, r1
+  JumpIfFalse  r26, L1
+  Index        r1, r22, r25
+  Move         r26, r1
+  Const        r22, "ss_sold_date_sk"
+  Index        r27, r21, r22
+  Const        r22, "d_date_sk"
+  Index        r28, r26, r22
+  Equal        r22, r27, r28
+  JumpIfFalse  r22, L2
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  IterPrep     r27, r2
+L11:
+  Len          r28, r27
+  Const        r22, 0
+  LessInt      r2, r22, r28
+  JumpIfFalse  r2, L2
+  Index        r28, r27, r22
 L12:
-  // from dn1 in dn
-  Const        r150, []
-  IterPrep     r151, r5
-  Len          r152, r151
-  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
-  IterPrep     r153, r4
-  Len          r154, r153
-  Const        r155, "c_customer_sk"
-  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
-  Const        r156, "c_last_name"
-  Const        r157, "c_first_name"
-  Const        r158, "c_salutation"
-  Const        r159, "c_preferred_cust_flag"
-  // from dn1 in dn
-  Const        r160, 0
-L19:
-  LessInt      r161, r160, r152
-  JumpIfFalse  r161, L14
-  Index        r163, r151, r160
-  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
-  Const        r164, 0
-L18:
-  LessInt      r165, r164, r154
-  JumpIfFalse  r165, L15
-  Index        r167, r153, r164
-  Index        r168, r163, r9
-  Index        r169, r167, r155
-  Equal        r170, r168, r169
-  JumpIfFalse  r170, L16
-  // where dn1.cnt >= 15 && dn1.cnt <= 20
-  Index        r171, r163, r17
-  Const        r172, 15
-  LessEq       r173, r172, r171
-  Index        r174, r163, r17
-  Const        r175, 20
-  LessEq       r176, r174, r175
-  JumpIfFalse  r173, L17
-  Move         r173, r176
+  Move         r2, r28
+  Const        r27, "ss_store_sk"
+  Index        r28, r21, r27
+  Const        r29, "s_store_sk"
 L17:
-  JumpIfFalse  r173, L16
-  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
-  Const        r177, "c_last_name"
-  Index        r178, r167, r156
-  Const        r179, "c_first_name"
-  Index        r180, r167, r157
-  Const        r181, "c_salutation"
-  Index        r182, r167, r158
-  Const        r183, "c_preferred_cust_flag"
-  Index        r184, r167, r159
-  Const        r185, "ss_ticket_number"
-  Index        r186, r163, r7
-  Const        r187, "cnt"
-  Index        r188, r163, r17
-  Move         r189, r177
-  Move         r190, r178
-  Move         r191, r179
-  Move         r192, r180
-  Move         r193, r181
-  Move         r194, r182
-  Move         r195, r183
-  Move         r196, r184
-  Move         r197, r185
-  Move         r198, r186
-  Move         r199, r187
-  Move         r200, r188
-  MakeMap      r201, 6, r189
-  // sort by c.c_last_name
-  Index        r203, r167, r156
+  Index        r30, r2, r29
+  Equal        r29, r28, r30
+  JumpIfFalse  r29, L3
+  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  IterPrep     r28, r3
+L6:
+  Len          r30, r28
+  Const        r29, 0
+  LessInt      r3, r29, r30
+  JumpIfFalse  r3, L3
+  Index        r30, r28, r29
+  Move         r3, r30
+  Const        r28, "ss_hdemo_sk"
+  Index        r30, r21, r28
+  Const        r28, "hd_demo_sk"
+L18:
+  Index        r31, r3, r28
+  Equal        r32, r30, r31
+  JumpIfFalse  r32, L4
+  // where (d.d_dom >= 1 && d.d_dom <= 3) && hd.hd_buy_potential == ">10000" && hd.hd_vehicle_count > 0 && (hd.hd_dep_count / hd.hd_vehicle_count) > 1.2 && d.d_year == 2000 && s.s_county == "A"
+  Index        r30, r26, r10
+  Const        r31, 1
+  LessEq       r32, r31, r30
+  Index        r30, r26, r10
+  Const        r10, 3
+  LessEq       r33, r30, r10
+  Move         r30, r32
+  JumpIfFalse  r30, L5
+  Move         r30, r33
+  Index        r10, r3, r12
+  Const        r32, 0
+  Less         r33, r32, r10
+  Index        r10, r3, r13
+  Index        r13, r3, r12
+  Div          r12, r10, r13
+  Const        r10, 1.2
+  LessFloat    r13, r10, r12
+  Index        r12, r3, r11
+  Const        r10, ">10000"
+  Equal        r11, r12, r10
+  Index        r12, r26, r14
+  Const        r10, 2000
+  Equal        r14, r12, r10
+  Index        r12, r2, r15
+  Const        r10, "A"
+  Equal        r15, r12, r10
+  Move         r12, r30
+  JumpIfFalse  r12, L5
+  Move         r12, r11
+  JumpIfFalse  r12, L5
+  Move         r12, r33
+  JumpIfFalse  r12, L5
+  Move         r12, r13
+  JumpIfFalse  r12, L5
+  Move         r12, r14
+  JumpIfFalse  r12, L5
+  Move         r12, r15
+  JumpIfFalse  r12, L4
+  // from ss in store_sales
+  Const        r10, "ss"
+  Move         r30, r21
+  Const        r33, "d"
+  Move         r13, r26
+  Const        r11, "s"
+  Move         r14, r2
+  Const        r15, "hd"
+  Move         r12, r3
+  Move         r34, r10
+  Move         r35, r30
+  Move         r36, r33
+  Move         r37, r13
+  Move         r38, r11
+  Move         r39, r14
+  Move         r40, r15
+  Move         r41, r12
+  MakeMap      r26, 4, r34
+  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
+  Const        r2, "ticket"
+  Index        r3, r21, r7
+  Const        r10, "cust"
+  Index        r30, r21, r9
+  Move         r34, r2
+  Move         r35, r3
+  Move         r36, r10
+  Move         r37, r30
+  MakeMap      r33, 2, r34
+  Str          r13, r33
+  In           r11, r13, r18
+  JumpIfTrue   r11, L6
+  // from ss in store_sales
+  Const        r14, "__group__"
+  Const        r15, true
+  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
+  Move         r12, r33
+  // from ss in store_sales
+  Const        r38, "items"
+  Move         r39, r19
+  Const        r40, "count"
+  Move         r42, r14
+  Move         r43, r15
+  Move         r44, r16
+  Move         r45, r12
+  Move         r46, r38
+  Move         r47, r39
+  Move         r48, r40
+  Move         r49, r32
+  MakeMap      r41, 4, r42
+  SetIndex     r18, r13, r41
+  Append       r21, r20, r41
+  Move         r20, r21
+  Index        r2, r18, r13
+  Index        r3, r2, r38
+  Append       r10, r3, r26
+  SetIndex     r2, r38, r10
+  Index        r30, r2, r40
+  AddInt       r34, r30, r31
+  SetIndex     r2, r40, r34
+  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  AddInt       r29, r29, r31
+  Jump         L7
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  AddInt       r22, r22, r31
+  Jump         L8
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  AddInt       r25, r25, r31
+  Jump         L9
+  // from ss in store_sales
+  AddInt       r23, r23, r31
+  Jump         L10
+  Move         r35, r32
+  Len          r36, r20
+  LessInt      r37, r35, r36
+  JumpIfFalse  r37, L11
+  Index        r11, r20, r35
+  Move         r33, r11
+  // select {ss_ticket_number: g.key.ticket, ss_customer_sk: g.key.cust, cnt: count(g)}
+  Const        r19, "ss_ticket_number"
+  Index        r14, r33, r16
+  Index        r15, r14, r6
+  Const        r12, "ss_customer_sk"
+  Index        r39, r33, r16
+  Index        r42, r39, r8
+  Const        r43, "cnt"
+  Index        r44, r33, r40
+  Move         r50, r19
+  Move         r51, r15
+  Move         r52, r12
+  Move         r53, r42
+  Move         r54, r43
+  Move         r55, r44
+  MakeMap      r45, 3, r50
+  // from ss in store_sales
+  Append       r46, r5, r45
+  Move         r5, r46
+  AddInt       r35, r35, r31
+  Jump         L12
   // from dn1 in dn
-  Move         r204, r201
-  MakeList     r205, 2, r203
-  Append       r150, r150, r205
-L16:
+  Const        r48, []
+  IterPrep     r49, r5
+  Len          r41, r49
   // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
-  AddInt       r164, r164, r61
-  Jump         L18
-L15:
+  IterPrep     r21, r4
+  Len          r18, r21
+  Const        r13, "c_customer_sk"
+  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
+  Const        r26, "c_last_name"
+  Const        r38, "c_first_name"
+  Const        r3, "c_salutation"
+  Const        r10, "c_preferred_cust_flag"
   // from dn1 in dn
-  AddInt       r160, r160, r61
-  Jump         L19
-L14:
+  Const        r23, 0
+  LessInt      r24, r23, r41
+  JumpIfFalse  r24, L13
+  Index        r25, r49, r23
+  Move         r1, r25
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  Const        r47, 0
+  LessInt      r22, r47, r18
+  JumpIfFalse  r22, L14
+  Index        r27, r21, r47
+  Move         r29, r27
+  Index        r28, r1, r9
+  Index        r2, r29, r13
+  Equal        r30, r28, r2
+  JumpIfFalse  r30, L15
+  // where dn1.cnt >= 15 && dn1.cnt <= 20
+  Index        r34, r1, r17
+  Const        r32, 15
+  LessEq       r36, r32, r34
+  Index        r37, r1, r17
+  Const        r20, 20
+  LessEq       r11, r37, r20
+  Move         r6, r36
+  JumpIfFalse  r6, L16
+  Move         r6, r11
+L16:
+  JumpIfFalse  r6, L15
+  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
+  Const        r14, "c_last_name"
+  Index        r16, r29, r26
+  Const        r8, "c_first_name"
+  Index        r39, r29, r38
+  Const        r40, "c_salutation"
+  Index        r33, r29, r3
+  Const        r19, "c_preferred_cust_flag"
+  Index        r15, r29, r10
+  Const        r12, "ss_ticket_number"
+  Index        r42, r1, r7
+  Const        r43, "cnt"
+  Index        r44, r1, r17
+  Move         r56, r14
+  Move         r57, r16
+  Move         r58, r8
+  Move         r59, r39
+  Move         r60, r40
+  Move         r61, r33
+  Move         r62, r19
+  Move         r63, r15
+  Move         r64, r12
+  Move         r65, r42
+  Move         r66, r43
+  Move         r67, r44
+  MakeMap      r50, 6, r56
   // sort by c.c_last_name
-  Sort         r150, r150
+  Index        r51, r29, r26
+  Move         r52, r51
+  // from dn1 in dn
+  Move         r53, r50
+  MakeList     r54, 2, r52
+  Append       r55, r48, r54
+  Move         r48, r55
+L15:
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  AddInt       r47, r47, r31
+  Jump         L17
+L14:
+  // from dn1 in dn
+  AddInt       r23, r23, r31
+  Jump         L18
+L13:
+  // sort by c.c_last_name
+  Sort         r35, r48
+  // from dn1 in dn
+  Move         r48, r35
   // json(result)
-  JSON         r150
+  JSON         r48
   // expect result == [{c_last_name: "Smith", c_first_name: "John", c_salutation: "Mr.", c_preferred_cust_flag: "Y", ss_ticket_number: 1, cnt: 16}]
-  Const        r208, [{"c_first_name": "John", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Mr.", "cnt": 16, "ss_ticket_number": 1}]
-  Equal        r209, r150, r208
-  Expect       r209
+  Const        r45, [{"c_first_name": "John", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Mr.", "cnt": 16, "ss_ticket_number": 1}]
+  Equal        r46, r48, r45
+  Expect       r46
   Return       r0

--- a/tests/dataset/tpc-ds/out/q35.ir.out
+++ b/tests/dataset/tpc-ds/out/q35.ir.out
@@ -1,280 +1,293 @@
-func main (regs=188)
+func main (regs=64)
   // let customer = [
   Const        r0, [{"c_current_addr_sk": 1, "c_current_cdemo_sk": 1, "c_customer_sk": 1}, {"c_current_addr_sk": 2, "c_current_cdemo_sk": 2, "c_customer_sk": 2}]
   // let customer_address = [
   Const        r1, [{"ca_address_sk": 1, "ca_state": "CA"}, {"ca_address_sk": 2, "ca_state": "NY"}]
   // let customer_demographics = [
   Const        r2, [{"cd_demo_sk": 1, "cd_dep_college_count": 0, "cd_dep_count": 1, "cd_dep_employed_count": 1, "cd_gender": "M", "cd_marital_status": "S"}, {"cd_demo_sk": 2, "cd_dep_college_count": 1, "cd_dep_count": 2, "cd_dep_employed_count": 1, "cd_gender": "F", "cd_marital_status": "M"}]
+L1:
   // let store_sales = [
   Const        r3, [{"ss_customer_sk": 1, "ss_sold_date_sk": 1}]
+L4:
   // let date_dim = [
   Const        r4, [{"d_date_sk": 1, "d_qoy": 1, "d_year": 2000}]
   // from ss in store_sales
   Const        r5, []
   IterPrep     r6, r3
-  Len          r7, r6
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r8, r4
-  Len          r9, r8
-  Const        r10, "ss_sold_date_sk"
-  Const        r11, "d_date_sk"
-  // where d.d_year == 2000 && d.d_qoy < 4
-  Const        r12, "d_year"
-  Const        r13, "d_qoy"
-  // select ss.ss_customer_sk
-  Const        r14, "ss_customer_sk"
-  // from ss in store_sales
-  Const        r15, 0
-L5:
-  LessInt      r16, r15, r7
-  JumpIfFalse  r16, L0
-  Index        r18, r6, r15
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  Const        r19, 0
-L4:
-  LessInt      r20, r19, r9
-  JumpIfFalse  r20, L1
-  Index        r22, r8, r19
-  Index        r23, r18, r10
-  Index        r24, r22, r11
-  Equal        r25, r23, r24
-  JumpIfFalse  r25, L2
-  // where d.d_year == 2000 && d.d_qoy < 4
-  Index        r26, r22, r12
-  Index        r27, r22, r13
-  Const        r28, 4
-  Less         r29, r27, r28
-  Const        r30, 2000
-  Equal        r31, r26, r30
-  JumpIfFalse  r31, L3
-  Move         r31, r29
-L3:
-  JumpIfFalse  r31, L2
-  // select ss.ss_customer_sk
-  Index        r32, r18, r14
-  // from ss in store_sales
-  Append       r5, r5, r32
 L2:
+  Len          r3, r6
+L3:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  Const        r34, 1
-  AddInt       r19, r19, r34
-  Jump         L4
-L1:
+  IterPrep     r7, r4
+  Len          r4, r7
+  Const        r8, "ss_sold_date_sk"
+  Const        r9, "d_date_sk"
+  // where d.d_year == 2000 && d.d_qoy < 4
+  Const        r10, "d_year"
+  Const        r11, "d_qoy"
+L5:
+  // select ss.ss_customer_sk
+  Const        r12, "ss_customer_sk"
   // from ss in store_sales
-  AddInt       r15, r15, r34
-  Jump         L5
+  Const        r13, 0
 L0:
-  // from c in customer
-  Const        r35, []
-  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
-  Const        r36, "state"
-  Const        r37, "ca_state"
-  Const        r38, "gender"
-  Const        r39, "cd_gender"
-  Const        r40, "marital"
-  Const        r41, "cd_marital_status"
-  Const        r42, "dep"
-  Const        r43, "cd_dep_count"
-  Const        r44, "emp"
-  Const        r45, "cd_dep_employed_count"
-  Const        r46, "col"
-  Const        r47, "cd_dep_college_count"
-  // where c.c_customer_sk in purchased
-  Const        r48, "c_customer_sk"
-  // ca_state: g.key.state,
-  Const        r49, "key"
-  // cnt: count(g)
-  Const        r50, "cnt"
-  // from c in customer
-  MakeMap      r51, 0, r0
-  Const        r52, []
-  IterPrep     r54, r0
-  Len          r55, r54
-  Const        r56, 0
-L13:
-  LessInt      r57, r56, r55
-  JumpIfFalse  r57, L6
-  Index        r59, r54, r56
-  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  IterPrep     r60, r1
-  Len          r61, r60
-  Const        r62, 0
-L12:
-  LessInt      r63, r62, r61
-  JumpIfFalse  r63, L7
-  Index        r65, r60, r62
-  Const        r66, "c_current_addr_sk"
-  Index        r67, r59, r66
-  Const        r68, "ca_address_sk"
-  Index        r69, r65, r68
-  Equal        r70, r67, r69
-  JumpIfFalse  r70, L8
-  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
-  IterPrep     r71, r2
-  Len          r72, r71
-  Const        r73, 0
-L11:
-  LessInt      r74, r73, r72
-  JumpIfFalse  r74, L8
-  Index        r76, r71, r73
-  Const        r77, "c_current_cdemo_sk"
-  Index        r78, r59, r77
-  Const        r79, "cd_demo_sk"
-  Index        r80, r76, r79
-  Equal        r81, r78, r80
-  JumpIfFalse  r81, L9
-  // where c.c_customer_sk in purchased
-  Index        r82, r59, r48
-  In           r83, r82, r5
-  JumpIfFalse  r83, L9
-  // from c in customer
-  Const        r84, "c"
-  Move         r85, r59
-  Const        r86, "ca"
-  Move         r87, r65
-  Const        r88, "cd"
-  Move         r89, r76
-  MakeMap      r90, 3, r84
-  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
-  Const        r91, "state"
-  Index        r92, r65, r37
-  Const        r93, "gender"
-  Index        r94, r76, r39
-  Const        r95, "marital"
-  Index        r96, r76, r41
-  Const        r97, "dep"
-  Index        r98, r76, r43
-  Const        r99, "emp"
-  Index        r100, r76, r45
-  Const        r101, "col"
-  Index        r102, r76, r47
-  Move         r103, r91
-  Move         r104, r92
-  Move         r105, r93
-  Move         r106, r94
-  Move         r107, r95
-  Move         r108, r96
-  Move         r109, r97
-  Move         r110, r98
-  Move         r111, r99
-  Move         r112, r100
-  Move         r113, r101
-  Move         r114, r102
-  MakeMap      r115, 6, r103
-  Str          r116, r115
-  In           r117, r116, r51
-  JumpIfTrue   r117, L10
-  // from c in customer
-  Const        r118, []
-  Const        r119, "__group__"
-  Const        r120, true
-  Const        r121, "key"
-  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
-  Move         r122, r115
-  // from c in customer
-  Const        r123, "items"
-  Move         r124, r118
-  Const        r125, "count"
-  Const        r126, 0
-  Move         r127, r119
-  Move         r128, r120
-  Move         r129, r121
-  Move         r130, r122
-  Move         r131, r123
-  Move         r132, r124
-  Move         r133, r125
-  Move         r134, r126
-  MakeMap      r135, 4, r127
-  SetIndex     r51, r116, r135
-  Append       r52, r52, r135
-L10:
-  Const        r137, "items"
-  Index        r138, r51, r116
-  Index        r139, r138, r137
-  Append       r140, r139, r90
-  SetIndex     r138, r137, r140
-  Const        r141, "count"
-  Index        r142, r138, r141
-  AddInt       r143, r142, r34
-  SetIndex     r138, r141, r143
+  LessInt      r14, r13, r3
+  JumpIfFalse  r14, L0
+  Index        r3, r6, r13
+  Move         r6, r3
 L9:
-  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
-  AddInt       r73, r73, r34
-  Jump         L11
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r3, 0
+  LessInt      r15, r3, r4
+  JumpIfFalse  r15, L1
+L13:
+  Index        r4, r7, r3
 L8:
-  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  AddInt       r62, r62, r34
-  Jump         L12
+  Move         r15, r4
+  Index        r7, r6, r8
+  Index        r8, r15, r9
+  Equal        r9, r7, r8
+L12:
+  JumpIfFalse  r9, L2
+  // where d.d_year == 2000 && d.d_qoy < 4
+  Index        r7, r15, r10
+  Index        r8, r15, r11
+L11:
+  Const        r9, 4
+  Less         r10, r8, r9
+  Const        r11, 2000
+  Equal        r15, r7, r11
+  Move         r8, r15
+  JumpIfFalse  r8, L3
+  Move         r8, r10
+  JumpIfFalse  r8, L2
+  // select ss.ss_customer_sk
+  Index        r9, r6, r12
+  // from ss in store_sales
+  Append       r7, r5, r9
+L10:
+  Move         r5, r7
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r11, 1
+  AddInt       r3, r3, r11
+  Jump         L4
+  // from ss in store_sales
+  AddInt       r13, r13, r11
+  Jump         L5
+  // from c in customer
+  Const        r10, []
+  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
+  Const        r15, "state"
+  Const        r8, "ca_state"
+  Const        r12, "gender"
 L7:
-  // from c in customer
-  AddInt       r56, r56, r34
-  Jump         L13
+  Const        r6, "cd_gender"
+  Const        r9, "marital"
 L6:
-  Const        r144, 0
-  Len          r146, r52
+  Const        r7, "cd_marital_status"
+  Const        r13, "dep"
 L15:
-  LessInt      r147, r144, r146
-  JumpIfFalse  r147, L14
-  Index        r149, r52, r144
+  Const        r14, "cd_dep_count"
+  Const        r3, "emp"
+  Const        r4, "cd_dep_employed_count"
+  Const        r16, "col"
+  Const        r17, "cd_dep_college_count"
+  // where c.c_customer_sk in purchased
+  Const        r18, "c_customer_sk"
   // ca_state: g.key.state,
-  Const        r150, "ca_state"
-  Index        r151, r149, r49
-  Index        r152, r151, r36
-  // cd_gender: g.key.gender,
-  Const        r153, "cd_gender"
-  Index        r154, r149, r49
-  Index        r155, r154, r38
-  // cd_marital_status: g.key.marital,
-  Const        r156, "cd_marital_status"
-  Index        r157, r149, r49
-  Index        r158, r157, r40
-  // cd_dep_count: g.key.dep,
-  Const        r159, "cd_dep_count"
-  Index        r160, r149, r49
-  Index        r161, r160, r42
-  // cd_dep_employed_count: g.key.emp,
-  Const        r162, "cd_dep_employed_count"
-  Index        r163, r149, r49
-  Index        r164, r163, r44
-  // cd_dep_college_count: g.key.col,
-  Const        r165, "cd_dep_college_count"
-  Index        r166, r149, r49
-  Index        r167, r166, r46
+  Const        r19, "key"
   // cnt: count(g)
-  Const        r168, "cnt"
-  Index        r169, r149, r141
-  // ca_state: g.key.state,
-  Move         r170, r150
-  Move         r171, r152
-  // cd_gender: g.key.gender,
-  Move         r172, r153
-  Move         r173, r155
-  // cd_marital_status: g.key.marital,
-  Move         r174, r156
-  Move         r175, r158
-  // cd_dep_count: g.key.dep,
-  Move         r176, r159
-  Move         r177, r161
-  // cd_dep_employed_count: g.key.emp,
-  Move         r178, r162
-  Move         r179, r164
-  // cd_dep_college_count: g.key.col,
-  Move         r180, r165
-  Move         r181, r167
-  // cnt: count(g)
-  Move         r182, r168
-  Move         r183, r169
-  // select {
-  MakeMap      r184, 7, r170
+  Const        r20, "cnt"
   // from c in customer
-  Append       r35, r35, r184
-  AddInt       r144, r144, r34
+  MakeMap      r20, 0, r0
+  Const        r21, []
+  Move         r22, r21
+  IterPrep     r23, r0
+  Len          r24, r23
+  Const        r25, 0
+  LessInt      r26, r25, r24
+  JumpIfFalse  r26, L6
+  Index        r24, r23, r25
+  Move         r26, r24
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  IterPrep     r23, r1
+  Len          r24, r23
+  Const        r1, 0
+  LessInt      r27, r1, r24
+  JumpIfFalse  r27, L7
+  Index        r24, r23, r1
+  Move         r27, r24
+  Const        r23, "c_current_addr_sk"
+  Index        r24, r26, r23
+  Const        r23, "ca_address_sk"
+  Index        r28, r27, r23
+  Equal        r29, r24, r28
+  JumpIfFalse  r29, L8
+  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
+  IterPrep     r24, r2
+  Len          r28, r24
+  Const        r29, 0
+  LessInt      r2, r29, r28
+  JumpIfFalse  r2, L8
+  Index        r28, r24, r29
+  Move         r2, r28
+  Const        r24, "c_current_cdemo_sk"
+  Index        r30, r26, r24
+  Const        r24, "cd_demo_sk"
+  Index        r31, r2, r24
+  Equal        r24, r30, r31
+  JumpIfFalse  r24, L9
+  // where c.c_customer_sk in purchased
+  Index        r30, r26, r18
+  In           r31, r30, r5
+  JumpIfFalse  r31, L9
+  // from c in customer
+  Const        r24, "c"
+  Move         r18, r26
+  Const        r5, "ca"
+  Move         r30, r27
+  Const        r31, "cd"
+  Move         r26, r2
+  Move         r32, r24
+  Move         r33, r18
+  Move         r34, r5
+  Move         r35, r30
+  Move         r36, r31
+  Move         r37, r26
+  MakeMap      r24, 3, r32
+  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
+  Const        r18, "state"
+  Index        r5, r27, r8
+  Const        r30, "gender"
+  Index        r26, r2, r6
+  Const        r32, "marital"
+  Index        r33, r2, r7
+  Const        r34, "dep"
+  Index        r35, r2, r14
+  Const        r36, "emp"
+  Index        r37, r2, r4
+  Const        r8, "col"
+  Index        r27, r2, r17
+  Move         r38, r18
+  Move         r39, r5
+  Move         r40, r30
+  Move         r41, r26
+  Move         r42, r32
+  Move         r43, r33
+  Move         r44, r34
+  Move         r45, r35
+  Move         r46, r36
+  Move         r47, r37
+  Move         r48, r8
+  Move         r49, r27
+  MakeMap      r6, 6, r38
+  Str          r7, r6
+  In           r14, r7, r20
+  JumpIfTrue   r14, L10
+  // from c in customer
+  Const        r4, "__group__"
+  Const        r17, true
+  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
+  Move         r2, r6
+  // from c in customer
+  Const        r18, "items"
+  Move         r5, r21
+  Const        r30, "count"
+  Const        r26, 0
+  Move         r38, r4
+  Move         r39, r17
+  Move         r40, r19
+  Move         r41, r2
+  Move         r42, r18
+  Move         r43, r5
+  Move         r44, r30
+  Move         r45, r26
+  MakeMap      r32, 4, r38
+  SetIndex     r20, r7, r32
+  Append       r33, r22, r32
+  Move         r22, r33
+  Index        r34, r20, r7
+  Index        r35, r34, r18
+  Append       r36, r35, r24
+  SetIndex     r34, r18, r36
+  Index        r37, r34, r30
+  AddInt       r8, r37, r11
+  SetIndex     r34, r30, r8
+  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
+  AddInt       r29, r29, r11
+  Jump         L11
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  AddInt       r1, r1, r11
+  Jump         L12
+  // from c in customer
+  AddInt       r25, r25, r11
+  Jump         L13
+  Move         r27, r26
+  Len          r46, r22
+  LessInt      r47, r27, r46
+  JumpIfFalse  r47, L14
+  Index        r48, r22, r27
+  Move         r49, r48
+  // ca_state: g.key.state,
+  Const        r14, "ca_state"
+  Index        r6, r49, r19
+  Index        r21, r6, r15
+  // cd_gender: g.key.gender,
+  Const        r4, "cd_gender"
+  Index        r17, r49, r19
+  Index        r2, r17, r12
+  // cd_marital_status: g.key.marital,
+  Const        r5, "cd_marital_status"
+  Index        r38, r49, r19
+  Index        r39, r38, r9
+  // cd_dep_count: g.key.dep,
+  Const        r40, "cd_dep_count"
+  Index        r41, r49, r19
+  Index        r42, r41, r13
+  // cd_dep_employed_count: g.key.emp,
+  Const        r43, "cd_dep_employed_count"
+  Index        r44, r49, r19
+  Index        r45, r44, r3
+  // cd_dep_college_count: g.key.col,
+  Const        r32, "cd_dep_college_count"
+  Index        r33, r49, r19
+  Index        r20, r33, r16
+  // cnt: count(g)
+  Const        r7, "cnt"
+  Index        r24, r49, r30
+  // ca_state: g.key.state,
+  Move         r50, r14
+  Move         r51, r21
+  // cd_gender: g.key.gender,
+  Move         r52, r4
+  Move         r53, r2
+  // cd_marital_status: g.key.marital,
+  Move         r54, r5
+  Move         r55, r39
+  // cd_dep_count: g.key.dep,
+  Move         r56, r40
+  Move         r57, r42
+  // cd_dep_employed_count: g.key.emp,
+  Move         r58, r43
+  Move         r59, r45
+  // cd_dep_college_count: g.key.col,
+  Move         r60, r32
+  Move         r61, r20
+  // cnt: count(g)
+  Move         r62, r7
+  Move         r63, r24
+  // select {
+  MakeMap      r18, 3, r50
+  // from c in customer
+  Append       r35, r10, r18
+  Move         r10, r35
+  AddInt       r27, r27, r11
   Jump         L15
 L14:
   // json(groups)
-  JSON         r35
+  JSON         r10
   // expect groups == [{ca_state: "CA", cd_gender: "M", cd_marital_status: "S", cd_dep_count: 1, cd_dep_employed_count: 1, cd_dep_college_count: 0, cnt: 1}]
-  Const        r186, [{"ca_state": "CA", "cd_dep_college_count": 0, "cd_dep_count": 1, "cd_dep_employed_count": 1, "cd_gender": "M", "cd_marital_status": "S", "cnt": 1}]
-  Equal        r187, r35, r186
-  Expect       r187
+  Const        r36, [{"ca_state": "CA", "cd_dep_college_count": 0, "cd_dep_count": 1, "cd_dep_employed_count": 1, "cd_gender": "M", "cd_marital_status": "S", "cnt": 1}]
+  Equal        r25, r10, r36
+  Expect       r25
   Return       r0

--- a/tests/dataset/tpc-ds/out/q36.ir.out
+++ b/tests/dataset/tpc-ds/out/q36.ir.out
@@ -1,10 +1,11 @@
-func main (regs=167)
+func main (regs=54)
   // let store_sales = [
-  Const        r0, [{"ss_ext_sales_price": 100, "ss_item_sk": 1, "ss_net_profit": 20, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 200, "ss_item_sk": 2, "ss_net_profit": 50, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 150, "ss_item_sk": 3, "ss_net_profit": 30, "ss_sold_date_sk": 1, "ss_store_sk": 2}]
+  Const        r0, [{"ss_ext_sales_price": 100.0, "ss_item_sk": 1, "ss_net_profit": 20.0, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 200.0, "ss_item_sk": 2, "ss_net_profit": 50.0, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 150.0, "ss_item_sk": 3, "ss_net_profit": 30.0, "ss_sold_date_sk": 1, "ss_store_sk": 2}]
   // let item = [
   Const        r1, [{"i_category": "Books", "i_class": "C1", "i_item_sk": 1}, {"i_category": "Books", "i_class": "C2", "i_item_sk": 2}, {"i_category": "Electronics", "i_class": "C3", "i_item_sk": 3}]
   // let store = [
   Const        r2, [{"s_state": "A", "s_store_sk": 1}, {"s_state": "B", "s_store_sk": 2}]
+L10:
   // let date_dim = [
   Const        r3, [{"d_date_sk": 1, "d_year": 2000}]
   // from ss in store_sales
@@ -16,231 +17,250 @@ func main (regs=167)
   Const        r8, "i_class"
   // where d.d_year == 2000 && (s.s_state == "A" || s.s_state == "B")
   Const        r9, "d_year"
+L1:
   Const        r10, "s_state"
   // i_category: g.key.category,
   Const        r11, "key"
   // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
   Const        r12, "gross_margin"
-  Const        r13, "ss_net_profit"
-  Const        r14, "ss_ext_sales_price"
+  Const        r12, "ss_net_profit"
+  Const        r13, "ss_ext_sales_price"
   // from ss in store_sales
-  MakeMap      r15, 0, r0
-  Const        r16, []
-  IterPrep     r18, r0
-  Len          r19, r18
-  Const        r20, 0
-L11:
-  LessInt      r21, r20, r19
-  JumpIfFalse  r21, L0
-  Index        r23, r18, r20
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r24, r3
-  Len          r25, r24
-  Const        r26, 0
-L10:
-  LessInt      r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r29, r24, r26
-  Const        r30, "ss_sold_date_sk"
-  Index        r31, r23, r30
-  Const        r32, "d_date_sk"
-  Index        r33, r29, r32
-  Equal        r34, r31, r33
-  JumpIfFalse  r34, L2
-  // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r35, r1
-  Len          r36, r35
-  Const        r37, 0
-L9:
-  LessInt      r38, r37, r36
-  JumpIfFalse  r38, L2
-  Index        r40, r35, r37
-  Const        r41, "ss_item_sk"
-  Index        r42, r23, r41
-  Const        r43, "i_item_sk"
-  Index        r44, r40, r43
-  Equal        r45, r42, r44
-  JumpIfFalse  r45, L3
-  // join s in store on ss.ss_store_sk == s.s_store_sk
-  IterPrep     r46, r2
-  Len          r47, r46
-  Const        r48, 0
-L8:
-  LessInt      r49, r48, r47
-  JumpIfFalse  r49, L3
-  Index        r51, r46, r48
-  Const        r52, "ss_store_sk"
-  Index        r53, r23, r52
-  Const        r54, "s_store_sk"
-  Index        r55, r51, r54
-  Equal        r56, r53, r55
-  JumpIfFalse  r56, L4
-  // where d.d_year == 2000 && (s.s_state == "A" || s.s_state == "B")
-  Index        r57, r29, r9
-  Const        r58, 2000
-  Equal        r59, r57, r58
-  JumpIfFalse  r59, L5
-  Index        r60, r51, r10
-  Const        r61, "A"
-  Equal        r62, r60, r61
-  Index        r63, r51, r10
-  Const        r64, "B"
-  Equal        r65, r63, r64
-  JumpIfTrue   r62, L6
-L6:
-  Move         r59, r65
-L5:
-  JumpIfFalse  r59, L4
-  // from ss in store_sales
-  Const        r66, "ss"
-  Move         r67, r23
-  Const        r68, "d"
-  Move         r69, r29
-  Const        r70, "i"
-  Move         r71, r40
-  Const        r72, "s"
-  Move         r73, r51
-  MakeMap      r74, 4, r66
-  // group by {category: i.i_category, class: i.i_class} into g
-  Const        r75, "category"
-  Index        r76, r40, r6
-  Const        r77, "class"
-  Index        r78, r40, r8
-  Move         r79, r75
-  Move         r80, r76
-  Move         r81, r77
-  Move         r82, r78
-  MakeMap      r83, 2, r79
-  Str          r84, r83
-  In           r85, r84, r15
-  JumpIfTrue   r85, L7
-  // from ss in store_sales
-  Const        r86, []
-  Const        r87, "__group__"
-  Const        r88, true
-  Const        r89, "key"
-  // group by {category: i.i_category, class: i.i_class} into g
-  Move         r90, r83
-  // from ss in store_sales
-  Const        r91, "items"
-  Move         r92, r86
-  Const        r93, "count"
-  Const        r94, 0
-  Move         r95, r87
-  Move         r96, r88
-  Move         r97, r89
-  Move         r98, r90
-  Move         r99, r91
-  Move         r100, r92
-  Move         r101, r93
-  Move         r102, r94
-  MakeMap      r103, 4, r95
-  SetIndex     r15, r84, r103
-  Append       r16, r16, r103
-L7:
-  Const        r105, "items"
-  Index        r106, r15, r84
-  Index        r107, r106, r105
-  Append       r108, r107, r74
-  SetIndex     r106, r105, r108
-  Const        r109, "count"
-  Index        r110, r106, r109
-  Const        r111, 1
-  AddInt       r112, r110, r111
-  SetIndex     r106, r109, r112
-L4:
-  // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r48, r48, r111
-  Jump         L8
+  MakeMap      r14, 0, r0
+  Const        r15, []
 L3:
-  // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r37, r37, r111
-  Jump         L9
-L2:
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r26, r26, r111
-  Jump         L10
-L1:
-  // from ss in store_sales
-  AddInt       r20, r20, r111
-  Jump         L11
+  Move         r16, r15
+  IterPrep     r17, r0
+  Len          r18, r17
 L0:
-  Const        r114, 0
-  Move         r113, r114
-  Len          r115, r16
-L17:
-  LessInt      r116, r113, r115
-  JumpIfFalse  r116, L12
-  Index        r118, r16, r113
+  Const        r19, 0
+  LessInt      r20, r19, r18
+  JumpIfFalse  r20, L0
+L9:
+  Index        r18, r17, r19
+L8:
+  Move         r17, r18
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r18, r3
+  Len          r3, r18
+L4:
+  Const        r21, 0
+  LessInt      r22, r21, r3
+  JumpIfFalse  r22, L1
+  Index        r3, r18, r21
+  Move         r22, r3
+L6:
+  Const        r18, "ss_sold_date_sk"
+L5:
+  Index        r23, r17, r18
+  Const        r18, "d_date_sk"
+  Index        r24, r22, r18
+L2:
+  Equal        r18, r23, r24
+  JumpIfFalse  r18, L2
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r23, r1
+L7:
+  Len          r24, r23
+  Const        r18, 0
+  LessInt      r1, r18, r24
+  JumpIfFalse  r1, L2
+  Index        r24, r23, r18
+  Move         r1, r24
+  Const        r23, "ss_item_sk"
+  Index        r24, r17, r23
+L12:
+  Const        r25, "i_item_sk"
+  Index        r26, r1, r25
+  Equal        r25, r24, r26
+  JumpIfFalse  r25, L3
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  IterPrep     r24, r2
+  Len          r26, r24
+  Const        r25, 0
+  LessInt      r2, r25, r26
+  JumpIfFalse  r2, L3
+  Index        r26, r24, r25
+  Move         r2, r26
+  Const        r24, "ss_store_sk"
+  Index        r26, r17, r24
+  Const        r24, "s_store_sk"
+  Index        r27, r2, r24
+  Equal        r28, r26, r27
+  JumpIfFalse  r28, L4
+  // where d.d_year == 2000 && (s.s_state == "A" || s.s_state == "B")
+  Index        r26, r22, r9
+  Const        r27, 2000
+  Equal        r28, r26, r27
+  Move         r9, r28
+  JumpIfFalse  r9, L5
+  Index        r26, r2, r10
+  Const        r27, "A"
+  Equal        r28, r26, r27
+  Index        r26, r2, r10
+  Const        r27, "B"
+  Equal        r10, r26, r27
+  Move         r26, r28
+  JumpIfTrue   r26, L6
+  Move         r26, r10
+  Move         r9, r26
+  JumpIfFalse  r9, L4
+  // from ss in store_sales
+  Const        r27, "ss"
+  Move         r9, r17
+  Const        r28, "d"
+  Move         r10, r22
+  Const        r26, "i"
+  Move         r17, r1
+  Const        r22, "s"
+  Move         r29, r2
+  Move         r30, r27
+  Move         r31, r9
+  Move         r32, r28
+  Move         r33, r10
+  Move         r34, r26
+  Move         r35, r17
+  Move         r36, r22
+  Move         r37, r29
+  MakeMap      r2, 4, r30
+  // group by {category: i.i_category, class: i.i_class} into g
+  Const        r27, "category"
+  Index        r9, r1, r6
+  Const        r28, "class"
+  Index        r10, r1, r8
+  Move         r30, r27
+  Move         r31, r9
+  Move         r32, r28
+  Move         r33, r10
+  MakeMap      r26, 2, r30
+  Str          r17, r26
+  In           r22, r17, r14
+  JumpIfTrue   r22, L7
+  // from ss in store_sales
+  Const        r29, "__group__"
+  Const        r34, true
+  // group by {category: i.i_category, class: i.i_class} into g
+  Move         r35, r26
+  // from ss in store_sales
+  Const        r36, "items"
+  Move         r37, r15
+  Const        r6, "count"
+  Const        r8, 0
+  Move         r38, r29
+  Move         r39, r34
+  Move         r40, r11
+  Move         r41, r35
+  Move         r42, r36
+  Move         r43, r37
+  Move         r44, r6
+  Move         r45, r8
+  MakeMap      r1, 4, r38
+  SetIndex     r14, r17, r1
+  Append       r27, r16, r1
+  Move         r16, r27
+  Index        r9, r14, r17
+  Index        r28, r9, r36
+  Append       r10, r28, r2
+  SetIndex     r9, r36, r10
+  Index        r30, r9, r6
+  Const        r31, 1
+  AddInt       r32, r30, r31
+  SetIndex     r9, r6, r32
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  AddInt       r25, r25, r31
+  Jump         L8
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  AddInt       r18, r18, r31
+  Jump         L9
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  AddInt       r21, r21, r31
+  Jump         L10
+  // from ss in store_sales
+  AddInt       r19, r19, r31
+  Jump         L0
+  Move         r33, r8
+  Len          r22, r16
+  LessInt      r26, r33, r22
+  JumpIfFalse  r26, L11
+  Index        r15, r16, r33
+  Move         r29, r15
   // i_category: g.key.category,
-  Const        r119, "i_category"
-  Index        r120, r118, r11
-  Index        r121, r120, r5
+  Const        r34, "i_category"
+  Index        r35, r29, r11
+  Index        r37, r35, r5
   // i_class: g.key.class,
-  Const        r122, "i_class"
-  Index        r123, r118, r11
-  Index        r124, r123, r7
+  Const        r38, "i_class"
+  Index        r39, r29, r11
+  Index        r40, r39, r7
   // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
-  Const        r125, "gross_margin"
-  Const        r126, []
-  IterPrep     r127, r118
-  Len          r128, r127
-  Move         r129, r114
+  Const        r41, "gross_margin"
+  Const        r42, []
+  IterPrep     r43, r29
+  Len          r44, r43
+  Move         r45, r8
+  LessInt      r1, r45, r44
+  JumpIfFalse  r1, L7
+  Index        r27, r43, r45
+  Move         r14, r27
+  Index        r17, r14, r12
+  Append       r2, r42, r17
+  Move         r42, r2
+  AddInt       r45, r45, r31
+  Jump         L12
+  Sum          r36, r42
+  Const        r28, []
+  IterPrep     r10, r29
+  Len          r19, r10
+  Move         r20, r8
 L14:
-  LessInt      r130, r129, r128
-  JumpIfFalse  r130, L13
-  Index        r132, r127, r129
-  Index        r133, r132, r13
-  Append       r126, r126, r133
-  AddInt       r129, r129, r111
+  LessInt      r21, r20, r19
+  JumpIfFalse  r21, L13
+  Index        r3, r10, r20
+  Move         r14, r3
+  Index        r18, r14, r13
+  Append       r23, r28, r18
+  Move         r28, r23
+  AddInt       r20, r20, r31
   Jump         L14
 L13:
-  Sum          r135, r126
-  Const        r136, []
-  IterPrep     r137, r118
-  Len          r138, r137
-  Move         r139, r114
-L16:
-  LessInt      r140, r139, r138
-  JumpIfFalse  r140, L15
-  Index        r132, r137, r139
-  Index        r142, r132, r14
-  Append       r136, r136, r142
-  AddInt       r139, r139, r111
-  Jump         L16
-L15:
-  Sum          r144, r136
-  Div          r145, r135, r144
+  Sum          r25, r28
+  Div          r24, r36, r25
   // i_category: g.key.category,
-  Move         r146, r119
-  Move         r147, r121
+  Move         r48, r34
+  Move         r49, r37
   // i_class: g.key.class,
-  Move         r148, r122
-  Move         r149, r124
+  Move         r50, r38
+  Move         r51, r40
   // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
-  Move         r150, r125
-  Move         r151, r145
+  Move         r52, r41
+  Move         r53, r24
   // select {
-  MakeMap      r152, 3, r146
+  MakeMap      r6, 3, r48
   // sort by [g.key.category, g.key.class]
-  Index        r153, r118, r11
-  Index        r155, r153, r5
-  Index        r156, r118, r11
-  Index        r158, r156, r7
-  MakeList     r160, 2, r155
+  Index        r9, r29, r11
+  Index        r30, r9, r5
+  Move         r46, r30
+  Index        r47, r29, r11
+  Index        r32, r47, r7
+  Move         r22, r32
+  MakeList     r26, 2, r46
+  Move         r48, r26
   // from ss in store_sales
-  Move         r161, r152
-  MakeList     r162, 2, r160
-  Append       r4, r4, r162
-  AddInt       r113, r113, r111
-  Jump         L17
-L12:
+  Move         r49, r6
+  MakeList     r16, 2, r48
+  Append       r15, r4, r16
+  Move         r4, r15
+  AddInt       r33, r33, r31
+  Jump         L10
+L11:
   // sort by [g.key.category, g.key.class]
-  Sort         r4, r4
+  Sort         r35, r4
+  // from ss in store_sales
+  Move         r4, r35
   // json(result)
   JSON         r4
   // expect result == [
-  Const        r165, [{"gross_margin": 0.2, "i_category": "Books", "i_class": "C1"}, {"gross_margin": 0.25, "i_category": "Books", "i_class": "C2"}, {"gross_margin": 0.2, "i_category": "Electronics", "i_class": "C3"}]
-  Equal        r166, r4, r165
-  Expect       r166
+  Const        r39, [{"gross_margin": 0.2, "i_category": "Books", "i_class": "C1"}, {"gross_margin": 0.25, "i_category": "Books", "i_class": "C2"}, {"gross_margin": 0.2, "i_category": "Electronics", "i_class": "C3"}]
+  Equal        r44, r4, r39
+  Expect       r44
   Return       r0

--- a/tests/dataset/tpc-ds/out/q37.ir.out
+++ b/tests/dataset/tpc-ds/out/q37.ir.out
@@ -1,8 +1,10 @@
-func main (regs=155)
+func main (regs=54)
   // let item = [
-  Const        r0, [{"i_current_price": 30, "i_item_desc": "Item1", "i_item_id": "I1", "i_item_sk": 1, "i_manufact_id": 800}, {"i_current_price": 60, "i_item_desc": "Item2", "i_item_id": "I2", "i_item_sk": 2, "i_manufact_id": 801}]
+  Const        r0, [{"i_current_price": 30.0, "i_item_desc": "Item1", "i_item_id": "I1", "i_item_sk": 1, "i_manufact_id": 800}, {"i_current_price": 60.0, "i_item_desc": "Item2", "i_item_id": "I2", "i_item_sk": 2, "i_manufact_id": 801}]
+L8:
   // let inventory = [
   Const        r1, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 200, "inv_warehouse_sk": 1}, {"inv_date_sk": 1, "inv_item_sk": 2, "inv_quantity_on_hand": 300, "inv_warehouse_sk": 1}]
+L3:
   // let date_dim = [
   Const        r2, [{"d_date": "2000-01-15", "d_date_sk": 1}]
   // let catalog_sales = [
@@ -21,205 +23,218 @@ func main (regs=155)
   Const        r12, "inv_quantity_on_hand"
   // select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
   Const        r13, "key"
+L2:
   // from i in item
   MakeMap      r14, 0, r0
   Const        r15, []
+  Move         r16, r15
   IterPrep     r17, r0
   Len          r18, r17
   Const        r19, 0
-L10:
+L9:
   LessInt      r20, r19, r18
   JumpIfFalse  r20, L0
-  Index        r22, r17, r19
-  // join inv in inventory on i.i_item_sk == inv.inv_item_sk
-  IterPrep     r23, r1
-  Len          r24, r23
-  Const        r25, 0
-L9:
-  LessInt      r26, r25, r24
-  JumpIfFalse  r26, L1
-  Index        r28, r23, r25
-  Const        r29, "i_item_sk"
-  Index        r30, r22, r29
-  Const        r31, "inv_item_sk"
-  Index        r32, r28, r31
-  Equal        r33, r30, r32
-  JumpIfFalse  r33, L2
-  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
-  IterPrep     r34, r2
-  Len          r35, r34
-  Const        r36, 0
-L8:
-  LessInt      r37, r36, r35
-  JumpIfFalse  r37, L2
-  Index        r39, r34, r36
-  Const        r40, "inv_date_sk"
-  Index        r41, r28, r40
-  Const        r42, "d_date_sk"
-  Index        r43, r39, r42
-  Equal        r44, r41, r43
-  JumpIfFalse  r44, L3
-  // join cs in catalog_sales on cs.cs_item_sk == i.i_item_sk
-  IterPrep     r45, r3
-  Len          r46, r45
-  Const        r47, 0
-L7:
-  LessInt      r48, r47, r46
-  JumpIfFalse  r48, L3
-  Index        r50, r45, r47
-  Const        r51, "cs_item_sk"
-  Index        r52, r50, r51
-  Index        r53, r22, r29
-  Equal        r54, r52, r53
-  JumpIfFalse  r54, L4
-  // where i.i_current_price >= 20 && i.i_current_price <= 50 && i.i_manufact_id >= 800 && i.i_manufact_id <= 803 && inv.inv_quantity_on_hand >= 100 && inv.inv_quantity_on_hand <= 500
-  Index        r55, r22, r10
-  Const        r56, 20
-  LessEq       r57, r56, r55
-  Index        r58, r22, r10
-  Const        r59, 50
-  LessEq       r60, r58, r59
-  Index        r61, r22, r11
-  Const        r62, 800
-  LessEq       r63, r62, r61
-  Index        r64, r22, r11
-  Const        r65, 803
-  LessEq       r66, r64, r65
-  Index        r67, r28, r12
-  Const        r68, 100
-  LessEq       r69, r68, r67
-  Index        r70, r28, r12
-  Const        r71, 500
-  LessEq       r72, r70, r71
-  JumpIfFalse  r57, L5
-  Move         r57, r60
-  JumpIfFalse  r57, L5
-  Move         r57, r63
-  JumpIfFalse  r57, L5
-  Move         r57, r66
-  JumpIfFalse  r57, L5
-  Move         r57, r69
-  JumpIfFalse  r57, L5
-  Move         r57, r72
-L5:
-  JumpIfFalse  r57, L4
-  // from i in item
-  Const        r73, "i"
-  Move         r74, r22
-  Const        r75, "inv"
-  Move         r76, r28
-  Const        r77, "d"
-  Move         r78, r39
-  Const        r79, "cs"
-  Move         r80, r50
-  MakeMap      r81, 4, r73
-  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
-  Const        r82, "id"
-  Index        r83, r22, r6
-  Const        r84, "desc"
-  Index        r85, r22, r8
-  Const        r86, "price"
-  Index        r87, r22, r10
-  Move         r88, r82
-  Move         r89, r83
-  Move         r90, r84
-  Move         r91, r85
-  Move         r92, r86
-  Move         r93, r87
-  MakeMap      r94, 3, r88
-  Str          r95, r94
-  In           r96, r95, r14
-  JumpIfTrue   r96, L6
-  // from i in item
-  Const        r97, []
-  Const        r98, "__group__"
-  Const        r99, true
-  Const        r100, "key"
-  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
-  Move         r101, r94
-  // from i in item
-  Const        r102, "items"
-  Move         r103, r97
-  Const        r104, "count"
-  Const        r105, 0
-  Move         r106, r98
-  Move         r107, r99
-  Move         r108, r100
-  Move         r109, r101
-  Move         r110, r102
-  Move         r111, r103
-  Move         r112, r104
-  Move         r113, r105
-  MakeMap      r114, 4, r106
-  SetIndex     r14, r95, r114
-  Append       r15, r15, r114
-L6:
-  Const        r116, "items"
-  Index        r117, r14, r95
-  Index        r118, r117, r116
-  Append       r119, r118, r81
-  SetIndex     r117, r116, r119
-  Const        r120, "count"
-  Index        r121, r117, r120
-  Const        r122, 1
-  AddInt       r123, r121, r122
-  SetIndex     r117, r120, r123
-L4:
-  // join cs in catalog_sales on cs.cs_item_sk == i.i_item_sk
-  AddInt       r47, r47, r122
-  Jump         L7
-L3:
-  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
-  AddInt       r36, r36, r122
-  Jump         L8
-L2:
-  // join inv in inventory on i.i_item_sk == inv.inv_item_sk
-  AddInt       r25, r25, r122
-  Jump         L9
 L1:
+  Index        r18, r17, r19
+L7:
+  Move         r17, r18
+  // join inv in inventory on i.i_item_sk == inv.inv_item_sk
+  IterPrep     r18, r1
+L6:
+  Len          r1, r18
+  Const        r21, 0
+  LessInt      r22, r21, r1
+  JumpIfFalse  r22, L1
+  Index        r1, r18, r21
+  Move         r22, r1
+  Const        r18, "i_item_sk"
+  Index        r23, r17, r18
+  Const        r24, "inv_item_sk"
+  Index        r25, r22, r24
+  Equal        r24, r23, r25
+  JumpIfFalse  r24, L2
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  IterPrep     r23, r2
+  Len          r25, r23
+  Const        r24, 0
+  LessInt      r2, r24, r25
+  JumpIfFalse  r2, L2
+  Index        r25, r23, r24
+  Move         r2, r25
+  Const        r23, "inv_date_sk"
+  Index        r25, r22, r23
+L4:
+  Const        r26, "d_date_sk"
+  Index        r27, r2, r26
+  Equal        r26, r25, r27
+L5:
+  JumpIfFalse  r26, L3
+  // join cs in catalog_sales on cs.cs_item_sk == i.i_item_sk
+  IterPrep     r25, r3
+  Len          r27, r25
+  Const        r26, 0
+  LessInt      r3, r26, r27
+  JumpIfFalse  r3, L3
+  Index        r27, r25, r26
+  Move         r3, r27
+  Const        r25, "cs_item_sk"
+  Index        r27, r3, r25
+  Index        r25, r17, r18
+  Equal        r18, r27, r25
+  JumpIfFalse  r18, L4
+  // where i.i_current_price >= 20 && i.i_current_price <= 50 && i.i_manufact_id >= 800 && i.i_manufact_id <= 803 && inv.inv_quantity_on_hand >= 100 && inv.inv_quantity_on_hand <= 500
+  Index        r27, r17, r10
+  Const        r18, 20
+  LessEq       r28, r18, r27
+  Index        r27, r17, r10
+  Const        r18, 50
+  LessEq       r29, r27, r18
+  Index        r27, r17, r11
+  Const        r18, 800
+  LessEq       r30, r18, r27
+  Index        r27, r17, r11
+  Const        r18, 803
+  LessEq       r11, r27, r18
+  Index        r27, r22, r12
+  Const        r18, 100
+  LessEq       r31, r18, r27
+  Index        r27, r22, r12
+  Const        r18, 500
+  LessEq       r12, r27, r18
+  Move         r27, r28
+  JumpIfFalse  r27, L3
+  Move         r27, r29
+  JumpIfFalse  r27, L3
+  Move         r27, r30
+  JumpIfFalse  r27, L3
+  Move         r27, r11
+  JumpIfFalse  r27, L3
+  Move         r27, r31
+  JumpIfFalse  r27, L3
+  Move         r27, r12
+  JumpIfFalse  r27, L4
   // from i in item
-  AddInt       r19, r19, r122
-  Jump         L10
+  Const        r18, "i"
+  Move         r28, r17
+  Const        r29, "inv"
+  Move         r30, r22
+  Const        r11, "d"
+  Move         r31, r2
+  Const        r12, "cs"
+  Move         r27, r3
+  Move         r32, r18
+  Move         r33, r28
+  Move         r34, r29
+  Move         r35, r30
+  Move         r36, r11
+  Move         r37, r31
+  Move         r38, r12
+  Move         r39, r27
+  MakeMap      r22, 4, r32
+  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
+  Const        r2, "id"
+  Index        r3, r17, r6
+  Const        r18, "desc"
+  Index        r28, r17, r8
+  Const        r29, "price"
+  Index        r30, r17, r10
+  Move         r32, r2
+  Move         r33, r3
+  Move         r34, r18
+  Move         r35, r28
+  Move         r36, r29
+  Move         r37, r30
+  MakeMap      r11, 3, r32
+  Str          r31, r11
+  In           r12, r31, r14
+  JumpIfTrue   r12, L5
+  // from i in item
+  Const        r27, "__group__"
+  Const        r38, true
+  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
+  Move         r39, r11
+  // from i in item
+  Const        r6, "items"
+  Move         r8, r15
+  Const        r10, "count"
+  Const        r17, 0
+  Move         r40, r27
+  Move         r41, r38
+  Move         r42, r13
+  Move         r43, r39
+  Move         r44, r6
+  Move         r45, r8
+  Move         r46, r10
+  Move         r47, r17
+  MakeMap      r2, 4, r40
+  SetIndex     r14, r31, r2
+  Append       r3, r16, r2
+  Move         r16, r3
+  Index        r18, r14, r31
+  Index        r28, r18, r6
+  Append       r29, r28, r22
+  SetIndex     r18, r6, r29
+  Index        r30, r18, r10
+  Const        r32, 1
+  AddInt       r33, r30, r32
+  SetIndex     r18, r10, r33
+  // join cs in catalog_sales on cs.cs_item_sk == i.i_item_sk
+  AddInt       r26, r26, r32
+  Jump         L6
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  AddInt       r24, r24, r32
+  Jump         L7
+  // join inv in inventory on i.i_item_sk == inv.inv_item_sk
+  AddInt       r21, r21, r32
+  Jump         L8
+  // from i in item
+  AddInt       r19, r19, r32
+  Jump         L9
 L0:
-  Const        r124, 0
-  Len          r126, r15
-L12:
-  LessInt      r127, r124, r126
-  JumpIfFalse  r127, L11
-  Index        r129, r15, r124
-  // select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
-  Const        r130, "i_item_id"
-  Index        r131, r129, r13
-  Index        r132, r131, r5
-  Const        r133, "i_item_desc"
-  Index        r134, r129, r13
-  Index        r135, r134, r7
-  Const        r136, "i_current_price"
-  Index        r137, r129, r13
-  Index        r138, r137, r9
-  Move         r139, r130
-  Move         r140, r132
-  Move         r141, r133
-  Move         r142, r135
-  Move         r143, r136
-  Move         r144, r138
-  MakeMap      r145, 3, r139
-  // sort by g.key.id
-  Index        r146, r129, r13
-  Index        r148, r146, r5
-  // from i in item
-  Move         r149, r145
-  MakeList     r150, 2, r148
-  Append       r4, r4, r150
-  AddInt       r124, r124, r122
-  Jump         L12
+  Move         r34, r17
+  Len          r35, r16
 L11:
+  LessInt      r36, r34, r35
+  JumpIfFalse  r36, L10
+  Index        r37, r16, r34
+  Move         r12, r37
+  // select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
+  Const        r11, "i_item_id"
+  Index        r15, r12, r13
+  Index        r27, r15, r5
+  Const        r38, "i_item_desc"
+  Index        r39, r12, r13
+  Index        r8, r39, r7
+  Const        r40, "i_current_price"
+  Index        r41, r12, r13
+  Index        r42, r41, r9
+  Move         r48, r11
+  Move         r49, r27
+  Move         r50, r38
+  Move         r51, r8
+  Move         r52, r40
+  Move         r53, r42
+  MakeMap      r43, 3, r48
   // sort by g.key.id
-  Sort         r4, r4
+  Index        r44, r12, r13
+  Index        r45, r44, r5
+  Move         r46, r45
+  // from i in item
+  Move         r47, r43
+  MakeList     r2, 2, r46
+  Append       r3, r4, r2
+  Move         r4, r3
+  AddInt       r34, r34, r32
+  Jump         L11
+L10:
+  // sort by g.key.id
+  Sort         r14, r4
+  // from i in item
+  Move         r4, r14
   // json(result)
   JSON         r4
   // expect result == [{i_item_id: "I1", i_item_desc: "Item1", i_current_price: 30.0}]
-  Const        r153, [{"i_current_price": 30, "i_item_desc": "Item1", "i_item_id": "I1"}]
-  Equal        r154, r4, r153
-  Expect       r154
+  Const        r31, [{"i_current_price": 30.0, "i_item_desc": "Item1", "i_item_id": "I1"}]
+  Equal        r22, r4, r31
+  Expect       r22
   Return       r0

--- a/tests/dataset/tpc-ds/out/q38.ir.out
+++ b/tests/dataset/tpc-ds/out/q38.ir.out
@@ -1,125 +1,137 @@
-func main (regs=58)
+func main (regs=15)
   // let customer = [
   Const        r0, [{"c_customer_sk": 1, "c_first_name": "John", "c_last_name": "Smith"}, {"c_customer_sk": 2, "c_first_name": "Alice", "c_last_name": "Jones"}]
   // let store_sales = [
   Const        r1, [{"d_month_seq": 1200, "ss_customer_sk": 1}, {"d_month_seq": 1205, "ss_customer_sk": 2}]
+L0:
   // let catalog_sales = [
   Const        r2, [{"cs_bill_customer_sk": 1, "d_month_seq": 1203}]
+L6:
   // let web_sales = [
   Const        r3, [{"d_month_seq": 1206, "ws_bill_customer_sk": 1}]
   // let store_ids = distinct(from s in store_sales where s.d_month_seq >= 1200 && s.d_month_seq <= 1211 select s.ss_customer_sk)
   Const        r4, []
   Const        r5, "d_month_seq"
+L1:
   Const        r6, "ss_customer_sk"
   IterPrep     r7, r1
-  Len          r8, r7
-  Const        r10, 0
-  Move         r9, r10
-L3:
-  LessInt      r11, r9, r8
-  JumpIfFalse  r11, L0
-  Index        r13, r7, r9
-  Index        r14, r13, r5
-  Const        r15, 1200
-  LessEq       r16, r15, r14
-  Index        r17, r13, r5
-  Const        r18, 1211
-  LessEq       r19, r17, r18
-  JumpIfFalse  r16, L1
-  Move         r16, r19
-L1:
-  JumpIfFalse  r16, L2
-  Index        r20, r13, r6
-  Append       r4, r4, r20
-L2:
-  Const        r22, 1
-  AddInt       r9, r9, r22
-  Jump         L3
-L0:
-  Distinct     23,4,0,0
-  // let catalog_ids = distinct(from c in catalog_sales where c.d_month_seq >= 1200 && c.d_month_seq <= 1211 select c.cs_bill_customer_sk)
-  Const        r24, []
-  Const        r25, "cs_bill_customer_sk"
-  IterPrep     r26, r2
-  Len          r27, r26
-  Move         r28, r10
-L7:
-  LessInt      r29, r28, r27
-  JumpIfFalse  r29, L4
-  Index        r31, r26, r28
-  Index        r32, r31, r5
-  LessEq       r33, r15, r32
-  Index        r34, r31, r5
-  LessEq       r35, r34, r18
-  JumpIfFalse  r33, L5
-  Move         r33, r35
 L5:
-  JumpIfFalse  r33, L6
-  Index        r36, r31, r25
-  Append       r24, r24, r36
-L6:
-  AddInt       r28, r28, r22
-  Jump         L7
-L4:
-  Distinct     38,24,0,0
-  // let web_ids = distinct(from w in web_sales where w.d_month_seq >= 1200 && w.d_month_seq <= 1211 select w.ws_bill_customer_sk)
-  Const        r39, []
-  Const        r40, "ws_bill_customer_sk"
-  IterPrep     r41, r3
-  Len          r42, r41
-  Move         r43, r10
-L11:
-  LessInt      r44, r43, r42
-  JumpIfFalse  r44, L8
-  Index        r46, r41, r43
-  Index        r47, r46, r5
-  LessEq       r48, r15, r47
-  Index        r49, r46, r5
-  LessEq       r50, r49, r18
-  JumpIfFalse  r48, L9
-  Move         r48, r50
-L9:
-  JumpIfFalse  r48, L10
-  Index        r51, r46, r40
-  Append       r39, r39, r51
+  Len          r1, r7
+L2:
+  Const        r8, 0
+L3:
+  Move         r9, r8
+  LessInt      r10, r9, r1
+  JumpIfFalse  r10, L0
 L10:
-  AddInt       r43, r43, r22
-  Jump         L11
+  Index        r1, r7, r9
+L4:
+  Move         r7, r1
+  Index        r1, r7, r5
+  Const        r11, 1200
+  LessEq       r12, r11, r1
+  Index        r1, r7, r5
+  Const        r13, 1211
+  LessEq       r14, r1, r13
+  Move         r1, r12
+  JumpIfFalse  r1, L1
+  Move         r1, r14
+  JumpIfFalse  r1, L2
+  Index        r12, r7, r6
+  Append       r14, r4, r12
+  Move         r4, r14
+  Const        r1, 1
+  AddInt       r9, r9, r1
+  Jump         L3
+  Distinct     6,4,0,0
+  // let catalog_ids = distinct(from c in catalog_sales where c.d_month_seq >= 1200 && c.d_month_seq <= 1211 select c.cs_bill_customer_sk)
+  Const        r7, []
+  Const        r12, "cs_bill_customer_sk"
+  IterPrep     r14, r2
+  Len          r9, r14
+  Move         r10, r8
+  LessInt      r4, r10, r9
+  JumpIfFalse  r4, L4
+  Index        r2, r14, r10
+  Move         r9, r2
+  Index        r4, r9, r5
+  LessEq       r14, r11, r4
+  Index        r2, r9, r5
+  LessEq       r4, r2, r13
+  Move         r2, r14
+  JumpIfFalse  r2, L5
+  Move         r2, r4
+  JumpIfFalse  r2, L6
+  Index        r14, r9, r12
+  Append       r4, r7, r14
+  Move         r7, r4
+  AddInt       r10, r10, r1
+  Jump         L0
+  Distinct     12,7,0,0
+  // let web_ids = distinct(from w in web_sales where w.d_month_seq >= 1200 && w.d_month_seq <= 1211 select w.ws_bill_customer_sk)
+  Const        r9, []
+  Const        r10, "ws_bill_customer_sk"
+  IterPrep     r2, r3
+  Len          r14, r2
+  Move         r4, r8
+  LessInt      r7, r4, r14
+  JumpIfFalse  r7, L7
+  Index        r3, r2, r4
+  Move         r8, r3
+  Index        r14, r8, r5
+  LessEq       r7, r11, r14
+  Index        r2, r8, r5
+  LessEq       r3, r2, r13
+  Move         r11, r7
+  JumpIfFalse  r11, L8
+  Move         r11, r3
 L8:
-  Distinct     53,39,0,0
+  JumpIfFalse  r11, L9
+  Index        r14, r8, r10
+  Append       r5, r9, r14
+  Move         r9, r5
+L9:
+  AddInt       r4, r4, r1
+  Jump         L10
+L7:
+  Distinct     2,9,0,0
   // let hot = store_ids intersect catalog_ids intersect web_ids
-  Intersect    r54, r23, r38
-  Intersect    r55, r54, r53
+  Intersect    r7, r6, r12
+  Intersect    r3, r7, r2
   // let result = len(hot)
-  Len          r56, r55
+  Len          r11, r3
   // json(result)
-  JSON         r56
+  JSON         r11
   // expect result == 1
-  EqualInt     r57, r56, r22
-  Expect       r57
+  EqualInt     r13, r11, r1
+  Expect       r13
   Return       r0
 
   // fun distinct(xs: list<any>): list<any> {
-func distinct (regs=14)
+func distinct (regs=6)
   // var out = []
-  Const        r2, []
+  Const        r1, []
+  Move         r2, r1
   // for x in xs {
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  IterPrep     r1, r0
+  Len          r3, r1
 L2:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Index        r8, r3, r5
-  // if !contains(out, x) {
-  Not          r10, r9
-  JumpIfFalse  r10, L1
-  // out = append(out, x)
-  Append       r2, r2, r8
+  Const        r4, 0
 L1:
+  LessInt      r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r3, r1, r4
+  Move         r5, r3
+  // if !contains(out, x) {
+  Not          r1, r3
+  JumpIfFalse  r1, L1
+  // out = append(out, x)
+  Append       r1, r2, r5
+  Move         r2, r1
   // for x in xs {
-  Const        r12, 1
-  Add          r5, r5, r12
+  Const        r3, 1
+  AddInt       r5, r4, r3
+  Move         r4, r5
   Jump         L2
 L0:
   // return out

--- a/tests/dataset/tpc-ds/out/q39.ir.out
+++ b/tests/dataset/tpc-ds/out/q39.ir.out
@@ -1,10 +1,11 @@
-func main (regs=241)
+func main (regs=64)
   // let inventory = [
   Const        r0, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 10, "inv_warehouse_sk": 1}, {"inv_date_sk": 2, "inv_item_sk": 1, "inv_quantity_on_hand": 10, "inv_warehouse_sk": 1}, {"inv_date_sk": 3, "inv_item_sk": 1, "inv_quantity_on_hand": 250, "inv_warehouse_sk": 1}]
   // let item = [
   Const        r1, [{"i_item_sk": 1}]
   // let warehouse = [
   Const        r2, [{"w_warehouse_name": "W1", "w_warehouse_sk": 1}]
+L8:
   // let date_dim = [
   Const        r3, [{"d_date_sk": 1, "d_moy": 1, "d_year": 2000}, {"d_date_sk": 2, "d_moy": 2, "d_year": 2000}, {"d_date_sk": 3, "d_moy": 3, "d_year": 2000}]
   // from inv in inventory
@@ -14,348 +15,374 @@ func main (regs=241)
   Const        r6, "w_warehouse_sk"
   Const        r7, "i"
   Const        r8, "i_item_sk"
-  Const        r9, "month"
-  Const        r10, "d_moy"
-  // where d.d_year == 2000
-  Const        r11, "d_year"
-  // select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
-  Const        r12, "key"
-  Const        r13, "qty"
-  Const        r14, "inv_quantity_on_hand"
-  // from inv in inventory
-  MakeMap      r15, 0, r0
-  Const        r16, []
-  IterPrep     r18, r0
-  Len          r19, r18
-  Const        r20, 0
-L9:
-  LessInt      r21, r20, r19
-  JumpIfFalse  r21, L0
-  Index        r23, r18, r20
-  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
-  IterPrep     r24, r3
-  Len          r25, r24
-  Const        r26, 0
-L8:
-  LessInt      r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r29, r24, r26
-  Const        r30, "inv_date_sk"
-  Index        r31, r23, r30
-  Const        r32, "d_date_sk"
-  Index        r33, r29, r32
-  Equal        r34, r31, r33
-  JumpIfFalse  r34, L2
-  // join i in item on inv.inv_item_sk == i.i_item_sk
-  IterPrep     r35, r1
-  Len          r36, r35
-  Const        r37, 0
-L7:
-  LessInt      r38, r37, r36
-  JumpIfFalse  r38, L2
-  Index        r40, r35, r37
-  Const        r41, "inv_item_sk"
-  Index        r42, r23, r41
-  Index        r43, r40, r8
-  Equal        r44, r42, r43
-  JumpIfFalse  r44, L3
-  // join w in warehouse on inv.inv_warehouse_sk == w.w_warehouse_sk
-  IterPrep     r45, r2
-  Len          r46, r45
-  Const        r47, 0
-L6:
-  LessInt      r48, r47, r46
-  JumpIfFalse  r48, L3
-  Index        r50, r45, r47
-  Const        r51, "inv_warehouse_sk"
-  Index        r52, r23, r51
-  Index        r53, r50, r6
-  Equal        r54, r52, r53
-  JumpIfFalse  r54, L4
-  // where d.d_year == 2000
-  Index        r55, r29, r11
-  Const        r56, 2000
-  Equal        r57, r55, r56
-  JumpIfFalse  r57, L4
-  // from inv in inventory
-  Const        r58, "inv"
-  Move         r59, r23
-  Const        r60, "d"
-  Move         r61, r29
-  Move         r62, r40
-  Move         r63, r50
-  MakeMap      r64, 4, r58
-  // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
-  Const        r65, "w"
-  Index        r66, r50, r6
-  Const        r67, "i"
-  Index        r68, r40, r8
-  Const        r69, "month"
-  Index        r70, r29, r10
-  Move         r71, r65
-  Move         r72, r66
-  Move         r73, r67
-  Move         r74, r68
-  Move         r75, r69
-  Move         r76, r70
-  MakeMap      r77, 3, r71
-  Str          r78, r77
-  In           r79, r78, r15
-  JumpIfTrue   r79, L5
-  // from inv in inventory
-  Const        r80, []
-  Const        r81, "__group__"
-  Const        r82, true
-  Const        r83, "key"
-  // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
-  Move         r84, r77
-  // from inv in inventory
-  Const        r85, "items"
-  Move         r86, r80
-  Const        r87, "count"
-  Const        r88, 0
-  Move         r89, r81
-  Move         r90, r82
-  Move         r91, r83
-  Move         r92, r84
-  Move         r93, r85
-  Move         r94, r86
-  Move         r95, r87
-  Move         r96, r88
-  MakeMap      r97, 4, r89
-  SetIndex     r15, r78, r97
-  Append       r16, r16, r97
 L5:
-  Const        r99, "items"
-  Index        r100, r15, r78
-  Index        r101, r100, r99
-  Append       r102, r101, r64
-  SetIndex     r100, r99, r102
-  Const        r103, "count"
-  Index        r104, r100, r103
-  Const        r105, 1
-  AddInt       r106, r104, r105
-  SetIndex     r100, r103, r106
-L4:
-  // join w in warehouse on inv.inv_warehouse_sk == w.w_warehouse_sk
-  AddInt       r47, r47, r105
-  Jump         L6
-L3:
-  // join i in item on inv.inv_item_sk == i.i_item_sk
-  AddInt       r37, r37, r105
-  Jump         L7
-L2:
-  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
-  AddInt       r26, r26, r105
-  Jump         L8
-L1:
-  // from inv in inventory
-  AddInt       r20, r20, r105
-  Jump         L9
-L0:
-  Const        r108, 0
-  Move         r107, r108
-  Len          r109, r16
-L13:
-  LessInt      r110, r107, r109
-  JumpIfFalse  r110, L10
-  Index        r112, r16, r107
+  Const        r9, "month"
+  Const        r9, "d_moy"
+  // where d.d_year == 2000
+  Const        r10, "d_year"
   // select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
-  Const        r113, "w"
-  Index        r114, r112, r12
-  Index        r115, r114, r5
-  Const        r116, "i"
-  Index        r117, r112, r12
-  Index        r118, r117, r7
-  Const        r119, "qty"
-  Const        r120, []
-  IterPrep     r121, r112
-  Len          r122, r121
-  Move         r123, r108
-L12:
-  LessInt      r124, r123, r122
-  JumpIfFalse  r124, L11
-  Index        r126, r121, r123
-  Index        r127, r126, r14
-  Append       r120, r120, r127
-  AddInt       r123, r123, r105
-  Jump         L12
-L11:
-  Sum          r129, r120
-  Move         r130, r113
-  Move         r131, r115
-  Move         r132, r116
-  Move         r133, r118
-  Move         r134, r119
-  Move         r135, r129
-  MakeMap      r136, 3, r130
+  Const        r11, "key"
+  Const        r12, "qty"
+L2:
+  Const        r13, "inv_quantity_on_hand"
   // from inv in inventory
-  Append       r4, r4, r136
-  AddInt       r107, r107, r105
-  Jump         L13
-L10:
-  // var grouped: map<string, map<string, any>> = {}
-  Const        r139, {}
-  // for m in monthly {
-  IterPrep     r140, r4
-  Len          r141, r140
-  Const        r142, 0
-L17:
-  Less         r143, r142, r141
-  JumpIfFalse  r143, L14
-  Index        r145, r140, r142
-  // let key = str({w: m.w, i: m.i})
-  Const        r146, "w"
-  Index        r147, r145, r5
-  Const        r148, "i"
-  Index        r149, r145, r7
-  Move         r150, r146
-  Move         r151, r147
-  Move         r152, r148
-  Move         r153, r149
-  MakeMap      r154, 2, r150
-  Str          r155, r154
-  // if key in grouped {
-  In           r156, r155, r139
-  JumpIfFalse  r156, L15
-  // let g = grouped[key]
-  Index        r157, r139, r155
-  // grouped[key] = {w: g.w, i: g.i, qtys: append(g.qtys, m.qty)}
-  Const        r158, "w"
-  Index        r159, r157, r5
-  Const        r160, "i"
-  Index        r161, r157, r7
-  Const        r162, "qtys"
-  Const        r163, "qtys"
-  Index        r164, r157, r163
-  Index        r165, r145, r13
-  Append       r166, r164, r165
-  Move         r167, r158
-  Move         r168, r159
-  Move         r169, r160
-  Move         r170, r161
-  Move         r171, r162
-  Move         r172, r166
-  MakeMap      r173, 3, r167
-  SetIndex     r139, r155, r173
-  // if key in grouped {
-  Jump         L16
-L15:
-  // grouped[key] = {w: m.w, i: m.i, qtys: [m.qty]}
-  Const        r174, "w"
-  Index        r175, r145, r5
-  Const        r176, "i"
-  Index        r177, r145, r7
-  Const        r178, "qtys"
-  Index        r180, r145, r13
-  MakeList     r181, 1, r180
-  Move         r182, r174
-  Move         r183, r175
-  Move         r184, r176
-  Move         r185, r177
-  Move         r186, r178
-  Move         r187, r181
-  MakeMap      r188, 3, r182
-  SetIndex     r139, r155, r188
-L16:
-  // for m in monthly {
-  Const        r189, 1
-  Add          r142, r142, r189
-  Jump         L17
+  MakeMap      r14, 0, r0
+L11:
+  Const        r15, []
+  Move         r16, r15
+  IterPrep     r17, r0
+  Len          r18, r17
+L9:
+  Const        r19, 0
+  LessInt      r20, r19, r18
+  JumpIfFalse  r20, L0
+L7:
+  Index        r18, r17, r19
+L6:
+  Move         r17, r18
+L1:
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  IterPrep     r18, r3
+  Len          r3, r18
+  Const        r21, 0
+L3:
+  LessInt      r22, r21, r3
+  JumpIfFalse  r22, L1
+  Index        r3, r18, r21
+L12:
+  Move         r22, r3
+L0:
+  Const        r18, "inv_date_sk"
+  Index        r23, r17, r18
+  Const        r18, "d_date_sk"
+  Index        r24, r22, r18
+  Equal        r18, r23, r24
+  JumpIfFalse  r18, L2
+  // join i in item on inv.inv_item_sk == i.i_item_sk
+  IterPrep     r23, r1
+  Len          r24, r23
+  Const        r18, 0
+  LessInt      r1, r18, r24
+  JumpIfFalse  r1, L2
+  Index        r24, r23, r18
+L4:
+  Move         r1, r24
+  Const        r23, "inv_item_sk"
+  Index        r24, r17, r23
+L13:
+  Index        r25, r1, r8
+  Equal        r26, r24, r25
 L14:
-  // var summary = []
-  Const        r192, []
-  // for g in values(grouped) {
-  Const        r193, []
-  IterPrep     r194, r193
-  Len          r195, r194
-  Const        r196, 0
-L22:
-  Less         r197, r196, r195
-  JumpIfFalse  r197, L18
-  Index        r112, r194, r196
-  // let mean = avg(g.qtys)
-  Index        r199, r112, r163
-  Avg          r200, r199
-  // var sumsq = 0.0
-  Const        r202, 0
-  // for q in g.qtys {
-  Index        r203, r112, r163
-  IterPrep     r204, r203
-  Len          r205, r204
-  Const        r206, 0
+  JumpIfFalse  r26, L3
+  // join w in warehouse on inv.inv_warehouse_sk == w.w_warehouse_sk
+  IterPrep     r24, r2
+  Len          r25, r24
+L10:
+  Const        r26, 0
+  LessInt      r2, r26, r25
+  JumpIfFalse  r2, L3
+  Index        r25, r24, r26
+  Move         r2, r25
+L15:
+  Const        r24, "inv_warehouse_sk"
+  Index        r25, r17, r24
+  Index        r24, r2, r6
+  Equal        r27, r25, r24
+  JumpIfFalse  r27, L4
 L20:
-  Less         r207, r206, r205
-  JumpIfFalse  r207, L19
-  Index        r209, r204, r206
-  // sumsq = sumsq + (q - mean) * (q - mean)
-  SubFloat     r210, r209, r200
-  SubFloat     r211, r209, r200
-  MulFloat     r212, r210, r211
-  AddFloat     r202, r202, r212
-  // for q in g.qtys {
-  Const        r214, 1
-  Add          r206, r206, r214
-  Jump         L20
-L19:
-  // let variance = sumsq / len(g.qtys)
-  Index        r216, r112, r163
-  Len          r217, r216
-  DivFloat     r219, r202, r217
-  // let cov = sqrt(variance) / mean
-  Call         r220, sqrt, r219
-  DivFloat     r221, r220, r200
-  // if cov > 1.5 {
-  Const        r222, 1.5
-  LessFloat    r223, r222, r221
-  JumpIfFalse  r223, L21
-  // summary = append(summary, {w_warehouse_sk: g.w, i_item_sk: g.i, cov: cov})
-  Const        r224, "w_warehouse_sk"
-  Index        r225, r112, r5
-  Const        r226, "i_item_sk"
-  Index        r227, r112, r7
-  Const        r228, "cov"
-  Move         r229, r224
-  Move         r230, r225
-  Move         r231, r226
-  Move         r232, r227
-  Move         r233, r228
-  Move         r234, r221
-  MakeMap      r235, 3, r229
-  Append       r192, r192, r235
-L21:
+  // where d.d_year == 2000
+  Index        r25, r22, r10
+  Const        r27, 2000
+  Equal        r10, r25, r27
+  JumpIfFalse  r10, L4
+  // from inv in inventory
+  Const        r25, "inv"
+  Move         r27, r17
+  Const        r10, "d"
+  Move         r17, r22
+  Move         r28, r1
+  Move         r29, r2
+  Move         r30, r25
+  Move         r31, r27
+  Move         r32, r10
+  Move         r33, r17
+  Move         r34, r7
+  Move         r35, r28
+  Move         r36, r5
+  Move         r37, r29
+  MakeMap      r25, 4, r30
+  // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
+  Const        r27, "w"
+  Index        r10, r2, r6
+  Const        r17, "i"
+  Index        r28, r1, r8
+  Const        r29, "month"
+  Index        r30, r22, r9
+  Move         r31, r27
+  Move         r32, r10
+  Move         r33, r17
+  Move         r34, r28
+  Move         r35, r29
+  Move         r36, r30
+  MakeMap      r37, 3, r31
+  Str          r6, r37
+  In           r2, r6, r14
+  JumpIfTrue   r2, L5
+  // from inv in inventory
+  Const        r8, "__group__"
+  Const        r1, true
+  // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
+  Move         r9, r37
+  // from inv in inventory
+  Const        r22, "items"
+  Move         r27, r15
+  Const        r10, "count"
+  Const        r17, 0
+  Move         r38, r8
+  Move         r39, r1
+  Move         r40, r11
+  Move         r41, r9
+  Move         r42, r22
+  Move         r43, r27
+  Move         r44, r10
+  Move         r45, r17
+  MakeMap      r28, 4, r38
+  SetIndex     r14, r6, r28
+  Append       r29, r16, r28
+  Move         r16, r29
+  Index        r30, r14, r6
+  Index        r31, r30, r22
+  Append       r32, r31, r25
+  SetIndex     r30, r22, r32
+  Index        r33, r30, r10
+  Const        r34, 1
+  AddInt       r35, r33, r34
+  SetIndex     r30, r10, r35
+  // join w in warehouse on inv.inv_warehouse_sk == w.w_warehouse_sk
+  AddInt       r26, r26, r34
+  Jump         L6
+  // join i in item on inv.inv_item_sk == i.i_item_sk
+  AddInt       r18, r18, r34
+  Jump         L7
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  AddInt       r21, r21, r34
+  Jump         L8
+  // from inv in inventory
+  AddInt       r19, r19, r34
+  Jump         L9
+  Move         r36, r17
+  Len          r2, r16
+  LessInt      r37, r36, r2
+  JumpIfFalse  r37, L10
+  Index        r8, r16, r36
+  Move         r1, r8
+  // select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
+  Const        r9, "w"
+  Index        r27, r1, r11
+  Index        r38, r27, r5
+  Const        r39, "i"
+  Index        r40, r1, r11
+  Index        r41, r40, r7
+  Const        r42, "qty"
+  Const        r43, []
+  IterPrep     r44, r1
+  Len          r45, r44
+  Move         r28, r17
+  LessInt      r29, r28, r45
+  JumpIfFalse  r29, L11
+  Index        r14, r44, r28
+  Move         r6, r14
+  Index        r25, r6, r13
+  Append       r22, r43, r25
+  Move         r43, r22
+  AddInt       r28, r28, r34
+  Jump         L12
+  Sum          r32, r43
+  Move         r46, r9
+  Move         r47, r38
+  Move         r48, r39
+  Move         r49, r41
+  Move         r50, r42
+  Move         r51, r32
+  MakeMap      r19, 3, r46
+  // from inv in inventory
+  Append       r20, r4, r19
+  Move         r4, r20
+  AddInt       r36, r36, r34
+  Jump         L13
+  // var grouped: map<string, map<string, any>> = {}
+  Const        r21, {}
+  Move         r3, r21
+  // for m in monthly {
+  IterPrep     r18, r4
+  Len          r23, r18
+  Const        r26, 0
+  LessInt      r24, r26, r23
+  JumpIfFalse  r24, L5
+  Index        r10, r18, r26
+  Move         r30, r10
+  // let key = str({w: m.w, i: m.i})
+  Const        r31, "w"
+  Index        r33, r30, r5
+  Const        r35, "i"
+  Index        r2, r30, r7
+  Move         r46, r31
+  Move         r47, r33
+  Move         r48, r35
+  Move         r49, r2
+  MakeMap      r37, 2, r46
+  Str          r16, r37
+  // if key in grouped {
+  In           r8, r16, r3
+  JumpIfFalse  r8, L14
+  // let g = grouped[key]
+  Index        r27, r3, r16
+  // grouped[key] = {w: g.w, i: g.i, qtys: append(g.qtys, m.qty)}
+  Const        r11, "w"
+  Index        r40, r27, r5
+  Const        r17, "i"
+  Index        r45, r27, r7
+  Const        r29, "qtys"
+  Const        r44, "qtys"
+  Index        r14, r27, r44
+  Index        r13, r30, r12
+  Append       r6, r14, r13
+  Move         r52, r11
+  Move         r53, r40
+  Move         r54, r17
+  Move         r55, r45
+  Move         r56, r29
+  Move         r57, r6
+  MakeMap      r28, 3, r52
+  SetIndex     r3, r16, r28
+  // if key in grouped {
+  Jump         L1
+  // grouped[key] = {w: m.w, i: m.i, qtys: [m.qty]}
+  Const        r22, "w"
+  Index        r43, r30, r5
+  Const        r9, "i"
+  Index        r38, r30, r7
+  Const        r39, "qtys"
+  Index        r41, r30, r12
+  Move         r42, r41
+  MakeList     r32, 1, r42
+  Move         r58, r22
+  Move         r59, r43
+  Move         r60, r9
+  Move         r61, r38
+  Move         r62, r39
+  Move         r63, r32
+  MakeMap      r34, 3, r58
+  SetIndex     r3, r16, r34
+  // for m in monthly {
+  Const        r36, 1
+  AddInt       r50, r26, r36
+  Move         r26, r50
+  Jump         L15
+  // var summary = []
+  Move         r51, r15
   // for g in values(grouped) {
-  Const        r237, 1
-  Add          r196, r196, r237
-  Jump         L22
+  Const        r19, []
+  IterPrep     r20, r19
+  Len          r21, r20
+  Const        r4, 0
+  LessInt      r23, r4, r21
+  JumpIfFalse  r23, L16
+  Index        r24, r20, r4
+  Move         r1, r24
+  // let mean = avg(g.qtys)
+  Index        r18, r1, r44
+  Avg          r10, r18
+  // var sumsq = 0.0
+  Const        r31, 0.0
+  Move         r33, r31
+  // for q in g.qtys {
+  Index        r35, r1, r44
+  IterPrep     r2, r35
+  Len          r46, r2
+  Const        r47, 0
 L18:
+  LessInt      r48, r47, r46
+  JumpIfFalse  r48, L17
+  Index        r49, r2, r47
+  Move         r37, r49
+  // sumsq = sumsq + (q - mean) * (q - mean)
+  SubFloat     r8, r37, r10
+  SubFloat     r27, r37, r10
+  MulFloat     r14, r8, r27
+  AddFloat     r13, r33, r14
+  Move         r33, r13
+  // for q in g.qtys {
+  Const        r11, 1
+  AddInt       r40, r47, r11
+  Move         r47, r40
+  Jump         L18
+L17:
+  // let variance = sumsq / len(g.qtys)
+  Index        r17, r1, r44
+  Len          r45, r17
+  DivFloat     r29, r33, r45
+  // let cov = sqrt(variance) / mean
+  Move         r6, r29
+  Call         r28, sqrt, r6
+  DivFloat     r12, r28, r10
+  // if cov > 1.5 {
+  Const        r30, 1.5
+  LessFloat    r41, r30, r12
+  JumpIfFalse  r41, L19
+  // summary = append(summary, {w_warehouse_sk: g.w, i_item_sk: g.i, cov: cov})
+  Const        r25, "w_warehouse_sk"
+  Index        r42, r1, r5
+  Const        r22, "i_item_sk"
+  Index        r43, r1, r7
+  Const        r9, "cov"
+  Move         r58, r25
+  Move         r59, r42
+  Move         r60, r22
+  Move         r61, r43
+  Move         r62, r9
+  Move         r63, r12
+  MakeMap      r38, 3, r58
+  Append       r39, r51, r38
+  Move         r51, r39
+L19:
+  // for g in values(grouped) {
+  Const        r32, 1
+  AddInt       r3, r4, r32
+  Move         r4, r3
+  Jump         L20
+L16:
   // json(summary)
-  JSON         r192
+  JSON         r51
   // expect summary == [{w_warehouse_sk: 1, i_item_sk: 1, cov: 1.5396007178390022}]
-  Const        r239, [{"cov": 1.539600717839002, "i_item_sk": 1, "w_warehouse_sk": 1}]
-  Equal        r240, r192, r239
-  Expect       r240
+  Const        r16, [{"cov": 1.539600717839002, "i_item_sk": 1, "w_warehouse_sk": 1}]
+  Equal        r34, r51, r16
+  Expect       r34
   Return       r0
 
   // fun sqrt(x: float): float {
-func sqrt (regs=13)
+func sqrt (regs=6)
   // let guess = x / 2.0
-  Const        r1, 2
-  DivFloat     r3, r0, r1
+  Const        r1, 2.0
+  DivFloat     r2, r0, r1
+  // var result = guess
+  Move         r3, r2
   // for i in 0..5 {
-  Const        r4, 0
-  Const        r5, 5
-  Move         r6, r4
+  Const        r2, 0
+  Const        r4, 5
 L1:
-  Less         r7, r6, r5
-  JumpIfFalse  r7, L0
+  Move         r5, r2
+  LessInt      r2, r5, r4
+  JumpIfFalse  r2, L0
   // result = (result + x / result) / 2.0
-  DivFloat     r8, r0, r3
-  AddFloat     r9, r3, r8
-  DivFloat     r3, r9, r1
+  DivFloat     r4, r0, r3
+  AddFloat     r2, r3, r4
+  DivFloat     r4, r2, r1
+  Move         r3, r4
   // for i in 0..5 {
-  Const        r11, 1
-  Add          r6, r6, r11
+  Const        r1, 1
+  AddInt       r2, r5, r1
+  Move         r5, r2
   Jump         L1
 L0:
   // return result


### PR DESCRIPTION
## Summary
- support nested struct field access when building row maps
- refresh IR outputs for TPC-DS queries q30–q39

## Testing
- `gofmt -w runtime/vm/vm.go`


------
https://chatgpt.com/codex/tasks/task_e_68632d233b188320b93d2b7015d3d218