### PR TITLE
Fix numeric string float parsing and refresh IR

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6897,13 +6897,8 @@ func toFloat(v Value) float64 {
 		if f, err := strconv.ParseFloat(v.Str, 64); err == nil {
 			return f
 		}
-	}
-	if v.Tag == ValueStr {
-		if f, err := strconv.ParseFloat(v.Str, 64); err == nil {
-			return f
-		}
-	}
-	if v.Tag == ValueNull {
+		return 0
+	case ValueNull:
 		return 0
 	}
 	return float64(v.Int)

--- a/tests/dataset/tpc-ds/out/q80.ir.out
+++ b/tests/dataset/tpc-ds/out/q80.ir.out
@@ -77,3 +77,4 @@ L4:
   EqualFloat   r46, r44, r45
   Expect       r46
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q81.ir.out
+++ b/tests/dataset/tpc-ds/out/q81.ir.out
@@ -162,3 +162,4 @@ L10:
   EqualFloat   r95, r93, r94
   Expect       r95
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q82.ir.out
+++ b/tests/dataset/tpc-ds/out/q82.ir.out
@@ -56,3 +56,4 @@ L0:
   Equal        r28, r3, r27
   Expect       r28
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q83.ir.out
+++ b/tests/dataset/tpc-ds/out/q83.ir.out
@@ -70,3 +70,4 @@ L4:
   Equal        r37, r35, r36
   Expect       r37
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q84.ir.out
+++ b/tests/dataset/tpc-ds/out/q84.ir.out
@@ -22,3 +22,4 @@ func main (regs=11)
   Const        r10, true
   Expect       r10
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q85.ir.out
+++ b/tests/dataset/tpc-ds/out/q85.ir.out
@@ -28,3 +28,4 @@ L0:
   EqualFloat   r15, r13, r14
   Expect       r15
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q86.ir.out
+++ b/tests/dataset/tpc-ds/out/q86.ir.out
@@ -48,3 +48,4 @@ L0:
   EqualFloat   r24, r22, r23
   Expect       r24
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q87.ir.out
+++ b/tests/dataset/tpc-ds/out/q87.ir.out
@@ -73,3 +73,4 @@ L0:
 func to_list (regs=1)
   // fun to_list(xs: list<any>): list<any> { return xs }
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q88.ir.out
+++ b/tests/dataset/tpc-ds/out/q88.ir.out
@@ -11,3 +11,4 @@ func main (regs=4)
   Const        r3, true
   Expect       r3
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q89.ir.out
+++ b/tests/dataset/tpc-ds/out/q89.ir.out
@@ -28,3 +28,4 @@ L0:
   EqualFloat   r15, r13, r14
   Expect       r15
   Return       r0
+


### PR DESCRIPTION
## Summary
- handle numeric strings in `toFloat` only once
- refresh TPC‑DS IR files q80–q89

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686331effe648320bfde82a0d60427f0