### PR TITLE
Enhance VM recursion safety

### DIFF
--- a/tests/dataset/tpc-ds/out/q72.ir.out
+++ b/tests/dataset/tpc-ds/out/q72.ir.out
@@ -1,4 +1,4 @@
-func main (regs=276)
+func main (regs=271)
   // let catalog_sales = [
   Const        r0, [{"cs_bill_cdemo_sk": 1, "cs_bill_hdemo_sk": 1, "cs_item_sk": 1, "cs_order_number": 1, "cs_promo_sk": nil, "cs_quantity": 1, "cs_ship_date_sk": 3, "cs_sold_date_sk": 1}]
   // let inventory = [
@@ -49,7 +49,7 @@ func main (regs=276)
   IterPrep     r28, r0
   Len          r29, r28
   Const        r30, 0
-L24:
+L20:
   LessInt      r31, r30, r29
   JumpIfFalse  r31, L0
   Index        r32, r28, r30
@@ -58,7 +58,7 @@ L24:
   IterPrep     r34, r1
   Len          r35, r34
   Const        r36, 0
-L23:
+L19:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L1
   Index        r38, r34, r36
@@ -73,7 +73,7 @@ L23:
   IterPrep     r45, r2
   Len          r46, r45
   Const        r47, 0
-L22:
+L18:
   LessInt      r48, r47, r46
   JumpIfFalse  r48, L2
   Index        r49, r45, r47
@@ -88,7 +88,7 @@ L22:
   IterPrep     r56, r3
   Len          r57, r56
   Const        r58, 0
-L21:
+L17:
   LessInt      r59, r58, r57
   JumpIfFalse  r59, L3
   Index        r60, r56, r58
@@ -102,7 +102,7 @@ L21:
   IterPrep     r66, r4
   Len          r67, r66
   Const        r68, 0
-L20:
+L16:
   LessInt      r69, r68, r67
   JumpIfFalse  r69, L4
   Index        r70, r66, r68
@@ -117,7 +117,7 @@ L20:
   IterPrep     r77, r5
   Len          r78, r77
   Const        r79, 0
-L19:
+L15:
   LessInt      r80, r79, r78
   JumpIfFalse  r80, L5
   Index        r81, r77, r79
@@ -132,7 +132,7 @@ L19:
   IterPrep     r88, r6
   Len          r89, r88
   Const        r90, 0
-L18:
+L14:
   LessInt      r91, r90, r89
   JumpIfFalse  r91, L6
   Index        r92, r88, r90
@@ -147,7 +147,7 @@ L18:
   IterPrep     r99, r6
   Len          r100, r99
   Const        r101, 0
-L17:
+L13:
   LessInt      r102, r101, r100
   JumpIfFalse  r102, L7
   Index        r103, r99, r101
@@ -161,7 +161,7 @@ L17:
   IterPrep     r109, r6
   Len          r110, r109
   Const        r111, 0
-L16:
+L12:
   LessInt      r112, r111, r110
   JumpIfFalse  r112, L8
   Index        r113, r109, r111
@@ -203,48 +203,44 @@ L16:
   Move         r139, r129
   JumpIfFalse  r139, L10
   Move         r139, r125
-L10:
   // inv.inv_quantity_on_hand < cs.cs_quantity &&
-  Move         r140, r139
-  JumpIfFalse  r140, L11
-  Move         r140, r127
-L11:
+  JumpIfFalse  r139, L10
+  Move         r139, r127
   // d3.d_date > d1.d_date + 5 &&
-  Move         r141, r140
-  JumpIfFalse  r141, L12
-  Move         r141, r132
-L12:
+  JumpIfFalse  r139, L10
+  Move         r139, r132
   // hd.hd_buy_potential == "5001-10000" &&
-  Move         r142, r141
-  JumpIfFalse  r142, L13
-  Move         r142, r135
-L13:
+  JumpIfFalse  r139, L10
+  Move         r139, r135
   // d1.d_year == 2000 &&
-  Move         r143, r142
-  JumpIfFalse  r143, L14
-  Move         r143, r138
-L14:
+  JumpIfFalse  r139, L10
+  Move         r139, r138
+L10:
   // where d1.d_week_seq == d2.d_week_seq &&
-  JumpIfFalse  r143, L9
+  JumpIfFalse  r139, L9
   // from cs in catalog_sales
-  Const        r144, "cs"
-  Move         r145, r33
-  Const        r146, "inv"
-  Move         r147, r39
-  Const        r148, "w"
-  Move         r149, r50
-  Const        r150, "i"
-  Move         r151, r61
-  Const        r152, "cd"
-  Move         r153, r71
-  Const        r154, "hd"
-  Move         r155, r82
-  Const        r156, "d1"
-  Move         r157, r93
-  Const        r158, "d2"
-  Move         r159, r104
-  Const        r160, "d3"
-  Move         r161, r114
+  Const        r140, "cs"
+  Move         r141, r33
+  Const        r142, "inv"
+  Move         r143, r39
+  Const        r144, "w"
+  Move         r145, r50
+  Const        r146, "i"
+  Move         r147, r61
+  Const        r148, "cd"
+  Move         r149, r71
+  Const        r150, "hd"
+  Move         r151, r82
+  Const        r152, "d1"
+  Move         r153, r93
+  Const        r154, "d2"
+  Move         r155, r104
+  Const        r156, "d3"
+  Move         r157, r114
+  Move         r158, r140
+  Move         r159, r141
+  Move         r160, r142
+  Move         r161, r143
   Move         r162, r144
   Move         r163, r145
   Move         r164, r146
@@ -259,193 +255,187 @@ L14:
   Move         r173, r155
   Move         r174, r156
   Move         r175, r157
-  Move         r176, r158
-  Move         r177, r159
-  Move         r178, r160
-  Move         r179, r161
-  MakeMap      r180, 9, r162
+  MakeMap      r176, 9, r158
   // group by { item_desc: i.i_item_desc, warehouse: w.w_warehouse_name, week_seq: d1.d_week_seq } into g
-  Const        r181, "item_desc"
-  Index        r182, r61, r9
-  Const        r183, "warehouse"
-  Index        r184, r50, r11
-  Const        r185, "week_seq"
-  Index        r186, r93, r13
+  Const        r177, "item_desc"
+  Index        r178, r61, r9
+  Const        r179, "warehouse"
+  Index        r180, r50, r11
+  Const        r181, "week_seq"
+  Index        r182, r93, r13
+  Move         r183, r177
+  Move         r184, r178
+  Move         r185, r179
+  Move         r186, r180
   Move         r187, r181
   Move         r188, r182
-  Move         r189, r183
-  Move         r190, r184
-  Move         r191, r185
-  Move         r192, r186
-  MakeMap      r193, 3, r187
-  Str          r194, r193
-  In           r195, r194, r25
-  JumpIfTrue   r195, L15
+  MakeMap      r189, 3, r183
+  Str          r190, r189
+  In           r191, r190, r25
+  JumpIfTrue   r191, L11
   // from cs in catalog_sales
-  Const        r196, []
-  Const        r197, "__group__"
-  Const        r198, true
+  Const        r192, "__group__"
+  Const        r193, true
   // group by { item_desc: i.i_item_desc, warehouse: w.w_warehouse_name, week_seq: d1.d_week_seq } into g
-  Move         r199, r193
+  Move         r194, r189
   // from cs in catalog_sales
-  Const        r200, "items"
-  Move         r201, r196
-  Const        r202, "count"
-  Const        r203, 0
-  Move         r204, r197
-  Move         r205, r198
-  Move         r206, r20
-  Move         r207, r199
-  Move         r208, r200
-  Move         r209, r201
-  Move         r210, r202
-  Move         r211, r203
-  MakeMap      r212, 4, r204
-  SetIndex     r25, r194, r212
-  Append       r213, r26, r212
-  Move         r26, r213
-L15:
-  Index        r214, r25, r194
-  Index        r215, r214, r200
-  Append       r216, r215, r180
-  SetIndex     r214, r200, r216
-  Index        r217, r214, r202
-  Const        r218, 1
-  AddInt       r219, r217, r218
-  SetIndex     r214, r202, r219
+  Const        r195, "items"
+  Move         r196, r27
+  Const        r197, "count"
+  Const        r198, 0
+  Move         r199, r192
+  Move         r200, r193
+  Move         r201, r20
+  Move         r202, r194
+  Move         r203, r195
+  Move         r204, r196
+  Move         r205, r197
+  Move         r206, r198
+  MakeMap      r207, 4, r199
+  SetIndex     r25, r190, r207
+  Append       r208, r26, r207
+  Move         r26, r208
+L11:
+  Index        r209, r25, r190
+  Index        r210, r209, r195
+  Append       r211, r210, r176
+  SetIndex     r209, r195, r211
+  Index        r212, r209, r197
+  Const        r213, 1
+  AddInt       r214, r212, r213
+  SetIndex     r209, r197, r214
 L9:
   // join d3 in date_dim on d3.d_date_sk == cs.cs_ship_date_sk
-  AddInt       r111, r111, r218
-  Jump         L16
+  AddInt       r111, r111, r213
+  Jump         L12
 L8:
   // join d2 in date_dim on d2.d_date_sk == inv.inv_date_sk
-  AddInt       r101, r101, r218
-  Jump         L17
+  AddInt       r101, r101, r213
+  Jump         L13
 L7:
   // join d1 in date_dim on d1.d_date_sk == cs.cs_sold_date_sk
-  AddInt       r90, r90, r218
-  Jump         L18
+  AddInt       r90, r90, r213
+  Jump         L14
 L6:
   // join hd in household_demographics on hd.hd_demo_sk == cs.cs_bill_hdemo_sk
-  AddInt       r79, r79, r218
-  Jump         L19
+  AddInt       r79, r79, r213
+  Jump         L15
 L5:
   // join cd in customer_demographics on cd.cd_demo_sk == cs.cs_bill_cdemo_sk
-  AddInt       r68, r68, r218
-  Jump         L20
+  AddInt       r68, r68, r213
+  Jump         L16
 L4:
   // join i in item on i.i_item_sk == cs.cs_item_sk
-  AddInt       r58, r58, r218
-  Jump         L21
+  AddInt       r58, r58, r213
+  Jump         L17
 L3:
   // join w in warehouse on w.w_warehouse_sk == inv.inv_warehouse_sk
-  AddInt       r47, r47, r218
-  Jump         L22
+  AddInt       r47, r47, r213
+  Jump         L18
 L2:
   // join inv in inventory on inv.inv_item_sk == cs.cs_item_sk
-  AddInt       r36, r36, r218
-  Jump         L23
+  AddInt       r36, r36, r213
+  Jump         L19
 L1:
   // from cs in catalog_sales
-  AddInt       r30, r30, r218
-  Jump         L24
+  AddInt       r30, r30, r213
+  Jump         L20
 L0:
-  Move         r220, r203
-  Len          r221, r26
-L32:
-  LessInt      r222, r220, r221
-  JumpIfFalse  r222, L25
-  Index        r223, r26, r220
-  Move         r224, r223
-  // i_item_desc: g.key.item_desc,
-  Const        r225, "i_item_desc"
-  Index        r226, r224, r20
-  Index        r227, r226, r8
-  // w_warehouse_name: g.key.warehouse,
-  Const        r228, "w_warehouse_name"
-  Index        r229, r224, r20
-  Index        r230, r229, r10
-  // d_week_seq: g.key.week_seq,
-  Const        r231, "d_week_seq"
-  Index        r232, r224, r20
-  Index        r233, r232, r12
-  // no_promo: count(from x in g where x.cs_promo_sk == null select x),
-  Const        r234, "no_promo"
-  Const        r235, []
-  IterPrep     r236, r224
-  Len          r237, r236
-  Move         r238, r203
+  Move         r215, r198
+  Len          r216, r26
 L28:
-  LessInt      r239, r238, r237
-  JumpIfFalse  r239, L26
-  Index        r240, r236, r238
-  Move         r241, r240
-  Index        r242, r241, r22
-  Const        r243, nil
-  Equal        r244, r242, r243
-  JumpIfFalse  r244, L27
-  Append       r245, r235, r241
-  Move         r235, r245
-L27:
-  AddInt       r238, r238, r218
-  Jump         L28
-L26:
-  Count        r246, r235
-  // promo: count(from x in g where x.cs_promo_sk != null select x),
-  Const        r247, "promo"
-  Const        r248, []
-  IterPrep     r249, r224
-  Len          r250, r249
-  Move         r251, r203
-L31:
-  LessInt      r252, r251, r250
-  JumpIfFalse  r252, L29
-  Index        r253, r249, r251
-  Move         r241, r253
-  Index        r254, r241, r22
-  NotEqual     r255, r254, r243
-  JumpIfFalse  r255, L30
-  Append       r256, r248, r241
-  Move         r248, r256
-L30:
-  AddInt       r251, r251, r218
-  Jump         L31
-L29:
-  Count        r257, r248
-  // total_cnt: count(g)
-  Const        r258, "total_cnt"
-  Index        r259, r224, r202
+  LessInt      r217, r215, r216
+  JumpIfFalse  r217, L21
+  Index        r218, r26, r215
+  Move         r219, r218
   // i_item_desc: g.key.item_desc,
-  Move         r260, r225
-  Move         r261, r227
+  Const        r220, "i_item_desc"
+  Index        r221, r219, r20
+  Index        r222, r221, r8
   // w_warehouse_name: g.key.warehouse,
-  Move         r262, r228
-  Move         r263, r230
+  Const        r223, "w_warehouse_name"
+  Index        r224, r219, r20
+  Index        r225, r224, r10
   // d_week_seq: g.key.week_seq,
-  Move         r264, r231
-  Move         r265, r233
+  Const        r226, "d_week_seq"
+  Index        r227, r219, r20
+  Index        r228, r227, r12
   // no_promo: count(from x in g where x.cs_promo_sk == null select x),
-  Move         r266, r234
-  Move         r267, r246
+  Const        r229, "no_promo"
+  Const        r230, []
+  IterPrep     r231, r219
+  Len          r232, r231
+  Move         r233, r198
+L24:
+  LessInt      r234, r233, r232
+  JumpIfFalse  r234, L22
+  Index        r235, r231, r233
+  Move         r236, r235
+  Index        r237, r236, r22
+  Const        r238, nil
+  Equal        r239, r237, r238
+  JumpIfFalse  r239, L23
+  Append       r240, r230, r236
+  Move         r230, r240
+L23:
+  AddInt       r233, r233, r213
+  Jump         L24
+L22:
+  Count        r241, r230
   // promo: count(from x in g where x.cs_promo_sk != null select x),
-  Move         r268, r247
-  Move         r269, r257
-  // total_cnt: count(g)
-  Move         r270, r258
-  Move         r271, r259
-  // select {
-  MakeMap      r272, 6, r260
-  // from cs in catalog_sales
-  Append       r273, r7, r272
-  Move         r7, r273
-  AddInt       r220, r220, r218
-  Jump         L32
+  Const        r242, "promo"
+  Const        r243, []
+  IterPrep     r244, r219
+  Len          r245, r244
+  Move         r246, r198
+L27:
+  LessInt      r247, r246, r245
+  JumpIfFalse  r247, L25
+  Index        r248, r244, r246
+  Move         r236, r248
+  Index        r249, r236, r22
+  NotEqual     r250, r249, r238
+  JumpIfFalse  r250, L26
+  Append       r251, r243, r236
+  Move         r243, r251
+L26:
+  AddInt       r246, r246, r213
+  Jump         L27
 L25:
+  Count        r252, r243
+  // total_cnt: count(g)
+  Const        r253, "total_cnt"
+  Index        r254, r219, r197
+  // i_item_desc: g.key.item_desc,
+  Move         r255, r220
+  Move         r256, r222
+  // w_warehouse_name: g.key.warehouse,
+  Move         r257, r223
+  Move         r258, r225
+  // d_week_seq: g.key.week_seq,
+  Move         r259, r226
+  Move         r260, r228
+  // no_promo: count(from x in g where x.cs_promo_sk == null select x),
+  Move         r261, r229
+  Move         r262, r241
+  // promo: count(from x in g where x.cs_promo_sk != null select x),
+  Move         r263, r242
+  Move         r264, r252
+  // total_cnt: count(g)
+  Move         r265, r253
+  Move         r266, r254
+  // select {
+  MakeMap      r267, 6, r255
+  // from cs in catalog_sales
+  Append       r268, r7, r267
+  Move         r7, r268
+  AddInt       r215, r215, r213
+  Jump         L28
+L21:
   // json(result)
   JSON         r7
   // expect result == [
-  Const        r274, [{"d_week_seq": 10, "i_item_desc": "ItemA", "no_promo": 1, "promo": 0, "total_cnt": 1, "w_warehouse_name": "Main"}]
-  Equal        r275, r7, r274
-  Expect       r275
+  Const        r269, [{"d_week_seq": 10, "i_item_desc": "ItemA", "no_promo": 1, "promo": 0, "total_cnt": 1, "w_warehouse_name": "Main"}]
+  Equal        r270, r7, r269
+  Expect       r270
   Return       r0
-

--- a/tests/dataset/tpc-ds/out/q73.ir.out
+++ b/tests/dataset/tpc-ds/out/q73.ir.out
@@ -1,4 +1,4 @@
-func main (regs=231)
+func main (regs=224)
   // let store_sales = [
   Const        r0, [{"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}]
   // let date_dim = [
@@ -38,7 +38,7 @@ func main (regs=231)
   IterPrep     r21, r0
   Len          r22, r21
   Const        r23, 0
-L18:
+L12:
   LessInt      r24, r23, r22
   JumpIfFalse  r24, L0
   Index        r25, r21, r23
@@ -47,7 +47,7 @@ L18:
   IterPrep     r27, r1
   Len          r28, r27
   Const        r29, 0
-L17:
+L11:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L1
   Index        r31, r27, r29
@@ -62,7 +62,7 @@ L17:
   IterPrep     r38, r2
   Len          r39, r38
   Const        r40, 0
-L16:
+L10:
   LessInt      r41, r40, r39
   JumpIfFalse  r41, L2
   Index        r42, r38, r40
@@ -77,7 +77,7 @@ L16:
   IterPrep     r49, r3
   Len          r50, r49
   Const        r51, 0
-L15:
+L9:
   LessInt      r52, r51, r50
   JumpIfFalse  r52, L3
   Index        r53, r49, r51
@@ -114,7 +114,7 @@ L15:
   Move         r76, r65
   JumpIfFalse  r76, L5
   Move         r76, r68
-L5:
+  JumpIfFalse  r76, L5
   // (hd.hd_buy_potential == "1001-5000" || hd.hd_buy_potential == "0-500") &&
   Index        r77, r54, r11
   Const        r78, "1001-5000"
@@ -127,267 +127,254 @@ L5:
   Move         r83, r82
 L6:
   // where d.d_dom >= 1 && d.d_dom <= 2 &&
-  Move         r84, r76
-  JumpIfFalse  r84, L7
-  Move         r84, r83
-L7:
+  Move         r76, r83
   // (hd.hd_buy_potential == "1001-5000" || hd.hd_buy_potential == "0-500") &&
-  Move         r85, r84
-  JumpIfFalse  r85, L8
-  Move         r85, r71
-L8:
+  JumpIfFalse  r76, L5
+  Move         r76, r71
   // hd.hd_vehicle_count > 0 &&
-  Move         r86, r85
-  JumpIfFalse  r86, L9
-  Move         r86, r72
-L9:
+  JumpIfFalse  r76, L5
+  Move         r76, r72
+  // hd.hd_dep_count / hd.hd_vehicle_count > 1 &&
+  JumpIfFalse  r76, L5
   // (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
+  Index        r84, r32, r14
+  Const        r85, 1998
+  Equal        r86, r84, r85
   Index        r87, r32, r14
-  Const        r88, 1998
+  Const        r88, 1999
   Equal        r89, r87, r88
   Index        r90, r32, r14
-  Const        r91, 1999
+  Const        r91, 2000
   Equal        r92, r90, r91
-  Index        r93, r32, r14
-  Const        r94, 2000
-  Equal        r95, r93, r94
-  Move         r96, r89
-  JumpIfTrue   r96, L10
-  Move         r96, r92
-L10:
-  Move         r97, r96
-  JumpIfTrue   r97, L11
-  Move         r97, r95
-L11:
+  Move         r93, r86
+  JumpIfTrue   r93, L7
+  Move         r93, r89
+  JumpIfTrue   r93, L7
+  Move         r93, r92
+L7:
   // hd.hd_dep_count / hd.hd_vehicle_count > 1 &&
-  Move         r98, r86
-  JumpIfFalse  r98, L12
-  Move         r98, r97
-L12:
+  Move         r76, r93
   // (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
-  Move         r99, r98
-  JumpIfFalse  r99, L13
-  Move         r99, r75
-L13:
+  JumpIfFalse  r76, L5
+  Move         r76, r75
+L5:
   // where d.d_dom >= 1 && d.d_dom <= 2 &&
-  JumpIfFalse  r99, L4
+  JumpIfFalse  r76, L4
   // from ss in store_sales
-  Const        r100, "ss"
-  Move         r101, r26
-  Const        r102, "d"
-  Move         r103, r32
-  Const        r104, "s"
-  Move         r105, r43
-  Const        r106, "hd"
-  Move         r107, r54
+  Const        r94, "ss"
+  Move         r95, r26
+  Const        r96, "d"
+  Move         r97, r32
+  Const        r98, "s"
+  Move         r99, r43
+  Const        r100, "hd"
+  Move         r101, r54
+  Move         r102, r94
+  Move         r103, r95
+  Move         r104, r96
+  Move         r105, r97
+  Move         r106, r98
+  Move         r107, r99
   Move         r108, r100
   Move         r109, r101
-  Move         r110, r102
-  Move         r111, r103
-  Move         r112, r104
-  Move         r113, r105
-  Move         r114, r106
-  Move         r115, r107
-  MakeMap      r116, 4, r108
+  MakeMap      r110, 4, r102
   // group by { ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk } into g
-  Const        r117, "ticket"
-  Index        r118, r26, r7
-  Const        r119, "cust"
-  Index        r120, r26, r9
-  Move         r121, r117
-  Move         r122, r118
-  Move         r123, r119
-  Move         r124, r120
-  MakeMap      r125, 2, r121
-  Str          r126, r125
-  In           r127, r126, r18
-  JumpIfTrue   r127, L14
+  Const        r111, "ticket"
+  Index        r112, r26, r7
+  Const        r113, "cust"
+  Index        r114, r26, r9
+  Move         r115, r111
+  Move         r116, r112
+  Move         r117, r113
+  Move         r118, r114
+  MakeMap      r119, 2, r115
+  Str          r120, r119
+  In           r121, r120, r18
+  JumpIfTrue   r121, L8
   // from ss in store_sales
-  Const        r128, []
-  Const        r129, "__group__"
-  Const        r130, true
+  Const        r122, "__group__"
+  Const        r123, true
   // group by { ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk } into g
-  Move         r131, r125
+  Move         r124, r119
   // from ss in store_sales
-  Const        r132, "items"
-  Move         r133, r128
-  Const        r134, "count"
-  Move         r135, r129
-  Move         r136, r130
-  Move         r137, r16
-  Move         r138, r131
-  Move         r139, r132
-  Move         r140, r133
-  Move         r141, r134
-  Move         r142, r70
-  MakeMap      r143, 4, r135
-  SetIndex     r18, r126, r143
-  Append       r144, r19, r143
-  Move         r19, r144
-L14:
-  Index        r145, r18, r126
-  Index        r146, r145, r132
-  Append       r147, r146, r116
-  SetIndex     r145, r132, r147
-  Index        r148, r145, r134
-  AddInt       r149, r148, r64
-  SetIndex     r145, r134, r149
+  Const        r125, "items"
+  Move         r126, r20
+  Const        r127, "count"
+  Move         r128, r122
+  Move         r129, r123
+  Move         r130, r16
+  Move         r131, r124
+  Move         r132, r125
+  Move         r133, r126
+  Move         r134, r127
+  Move         r135, r70
+  MakeMap      r136, 4, r128
+  SetIndex     r18, r120, r136
+  Append       r137, r19, r136
+  Move         r19, r137
+L8:
+  Index        r138, r18, r120
+  Index        r139, r138, r125
+  Append       r140, r139, r110
+  SetIndex     r138, r125, r140
+  Index        r141, r138, r127
+  AddInt       r142, r141, r64
+  SetIndex     r138, r127, r142
 L4:
   // join hd in household_demographics on hd.hd_demo_sk == ss.ss_hdemo_sk
   AddInt       r51, r51, r64
-  Jump         L15
+  Jump         L9
 L3:
   // join s in store on s.s_store_sk == ss.ss_store_sk
   AddInt       r40, r40, r64
-  Jump         L16
+  Jump         L10
 L2:
   // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
   AddInt       r29, r29, r64
-  Jump         L17
+  Jump         L11
 L1:
   // from ss in store_sales
   AddInt       r23, r23, r64
-  Jump         L18
+  Jump         L12
 L0:
-  Move         r150, r70
-  Len          r151, r19
-L20:
-  LessInt      r152, r150, r151
-  JumpIfFalse  r152, L19
-  Index        r153, r19, r150
-  Move         r154, r153
+  Move         r143, r70
+  Len          r144, r19
+L14:
+  LessInt      r145, r143, r144
+  JumpIfFalse  r145, L13
+  Index        r146, r19, r143
+  Move         r147, r146
   // select { key: g.key, cnt: count(g) }
-  Const        r155, "key"
-  Index        r156, r154, r16
-  Const        r157, "cnt"
-  Index        r158, r154, r134
-  Move         r159, r155
-  Move         r160, r156
-  Move         r161, r157
-  Move         r162, r158
-  MakeMap      r163, 2, r159
+  Const        r148, "key"
+  Index        r149, r147, r16
+  Const        r150, "cnt"
+  Index        r151, r147, r127
+  Move         r152, r148
+  Move         r153, r149
+  Move         r154, r150
+  Move         r155, r151
+  MakeMap      r156, 2, r152
   // from ss in store_sales
-  Append       r164, r5, r163
-  Move         r5, r164
-  AddInt       r150, r150, r64
-  Jump         L20
+  Append       r157, r5, r156
+  Move         r5, r157
+  AddInt       r143, r143, r64
+  Jump         L14
+L13:
+  // from g in groups
+  Const        r158, []
+  IterPrep     r159, r5
+  Len          r160, r159
+  // join c in customer on c.c_customer_sk == g.key.cust
+  IterPrep     r161, r4
+  Len          r162, r161
+  Const        r163, "c_customer_sk"
+  // c_last_name: c.c_last_name,
+  Const        r164, "c_last_name"
+  // c_first_name: c.c_first_name,
+  Const        r165, "c_first_name"
+  // c_salutation: c.c_salutation,
+  Const        r166, "c_salutation"
+  // c_preferred_cust_flag: c.c_preferred_cust_flag,
+  Const        r167, "c_preferred_cust_flag"
+  // from g in groups
+  Const        r168, 0
+L20:
+  LessInt      r169, r168, r160
+  JumpIfFalse  r169, L15
+  Index        r170, r159, r168
+  Move         r147, r170
+  // join c in customer on c.c_customer_sk == g.key.cust
+  Const        r171, 0
 L19:
-  // from g in groups
-  Const        r165, []
-  IterPrep     r166, r5
-  Len          r167, r166
-  // join c in customer on c.c_customer_sk == g.key.cust
-  IterPrep     r168, r4
-  Len          r169, r168
-  Const        r170, "c_customer_sk"
-  // c_last_name: c.c_last_name,
-  Const        r171, "c_last_name"
-  // c_first_name: c.c_first_name,
-  Const        r172, "c_first_name"
-  // c_salutation: c.c_salutation,
-  Const        r173, "c_salutation"
-  // c_preferred_cust_flag: c.c_preferred_cust_flag,
-  Const        r174, "c_preferred_cust_flag"
-  // from g in groups
-  Const        r175, 0
-L26:
-  LessInt      r176, r175, r167
-  JumpIfFalse  r176, L21
-  Index        r177, r166, r175
-  Move         r154, r177
-  // join c in customer on c.c_customer_sk == g.key.cust
-  Const        r178, 0
-L25:
-  LessInt      r179, r178, r169
-  JumpIfFalse  r179, L22
-  Index        r180, r168, r178
-  Move         r181, r180
-  Index        r182, r181, r170
-  Index        r183, r154, r16
-  Index        r184, r183, r8
-  Equal        r185, r182, r184
-  JumpIfFalse  r185, L23
+  LessInt      r172, r171, r162
+  JumpIfFalse  r172, L16
+  Index        r173, r161, r171
+  Move         r174, r173
+  Index        r175, r174, r163
+  Index        r176, r147, r16
+  Index        r177, r176, r8
+  Equal        r178, r175, r177
+  JumpIfFalse  r178, L17
   // where g.cnt >= 1 && g.cnt <= 5
-  Index        r186, r154, r17
-  LessEq       r187, r64, r186
-  Index        r188, r154, r17
-  Const        r189, 5
-  LessEq       r190, r188, r189
-  Move         r191, r187
-  JumpIfFalse  r191, L24
-  Move         r191, r190
-L24:
-  JumpIfFalse  r191, L23
+  Index        r179, r147, r17
+  LessEq       r180, r64, r179
+  Index        r181, r147, r17
+  Const        r182, 5
+  LessEq       r183, r181, r182
+  Move         r184, r180
+  JumpIfFalse  r184, L18
+  Move         r184, r183
+L18:
+  JumpIfFalse  r184, L17
   // c_last_name: c.c_last_name,
-  Const        r192, "c_last_name"
-  Index        r193, r181, r171
+  Const        r185, "c_last_name"
+  Index        r186, r174, r164
   // c_first_name: c.c_first_name,
-  Const        r194, "c_first_name"
-  Index        r195, r181, r172
+  Const        r187, "c_first_name"
+  Index        r188, r174, r165
   // c_salutation: c.c_salutation,
-  Const        r196, "c_salutation"
-  Index        r197, r181, r173
+  Const        r189, "c_salutation"
+  Index        r190, r174, r166
   // c_preferred_cust_flag: c.c_preferred_cust_flag,
-  Const        r198, "c_preferred_cust_flag"
-  Index        r199, r181, r174
+  Const        r191, "c_preferred_cust_flag"
+  Index        r192, r174, r167
   // ss_ticket_number: g.key.ticket,
-  Const        r200, "ss_ticket_number"
-  Index        r201, r154, r16
-  Index        r202, r201, r6
+  Const        r193, "ss_ticket_number"
+  Index        r194, r147, r16
+  Index        r195, r194, r6
   // cnt: g.cnt
-  Const        r203, "cnt"
-  Index        r204, r154, r17
+  Const        r196, "cnt"
+  Index        r197, r147, r17
   // c_last_name: c.c_last_name,
+  Move         r198, r185
+  Move         r199, r186
+  // c_first_name: c.c_first_name,
+  Move         r200, r187
+  Move         r201, r188
+  // c_salutation: c.c_salutation,
+  Move         r202, r189
+  Move         r203, r190
+  // c_preferred_cust_flag: c.c_preferred_cust_flag,
+  Move         r204, r191
   Move         r205, r192
-  Move         r206, r193
-  // c_first_name: c.c_first_name,
-  Move         r207, r194
-  Move         r208, r195
-  // c_salutation: c.c_salutation,
-  Move         r209, r196
-  Move         r210, r197
-  // c_preferred_cust_flag: c.c_preferred_cust_flag,
-  Move         r211, r198
-  Move         r212, r199
   // ss_ticket_number: g.key.ticket,
-  Move         r213, r200
-  Move         r214, r202
+  Move         r206, r193
+  Move         r207, r195
   // cnt: g.cnt
-  Move         r215, r203
-  Move         r216, r204
+  Move         r208, r196
+  Move         r209, r197
   // select {
-  MakeMap      r217, 6, r205
+  MakeMap      r210, 6, r198
   // sort by [-g.cnt, c.c_last_name]
-  Index        r218, r154, r17
-  Neg          r219, r218
-  Move         r220, r219
-  Index        r221, r181, r171
-  Move         r222, r221
-  MakeList     r223, 2, r220
-  Move         r224, r223
+  Index        r211, r147, r17
+  Neg          r212, r211
+  Move         r213, r212
+  Index        r214, r174, r164
+  Move         r215, r214
+  MakeList     r216, 2, r213
+  Move         r217, r216
   // from g in groups
-  Move         r225, r217
-  MakeList     r226, 2, r224
-  Append       r227, r165, r226
-  Move         r165, r227
-L23:
+  Move         r218, r210
+  MakeList     r219, 2, r217
+  Append       r220, r158, r219
+  Move         r158, r220
+L17:
   // join c in customer on c.c_customer_sk == g.key.cust
-  AddInt       r178, r178, r64
-  Jump         L25
-L22:
+  AddInt       r171, r171, r64
+  Jump         L19
+L16:
   // from g in groups
-  AddInt       r175, r175, r64
-  Jump         L26
-L21:
+  AddInt       r168, r168, r64
+  Jump         L20
+L15:
   // sort by [-g.cnt, c.c_last_name]
-  Sort         r228, r165
+  Sort         r221, r158
   // from g in groups
-  Move         r165, r228
+  Move         r158, r221
   // json(result)
-  JSON         r165
+  JSON         r158
   // expect result == [
-  Const        r229, [{"c_first_name": "Alice", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Ms.", "cnt": 1, "ss_ticket_number": 1}]
-  Equal        r230, r165, r229
-  Expect       r230
+  Const        r222, [{"c_first_name": "Alice", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Ms.", "cnt": 1, "ss_ticket_number": 1}]
+  Equal        r223, r158, r222
+  Expect       r223
   Return       r0
-

--- a/tests/dataset/tpc-ds/out/q74.ir.out
+++ b/tests/dataset/tpc-ds/out/q74.ir.out
@@ -1,12 +1,12 @@
-func main (regs=369)
+func main (regs=366)
   // let customer = [
   Const        r0, [{"c_customer_id": 1, "c_customer_sk": 1, "c_first_name": "Alice", "c_last_name": "Smith"}]
   // let date_dim = [
   Const        r1, [{"d_date_sk": 1, "d_year": 1998}, {"d_date_sk": 2, "d_year": 1999}]
   // let store_sales = [
-  Const        r2, [{"ss_customer_sk": 1, "ss_net_paid": 100, "ss_sold_date_sk": 1}, {"ss_customer_sk": 1, "ss_net_paid": 110, "ss_sold_date_sk": 2}]
+  Const        r2, [{"ss_customer_sk": 1, "ss_net_paid": 100.0, "ss_sold_date_sk": 1}, {"ss_customer_sk": 1, "ss_net_paid": 110.0, "ss_sold_date_sk": 2}]
   // let web_sales = [
-  Const        r3, [{"ws_bill_customer_sk": 1, "ws_net_paid": 40, "ws_sold_date_sk": 1}, {"ws_bill_customer_sk": 1, "ws_net_paid": 80, "ws_sold_date_sk": 2}]
+  Const        r3, [{"ws_bill_customer_sk": 1, "ws_net_paid": 40.0, "ws_sold_date_sk": 1}, {"ws_bill_customer_sk": 1, "ws_net_paid": 80.0, "ws_sold_date_sk": 2}]
   // from c in customer
   Const        r4, []
   // group by { id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, year: d.d_year } into g
@@ -116,442 +116,437 @@ L4:
   In           r89, r88, r21
   JumpIfTrue   r89, L5
   // from c in customer
-  Const        r90, []
-  Const        r91, "__group__"
-  Const        r92, true
+  Const        r90, "__group__"
+  Const        r91, true
   // group by { id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, year: d.d_year } into g
-  Move         r93, r87
+  Move         r92, r87
   // from c in customer
-  Const        r94, "items"
-  Move         r95, r90
-  Const        r96, "count"
-  Const        r97, 0
+  Const        r93, "items"
+  Move         r94, r23
+  Const        r95, "count"
+  Const        r96, 0
+  Move         r97, r90
   Move         r98, r91
-  Move         r99, r92
-  Move         r100, r14
+  Move         r99, r14
+  Move         r100, r92
   Move         r101, r93
   Move         r102, r94
   Move         r103, r95
   Move         r104, r96
-  Move         r105, r97
-  MakeMap      r106, 4, r98
-  SetIndex     r21, r88, r106
-  Append       r107, r22, r106
-  Move         r22, r107
+  MakeMap      r105, 4, r97
+  SetIndex     r21, r88, r105
+  Append       r106, r22, r105
+  Move         r22, r106
 L5:
-  Index        r108, r21, r88
-  Index        r109, r108, r94
-  Append       r110, r109, r70
-  SetIndex     r108, r94, r110
-  Index        r111, r108, r96
-  Const        r112, 1
-  AddInt       r113, r111, r112
-  SetIndex     r108, r96, r113
+  Index        r107, r21, r88
+  Index        r108, r107, r93
+  Append       r109, r108, r70
+  SetIndex     r107, r93, r109
+  Index        r110, r107, r95
+  Const        r111, 1
+  AddInt       r112, r110, r111
+  SetIndex     r107, r95, r112
 L3:
   // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
-  AddInt       r43, r43, r112
+  AddInt       r43, r43, r111
   Jump         L6
 L2:
   // join ss in store_sales on c.c_customer_sk == ss.ss_customer_sk
-  AddInt       r32, r32, r112
+  AddInt       r32, r32, r111
   Jump         L7
 L1:
   // from c in customer
-  AddInt       r26, r26, r112
+  AddInt       r26, r26, r111
   Jump         L8
 L0:
-  Move         r114, r97
-  Len          r115, r22
+  Move         r113, r96
+  Len          r114, r22
 L12:
-  LessInt      r116, r114, r115
-  JumpIfFalse  r116, L9
-  Index        r117, r22, r114
-  Move         r118, r117
+  LessInt      r115, r113, r114
+  JumpIfFalse  r115, L9
+  Index        r116, r22, r113
+  Move         r117, r116
   // select { customer_id: g.key.id, customer_first_name: g.key.first, customer_last_name: g.key.last, year: g.key.year, year_total: sum(from x in g select x.ss.ss_net_paid), sale_type: "s" },
-  Const        r119, "customer_id"
-  Index        r120, r118, r14
-  Index        r121, r120, r5
-  Const        r122, "customer_first_name"
-  Index        r123, r118, r14
-  Index        r124, r123, r7
-  Const        r125, "customer_last_name"
-  Index        r126, r118, r14
-  Index        r127, r126, r9
-  Const        r128, "year"
-  Index        r129, r118, r14
-  Index        r130, r129, r11
-  Const        r131, "year_total"
-  Const        r132, []
-  IterPrep     r133, r118
-  Len          r134, r133
-  Move         r135, r97
+  Const        r118, "customer_id"
+  Index        r119, r117, r14
+  Index        r120, r119, r5
+  Const        r121, "customer_first_name"
+  Index        r122, r117, r14
+  Index        r123, r122, r7
+  Const        r124, "customer_last_name"
+  Index        r125, r117, r14
+  Index        r126, r125, r9
+  Const        r127, "year"
+  Index        r128, r117, r14
+  Index        r129, r128, r11
+  Const        r130, "year_total"
+  Const        r131, []
+  IterPrep     r132, r117
+  Len          r133, r132
+  Move         r134, r96
 L11:
-  LessInt      r136, r135, r134
-  JumpIfFalse  r136, L10
-  Index        r137, r133, r135
-  Move         r138, r137
-  Index        r139, r138, r18
-  Index        r140, r139, r19
-  Append       r141, r132, r140
-  Move         r132, r141
-  AddInt       r135, r135, r112
+  LessInt      r135, r134, r133
+  JumpIfFalse  r135, L10
+  Index        r136, r132, r134
+  Move         r137, r136
+  Index        r138, r137, r18
+  Index        r139, r138, r19
+  Append       r140, r131, r139
+  Move         r131, r140
+  AddInt       r134, r134, r111
   Jump         L11
 L10:
-  Sum          r142, r132
-  Const        r143, "sale_type"
-  Const        r144, "s"
-  Move         r145, r119
+  Sum          r141, r131
+  Const        r142, "sale_type"
+  Const        r143, "s"
+  Move         r144, r118
+  Move         r145, r120
   Move         r146, r121
-  Move         r147, r122
+  Move         r147, r123
   Move         r148, r124
-  Move         r149, r125
+  Move         r149, r126
   Move         r150, r127
-  Move         r151, r128
+  Move         r151, r129
   Move         r152, r130
-  Move         r153, r131
+  Move         r153, r141
   Move         r154, r142
   Move         r155, r143
-  Move         r156, r144
-  MakeMap      r157, 6, r145
+  MakeMap      r156, 6, r144
   // from c in customer
-  Append       r158, r4, r157
-  Move         r4, r158
-  AddInt       r114, r114, r112
+  Append       r157, r4, r156
+  Move         r4, r157
+  AddInt       r113, r113, r111
   Jump         L12
 L9:
   // from c in customer
-  Const        r159, []
+  Const        r158, []
   // select { customer_id: g.key.id, customer_first_name: g.key.first, customer_last_name: g.key.last, year: g.key.year, year_total: sum(from x in g select x.ws.ws_net_paid), sale_type: "w" }
-  Const        r160, "ws"
-  Const        r161, "ws_net_paid"
+  Const        r159, "ws"
+  Const        r160, "ws_net_paid"
   // from c in customer
-  MakeMap      r162, 0, r0
-  Const        r164, []
-  Move         r163, r164
-  IterPrep     r165, r0
-  Len          r166, r165
-  Const        r167, 0
+  MakeMap      r161, 0, r0
+  Move         r162, r23
+  IterPrep     r163, r0
+  Len          r164, r163
+  Const        r165, 0
 L21:
-  LessInt      r168, r167, r166
-  JumpIfFalse  r168, L13
-  Index        r169, r165, r167
-  Move         r29, r169
+  LessInt      r166, r165, r164
+  JumpIfFalse  r166, L13
+  Index        r167, r163, r165
+  Move         r29, r167
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  IterPrep     r170, r3
-  Len          r171, r170
-  Const        r172, 0
+  IterPrep     r168, r3
+  Len          r169, r168
+  Const        r170, 0
 L20:
-  LessInt      r173, r172, r171
-  JumpIfFalse  r173, L14
-  Index        r174, r170, r172
-  Move         r175, r174
-  Index        r176, r29, r36
-  Const        r177, "ws_bill_customer_sk"
-  Index        r178, r175, r177
-  Equal        r179, r176, r178
-  JumpIfFalse  r179, L15
+  LessInt      r171, r170, r169
+  JumpIfFalse  r171, L14
+  Index        r172, r168, r170
+  Move         r173, r172
+  Index        r174, r29, r36
+  Const        r175, "ws_bill_customer_sk"
+  Index        r176, r173, r175
+  Equal        r177, r174, r176
+  JumpIfFalse  r177, L15
   // join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
-  IterPrep     r180, r1
-  Len          r181, r180
-  Const        r182, 0
+  IterPrep     r178, r1
+  Len          r179, r178
+  Const        r180, 0
 L19:
-  LessInt      r183, r182, r181
-  JumpIfFalse  r183, L15
-  Index        r184, r180, r182
-  Move         r185, r184
-  Index        r186, r185, r47
-  Const        r187, "ws_sold_date_sk"
-  Index        r188, r175, r187
-  Equal        r189, r186, r188
-  JumpIfFalse  r189, L16
+  LessInt      r181, r180, r179
+  JumpIfFalse  r181, L15
+  Index        r182, r178, r180
+  Move         r183, r182
+  Index        r184, r183, r47
+  Const        r185, "ws_sold_date_sk"
+  Index        r186, r173, r185
+  Equal        r187, r184, r186
+  JumpIfFalse  r187, L16
   // where d.d_year == 1998 || d.d_year == 1999
-  Index        r190, r185, r12
-  Equal        r191, r190, r53
-  Index        r192, r185, r12
-  Equal        r193, r192, r56
-  Move         r194, r191
-  JumpIfTrue   r194, L17
-  Move         r194, r193
+  Index        r188, r183, r12
+  Equal        r189, r188, r53
+  Index        r190, r183, r12
+  Equal        r191, r190, r56
+  Move         r192, r189
+  JumpIfTrue   r192, L17
+  Move         r192, r191
 L17:
-  JumpIfFalse  r194, L16
+  JumpIfFalse  r192, L16
   // from c in customer
-  Move         r195, r29
-  Move         r196, r175
-  Move         r197, r185
-  Move         r198, r59
-  Move         r199, r195
-  Move         r200, r160
-  Move         r201, r196
-  Move         r202, r62
-  Move         r203, r197
-  MakeMap      r204, 3, r198
+  Move         r193, r29
+  Move         r194, r173
+  Move         r195, r183
+  Move         r196, r59
+  Move         r197, r193
+  Move         r198, r159
+  Move         r199, r194
+  Move         r200, r62
+  Move         r201, r195
+  MakeMap      r202, 3, r196
   // group by { id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, year: d.d_year } into g
-  Const        r205, "id"
-  Index        r206, r29, r6
-  Const        r207, "first"
-  Index        r208, r29, r8
-  Const        r209, "last"
-  Index        r210, r29, r10
-  Const        r211, "year"
-  Index        r212, r185, r12
+  Const        r203, "id"
+  Index        r204, r29, r6
+  Const        r205, "first"
+  Index        r206, r29, r8
+  Const        r207, "last"
+  Index        r208, r29, r10
+  Const        r209, "year"
+  Index        r210, r183, r12
+  Move         r211, r203
+  Move         r212, r204
   Move         r213, r205
   Move         r214, r206
   Move         r215, r207
   Move         r216, r208
   Move         r217, r209
   Move         r218, r210
-  Move         r219, r211
-  Move         r220, r212
-  MakeMap      r221, 4, r213
-  Str          r222, r221
-  In           r223, r222, r162
-  JumpIfTrue   r223, L18
-  Move         r224, r221
+  MakeMap      r219, 4, r211
+  Str          r220, r219
+  In           r221, r220, r161
+  JumpIfTrue   r221, L18
+  Move         r222, r219
   // from c in customer
-  Move         r225, r90
-  Move         r226, r91
-  Move         r227, r92
-  Move         r228, r14
-  Move         r229, r224
-  Move         r230, r94
-  Move         r231, r225
-  Move         r232, r96
-  Move         r233, r97
-  MakeMap      r234, 4, r226
-  SetIndex     r162, r222, r234
-  Append       r235, r163, r234
-  Move         r163, r235
+  Move         r223, r23
+  Move         r224, r90
+  Move         r225, r91
+  Move         r226, r14
+  Move         r227, r222
+  Move         r228, r93
+  Move         r229, r223
+  Move         r230, r95
+  Move         r231, r96
+  MakeMap      r232, 4, r224
+  SetIndex     r161, r220, r232
+  Append       r233, r162, r232
+  Move         r162, r233
 L18:
-  Index        r236, r162, r222
-  Index        r237, r236, r94
-  Append       r238, r237, r204
-  SetIndex     r236, r94, r238
-  Index        r239, r236, r96
-  AddInt       r240, r239, r112
-  SetIndex     r236, r96, r240
+  Index        r234, r161, r220
+  Index        r235, r234, r93
+  Append       r236, r235, r202
+  SetIndex     r234, r93, r236
+  Index        r237, r234, r95
+  AddInt       r238, r237, r111
+  SetIndex     r234, r95, r238
 L16:
   // join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
-  AddInt       r182, r182, r112
+  AddInt       r180, r180, r111
   Jump         L19
 L15:
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  AddInt       r172, r172, r112
+  AddInt       r170, r170, r111
   Jump         L20
 L14:
   // from c in customer
-  AddInt       r167, r167, r112
+  AddInt       r165, r165, r111
   Jump         L21
 L13:
-  Move         r241, r97
-  Len          r242, r163
+  Move         r239, r96
+  Len          r240, r162
 L25:
-  LessInt      r243, r241, r242
-  JumpIfFalse  r243, L22
-  Index        r244, r163, r241
-  Move         r118, r244
+  LessInt      r241, r239, r240
+  JumpIfFalse  r241, L22
+  Index        r242, r162, r239
+  Move         r117, r242
   // select { customer_id: g.key.id, customer_first_name: g.key.first, customer_last_name: g.key.last, year: g.key.year, year_total: sum(from x in g select x.ws.ws_net_paid), sale_type: "w" }
-  Const        r245, "customer_id"
-  Index        r246, r118, r14
-  Index        r247, r246, r5
-  Const        r248, "customer_first_name"
-  Index        r249, r118, r14
-  Index        r250, r249, r7
-  Const        r251, "customer_last_name"
-  Index        r252, r118, r14
-  Index        r253, r252, r9
-  Const        r254, "year"
-  Index        r255, r118, r14
-  Index        r256, r255, r11
-  Const        r257, "year_total"
-  Const        r258, []
-  IterPrep     r259, r118
-  Len          r260, r259
-  Move         r261, r97
+  Const        r243, "customer_id"
+  Index        r244, r117, r14
+  Index        r245, r244, r5
+  Const        r246, "customer_first_name"
+  Index        r247, r117, r14
+  Index        r248, r247, r7
+  Const        r249, "customer_last_name"
+  Index        r250, r117, r14
+  Index        r251, r250, r9
+  Const        r252, "year"
+  Index        r253, r117, r14
+  Index        r254, r253, r11
+  Const        r255, "year_total"
+  Const        r256, []
+  IterPrep     r257, r117
+  Len          r258, r257
+  Move         r259, r96
 L24:
-  LessInt      r262, r261, r260
-  JumpIfFalse  r262, L23
-  Index        r263, r259, r261
-  Move         r138, r263
-  Index        r264, r138, r160
-  Index        r265, r264, r161
-  Append       r266, r258, r265
-  Move         r258, r266
-  AddInt       r261, r261, r112
+  LessInt      r260, r259, r258
+  JumpIfFalse  r260, L23
+  Index        r261, r257, r259
+  Move         r137, r261
+  Index        r262, r137, r159
+  Index        r263, r262, r160
+  Append       r264, r256, r263
+  Move         r256, r264
+  AddInt       r259, r259, r111
   Jump         L24
 L23:
-  Sum          r267, r258
-  Const        r268, "sale_type"
-  Const        r269, "w"
-  Move         r270, r245
-  Move         r271, r247
-  Move         r272, r248
-  Move         r273, r250
-  Move         r274, r251
-  Move         r275, r253
-  Move         r276, r254
-  Move         r277, r256
-  Move         r278, r257
+  Sum          r265, r256
+  Const        r266, "sale_type"
+  Const        r267, "w"
+  Move         r268, r243
+  Move         r269, r245
+  Move         r270, r246
+  Move         r271, r248
+  Move         r272, r249
+  Move         r273, r251
+  Move         r274, r252
+  Move         r275, r254
+  Move         r276, r255
+  Move         r277, r265
+  Move         r278, r266
   Move         r279, r267
-  Move         r280, r268
-  Move         r281, r269
-  MakeMap      r282, 6, r270
+  MakeMap      r280, 6, r268
   // from c in customer
-  Append       r283, r159, r282
-  Move         r159, r283
-  AddInt       r241, r241, r112
+  Append       r281, r158, r280
+  Move         r158, r281
+  AddInt       r239, r239, r111
   Jump         L25
 L22:
   // concat(
-  UnionAll     r284, r4, r159
+  UnionAll     r282, r4, r158
   // let s_firstyear = first(from y in year_total where y.sale_type == "s" && y.year == 1998 select y)
-  Const        r285, []
-  IterPrep     r286, r284
-  Len          r287, r286
-  Move         r288, r97
+  Const        r283, []
+  IterPrep     r284, r282
+  Len          r285, r284
+  Move         r286, r96
 L29:
-  LessInt      r289, r288, r287
-  JumpIfFalse  r289, L26
-  Index        r290, r286, r288
-  Move         r291, r290
-  Index        r292, r291, r20
-  Equal        r293, r292, r144
-  Index        r294, r291, r11
-  Equal        r295, r294, r53
-  Move         r296, r293
-  JumpIfFalse  r296, L27
-  Move         r296, r295
+  LessInt      r287, r286, r285
+  JumpIfFalse  r287, L26
+  Index        r288, r284, r286
+  Move         r289, r288
+  Index        r290, r289, r20
+  Equal        r291, r290, r143
+  Index        r292, r289, r11
+  Equal        r293, r292, r53
+  Move         r294, r291
+  JumpIfFalse  r294, L27
+  Move         r294, r293
 L27:
-  JumpIfFalse  r296, L28
-  Append       r297, r285, r291
-  Move         r285, r297
+  JumpIfFalse  r294, L28
+  Append       r295, r283, r289
+  Move         r283, r295
 L28:
-  AddInt       r288, r288, r112
+  AddInt       r286, r286, r111
   Jump         L29
 L26:
-  First        r298, r285
+  First        r296, r283
   // let s_secyear = first(from y in year_total where y.sale_type == "s" && y.year == 1999 select y)
-  Const        r299, []
-  IterPrep     r300, r284
-  Len          r301, r300
-  Move         r302, r97
+  Const        r297, []
+  IterPrep     r298, r282
+  Len          r299, r298
+  Move         r300, r96
 L33:
-  LessInt      r303, r302, r301
-  JumpIfFalse  r303, L30
-  Index        r304, r300, r302
-  Move         r291, r304
-  Index        r305, r291, r20
-  Equal        r306, r305, r144
-  Index        r307, r291, r11
-  Equal        r308, r307, r56
-  Move         r309, r306
-  JumpIfFalse  r309, L31
-  Move         r309, r308
+  LessInt      r301, r300, r299
+  JumpIfFalse  r301, L30
+  Index        r302, r298, r300
+  Move         r289, r302
+  Index        r303, r289, r20
+  Equal        r304, r303, r143
+  Index        r305, r289, r11
+  Equal        r306, r305, r56
+  Move         r307, r304
+  JumpIfFalse  r307, L31
+  Move         r307, r306
 L31:
-  JumpIfFalse  r309, L32
-  Append       r310, r299, r291
-  Move         r299, r310
+  JumpIfFalse  r307, L32
+  Append       r308, r297, r289
+  Move         r297, r308
 L32:
-  AddInt       r302, r302, r112
+  AddInt       r300, r300, r111
   Jump         L33
 L30:
-  First        r311, r299
+  First        r309, r297
   // let w_firstyear = first(from y in year_total where y.sale_type == "w" && y.year == 1998 select y)
-  Const        r312, []
-  IterPrep     r313, r284
-  Len          r314, r313
-  Move         r315, r97
+  Const        r310, []
+  IterPrep     r311, r282
+  Len          r312, r311
+  Move         r313, r96
 L37:
-  LessInt      r316, r315, r314
-  JumpIfFalse  r316, L34
-  Index        r317, r313, r315
-  Move         r291, r317
-  Index        r318, r291, r20
-  Equal        r319, r318, r269
-  Index        r320, r291, r11
-  Equal        r321, r320, r53
-  Move         r322, r319
-  JumpIfFalse  r322, L35
-  Move         r322, r321
+  LessInt      r314, r313, r312
+  JumpIfFalse  r314, L34
+  Index        r315, r311, r313
+  Move         r289, r315
+  Index        r316, r289, r20
+  Equal        r317, r316, r267
+  Index        r318, r289, r11
+  Equal        r319, r318, r53
+  Move         r320, r317
+  JumpIfFalse  r320, L35
+  Move         r320, r319
 L35:
-  JumpIfFalse  r322, L36
-  Append       r323, r312, r291
-  Move         r312, r323
+  JumpIfFalse  r320, L36
+  Append       r321, r310, r289
+  Move         r310, r321
 L36:
-  AddInt       r315, r315, r112
+  AddInt       r313, r313, r111
   Jump         L37
 L34:
-  First        r324, r312
+  First        r322, r310
   // let w_secyear = first(from y in year_total where y.sale_type == "w" && y.year == 1999 select y)
-  Const        r325, []
-  IterPrep     r326, r284
-  Len          r327, r326
-  Move         r328, r97
+  Const        r323, []
+  IterPrep     r324, r282
+  Len          r325, r324
+  Move         r326, r96
 L41:
-  LessInt      r329, r328, r327
-  JumpIfFalse  r329, L38
-  Index        r330, r326, r328
-  Move         r291, r330
-  Index        r331, r291, r20
-  Equal        r332, r331, r269
-  Index        r333, r291, r11
-  Equal        r334, r333, r56
-  Move         r335, r332
-  JumpIfFalse  r335, L39
-  Move         r335, r334
+  LessInt      r327, r326, r325
+  JumpIfFalse  r327, L38
+  Index        r328, r324, r326
+  Move         r289, r328
+  Index        r329, r289, r20
+  Equal        r330, r329, r267
+  Index        r331, r289, r11
+  Equal        r332, r331, r56
+  Move         r333, r330
+  JumpIfFalse  r333, L39
+  Move         r333, r332
 L39:
-  JumpIfFalse  r335, L40
-  Append       r336, r325, r291
-  Move         r325, r336
+  JumpIfFalse  r333, L40
+  Append       r334, r323, r289
+  Move         r323, r334
 L40:
-  AddInt       r328, r328, r112
+  AddInt       r326, r326, r111
   Jump         L41
 L38:
-  First        r337, r325
+  First        r335, r323
   // if s_firstyear.year_total > 0 && w_firstyear.year_total > 0 &&
-  Index        r338, r298, r17
-  Less         r339, r97, r338
-  Index        r340, r324, r17
-  Less         r341, r97, r340
+  Index        r336, r296, r17
+  Less         r337, r96, r336
+  Index        r338, r322, r17
+  Less         r339, r96, r338
   // (w_secyear.year_total / w_firstyear.year_total) > (s_secyear.year_total / s_firstyear.year_total) {
-  Index        r342, r337, r17
-  Index        r343, r324, r17
-  Div          r344, r342, r343
-  Index        r345, r311, r17
-  Index        r346, r298, r17
-  Div          r347, r345, r346
-  Less         r348, r347, r344
+  Index        r340, r335, r17
+  Index        r341, r322, r17
+  Div          r342, r340, r341
+  Index        r343, r309, r17
+  Index        r344, r296, r17
+  Div          r345, r343, r344
+  Less         r346, r345, r342
   // if s_firstyear.year_total > 0 && w_firstyear.year_total > 0 &&
-  Move         r349, r339
-  JumpIfFalse  r349, L42
-  Move         r349, r341
+  Move         r347, r337
+  JumpIfFalse  r347, L42
+  Move         r347, r339
+  JumpIfFalse  r347, L42
+  Move         r347, r346
 L42:
-  Move         r350, r349
-  JumpIfFalse  r350, L43
-  Move         r350, r348
-L43:
   // [{ customer_id: s_secyear.customer_id, customer_first_name: s_secyear.customer_first_name, customer_last_name: s_secyear.customer_last_name }]
-  Const        r351, "customer_id"
-  Index        r352, r311, r13
-  Const        r353, "customer_first_name"
-  Index        r354, r311, r15
-  Const        r355, "customer_last_name"
-  Index        r356, r311, r16
+  Const        r348, "customer_id"
+  Index        r349, r309, r13
+  Const        r350, "customer_first_name"
+  Index        r351, r309, r15
+  Const        r352, "customer_last_name"
+  Index        r353, r309, r16
+  Move         r354, r348
+  Move         r355, r349
+  Move         r356, r350
   Move         r357, r351
   Move         r358, r352
   Move         r359, r353
-  Move         r360, r354
-  Move         r361, r355
-  Move         r362, r356
-  MakeMap      r363, 3, r357
-  Move         r364, r363
-  MakeList     r365, 1, r364
+  MakeMap      r360, 3, r354
+  Move         r361, r360
+  MakeList     r362, 1, r361
   // if s_firstyear.year_total > 0 && w_firstyear.year_total > 0 &&
-  Select       366,350,365,90
+  Select       363,347,362,23
   // json(result)
-  JSON         r366
+  JSON         r363
   // expect result == [
-  Const        r367, [{"customer_first_name": "Alice", "customer_id": 1, "customer_last_name": "Smith"}]
-  Equal        r368, r366, r367
-  Expect       r368
+  Const        r364, [{"customer_first_name": "Alice", "customer_id": 1, "customer_last_name": "Smith"}]
+  Equal        r365, r363, r364
+  Expect       r365
   Return       r0
-

--- a/tests/dataset/tpc-ds/out/q75.ir.out
+++ b/tests/dataset/tpc-ds/out/q75.ir.out
@@ -1,12 +1,12 @@
-func main (regs=352)
+func main (regs=351)
   // let date_dim = [
   Const        r0, [{"d_date_sk": 1, "d_year": 2000}, {"d_date_sk": 2, "d_year": 2001}]
   // let store_sales = [
-  Const        r1, [{"ss_item_sk": 1, "ss_quantity": 50, "ss_sales_price": 500, "ss_sold_date_sk": 1}, {"ss_item_sk": 1, "ss_quantity": 40, "ss_sales_price": 400, "ss_sold_date_sk": 2}]
+  Const        r1, [{"ss_item_sk": 1, "ss_quantity": 50, "ss_sales_price": 500.0, "ss_sold_date_sk": 1}, {"ss_item_sk": 1, "ss_quantity": 40, "ss_sales_price": 400.0, "ss_sold_date_sk": 2}]
   // let web_sales = [
-  Const        r2, [{"ws_item_sk": 1, "ws_quantity": 30, "ws_sales_price": 300, "ws_sold_date_sk": 1}, {"ws_item_sk": 1, "ws_quantity": 25, "ws_sales_price": 250, "ws_sold_date_sk": 2}]
+  Const        r2, [{"ws_item_sk": 1, "ws_quantity": 30, "ws_sales_price": 300.0, "ws_sold_date_sk": 1}, {"ws_item_sk": 1, "ws_quantity": 25, "ws_sales_price": 250.0, "ws_sold_date_sk": 2}]
   // let catalog_sales = [
-  Const        r3, [{"cs_item_sk": 1, "cs_quantity": 20, "cs_sales_price": 200, "cs_sold_date_sk": 1}, {"cs_item_sk": 1, "cs_quantity": 15, "cs_sales_price": 150, "cs_sold_date_sk": 2}]
+  Const        r3, [{"cs_item_sk": 1, "cs_quantity": 20, "cs_sales_price": 200.0, "cs_sold_date_sk": 1}, {"cs_item_sk": 1, "cs_quantity": 15, "cs_sales_price": 150.0, "cs_sold_date_sk": 2}]
   // let item = [
   Const        r4, [{"i_brand_id": 1, "i_category": "Electronics", "i_category_id": 3, "i_class_id": 2, "i_item_sk": 1, "i_manufact_id": 4}]
   // from ss in store_sales join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk select { d_year: d.d_year, i_item_sk: ss.ss_item_sk, quantity: ss.ss_quantity, amount: ss.ss_sales_price },
@@ -261,36 +261,35 @@ L19:
   In           r191, r190, r140
   JumpIfTrue   r191, L18
   // from sd in sales_detail
-  Const        r192, []
-  Const        r193, "__group__"
-  Const        r194, true
+  Const        r192, "__group__"
+  Const        r193, true
   // group by { year: sd.d_year, brand_id: i.i_brand_id, class_id: i.i_class_id, category_id: i.i_category_id, manuf_id: i.i_manufact_id } into g
-  Move         r195, r189
+  Move         r194, r189
   // from sd in sales_detail
-  Const        r196, "items"
-  Move         r197, r192
-  Const        r198, "count"
-  Const        r199, 0
+  Const        r195, "items"
+  Move         r196, r142
+  Const        r197, "count"
+  Const        r198, 0
+  Move         r199, r192
   Move         r200, r193
-  Move         r201, r194
-  Move         r202, r136
+  Move         r201, r136
+  Move         r202, r194
   Move         r203, r195
   Move         r204, r196
   Move         r205, r197
   Move         r206, r198
-  Move         r207, r199
-  MakeMap      r208, 4, r200
-  SetIndex     r140, r190, r208
-  Append       r209, r141, r208
-  Move         r141, r209
+  MakeMap      r207, 4, r199
+  SetIndex     r140, r190, r207
+  Append       r208, r141, r207
+  Move         r141, r208
 L18:
-  Index        r210, r140, r190
-  Index        r211, r210, r196
-  Append       r212, r211, r168
-  SetIndex     r210, r196, r212
-  Index        r213, r210, r198
-  AddInt       r214, r213, r48
-  SetIndex     r210, r198, r214
+  Index        r209, r140, r190
+  Index        r210, r209, r195
+  Append       r211, r210, r168
+  SetIndex     r209, r195, r211
+  Index        r212, r209, r197
+  AddInt       r213, r212, r48
+  SetIndex     r209, r197, r213
 L17:
   // join i in item on i.i_item_sk == sd.i_item_sk
   AddInt       r151, r151, r48
@@ -300,223 +299,222 @@ L16:
   AddInt       r145, r145, r48
   Jump         L20
 L15:
-  Move         r215, r199
-  Len          r216, r141
+  Move         r214, r198
+  Len          r215, r141
 L26:
-  LessInt      r217, r215, r216
-  JumpIfFalse  r217, L21
-  Index        r218, r141, r215
-  Move         r219, r218
+  LessInt      r216, r214, r215
+  JumpIfFalse  r216, L21
+  Index        r217, r141, r214
+  Move         r218, r217
   // d_year: g.key.year,
-  Const        r220, "d_year"
-  Index        r221, r219, r136
-  Index        r222, r221, r126
+  Const        r219, "d_year"
+  Index        r220, r218, r136
+  Index        r221, r220, r126
   // i_brand_id: g.key.brand_id,
-  Const        r223, "i_brand_id"
-  Index        r224, r219, r136
-  Index        r225, r224, r127
+  Const        r222, "i_brand_id"
+  Index        r223, r218, r136
+  Index        r224, r223, r127
   // i_class_id: g.key.class_id,
-  Const        r226, "i_class_id"
-  Index        r227, r219, r136
-  Index        r228, r227, r129
+  Const        r225, "i_class_id"
+  Index        r226, r218, r136
+  Index        r227, r226, r129
   // i_category_id: g.key.category_id,
-  Const        r229, "i_category_id"
-  Index        r230, r219, r136
-  Index        r231, r230, r131
+  Const        r228, "i_category_id"
+  Index        r229, r218, r136
+  Index        r230, r229, r131
   // i_manufact_id: g.key.manuf_id,
-  Const        r232, "i_manufact_id"
-  Index        r233, r219, r136
-  Index        r234, r233, r133
+  Const        r231, "i_manufact_id"
+  Index        r232, r218, r136
+  Index        r233, r232, r133
   // sales_cnt: sum(from x in g select x.sd.quantity),
-  Const        r235, "sales_cnt"
-  Const        r236, []
-  IterPrep     r237, r219
-  Len          r238, r237
-  Move         r239, r199
+  Const        r234, "sales_cnt"
+  Const        r235, []
+  IterPrep     r236, r218
+  Len          r237, r236
+  Move         r238, r198
 L23:
-  LessInt      r240, r239, r238
-  JumpIfFalse  r240, L22
-  Index        r241, r237, r239
-  Move         r242, r241
-  Index        r243, r242, r138
-  Index        r244, r243, r15
-  Append       r245, r236, r244
-  Move         r236, r245
-  AddInt       r239, r239, r48
+  LessInt      r239, r238, r237
+  JumpIfFalse  r239, L22
+  Index        r240, r236, r238
+  Move         r241, r240
+  Index        r242, r241, r138
+  Index        r243, r242, r15
+  Append       r244, r235, r243
+  Move         r235, r244
+  AddInt       r238, r238, r48
   Jump         L23
 L22:
-  Sum          r246, r236
+  Sum          r245, r235
   // sales_amt: sum(from x in g select x.sd.amount)
-  Const        r247, "sales_amt"
-  Const        r248, []
-  IterPrep     r249, r219
-  Len          r250, r249
-  Move         r251, r199
+  Const        r246, "sales_amt"
+  Const        r247, []
+  IterPrep     r248, r218
+  Len          r249, r248
+  Move         r250, r198
 L25:
-  LessInt      r252, r251, r250
-  JumpIfFalse  r252, L24
-  Index        r253, r249, r251
-  Move         r242, r253
-  Index        r254, r242, r138
-  Index        r255, r254, r17
-  Append       r256, r248, r255
-  Move         r248, r256
-  AddInt       r251, r251, r48
+  LessInt      r251, r250, r249
+  JumpIfFalse  r251, L24
+  Index        r252, r248, r250
+  Move         r241, r252
+  Index        r253, r241, r138
+  Index        r254, r253, r17
+  Append       r255, r247, r254
+  Move         r247, r255
+  AddInt       r250, r250, r48
   Jump         L25
 L24:
-  Sum          r257, r248
+  Sum          r256, r247
   // d_year: g.key.year,
-  Move         r258, r220
-  Move         r259, r222
+  Move         r257, r219
+  Move         r258, r221
   // i_brand_id: g.key.brand_id,
-  Move         r260, r223
-  Move         r261, r225
+  Move         r259, r222
+  Move         r260, r224
   // i_class_id: g.key.class_id,
-  Move         r262, r226
-  Move         r263, r228
+  Move         r261, r225
+  Move         r262, r227
   // i_category_id: g.key.category_id,
-  Move         r264, r229
-  Move         r265, r231
+  Move         r263, r228
+  Move         r264, r230
   // i_manufact_id: g.key.manuf_id,
-  Move         r266, r232
-  Move         r267, r234
+  Move         r265, r231
+  Move         r266, r233
   // sales_cnt: sum(from x in g select x.sd.quantity),
-  Move         r268, r235
-  Move         r269, r246
+  Move         r267, r234
+  Move         r268, r245
   // sales_amt: sum(from x in g select x.sd.amount)
-  Move         r270, r247
-  Move         r271, r257
+  Move         r269, r246
+  Move         r270, r256
   // select {
-  MakeMap      r272, 7, r258
+  MakeMap      r271, 7, r257
   // from sd in sales_detail
-  Append       r273, r125, r272
-  Move         r125, r273
-  AddInt       r215, r215, r48
+  Append       r272, r125, r271
+  Move         r125, r272
+  AddInt       r214, r214, r48
   Jump         L26
 L21:
   // let prev_yr = first(from a in all_sales where a.d_year == 2000 select a)
-  Const        r274, []
-  IterPrep     r275, r125
-  Len          r276, r275
-  Move         r277, r199
+  Const        r273, []
+  IterPrep     r274, r125
+  Len          r275, r274
+  Move         r276, r198
 L29:
-  LessInt      r278, r277, r276
-  JumpIfFalse  r278, L27
-  Index        r279, r275, r277
-  Move         r280, r279
-  Index        r281, r280, r12
-  Const        r282, 2000
-  Equal        r283, r281, r282
-  JumpIfFalse  r283, L28
-  Append       r284, r274, r280
-  Move         r274, r284
+  LessInt      r277, r276, r275
+  JumpIfFalse  r277, L27
+  Index        r278, r274, r276
+  Move         r279, r278
+  Index        r280, r279, r12
+  Const        r281, 2000
+  Equal        r282, r280, r281
+  JumpIfFalse  r282, L28
+  Append       r283, r273, r279
+  Move         r273, r283
 L28:
-  AddInt       r277, r277, r48
+  AddInt       r276, r276, r48
   Jump         L29
 L27:
-  First        r285, r274
+  First        r284, r273
   // let curr_yr = first(from a in all_sales where a.d_year == 2001 select a)
-  Const        r286, []
-  IterPrep     r287, r125
-  Len          r288, r287
-  Move         r289, r199
+  Const        r285, []
+  IterPrep     r286, r125
+  Len          r287, r286
+  Move         r288, r198
 L32:
-  LessInt      r290, r289, r288
-  JumpIfFalse  r290, L30
-  Index        r291, r287, r289
-  Move         r280, r291
-  Index        r292, r280, r12
-  Const        r293, 2001
-  Equal        r294, r292, r293
-  JumpIfFalse  r294, L31
-  Append       r295, r286, r280
-  Move         r286, r295
+  LessInt      r289, r288, r287
+  JumpIfFalse  r289, L30
+  Index        r290, r286, r288
+  Move         r279, r290
+  Index        r291, r279, r12
+  Const        r292, 2001
+  Equal        r293, r291, r292
+  JumpIfFalse  r293, L31
+  Append       r294, r285, r279
+  Move         r285, r294
 L31:
-  AddInt       r289, r289, r48
+  AddInt       r288, r288, r48
   Jump         L32
 L30:
-  First        r296, r286
+  First        r295, r285
   // if (curr_yr.sales_cnt / prev_yr.sales_cnt) < 0.9 {
-  Index        r297, r296, r137
-  Index        r298, r285, r137
-  Div          r299, r297, r298
-  Const        r300, 0.9
-  LessFloat    r301, r299, r300
+  Index        r296, r295, r137
+  Index        r297, r284, r137
+  Div          r298, r296, r297
+  Const        r299, 0.9
+  LessFloat    r300, r298, r299
   // prev_year: prev_yr.d_year,
-  Const        r302, "prev_year"
-  Index        r303, r285, r12
+  Const        r301, "prev_year"
+  Index        r302, r284, r12
   // year: curr_yr.d_year,
-  Const        r304, "year"
-  Index        r305, r296, r12
+  Const        r303, "year"
+  Index        r304, r295, r12
   // i_brand_id: curr_yr.i_brand_id,
-  Const        r306, "i_brand_id"
-  Index        r307, r296, r128
+  Const        r305, "i_brand_id"
+  Index        r306, r295, r128
   // i_class_id: curr_yr.i_class_id,
-  Const        r308, "i_class_id"
-  Index        r309, r296, r130
+  Const        r307, "i_class_id"
+  Index        r308, r295, r130
   // i_category_id: curr_yr.i_category_id,
-  Const        r310, "i_category_id"
-  Index        r311, r296, r132
+  Const        r309, "i_category_id"
+  Index        r310, r295, r132
   // i_manufact_id: curr_yr.i_manufact_id,
-  Const        r312, "i_manufact_id"
-  Index        r313, r296, r134
+  Const        r311, "i_manufact_id"
+  Index        r312, r295, r134
   // prev_yr_cnt: prev_yr.sales_cnt,
-  Const        r314, "prev_yr_cnt"
-  Index        r315, r285, r137
+  Const        r313, "prev_yr_cnt"
+  Index        r314, r284, r137
   // curr_yr_cnt: curr_yr.sales_cnt,
-  Const        r316, "curr_yr_cnt"
-  Index        r317, r296, r137
+  Const        r315, "curr_yr_cnt"
+  Index        r316, r295, r137
   // sales_cnt_diff: curr_yr.sales_cnt - prev_yr.sales_cnt,
-  Const        r318, "sales_cnt_diff"
-  Index        r319, r296, r137
-  Index        r320, r285, r137
-  Sub          r321, r319, r320
+  Const        r317, "sales_cnt_diff"
+  Index        r318, r295, r137
+  Index        r319, r284, r137
+  Sub          r320, r318, r319
   // sales_amt_diff: curr_yr.sales_amt - prev_yr.sales_amt
-  Const        r322, "sales_amt_diff"
-  Index        r323, r296, r139
-  Index        r324, r285, r139
-  Sub          r325, r323, r324
+  Const        r321, "sales_amt_diff"
+  Index        r322, r295, r139
+  Index        r323, r284, r139
+  Sub          r324, r322, r323
   // prev_year: prev_yr.d_year,
+  Move         r325, r301
   Move         r326, r302
-  Move         r327, r303
   // year: curr_yr.d_year,
+  Move         r327, r303
   Move         r328, r304
-  Move         r329, r305
   // i_brand_id: curr_yr.i_brand_id,
+  Move         r329, r305
   Move         r330, r306
-  Move         r331, r307
   // i_class_id: curr_yr.i_class_id,
+  Move         r331, r307
   Move         r332, r308
-  Move         r333, r309
   // i_category_id: curr_yr.i_category_id,
+  Move         r333, r309
   Move         r334, r310
-  Move         r335, r311
   // i_manufact_id: curr_yr.i_manufact_id,
+  Move         r335, r311
   Move         r336, r312
-  Move         r337, r313
   // prev_yr_cnt: prev_yr.sales_cnt,
+  Move         r337, r313
   Move         r338, r314
-  Move         r339, r315
   // curr_yr_cnt: curr_yr.sales_cnt,
+  Move         r339, r315
   Move         r340, r316
-  Move         r341, r317
   // sales_cnt_diff: curr_yr.sales_cnt - prev_yr.sales_cnt,
-  Move         r342, r318
-  Move         r343, r321
+  Move         r341, r317
+  Move         r342, r320
   // sales_amt_diff: curr_yr.sales_amt - prev_yr.sales_amt
-  Move         r344, r322
-  Move         r345, r325
+  Move         r343, r321
+  Move         r344, r324
   // [{
-  MakeMap      r346, 10, r326
-  Move         r347, r346
-  MakeList     r348, 1, r347
+  MakeMap      r345, 10, r325
+  Move         r346, r345
+  MakeList     r347, 1, r346
   // if (curr_yr.sales_cnt / prev_yr.sales_cnt) < 0.9 {
-  Select       349,301,348,192
+  Select       348,300,347,142
   // json(result)
-  JSON         r349
+  JSON         r348
   // expect result == [
-  Const        r350, [{"curr_yr_cnt": 80, "i_brand_id": 1, "i_category_id": 3, "i_class_id": 2, "i_manufact_id": 4, "prev_year": 2000, "prev_yr_cnt": 100, "sales_amt_diff": -200, "sales_cnt_diff": -20, "year": 2001}]
-  Equal        r351, r349, r350
-  Expect       r351
+  Const        r349, [{"curr_yr_cnt": 80, "i_brand_id": 1, "i_category_id": 3, "i_class_id": 2, "i_manufact_id": 4, "prev_year": 2000, "prev_yr_cnt": 100, "sales_amt_diff": -200.0, "sales_cnt_diff": -20, "year": 2001}]
+  Equal        r350, r348, r349
+  Expect       r350
   Return       r0
-

--- a/tests/dataset/tpc-ds/out/q76.ir.out
+++ b/tests/dataset/tpc-ds/out/q76.ir.out
@@ -1,14 +1,14 @@
-func main (regs=302)
+func main (regs=301)
   // let date_dim = [
   Const        r0, [{"d_date_sk": 1, "d_qoy": 1, "d_year": 1998}]
   // let item = [
   Const        r1, [{"i_category": "CatA", "i_item_sk": 1}, {"i_category": "CatB", "i_item_sk": 2}, {"i_category": "CatC", "i_item_sk": 3}]
   // let store_sales = [
-  Const        r2, [{"ss_customer_sk": nil, "ss_ext_sales_price": 10, "ss_item_sk": 1, "ss_sold_date_sk": 1}]
+  Const        r2, [{"ss_customer_sk": nil, "ss_ext_sales_price": 10.0, "ss_item_sk": 1, "ss_sold_date_sk": 1}]
   // let web_sales = [
-  Const        r3, [{"ws_bill_customer_sk": nil, "ws_ext_sales_price": 15, "ws_item_sk": 2, "ws_sold_date_sk": 1}]
+  Const        r3, [{"ws_bill_customer_sk": nil, "ws_ext_sales_price": 15.0, "ws_item_sk": 2, "ws_sold_date_sk": 1}]
   // let catalog_sales = [
-  Const        r4, [{"cs_bill_customer_sk": nil, "cs_ext_sales_price": 20, "cs_item_sk": 3, "cs_sold_date_sk": 1}]
+  Const        r4, [{"cs_bill_customer_sk": nil, "cs_ext_sales_price": 20.0, "cs_item_sk": 3, "cs_sold_date_sk": 1}]
   // from ss in store_sales
   Const        r5, []
   // where ss.ss_customer_sk == null
@@ -337,131 +337,129 @@ L23:
   In           r221, r220, r193
   JumpIfTrue   r221, L22
   // from r in all_rows
-  Const        r222, []
-  Const        r223, "__group__"
-  Const        r224, true
+  Const        r222, "__group__"
+  Const        r223, true
   // group by { channel: r.channel, col_name: r.col_name, d_year: r.d_year, d_qoy: r.d_qoy, i_category: r.i_category } into g
-  Move         r225, r219
+  Move         r224, r219
   // from r in all_rows
-  Const        r226, "items"
-  Move         r227, r222
-  Const        r228, "count"
+  Const        r225, "items"
+  Move         r226, r195
+  Const        r227, "count"
+  Move         r228, r222
   Move         r229, r223
-  Move         r230, r224
-  Move         r231, r186
+  Move         r230, r186
+  Move         r231, r224
   Move         r232, r225
   Move         r233, r226
   Move         r234, r227
-  Move         r235, r228
-  Move         r236, r17
-  MakeMap      r237, 4, r229
-  SetIndex     r193, r220, r237
-  Append       r238, r194, r237
-  Move         r194, r238
+  Move         r235, r17
+  MakeMap      r236, 4, r228
+  SetIndex     r193, r220, r236
+  Append       r237, r194, r236
+  Move         r194, r237
 L22:
-  Index        r239, r193, r220
-  Index        r240, r239, r226
-  Append       r241, r240, r197
-  SetIndex     r239, r226, r241
-  Index        r242, r239, r228
-  AddInt       r243, r242, r72
-  SetIndex     r239, r228, r243
+  Index        r238, r193, r220
+  Index        r239, r238, r225
+  Append       r240, r239, r197
+  SetIndex     r238, r225, r240
+  Index        r241, r238, r227
+  AddInt       r242, r241, r72
+  SetIndex     r238, r227, r242
   AddInt       r192, r192, r72
   Jump         L23
 L21:
-  Move         r244, r17
-  Len          r245, r194
+  Move         r243, r17
+  Len          r244, r194
 L27:
-  LessInt      r246, r244, r245
-  JumpIfFalse  r246, L24
-  Index        r247, r194, r244
-  Move         r248, r247
+  LessInt      r245, r243, r244
+  JumpIfFalse  r245, L24
+  Index        r246, r194, r243
+  Move         r247, r246
   // channel: g.key.channel,
-  Const        r249, "channel"
-  Index        r250, r248, r186
-  Index        r251, r250, r7
+  Const        r248, "channel"
+  Index        r249, r247, r186
+  Index        r250, r249, r7
   // col_name: g.key.col_name,
-  Const        r252, "col_name"
-  Index        r253, r248, r186
-  Index        r254, r253, r8
+  Const        r251, "col_name"
+  Index        r252, r247, r186
+  Index        r253, r252, r8
   // d_year: g.key.d_year,
-  Const        r255, "d_year"
-  Index        r256, r248, r186
-  Index        r257, r256, r9
+  Const        r254, "d_year"
+  Index        r255, r247, r186
+  Index        r256, r255, r9
   // d_qoy: g.key.d_qoy,
-  Const        r258, "d_qoy"
-  Index        r259, r248, r186
-  Index        r260, r259, r10
+  Const        r257, "d_qoy"
+  Index        r258, r247, r186
+  Index        r259, r258, r10
   // i_category: g.key.i_category,
-  Const        r261, "i_category"
-  Index        r262, r248, r186
-  Index        r263, r262, r11
+  Const        r260, "i_category"
+  Index        r261, r247, r186
+  Index        r262, r261, r11
   // sales_cnt: count(g),
-  Const        r264, "sales_cnt"
-  Index        r265, r248, r228
+  Const        r263, "sales_cnt"
+  Index        r264, r247, r227
   // sales_amt: sum(from x in g select x.r.ext_sales_price)
-  Const        r266, "sales_amt"
-  Const        r267, []
-  IterPrep     r268, r248
-  Len          r269, r268
-  Move         r270, r17
+  Const        r265, "sales_amt"
+  Const        r266, []
+  IterPrep     r267, r247
+  Len          r268, r267
+  Move         r269, r17
 L26:
-  LessInt      r271, r270, r269
-  JumpIfFalse  r271, L25
-  Index        r272, r268, r270
-  Move         r273, r272
-  Index        r274, r273, r189
-  Index        r275, r274, r12
-  Append       r276, r267, r275
-  Move         r267, r276
-  AddInt       r270, r270, r72
+  LessInt      r270, r269, r268
+  JumpIfFalse  r270, L25
+  Index        r271, r267, r269
+  Move         r272, r271
+  Index        r273, r272, r189
+  Index        r274, r273, r12
+  Append       r275, r266, r274
+  Move         r266, r275
+  AddInt       r269, r269, r72
   Jump         L26
 L25:
-  Sum          r277, r267
+  Sum          r276, r266
   // channel: g.key.channel,
-  Move         r278, r249
-  Move         r279, r251
+  Move         r277, r248
+  Move         r278, r250
   // col_name: g.key.col_name,
-  Move         r280, r252
-  Move         r281, r254
+  Move         r279, r251
+  Move         r280, r253
   // d_year: g.key.d_year,
-  Move         r282, r255
-  Move         r283, r257
+  Move         r281, r254
+  Move         r282, r256
   // d_qoy: g.key.d_qoy,
-  Move         r284, r258
-  Move         r285, r260
+  Move         r283, r257
+  Move         r284, r259
   // i_category: g.key.i_category,
-  Move         r286, r261
-  Move         r287, r263
+  Move         r285, r260
+  Move         r286, r262
   // sales_cnt: count(g),
+  Move         r287, r263
   Move         r288, r264
-  Move         r289, r265
   // sales_amt: sum(from x in g select x.r.ext_sales_price)
-  Move         r290, r266
-  Move         r291, r277
+  Move         r289, r265
+  Move         r290, r276
   // select {
-  MakeMap      r292, 7, r278
+  MakeMap      r291, 7, r277
   // sort by g.key.channel
-  Index        r293, r248, r186
-  Index        r294, r293, r7
-  Move         r295, r294
+  Index        r292, r247, r186
+  Index        r293, r292, r7
+  Move         r294, r293
   // from r in all_rows
-  Move         r296, r292
-  MakeList     r297, 2, r295
-  Append       r298, r185, r297
-  Move         r185, r298
-  AddInt       r244, r244, r72
+  Move         r295, r291
+  MakeList     r296, 2, r294
+  Append       r297, r185, r296
+  Move         r185, r297
+  AddInt       r243, r243, r72
   Jump         L27
 L24:
   // sort by g.key.channel
-  Sort         r299, r185
+  Sort         r298, r185
   // from r in all_rows
-  Move         r185, r299
+  Move         r185, r298
   // json(result)
   JSON         r185
   // expect result == [
-  Const        r300, [{"channel": "store", "col_name": nil, "d_qoy": 1, "d_year": 1998, "i_category": "CatA", "sales_amt": 10, "sales_cnt": 1}, {"channel": "web", "col_name": nil, "d_qoy": 1, "d_year": 1998, "i_category": "CatB", "sales_amt": 15, "sales_cnt": 1}, {"channel": "catalog", "col_name": nil, "d_qoy": 1, "d_year": 1998, "i_category": "CatC", "sales_amt": 20, "sales_cnt": 1}]
-  Equal        r301, r185, r300
-  Expect       r301
+  Const        r299, [{"channel": "store", "col_name": nil, "d_qoy": 1, "d_year": 1998, "i_category": "CatA", "sales_amt": 10.0, "sales_cnt": 1}, {"channel": "web", "col_name": nil, "d_qoy": 1, "d_year": 1998, "i_category": "CatB", "sales_amt": 15.0, "sales_cnt": 1}, {"channel": "catalog", "col_name": nil, "d_qoy": 1, "d_year": 1998, "i_category": "CatC", "sales_amt": 20.0, "sales_cnt": 1}]
+  Equal        r300, r185, r299
+  Expect       r300
   Return       r0
-

--- a/tests/dataset/tpc-ds/out/q77.ir.out
+++ b/tests/dataset/tpc-ds/out/q77.ir.out
@@ -1,18 +1,18 @@
-func main (regs=853)
+func main (regs=846)
   // let date_dim = [
   Const        r0, [{"d_date": 1, "d_date_sk": 1}]
   // let store_sales = [
-  Const        r1, [{"s_store_sk": 1, "ss_ext_sales_price": 100, "ss_net_profit": 10, "ss_sold_date_sk": 1}]
+  Const        r1, [{"s_store_sk": 1, "ss_ext_sales_price": 100.0, "ss_net_profit": 10.0, "ss_sold_date_sk": 1}]
   // let store_returns = [
-  Const        r2, [{"s_store_sk": 1, "sr_net_loss": 1, "sr_return_amt": 5, "sr_returned_date_sk": 1}]
+  Const        r2, [{"s_store_sk": 1, "sr_net_loss": 1.0, "sr_return_amt": 5.0, "sr_returned_date_sk": 1}]
   // let catalog_sales = [
-  Const        r3, [{"cs_call_center_sk": 1, "cs_ext_sales_price": 150, "cs_net_profit": 15, "cs_sold_date_sk": 1}]
+  Const        r3, [{"cs_call_center_sk": 1, "cs_ext_sales_price": 150.0, "cs_net_profit": 15.0, "cs_sold_date_sk": 1}]
   // let catalog_returns = [
-  Const        r4, [{"cr_call_center_sk": 1, "cr_net_loss": 3, "cr_return_amount": 7, "cr_returned_date_sk": 1}]
+  Const        r4, [{"cr_call_center_sk": 1, "cr_net_loss": 3.0, "cr_return_amount": 7.0, "cr_returned_date_sk": 1}]
   // let web_sales = [
-  Const        r5, [{"ws_ext_sales_price": 200, "ws_net_profit": 20, "ws_sold_date_sk": 1, "ws_web_page_sk": 1}]
+  Const        r5, [{"ws_ext_sales_price": 200.0, "ws_net_profit": 20.0, "ws_sold_date_sk": 1, "ws_web_page_sk": 1}]
   // let web_returns = [
-  Const        r6, [{"wr_net_loss": 2, "wr_return_amt": 10, "wr_returned_date_sk": 1, "wr_web_page_sk": 1}]
+  Const        r6, [{"wr_net_loss": 2.0, "wr_return_amt": 10.0, "wr_returned_date_sk": 1, "wr_web_page_sk": 1}]
   // from ss in store_sales
   Const        r7, []
   // group by ss.s_store_sk into g
@@ -66,1275 +66,1267 @@ L4:
   In           r45, r44, r15
   JumpIfTrue   r45, L3
   // from ss in store_sales
-  Const        r46, []
-  Const        r47, "__group__"
-  Const        r48, true
+  Const        r46, "__group__"
+  Const        r47, true
   // group by ss.s_store_sk into g
-  Move         r49, r43
+  Move         r48, r43
   // from ss in store_sales
-  Const        r50, "items"
-  Move         r51, r46
-  Const        r52, "count"
-  Const        r53, 0
+  Const        r49, "items"
+  Move         r50, r17
+  Const        r51, "count"
+  Const        r52, 0
+  Move         r53, r46
   Move         r54, r47
-  Move         r55, r48
-  Move         r56, r9
+  Move         r55, r9
+  Move         r56, r48
   Move         r57, r49
   Move         r58, r50
   Move         r59, r51
   Move         r60, r52
-  Move         r61, r53
-  MakeMap      r62, 4, r54
-  SetIndex     r15, r44, r62
-  Append       r63, r16, r62
-  Move         r16, r63
+  MakeMap      r61, 4, r53
+  SetIndex     r15, r44, r61
+  Append       r62, r16, r61
+  Move         r16, r62
 L3:
-  Index        r64, r15, r44
-  Index        r65, r64, r50
-  Append       r66, r65, r42
-  SetIndex     r64, r50, r66
-  Index        r67, r64, r52
-  Const        r68, 1
-  AddInt       r69, r67, r68
-  SetIndex     r64, r52, r69
+  Index        r63, r15, r44
+  Index        r64, r63, r49
+  Append       r65, r64, r42
+  SetIndex     r63, r49, r65
+  Index        r66, r63, r51
+  Const        r67, 1
+  AddInt       r68, r66, r67
+  SetIndex     r63, r51, r68
 L2:
   // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
-  AddInt       r26, r26, r68
+  AddInt       r26, r26, r67
   Jump         L4
 L1:
   // from ss in store_sales
-  AddInt       r20, r20, r68
+  AddInt       r20, r20, r67
   Jump         L5
 L0:
-  Move         r70, r53
-  Len          r71, r16
+  Move         r69, r52
+  Len          r70, r16
 L11:
-  LessInt      r72, r70, r71
-  JumpIfFalse  r72, L6
-  Index        r73, r16, r70
-  Move         r74, r73
+  LessInt      r71, r69, r70
+  JumpIfFalse  r71, L6
+  Index        r72, r16, r69
+  Move         r73, r72
   // select { s_store_sk: g.key, sales: sum(from x in g select x.ss.ss_ext_sales_price), profit: sum(from x in g select x.ss.ss_net_profit) }
-  Const        r75, "s_store_sk"
-  Index        r76, r74, r9
-  Const        r77, "sales"
-  Const        r78, []
-  IterPrep     r79, r74
-  Len          r80, r79
-  Move         r81, r53
+  Const        r74, "s_store_sk"
+  Index        r75, r73, r9
+  Const        r76, "sales"
+  Const        r77, []
+  IterPrep     r78, r73
+  Len          r79, r78
+  Move         r80, r52
 L8:
-  LessInt      r82, r81, r80
-  JumpIfFalse  r82, L7
-  Index        r83, r79, r81
-  Move         r84, r83
-  Index        r85, r84, r11
-  Index        r86, r85, r12
-  Append       r87, r78, r86
-  Move         r78, r87
-  AddInt       r81, r81, r68
+  LessInt      r81, r80, r79
+  JumpIfFalse  r81, L7
+  Index        r82, r78, r80
+  Move         r83, r82
+  Index        r84, r83, r11
+  Index        r85, r84, r12
+  Append       r86, r77, r85
+  Move         r77, r86
+  AddInt       r80, r80, r67
   Jump         L8
 L7:
-  Sum          r88, r78
-  Const        r89, "profit"
-  Const        r90, []
-  IterPrep     r91, r74
-  Len          r92, r91
-  Move         r93, r53
+  Sum          r87, r77
+  Const        r88, "profit"
+  Const        r89, []
+  IterPrep     r90, r73
+  Len          r91, r90
+  Move         r92, r52
 L10:
-  LessInt      r94, r93, r92
-  JumpIfFalse  r94, L9
-  Index        r95, r91, r93
-  Move         r84, r95
-  Index        r96, r84, r11
-  Index        r97, r96, r14
-  Append       r98, r90, r97
-  Move         r90, r98
-  AddInt       r93, r93, r68
+  LessInt      r93, r92, r91
+  JumpIfFalse  r93, L9
+  Index        r94, r90, r92
+  Move         r83, r94
+  Index        r95, r83, r11
+  Index        r96, r95, r14
+  Append       r97, r89, r96
+  Move         r89, r97
+  AddInt       r92, r92, r67
   Jump         L10
 L9:
-  Sum          r99, r90
+  Sum          r98, r89
+  Move         r99, r74
   Move         r100, r75
   Move         r101, r76
-  Move         r102, r77
+  Move         r102, r87
   Move         r103, r88
-  Move         r104, r89
-  Move         r105, r99
-  MakeMap      r106, 3, r100
+  Move         r104, r98
+  MakeMap      r105, 3, r99
   // from ss in store_sales
-  Append       r107, r7, r106
-  Move         r7, r107
-  AddInt       r70, r70, r68
+  Append       r106, r7, r105
+  Move         r7, r106
+  AddInt       r69, r69, r67
   Jump         L11
 L6:
   // from sr in store_returns
-  Const        r108, []
+  Const        r107, []
   // select { s_store_sk: g.key, returns: sum(from x in g select x.sr.sr_return_amt), profit_loss: sum(from x in g select x.sr.sr_net_loss) }
-  Const        r109, "returns"
-  Const        r110, "sr"
-  Const        r111, "sr_return_amt"
-  Const        r112, "profit_loss"
-  Const        r113, "sr_net_loss"
+  Const        r108, "returns"
+  Const        r109, "sr"
+  Const        r110, "sr_return_amt"
+  Const        r111, "profit_loss"
+  Const        r112, "sr_net_loss"
   // from sr in store_returns
-  MakeMap      r114, 0, r0
-  Const        r116, []
-  Move         r115, r116
-  IterPrep     r117, r2
-  Len          r118, r117
-  Const        r119, 0
+  MakeMap      r113, 0, r0
+  Move         r114, r17
+  IterPrep     r115, r2
+  Len          r116, r115
+  Const        r117, 0
 L17:
-  LessInt      r120, r119, r118
-  JumpIfFalse  r120, L12
-  Index        r121, r117, r119
-  Move         r122, r121
+  LessInt      r118, r117, r116
+  JumpIfFalse  r118, L12
+  Index        r119, r115, r117
+  Move         r120, r119
   // join d in date_dim on d.d_date_sk == sr.sr_returned_date_sk
-  IterPrep     r123, r0
-  Len          r124, r123
-  Const        r125, 0
+  IterPrep     r121, r0
+  Len          r122, r121
+  Const        r123, 0
 L16:
-  LessInt      r126, r125, r124
-  JumpIfFalse  r126, L13
-  Index        r127, r123, r125
-  Move         r128, r127
-  Index        r129, r128, r30
-  Const        r130, "sr_returned_date_sk"
-  Index        r131, r122, r130
-  Equal        r132, r129, r131
-  JumpIfFalse  r132, L14
+  LessInt      r124, r123, r122
+  JumpIfFalse  r124, L13
+  Index        r125, r121, r123
+  Move         r126, r125
+  Index        r127, r126, r30
+  Const        r128, "sr_returned_date_sk"
+  Index        r129, r120, r128
+  Equal        r130, r127, r129
+  JumpIfFalse  r130, L14
   // from sr in store_returns
-  Move         r133, r122
-  Move         r134, r128
-  Move         r135, r110
-  Move         r136, r133
-  Move         r137, r36
-  Move         r138, r134
-  MakeMap      r139, 2, r135
+  Move         r131, r120
+  Move         r132, r126
+  Move         r133, r109
+  Move         r134, r131
+  Move         r135, r36
+  Move         r136, r132
+  MakeMap      r137, 2, r133
   // group by sr.s_store_sk into g
-  Index        r140, r122, r8
-  Str          r141, r140
-  In           r142, r141, r114
-  JumpIfTrue   r142, L15
-  Move         r143, r140
+  Index        r138, r120, r8
+  Str          r139, r138
+  In           r140, r139, r113
+  JumpIfTrue   r140, L15
+  Move         r141, r138
   // from sr in store_returns
-  Move         r144, r46
-  Move         r145, r47
-  Move         r146, r48
-  Move         r147, r9
-  Move         r148, r143
-  Move         r149, r50
-  Move         r150, r144
-  Move         r151, r52
-  Move         r152, r53
-  MakeMap      r153, 4, r145
-  SetIndex     r114, r141, r153
-  Append       r154, r115, r153
-  Move         r115, r154
+  Move         r142, r17
+  Move         r143, r46
+  Move         r144, r47
+  Move         r145, r9
+  Move         r146, r141
+  Move         r147, r49
+  Move         r148, r142
+  Move         r149, r51
+  Move         r150, r52
+  MakeMap      r151, 4, r143
+  SetIndex     r113, r139, r151
+  Append       r152, r114, r151
+  Move         r114, r152
 L15:
-  Index        r155, r114, r141
-  Index        r156, r155, r50
-  Append       r157, r156, r139
-  SetIndex     r155, r50, r157
-  Index        r158, r155, r52
-  AddInt       r159, r158, r68
-  SetIndex     r155, r52, r159
+  Index        r153, r113, r139
+  Index        r154, r153, r49
+  Append       r155, r154, r137
+  SetIndex     r153, r49, r155
+  Index        r156, r153, r51
+  AddInt       r157, r156, r67
+  SetIndex     r153, r51, r157
 L14:
   // join d in date_dim on d.d_date_sk == sr.sr_returned_date_sk
-  AddInt       r125, r125, r68
+  AddInt       r123, r123, r67
   Jump         L16
 L13:
   // from sr in store_returns
-  AddInt       r119, r119, r68
+  AddInt       r117, r117, r67
   Jump         L17
 L12:
-  Move         r160, r53
-  Len          r161, r115
+  Move         r158, r52
+  Len          r159, r114
 L23:
-  LessInt      r162, r160, r161
-  JumpIfFalse  r162, L18
-  Index        r163, r115, r160
-  Move         r74, r163
+  LessInt      r160, r158, r159
+  JumpIfFalse  r160, L18
+  Index        r161, r114, r158
+  Move         r73, r161
   // select { s_store_sk: g.key, returns: sum(from x in g select x.sr.sr_return_amt), profit_loss: sum(from x in g select x.sr.sr_net_loss) }
-  Const        r164, "s_store_sk"
-  Index        r165, r74, r9
-  Const        r166, "returns"
-  Const        r167, []
-  IterPrep     r168, r74
-  Len          r169, r168
-  Move         r170, r53
+  Const        r162, "s_store_sk"
+  Index        r163, r73, r9
+  Const        r164, "returns"
+  Const        r165, []
+  IterPrep     r166, r73
+  Len          r167, r166
+  Move         r168, r52
 L20:
-  LessInt      r171, r170, r169
-  JumpIfFalse  r171, L19
-  Index        r172, r168, r170
-  Move         r84, r172
-  Index        r173, r84, r110
-  Index        r174, r173, r111
-  Append       r175, r167, r174
-  Move         r167, r175
-  AddInt       r170, r170, r68
+  LessInt      r169, r168, r167
+  JumpIfFalse  r169, L19
+  Index        r170, r166, r168
+  Move         r83, r170
+  Index        r171, r83, r109
+  Index        r172, r171, r110
+  Append       r173, r165, r172
+  Move         r165, r173
+  AddInt       r168, r168, r67
   Jump         L20
 L19:
-  Sum          r176, r167
-  Const        r177, "profit_loss"
-  Const        r178, []
-  IterPrep     r179, r74
-  Len          r180, r179
-  Move         r181, r53
+  Sum          r174, r165
+  Const        r175, "profit_loss"
+  Const        r176, []
+  IterPrep     r177, r73
+  Len          r178, r177
+  Move         r179, r52
 L22:
-  LessInt      r182, r181, r180
-  JumpIfFalse  r182, L21
-  Index        r183, r179, r181
-  Move         r84, r183
-  Index        r184, r84, r110
-  Index        r185, r184, r113
-  Append       r186, r178, r185
-  Move         r178, r186
-  AddInt       r181, r181, r68
+  LessInt      r180, r179, r178
+  JumpIfFalse  r180, L21
+  Index        r181, r177, r179
+  Move         r83, r181
+  Index        r182, r83, r109
+  Index        r183, r182, r112
+  Append       r184, r176, r183
+  Move         r176, r184
+  AddInt       r179, r179, r67
   Jump         L22
 L21:
-  Sum          r187, r178
+  Sum          r185, r176
+  Move         r186, r162
+  Move         r187, r163
   Move         r188, r164
-  Move         r189, r165
-  Move         r190, r166
-  Move         r191, r176
-  Move         r192, r177
-  Move         r193, r187
-  MakeMap      r194, 3, r188
+  Move         r189, r174
+  Move         r190, r175
+  Move         r191, r185
+  MakeMap      r192, 3, r186
   // from sr in store_returns
-  Append       r195, r108, r194
-  Move         r108, r195
-  AddInt       r160, r160, r68
+  Append       r193, r107, r192
+  Move         r107, r193
+  AddInt       r158, r158, r67
   Jump         L23
 L18:
   // from cs in catalog_sales
-  Const        r196, []
+  Const        r194, []
   // group by cs.cs_call_center_sk into g
-  Const        r197, "cs_call_center_sk"
+  Const        r195, "cs_call_center_sk"
   // select { cs_call_center_sk: g.key, sales: sum(from x in g select x.cs.cs_ext_sales_price), profit: sum(from x in g select x.cs.cs_net_profit) }
-  Const        r198, "cs"
-  Const        r199, "cs_ext_sales_price"
-  Const        r200, "cs_net_profit"
+  Const        r196, "cs"
+  Const        r197, "cs_ext_sales_price"
+  Const        r198, "cs_net_profit"
   // from cs in catalog_sales
-  MakeMap      r201, 0, r0
-  Const        r203, []
-  Move         r202, r203
-  IterPrep     r204, r3
-  Len          r205, r204
-  Const        r206, 0
+  MakeMap      r199, 0, r0
+  Move         r200, r17
+  IterPrep     r201, r3
+  Len          r202, r201
+  Const        r203, 0
 L29:
-  LessInt      r207, r206, r205
-  JumpIfFalse  r207, L24
-  Index        r208, r204, r206
-  Move         r209, r208
+  LessInt      r204, r203, r202
+  JumpIfFalse  r204, L24
+  Index        r205, r201, r203
+  Move         r206, r205
   // join d in date_dim on d.d_date_sk == cs.cs_sold_date_sk
-  IterPrep     r210, r0
-  Len          r211, r210
-  Const        r212, 0
+  IterPrep     r207, r0
+  Len          r208, r207
+  Const        r209, 0
 L28:
-  LessInt      r213, r212, r211
-  JumpIfFalse  r213, L25
-  Index        r214, r210, r212
-  Move         r215, r214
-  Index        r216, r215, r30
-  Const        r217, "cs_sold_date_sk"
-  Index        r218, r209, r217
-  Equal        r219, r216, r218
-  JumpIfFalse  r219, L26
+  LessInt      r210, r209, r208
+  JumpIfFalse  r210, L25
+  Index        r211, r207, r209
+  Move         r212, r211
+  Index        r213, r212, r30
+  Const        r214, "cs_sold_date_sk"
+  Index        r215, r206, r214
+  Equal        r216, r213, r215
+  JumpIfFalse  r216, L26
   // from cs in catalog_sales
-  Move         r220, r209
-  Move         r221, r215
-  Move         r222, r198
-  Move         r223, r220
-  Move         r224, r36
-  Move         r225, r221
-  MakeMap      r226, 2, r222
+  Move         r217, r206
+  Move         r218, r212
+  Move         r219, r196
+  Move         r220, r217
+  Move         r221, r36
+  Move         r222, r218
+  MakeMap      r223, 2, r219
   // group by cs.cs_call_center_sk into g
-  Index        r227, r209, r197
-  Str          r228, r227
-  In           r229, r228, r201
-  JumpIfTrue   r229, L27
-  Move         r230, r227
+  Index        r224, r206, r195
+  Str          r225, r224
+  In           r226, r225, r199
+  JumpIfTrue   r226, L27
+  Move         r227, r224
   // from cs in catalog_sales
-  Move         r231, r46
-  Move         r232, r47
-  Move         r233, r48
-  Move         r234, r9
-  Move         r235, r230
-  Move         r236, r50
-  Move         r237, r231
-  Move         r238, r52
-  Move         r239, r53
-  MakeMap      r240, 4, r232
-  SetIndex     r201, r228, r240
-  Append       r241, r202, r240
-  Move         r202, r241
+  Move         r228, r17
+  Move         r229, r46
+  Move         r230, r47
+  Move         r231, r9
+  Move         r232, r227
+  Move         r233, r49
+  Move         r234, r228
+  Move         r235, r51
+  Move         r236, r52
+  MakeMap      r237, 4, r229
+  SetIndex     r199, r225, r237
+  Append       r238, r200, r237
+  Move         r200, r238
 L27:
-  Index        r242, r201, r228
-  Index        r243, r242, r50
-  Append       r244, r243, r226
-  SetIndex     r242, r50, r244
-  Index        r245, r242, r52
-  AddInt       r246, r245, r68
-  SetIndex     r242, r52, r246
+  Index        r239, r199, r225
+  Index        r240, r239, r49
+  Append       r241, r240, r223
+  SetIndex     r239, r49, r241
+  Index        r242, r239, r51
+  AddInt       r243, r242, r67
+  SetIndex     r239, r51, r243
 L26:
   // join d in date_dim on d.d_date_sk == cs.cs_sold_date_sk
-  AddInt       r212, r212, r68
+  AddInt       r209, r209, r67
   Jump         L28
 L25:
   // from cs in catalog_sales
-  AddInt       r206, r206, r68
+  AddInt       r203, r203, r67
   Jump         L29
 L24:
-  Move         r247, r53
-  Len          r248, r202
+  Move         r244, r52
+  Len          r245, r200
 L35:
-  LessInt      r249, r247, r248
-  JumpIfFalse  r249, L30
-  Index        r250, r202, r247
-  Move         r74, r250
+  LessInt      r246, r244, r245
+  JumpIfFalse  r246, L30
+  Index        r247, r200, r244
+  Move         r73, r247
   // select { cs_call_center_sk: g.key, sales: sum(from x in g select x.cs.cs_ext_sales_price), profit: sum(from x in g select x.cs.cs_net_profit) }
-  Const        r251, "cs_call_center_sk"
-  Index        r252, r74, r9
-  Const        r253, "sales"
-  Const        r254, []
-  IterPrep     r255, r74
-  Len          r256, r255
-  Move         r257, r53
+  Const        r248, "cs_call_center_sk"
+  Index        r249, r73, r9
+  Const        r250, "sales"
+  Const        r251, []
+  IterPrep     r252, r73
+  Len          r253, r252
+  Move         r254, r52
 L32:
-  LessInt      r258, r257, r256
-  JumpIfFalse  r258, L31
-  Index        r259, r255, r257
-  Move         r84, r259
-  Index        r260, r84, r198
-  Index        r261, r260, r199
-  Append       r262, r254, r261
-  Move         r254, r262
-  AddInt       r257, r257, r68
+  LessInt      r255, r254, r253
+  JumpIfFalse  r255, L31
+  Index        r256, r252, r254
+  Move         r83, r256
+  Index        r257, r83, r196
+  Index        r258, r257, r197
+  Append       r259, r251, r258
+  Move         r251, r259
+  AddInt       r254, r254, r67
   Jump         L32
 L31:
-  Sum          r263, r254
-  Const        r264, "profit"
-  Const        r265, []
-  IterPrep     r266, r74
-  Len          r267, r266
-  Move         r268, r53
+  Sum          r260, r251
+  Const        r261, "profit"
+  Const        r262, []
+  IterPrep     r263, r73
+  Len          r264, r263
+  Move         r265, r52
 L34:
-  LessInt      r269, r268, r267
-  JumpIfFalse  r269, L33
-  Index        r270, r266, r268
-  Move         r84, r270
-  Index        r271, r84, r198
-  Index        r272, r271, r200
-  Append       r273, r265, r272
-  Move         r265, r273
-  AddInt       r268, r268, r68
+  LessInt      r266, r265, r264
+  JumpIfFalse  r266, L33
+  Index        r267, r263, r265
+  Move         r83, r267
+  Index        r268, r83, r196
+  Index        r269, r268, r198
+  Append       r270, r262, r269
+  Move         r262, r270
+  AddInt       r265, r265, r67
   Jump         L34
 L33:
-  Sum          r274, r265
-  Move         r275, r251
-  Move         r276, r252
-  Move         r277, r253
-  Move         r278, r263
-  Move         r279, r264
-  Move         r280, r274
-  MakeMap      r281, 3, r275
+  Sum          r271, r262
+  Move         r272, r248
+  Move         r273, r249
+  Move         r274, r250
+  Move         r275, r260
+  Move         r276, r261
+  Move         r277, r271
+  MakeMap      r278, 3, r272
   // from cs in catalog_sales
-  Append       r282, r196, r281
-  Move         r196, r282
-  AddInt       r247, r247, r68
+  Append       r279, r194, r278
+  Move         r194, r279
+  AddInt       r244, r244, r67
   Jump         L35
 L30:
   // from cr in catalog_returns
-  Const        r283, []
+  Const        r280, []
   // group by cr.cr_call_center_sk into g
-  Const        r284, "cr_call_center_sk"
+  Const        r281, "cr_call_center_sk"
   // select { cr_call_center_sk: g.key, returns: sum(from x in g select x.cr.cr_return_amount), profit_loss: sum(from x in g select x.cr.cr_net_loss) }
-  Const        r285, "cr"
-  Const        r286, "cr_return_amount"
-  Const        r287, "cr_net_loss"
+  Const        r282, "cr"
+  Const        r283, "cr_return_amount"
+  Const        r284, "cr_net_loss"
   // from cr in catalog_returns
-  MakeMap      r288, 0, r0
-  Const        r290, []
-  Move         r289, r290
-  IterPrep     r291, r4
-  Len          r292, r291
-  Const        r293, 0
+  MakeMap      r285, 0, r0
+  Move         r286, r17
+  IterPrep     r287, r4
+  Len          r288, r287
+  Const        r289, 0
 L41:
-  LessInt      r294, r293, r292
-  JumpIfFalse  r294, L36
-  Index        r295, r291, r293
-  Move         r296, r295
+  LessInt      r290, r289, r288
+  JumpIfFalse  r290, L36
+  Index        r291, r287, r289
+  Move         r292, r291
   // join d in date_dim on d.d_date_sk == cr.cr_returned_date_sk
-  IterPrep     r297, r0
-  Len          r298, r297
-  Const        r299, 0
+  IterPrep     r293, r0
+  Len          r294, r293
+  Const        r295, 0
 L40:
-  LessInt      r300, r299, r298
-  JumpIfFalse  r300, L37
-  Index        r301, r297, r299
-  Move         r302, r301
-  Index        r303, r302, r30
-  Const        r304, "cr_returned_date_sk"
-  Index        r305, r296, r304
-  Equal        r306, r303, r305
-  JumpIfFalse  r306, L38
+  LessInt      r296, r295, r294
+  JumpIfFalse  r296, L37
+  Index        r297, r293, r295
+  Move         r298, r297
+  Index        r299, r298, r30
+  Const        r300, "cr_returned_date_sk"
+  Index        r301, r292, r300
+  Equal        r302, r299, r301
+  JumpIfFalse  r302, L38
   // from cr in catalog_returns
-  Move         r307, r296
-  Move         r308, r302
-  Move         r309, r285
-  Move         r310, r307
-  Move         r311, r36
-  Move         r312, r308
-  MakeMap      r313, 2, r309
+  Move         r303, r292
+  Move         r304, r298
+  Move         r305, r282
+  Move         r306, r303
+  Move         r307, r36
+  Move         r308, r304
+  MakeMap      r309, 2, r305
   // group by cr.cr_call_center_sk into g
-  Index        r314, r296, r284
-  Str          r315, r314
-  In           r316, r315, r288
-  JumpIfTrue   r316, L39
-  Move         r317, r314
+  Index        r310, r292, r281
+  Str          r311, r310
+  In           r312, r311, r285
+  JumpIfTrue   r312, L39
+  Move         r313, r310
   // from cr in catalog_returns
-  Move         r318, r46
-  Move         r319, r47
-  Move         r320, r48
-  Move         r321, r9
-  Move         r322, r317
-  Move         r323, r50
-  Move         r324, r318
-  Move         r325, r52
-  Move         r326, r53
-  MakeMap      r327, 4, r319
-  SetIndex     r288, r315, r327
-  Append       r328, r289, r327
-  Move         r289, r328
+  Move         r314, r17
+  Move         r315, r46
+  Move         r316, r47
+  Move         r317, r9
+  Move         r318, r313
+  Move         r319, r49
+  Move         r320, r314
+  Move         r321, r51
+  Move         r322, r52
+  MakeMap      r323, 4, r315
+  SetIndex     r285, r311, r323
+  Append       r324, r286, r323
+  Move         r286, r324
 L39:
-  Index        r329, r288, r315
-  Index        r330, r329, r50
-  Append       r331, r330, r313
-  SetIndex     r329, r50, r331
-  Index        r332, r329, r52
-  AddInt       r333, r332, r68
-  SetIndex     r329, r52, r333
+  Index        r325, r285, r311
+  Index        r326, r325, r49
+  Append       r327, r326, r309
+  SetIndex     r325, r49, r327
+  Index        r328, r325, r51
+  AddInt       r329, r328, r67
+  SetIndex     r325, r51, r329
 L38:
   // join d in date_dim on d.d_date_sk == cr.cr_returned_date_sk
-  AddInt       r299, r299, r68
+  AddInt       r295, r295, r67
   Jump         L40
 L37:
   // from cr in catalog_returns
-  AddInt       r293, r293, r68
+  AddInt       r289, r289, r67
   Jump         L41
 L36:
-  Move         r334, r53
-  Len          r335, r289
+  Move         r330, r52
+  Len          r331, r286
 L47:
-  LessInt      r336, r334, r335
-  JumpIfFalse  r336, L42
-  Index        r337, r289, r334
-  Move         r74, r337
+  LessInt      r332, r330, r331
+  JumpIfFalse  r332, L42
+  Index        r333, r286, r330
+  Move         r73, r333
   // select { cr_call_center_sk: g.key, returns: sum(from x in g select x.cr.cr_return_amount), profit_loss: sum(from x in g select x.cr.cr_net_loss) }
-  Const        r338, "cr_call_center_sk"
-  Index        r339, r74, r9
-  Const        r340, "returns"
-  Const        r341, []
-  IterPrep     r342, r74
-  Len          r343, r342
-  Move         r344, r53
+  Const        r334, "cr_call_center_sk"
+  Index        r335, r73, r9
+  Const        r336, "returns"
+  Const        r337, []
+  IterPrep     r338, r73
+  Len          r339, r338
+  Move         r340, r52
 L44:
-  LessInt      r345, r344, r343
-  JumpIfFalse  r345, L43
-  Index        r346, r342, r344
-  Move         r84, r346
-  Index        r347, r84, r285
-  Index        r348, r347, r286
-  Append       r349, r341, r348
-  Move         r341, r349
-  AddInt       r344, r344, r68
+  LessInt      r341, r340, r339
+  JumpIfFalse  r341, L43
+  Index        r342, r338, r340
+  Move         r83, r342
+  Index        r343, r83, r282
+  Index        r344, r343, r283
+  Append       r345, r337, r344
+  Move         r337, r345
+  AddInt       r340, r340, r67
   Jump         L44
 L43:
-  Sum          r350, r341
-  Const        r351, "profit_loss"
-  Const        r352, []
-  IterPrep     r353, r74
-  Len          r354, r353
-  Move         r355, r53
+  Sum          r346, r337
+  Const        r347, "profit_loss"
+  Const        r348, []
+  IterPrep     r349, r73
+  Len          r350, r349
+  Move         r351, r52
 L46:
-  LessInt      r356, r355, r354
-  JumpIfFalse  r356, L45
-  Index        r357, r353, r355
-  Move         r84, r357
-  Index        r358, r84, r285
-  Index        r359, r358, r287
-  Append       r360, r352, r359
-  Move         r352, r360
-  AddInt       r355, r355, r68
+  LessInt      r352, r351, r350
+  JumpIfFalse  r352, L45
+  Index        r353, r349, r351
+  Move         r83, r353
+  Index        r354, r83, r282
+  Index        r355, r354, r284
+  Append       r356, r348, r355
+  Move         r348, r356
+  AddInt       r351, r351, r67
   Jump         L46
 L45:
-  Sum          r361, r352
-  Move         r362, r338
-  Move         r363, r339
-  Move         r364, r340
-  Move         r365, r350
-  Move         r366, r351
-  Move         r367, r361
-  MakeMap      r368, 3, r362
+  Sum          r357, r348
+  Move         r358, r334
+  Move         r359, r335
+  Move         r360, r336
+  Move         r361, r346
+  Move         r362, r347
+  Move         r363, r357
+  MakeMap      r364, 3, r358
   // from cr in catalog_returns
-  Append       r369, r283, r368
-  Move         r283, r369
-  AddInt       r334, r334, r68
+  Append       r365, r280, r364
+  Move         r280, r365
+  AddInt       r330, r330, r67
   Jump         L47
 L42:
   // from ws in web_sales
-  Const        r370, []
+  Const        r366, []
   // group by ws.ws_web_page_sk into g
-  Const        r371, "ws_web_page_sk"
+  Const        r367, "ws_web_page_sk"
   // select { wp_web_page_sk: g.key, sales: sum(from x in g select x.ws.ws_ext_sales_price), profit: sum(from x in g select x.ws.ws_net_profit) }
-  Const        r372, "wp_web_page_sk"
-  Const        r373, "ws"
-  Const        r374, "ws_ext_sales_price"
-  Const        r375, "ws_net_profit"
+  Const        r368, "wp_web_page_sk"
+  Const        r369, "ws"
+  Const        r370, "ws_ext_sales_price"
+  Const        r371, "ws_net_profit"
   // from ws in web_sales
-  MakeMap      r376, 0, r0
-  Const        r378, []
-  Move         r377, r378
-  IterPrep     r379, r5
-  Len          r380, r379
-  Const        r381, 0
+  MakeMap      r372, 0, r0
+  Move         r373, r17
+  IterPrep     r374, r5
+  Len          r375, r374
+  Const        r376, 0
 L53:
-  LessInt      r382, r381, r380
-  JumpIfFalse  r382, L48
-  Index        r383, r379, r381
-  Move         r384, r383
+  LessInt      r377, r376, r375
+  JumpIfFalse  r377, L48
+  Index        r378, r374, r376
+  Move         r379, r378
   // join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
-  IterPrep     r385, r0
-  Len          r386, r385
-  Const        r387, 0
+  IterPrep     r380, r0
+  Len          r381, r380
+  Const        r382, 0
 L52:
-  LessInt      r388, r387, r386
-  JumpIfFalse  r388, L49
-  Index        r389, r385, r387
-  Move         r390, r389
-  Index        r391, r390, r30
-  Const        r392, "ws_sold_date_sk"
-  Index        r393, r384, r392
-  Equal        r394, r391, r393
-  JumpIfFalse  r394, L50
+  LessInt      r383, r382, r381
+  JumpIfFalse  r383, L49
+  Index        r384, r380, r382
+  Move         r385, r384
+  Index        r386, r385, r30
+  Const        r387, "ws_sold_date_sk"
+  Index        r388, r379, r387
+  Equal        r389, r386, r388
+  JumpIfFalse  r389, L50
   // from ws in web_sales
-  Move         r395, r384
-  Move         r396, r390
-  Move         r397, r373
-  Move         r398, r395
-  Move         r399, r36
-  Move         r400, r396
-  MakeMap      r401, 2, r397
+  Move         r390, r379
+  Move         r391, r385
+  Move         r392, r369
+  Move         r393, r390
+  Move         r394, r36
+  Move         r395, r391
+  MakeMap      r396, 2, r392
   // group by ws.ws_web_page_sk into g
-  Index        r402, r384, r371
-  Str          r403, r402
-  In           r404, r403, r376
-  JumpIfTrue   r404, L51
-  Move         r405, r402
+  Index        r397, r379, r367
+  Str          r398, r397
+  In           r399, r398, r372
+  JumpIfTrue   r399, L51
+  Move         r400, r397
   // from ws in web_sales
-  Move         r406, r46
-  Move         r407, r47
-  Move         r408, r48
-  Move         r409, r9
-  Move         r410, r405
-  Move         r411, r50
-  Move         r412, r406
-  Move         r413, r52
-  Move         r414, r53
-  MakeMap      r415, 4, r407
-  SetIndex     r376, r403, r415
-  Append       r416, r377, r415
-  Move         r377, r416
+  Move         r401, r17
+  Move         r402, r46
+  Move         r403, r47
+  Move         r404, r9
+  Move         r405, r400
+  Move         r406, r49
+  Move         r407, r401
+  Move         r408, r51
+  Move         r409, r52
+  MakeMap      r410, 4, r402
+  SetIndex     r372, r398, r410
+  Append       r411, r373, r410
+  Move         r373, r411
 L51:
-  Index        r417, r376, r403
-  Index        r418, r417, r50
-  Append       r419, r418, r401
-  SetIndex     r417, r50, r419
-  Index        r420, r417, r52
-  AddInt       r421, r420, r68
-  SetIndex     r417, r52, r421
+  Index        r412, r372, r398
+  Index        r413, r412, r49
+  Append       r414, r413, r396
+  SetIndex     r412, r49, r414
+  Index        r415, r412, r51
+  AddInt       r416, r415, r67
+  SetIndex     r412, r51, r416
 L50:
   // join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
-  AddInt       r387, r387, r68
+  AddInt       r382, r382, r67
   Jump         L52
 L49:
   // from ws in web_sales
-  AddInt       r381, r381, r68
+  AddInt       r376, r376, r67
   Jump         L53
 L48:
-  Move         r422, r53
-  Len          r423, r377
+  Move         r417, r52
+  Len          r418, r373
 L59:
-  LessInt      r424, r422, r423
-  JumpIfFalse  r424, L54
-  Index        r425, r377, r422
-  Move         r74, r425
+  LessInt      r419, r417, r418
+  JumpIfFalse  r419, L54
+  Index        r420, r373, r417
+  Move         r73, r420
   // select { wp_web_page_sk: g.key, sales: sum(from x in g select x.ws.ws_ext_sales_price), profit: sum(from x in g select x.ws.ws_net_profit) }
-  Const        r426, "wp_web_page_sk"
-  Index        r427, r74, r9
-  Const        r428, "sales"
-  Const        r429, []
-  IterPrep     r430, r74
-  Len          r431, r430
-  Move         r432, r53
+  Const        r421, "wp_web_page_sk"
+  Index        r422, r73, r9
+  Const        r423, "sales"
+  Const        r424, []
+  IterPrep     r425, r73
+  Len          r426, r425
+  Move         r427, r52
 L56:
-  LessInt      r433, r432, r431
-  JumpIfFalse  r433, L55
-  Index        r434, r430, r432
-  Move         r84, r434
-  Index        r435, r84, r373
-  Index        r436, r435, r374
-  Append       r437, r429, r436
-  Move         r429, r437
-  AddInt       r432, r432, r68
+  LessInt      r428, r427, r426
+  JumpIfFalse  r428, L55
+  Index        r429, r425, r427
+  Move         r83, r429
+  Index        r430, r83, r369
+  Index        r431, r430, r370
+  Append       r432, r424, r431
+  Move         r424, r432
+  AddInt       r427, r427, r67
   Jump         L56
 L55:
-  Sum          r438, r429
-  Const        r439, "profit"
-  Const        r440, []
-  IterPrep     r441, r74
-  Len          r442, r441
-  Move         r443, r53
+  Sum          r433, r424
+  Const        r434, "profit"
+  Const        r435, []
+  IterPrep     r436, r73
+  Len          r437, r436
+  Move         r438, r52
 L58:
-  LessInt      r444, r443, r442
-  JumpIfFalse  r444, L57
-  Index        r445, r441, r443
-  Move         r84, r445
-  Index        r446, r84, r373
-  Index        r447, r446, r375
-  Append       r448, r440, r447
-  Move         r440, r448
-  AddInt       r443, r443, r68
+  LessInt      r439, r438, r437
+  JumpIfFalse  r439, L57
+  Index        r440, r436, r438
+  Move         r83, r440
+  Index        r441, r83, r369
+  Index        r442, r441, r371
+  Append       r443, r435, r442
+  Move         r435, r443
+  AddInt       r438, r438, r67
   Jump         L58
 L57:
-  Sum          r449, r440
-  Move         r450, r426
-  Move         r451, r427
-  Move         r452, r428
-  Move         r453, r438
-  Move         r454, r439
-  Move         r455, r449
-  MakeMap      r456, 3, r450
+  Sum          r444, r435
+  Move         r445, r421
+  Move         r446, r422
+  Move         r447, r423
+  Move         r448, r433
+  Move         r449, r434
+  Move         r450, r444
+  MakeMap      r451, 3, r445
   // from ws in web_sales
-  Append       r457, r370, r456
-  Move         r370, r457
-  AddInt       r422, r422, r68
+  Append       r452, r366, r451
+  Move         r366, r452
+  AddInt       r417, r417, r67
   Jump         L59
 L54:
   // from wr in web_returns
-  Const        r458, []
+  Const        r453, []
   // group by wr.wr_web_page_sk into g
-  Const        r459, "wr_web_page_sk"
+  Const        r454, "wr_web_page_sk"
   // select { wp_web_page_sk: g.key, returns: sum(from x in g select x.wr.wr_return_amt), profit_loss: sum(from x in g select x.wr.wr_net_loss) }
-  Const        r460, "wr"
-  Const        r461, "wr_return_amt"
-  Const        r462, "wr_net_loss"
+  Const        r455, "wr"
+  Const        r456, "wr_return_amt"
+  Const        r457, "wr_net_loss"
   // from wr in web_returns
-  MakeMap      r463, 0, r0
-  Const        r465, []
-  Move         r464, r465
-  IterPrep     r466, r6
+  MakeMap      r458, 0, r0
+  Move         r459, r17
+  IterPrep     r460, r6
+  Len          r461, r460
+  Const        r462, 0
+L65:
+  LessInt      r463, r462, r461
+  JumpIfFalse  r463, L60
+  Index        r464, r460, r462
+  Move         r465, r464
+  // join d in date_dim on d.d_date_sk == wr.wr_returned_date_sk
+  IterPrep     r466, r0
   Len          r467, r466
   Const        r468, 0
-L65:
+L64:
   LessInt      r469, r468, r467
-  JumpIfFalse  r469, L60
+  JumpIfFalse  r469, L61
   Index        r470, r466, r468
   Move         r471, r470
-  // join d in date_dim on d.d_date_sk == wr.wr_returned_date_sk
-  IterPrep     r472, r0
-  Len          r473, r472
-  Const        r474, 0
-L64:
-  LessInt      r475, r474, r473
-  JumpIfFalse  r475, L61
-  Index        r476, r472, r474
-  Move         r477, r476
-  Index        r478, r477, r30
-  Const        r479, "wr_returned_date_sk"
-  Index        r480, r471, r479
-  Equal        r481, r478, r480
-  JumpIfFalse  r481, L62
+  Index        r472, r471, r30
+  Const        r473, "wr_returned_date_sk"
+  Index        r474, r465, r473
+  Equal        r475, r472, r474
+  JumpIfFalse  r475, L62
   // from wr in web_returns
-  Move         r482, r471
-  Move         r483, r477
-  Move         r484, r460
-  Move         r485, r482
-  Move         r486, r36
-  Move         r487, r483
-  MakeMap      r488, 2, r484
+  Move         r476, r465
+  Move         r477, r471
+  Move         r478, r455
+  Move         r479, r476
+  Move         r480, r36
+  Move         r481, r477
+  MakeMap      r482, 2, r478
   // group by wr.wr_web_page_sk into g
-  Index        r489, r471, r459
-  Str          r490, r489
-  In           r491, r490, r463
-  JumpIfTrue   r491, L63
-  Move         r492, r489
+  Index        r483, r465, r454
+  Str          r484, r483
+  In           r485, r484, r458
+  JumpIfTrue   r485, L63
+  Move         r486, r483
   // from wr in web_returns
-  Move         r493, r46
-  Move         r494, r47
-  Move         r495, r48
-  Move         r496, r9
-  Move         r497, r492
-  Move         r498, r50
-  Move         r499, r493
-  Move         r500, r52
-  Move         r501, r53
-  MakeMap      r502, 4, r494
-  SetIndex     r463, r490, r502
-  Append       r503, r464, r502
-  Move         r464, r503
+  Move         r487, r17
+  Move         r488, r46
+  Move         r489, r47
+  Move         r490, r9
+  Move         r491, r486
+  Move         r492, r49
+  Move         r493, r487
+  Move         r494, r51
+  Move         r495, r52
+  MakeMap      r496, 4, r488
+  SetIndex     r458, r484, r496
+  Append       r497, r459, r496
+  Move         r459, r497
 L63:
-  Index        r504, r463, r490
-  Index        r505, r504, r50
-  Append       r506, r505, r488
-  SetIndex     r504, r50, r506
-  Index        r507, r504, r52
-  AddInt       r508, r507, r68
-  SetIndex     r504, r52, r508
+  Index        r498, r458, r484
+  Index        r499, r498, r49
+  Append       r500, r499, r482
+  SetIndex     r498, r49, r500
+  Index        r501, r498, r51
+  AddInt       r502, r501, r67
+  SetIndex     r498, r51, r502
 L62:
   // join d in date_dim on d.d_date_sk == wr.wr_returned_date_sk
-  AddInt       r474, r474, r68
+  AddInt       r468, r468, r67
   Jump         L64
 L61:
   // from wr in web_returns
-  AddInt       r468, r468, r68
+  AddInt       r462, r462, r67
   Jump         L65
 L60:
-  Move         r509, r53
-  Len          r510, r464
+  Move         r503, r52
+  Len          r504, r459
 L71:
-  LessInt      r511, r509, r510
-  JumpIfFalse  r511, L66
-  Index        r512, r464, r509
-  Move         r74, r512
+  LessInt      r505, r503, r504
+  JumpIfFalse  r505, L66
+  Index        r506, r459, r503
+  Move         r73, r506
   // select { wp_web_page_sk: g.key, returns: sum(from x in g select x.wr.wr_return_amt), profit_loss: sum(from x in g select x.wr.wr_net_loss) }
-  Const        r513, "wp_web_page_sk"
-  Index        r514, r74, r9
-  Const        r515, "returns"
-  Const        r516, []
-  IterPrep     r517, r74
-  Len          r518, r517
-  Move         r519, r53
+  Const        r507, "wp_web_page_sk"
+  Index        r508, r73, r9
+  Const        r509, "returns"
+  Const        r510, []
+  IterPrep     r511, r73
+  Len          r512, r511
+  Move         r513, r52
 L68:
-  LessInt      r520, r519, r518
-  JumpIfFalse  r520, L67
-  Index        r521, r517, r519
-  Move         r84, r521
-  Index        r522, r84, r460
-  Index        r523, r522, r461
-  Append       r524, r516, r523
-  Move         r516, r524
-  AddInt       r519, r519, r68
+  LessInt      r514, r513, r512
+  JumpIfFalse  r514, L67
+  Index        r515, r511, r513
+  Move         r83, r515
+  Index        r516, r83, r455
+  Index        r517, r516, r456
+  Append       r518, r510, r517
+  Move         r510, r518
+  AddInt       r513, r513, r67
   Jump         L68
 L67:
-  Sum          r525, r516
-  Const        r526, "profit_loss"
-  Const        r527, []
-  IterPrep     r528, r74
-  Len          r529, r528
-  Move         r530, r53
+  Sum          r519, r510
+  Const        r520, "profit_loss"
+  Const        r521, []
+  IterPrep     r522, r73
+  Len          r523, r522
+  Move         r524, r52
 L70:
-  LessInt      r531, r530, r529
-  JumpIfFalse  r531, L69
-  Index        r532, r528, r530
-  Move         r84, r532
-  Index        r533, r84, r460
-  Index        r534, r533, r462
-  Append       r535, r527, r534
-  Move         r527, r535
-  AddInt       r530, r530, r68
+  LessInt      r525, r524, r523
+  JumpIfFalse  r525, L69
+  Index        r526, r522, r524
+  Move         r83, r526
+  Index        r527, r83, r455
+  Index        r528, r527, r457
+  Append       r529, r521, r528
+  Move         r521, r529
+  AddInt       r524, r524, r67
   Jump         L70
 L69:
-  Sum          r536, r527
-  Move         r537, r513
-  Move         r538, r514
-  Move         r539, r515
-  Move         r540, r525
-  Move         r541, r526
-  Move         r542, r536
-  MakeMap      r543, 3, r537
+  Sum          r530, r521
+  Move         r531, r507
+  Move         r532, r508
+  Move         r533, r509
+  Move         r534, r519
+  Move         r535, r520
+  Move         r536, r530
+  MakeMap      r537, 3, r531
   // from wr in web_returns
-  Append       r544, r458, r543
-  Move         r458, r544
-  AddInt       r509, r509, r68
+  Append       r538, r453, r537
+  Move         r453, r538
+  AddInt       r503, r503, r67
   Jump         L71
 L66:
   // from s in ss left join r in sr on s.s_store_sk == r.s_store_sk select {
-  Const        r545, []
-  IterPrep     r546, r7
-  Len          r547, r546
-  IterPrep     r548, r108
-  Len          r549, r548
-  MakeMap      r550, 0, r0
-  Const        r551, 0
+  Const        r539, []
+  IterPrep     r540, r7
+  Len          r541, r540
+  IterPrep     r542, r107
+  Len          r543, r542
+  MakeMap      r544, 0, r0
+  Const        r545, 0
 L74:
-  LessInt      r552, r551, r549
-  JumpIfFalse  r552, L72
-  Index        r553, r548, r551
-  Move         r554, r553
-  Index        r555, r554, r8
-  Index        r556, r550, r555
-  Const        r557, nil
-  NotEqual     r558, r556, r557
-  JumpIfTrue   r558, L73
-  MakeList     r559, 0, r0
-  SetIndex     r550, r555, r559
+  LessInt      r546, r545, r543
+  JumpIfFalse  r546, L72
+  Index        r547, r542, r545
+  Move         r548, r547
+  Index        r549, r548, r8
+  Index        r550, r544, r549
+  Const        r551, nil
+  NotEqual     r552, r550, r551
+  JumpIfTrue   r552, L73
+  MakeList     r553, 0, r0
+  SetIndex     r544, r549, r553
 L73:
-  Index        r556, r550, r555
-  Append       r560, r556, r553
-  SetIndex     r550, r555, r560
-  AddInt       r551, r551, r68
+  Index        r550, r544, r549
+  Append       r554, r550, r547
+  SetIndex     r544, r549, r554
+  AddInt       r545, r545, r67
   Jump         L74
 L72:
-  Const        r561, 0
+  Const        r555, 0
 L79:
-  LessInt      r562, r561, r547
-  JumpIfFalse  r562, L75
-  Index        r563, r546, r561
-  Move         r564, r563
-  Index        r565, r564, r8
-  Index        r566, r550, r565
-  NotEqual     r567, r566, r557
-  JumpIfFalse  r567, L76
-  Len          r568, r566
-  Const        r569, 0
+  LessInt      r556, r555, r541
+  JumpIfFalse  r556, L75
+  Index        r557, r540, r555
+  Move         r558, r557
+  Index        r559, r558, r8
+  Index        r560, r544, r559
+  NotEqual     r561, r560, r551
+  JumpIfFalse  r561, L76
+  Len          r562, r560
+  Const        r563, 0
 L77:
-  LessInt      r570, r569, r568
-  JumpIfFalse  r570, L76
-  Index        r571, r566, r569
-  Move         r554, r571
+  LessInt      r564, r563, r562
+  JumpIfFalse  r564, L76
+  Index        r565, r560, r563
+  Move         r548, r565
   // channel: "store channel",
-  Const        r572, "channel"
-  Const        r573, "store channel"
+  Const        r566, "channel"
+  Const        r567, "store channel"
   // id: s.s_store_sk,
-  Const        r574, "id"
-  Index        r575, r564, r8
+  Const        r568, "id"
+  Index        r569, r558, r8
   // sales: s.sales,
-  Const        r576, "sales"
-  Index        r577, r564, r10
+  Const        r570, "sales"
+  Index        r571, r558, r10
   // returns: if r == null { 0.0 } else { r.returns },
-  Const        r578, "returns"
-  Equal        r579, r554, r557
-  Const        r580, 0
-  Index        r581, r554, r109
-  Select       582,579,580,581
+  Const        r572, "returns"
+  Equal        r573, r548, r551
+  Const        r574, 0.0
+  Index        r575, r548, r108
+  Select       576,573,574,575
   // profit: s.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Const        r583, "profit"
-  Index        r584, r564, r13
-  Equal        r585, r554, r557
-  Index        r586, r554, r112
-  Select       587,585,580,586
-  Sub          r588, r584, r587
+  Const        r577, "profit"
+  Index        r578, r558, r13
+  Equal        r579, r548, r551
+  Index        r580, r548, r111
+  Select       581,579,574,580
+  Sub          r582, r578, r581
   // channel: "store channel",
+  Move         r583, r566
+  Move         r584, r567
+  // id: s.s_store_sk,
+  Move         r585, r568
+  Move         r586, r569
+  // sales: s.sales,
+  Move         r587, r570
+  Move         r588, r571
+  // returns: if r == null { 0.0 } else { r.returns },
   Move         r589, r572
-  Move         r590, r573
-  // id: s.s_store_sk,
-  Move         r591, r574
-  Move         r592, r575
-  // sales: s.sales,
-  Move         r593, r576
-  Move         r594, r577
-  // returns: if r == null { 0.0 } else { r.returns },
-  Move         r595, r578
-  Move         r596, r582
+  Move         r590, r576
   // profit: s.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Move         r597, r583
-  Move         r598, r588
+  Move         r591, r577
+  Move         r592, r582
   // from s in ss left join r in sr on s.s_store_sk == r.s_store_sk select {
-  MakeMap      r599, 5, r589
-  Append       r600, r545, r599
-  Move         r545, r600
-  AddInt       r569, r569, r68
+  MakeMap      r593, 5, r583
+  Append       r594, r539, r593
+  Move         r539, r594
+  AddInt       r563, r563, r67
   Jump         L77
 L76:
-  JumpIfTrue   r567, L78
-  Move         r554, r557
+  JumpIfTrue   r561, L78
+  Move         r548, r551
   // channel: "store channel",
-  Const        r601, "channel"
+  Const        r595, "channel"
   // id: s.s_store_sk,
-  Const        r602, "id"
-  Index        r603, r564, r8
+  Const        r596, "id"
+  Index        r597, r558, r8
   // sales: s.sales,
-  Const        r604, "sales"
-  Index        r605, r564, r10
+  Const        r598, "sales"
+  Index        r599, r558, r10
   // returns: if r == null { 0.0 } else { r.returns },
-  Const        r606, "returns"
-  Equal        r607, r554, r557
-  Index        r608, r554, r109
-  Select       609,607,580,608
+  Const        r600, "returns"
+  Equal        r601, r548, r551
+  Index        r602, r548, r108
+  Select       603,601,574,602
   // profit: s.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Const        r610, "profit"
-  Index        r611, r564, r13
-  Equal        r612, r554, r557
-  Index        r613, r554, r112
-  Select       614,612,580,613
-  Sub          r615, r611, r614
+  Const        r604, "profit"
+  Index        r605, r558, r13
+  Equal        r606, r548, r551
+  Index        r607, r548, r111
+  Select       608,606,574,607
+  Sub          r609, r605, r608
   // channel: "store channel",
-  Move         r616, r601
-  Move         r617, r573
+  Move         r610, r595
+  Move         r611, r567
   // id: s.s_store_sk,
-  Move         r618, r602
-  Move         r619, r603
+  Move         r612, r596
+  Move         r613, r597
   // sales: s.sales,
-  Move         r620, r604
-  Move         r621, r605
+  Move         r614, r598
+  Move         r615, r599
   // returns: if r == null { 0.0 } else { r.returns },
-  Move         r622, r606
-  Move         r623, r609
+  Move         r616, r600
+  Move         r617, r603
   // profit: s.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Move         r624, r610
-  Move         r625, r615
+  Move         r618, r604
+  Move         r619, r609
   // from s in ss left join r in sr on s.s_store_sk == r.s_store_sk select {
-  MakeMap      r626, 5, r616
-  Append       r627, r545, r626
-  Move         r545, r627
+  MakeMap      r620, 5, r610
+  Append       r621, r539, r620
+  Move         r539, r621
 L78:
-  AddInt       r561, r561, r68
+  AddInt       r555, r555, r67
   Jump         L79
 L75:
   // from c in cs join r in cr on c.cs_call_center_sk == r.cr_call_center_sk select { channel: "catalog channel", id: c.cs_call_center_sk, sales: c.sales, returns: r.returns, profit: c.profit - r.profit_loss },
-  Const        r628, []
-  IterPrep     r629, r196
-  Len          r630, r629
-  IterPrep     r631, r283
-  Len          r632, r631
-  Const        r633, "channel"
-  Const        r634, "id"
-  Const        r635, 0
+  Const        r622, []
+  IterPrep     r623, r194
+  Len          r624, r623
+  IterPrep     r625, r280
+  Len          r626, r625
+  Const        r627, "channel"
+  Const        r628, "id"
+  Const        r629, 0
 L84:
-  LessInt      r636, r635, r630
-  JumpIfFalse  r636, L80
-  Index        r637, r629, r635
-  Move         r638, r637
-  Const        r639, 0
+  LessInt      r630, r629, r624
+  JumpIfFalse  r630, L80
+  Index        r631, r623, r629
+  Move         r632, r631
+  Const        r633, 0
 L83:
-  LessInt      r640, r639, r632
-  JumpIfFalse  r640, L81
-  Index        r641, r631, r639
-  Move         r554, r641
-  Index        r642, r638, r197
-  Index        r643, r554, r284
-  Equal        r644, r642, r643
-  JumpIfFalse  r644, L82
-  Const        r645, "channel"
-  Const        r646, "catalog channel"
-  Const        r647, "id"
-  Index        r648, r638, r197
-  Const        r649, "sales"
-  Index        r650, r638, r10
-  Const        r651, "returns"
-  Index        r652, r554, r109
-  Const        r653, "profit"
-  Index        r654, r638, r13
-  Index        r655, r554, r112
-  Sub          r656, r654, r655
+  LessInt      r634, r633, r626
+  JumpIfFalse  r634, L81
+  Index        r635, r625, r633
+  Move         r548, r635
+  Index        r636, r632, r195
+  Index        r637, r548, r281
+  Equal        r638, r636, r637
+  JumpIfFalse  r638, L82
+  Const        r639, "channel"
+  Const        r640, "catalog channel"
+  Const        r641, "id"
+  Index        r642, r632, r195
+  Const        r643, "sales"
+  Index        r644, r632, r10
+  Const        r645, "returns"
+  Index        r646, r548, r108
+  Const        r647, "profit"
+  Index        r648, r632, r13
+  Index        r649, r548, r111
+  Sub          r650, r648, r649
+  Move         r651, r639
+  Move         r652, r640
+  Move         r653, r641
+  Move         r654, r642
+  Move         r655, r643
+  Move         r656, r644
   Move         r657, r645
   Move         r658, r646
   Move         r659, r647
-  Move         r660, r648
-  Move         r661, r649
-  Move         r662, r650
-  Move         r663, r651
-  Move         r664, r652
-  Move         r665, r653
-  Move         r666, r656
-  MakeMap      r667, 5, r657
-  Append       r668, r628, r667
-  Move         r628, r668
+  Move         r660, r650
+  MakeMap      r661, 5, r651
+  Append       r662, r622, r661
+  Move         r622, r662
 L82:
-  AddInt       r639, r639, r68
+  AddInt       r633, r633, r67
   Jump         L83
 L81:
-  AddInt       r635, r635, r68
+  AddInt       r629, r629, r67
   Jump         L84
 L80:
   // concat(
-  UnionAll     r669, r545, r628
+  UnionAll     r663, r539, r622
   // from w in ws left join r in wr on w.wp_web_page_sk == r.wp_web_page_sk select {
-  Const        r670, []
-  IterPrep     r671, r370
-  Len          r672, r671
-  IterPrep     r673, r458
-  Len          r674, r673
-  MakeMap      r675, 0, r0
-  Const        r676, 0
+  Const        r664, []
+  IterPrep     r665, r366
+  Len          r666, r665
+  IterPrep     r667, r453
+  Len          r668, r667
+  MakeMap      r669, 0, r0
+  Const        r670, 0
 L87:
-  LessInt      r677, r676, r674
-  JumpIfFalse  r677, L85
-  Index        r678, r673, r676
-  Move         r554, r678
-  Index        r679, r554, r372
-  Index        r680, r675, r679
-  NotEqual     r681, r680, r557
-  JumpIfTrue   r681, L86
-  MakeList     r682, 0, r0
-  SetIndex     r675, r679, r682
+  LessInt      r671, r670, r668
+  JumpIfFalse  r671, L85
+  Index        r672, r667, r670
+  Move         r548, r672
+  Index        r673, r548, r368
+  Index        r674, r669, r673
+  NotEqual     r675, r674, r551
+  JumpIfTrue   r675, L86
+  MakeList     r676, 0, r0
+  SetIndex     r669, r673, r676
 L86:
-  Index        r680, r675, r679
-  Append       r683, r680, r678
-  SetIndex     r675, r679, r683
-  AddInt       r676, r676, r68
+  Index        r674, r669, r673
+  Append       r677, r674, r672
+  SetIndex     r669, r673, r677
+  AddInt       r670, r670, r67
   Jump         L87
 L85:
-  Const        r684, 0
+  Const        r678, 0
 L92:
-  LessInt      r685, r684, r672
-  JumpIfFalse  r685, L88
-  Index        r686, r671, r684
-  Move         r687, r686
-  Index        r688, r687, r372
-  Index        r689, r675, r688
-  NotEqual     r690, r689, r557
-  JumpIfFalse  r690, L89
-  Len          r691, r689
-  Const        r692, 0
+  LessInt      r679, r678, r666
+  JumpIfFalse  r679, L88
+  Index        r680, r665, r678
+  Move         r681, r680
+  Index        r682, r681, r368
+  Index        r683, r669, r682
+  NotEqual     r684, r683, r551
+  JumpIfFalse  r684, L89
+  Len          r685, r683
+  Const        r686, 0
 L90:
-  LessInt      r693, r692, r691
-  JumpIfFalse  r693, L89
-  Index        r694, r689, r692
-  Move         r554, r694
+  LessInt      r687, r686, r685
+  JumpIfFalse  r687, L89
+  Index        r688, r683, r686
+  Move         r548, r688
   // channel: "web channel",
-  Const        r695, "channel"
-  Const        r696, "web channel"
+  Const        r689, "channel"
+  Const        r690, "web channel"
   // id: w.wp_web_page_sk,
-  Const        r697, "id"
-  Index        r698, r687, r372
+  Const        r691, "id"
+  Index        r692, r681, r368
   // sales: w.sales,
-  Const        r699, "sales"
-  Index        r700, r687, r10
+  Const        r693, "sales"
+  Index        r694, r681, r10
   // returns: if r == null { 0.0 } else { r.returns },
-  Const        r701, "returns"
-  Equal        r702, r554, r557
-  Index        r703, r554, r109
-  Select       704,702,580,703
+  Const        r695, "returns"
+  Equal        r696, r548, r551
+  Index        r697, r548, r108
+  Select       698,696,574,697
   // profit: w.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Const        r705, "profit"
-  Index        r706, r687, r13
-  Equal        r707, r554, r557
-  Index        r708, r554, r112
-  Select       709,707,580,708
-  Sub          r710, r706, r709
+  Const        r699, "profit"
+  Index        r700, r681, r13
+  Equal        r701, r548, r551
+  Index        r702, r548, r111
+  Select       703,701,574,702
+  Sub          r704, r700, r703
   // channel: "web channel",
+  Move         r705, r689
+  Move         r706, r690
+  // id: w.wp_web_page_sk,
+  Move         r707, r691
+  Move         r708, r692
+  // sales: w.sales,
+  Move         r709, r693
+  Move         r710, r694
+  // returns: if r == null { 0.0 } else { r.returns },
   Move         r711, r695
-  Move         r712, r696
-  // id: w.wp_web_page_sk,
-  Move         r713, r697
-  Move         r714, r698
-  // sales: w.sales,
-  Move         r715, r699
-  Move         r716, r700
-  // returns: if r == null { 0.0 } else { r.returns },
-  Move         r717, r701
-  Move         r718, r704
+  Move         r712, r698
   // profit: w.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Move         r719, r705
-  Move         r720, r710
+  Move         r713, r699
+  Move         r714, r704
   // from w in ws left join r in wr on w.wp_web_page_sk == r.wp_web_page_sk select {
-  MakeMap      r721, 5, r711
-  Append       r722, r670, r721
-  Move         r670, r722
-  AddInt       r692, r692, r68
+  MakeMap      r715, 5, r705
+  Append       r716, r664, r715
+  Move         r664, r716
+  AddInt       r686, r686, r67
   Jump         L90
 L89:
-  JumpIfTrue   r690, L91
-  Move         r554, r557
+  JumpIfTrue   r684, L91
+  Move         r548, r551
   // channel: "web channel",
-  Const        r723, "channel"
+  Const        r717, "channel"
   // id: w.wp_web_page_sk,
-  Const        r724, "id"
-  Index        r725, r687, r372
+  Const        r718, "id"
+  Index        r719, r681, r368
   // sales: w.sales,
-  Const        r726, "sales"
-  Index        r727, r687, r10
+  Const        r720, "sales"
+  Index        r721, r681, r10
   // returns: if r == null { 0.0 } else { r.returns },
-  Const        r728, "returns"
-  Equal        r729, r554, r557
-  Index        r730, r554, r109
-  Select       731,729,580,730
+  Const        r722, "returns"
+  Equal        r723, r548, r551
+  Index        r724, r548, r108
+  Select       725,723,574,724
   // profit: w.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Const        r732, "profit"
-  Index        r733, r687, r13
-  Equal        r734, r554, r557
-  Index        r735, r554, r112
-  Select       736,734,580,735
-  Sub          r737, r733, r736
+  Const        r726, "profit"
+  Index        r727, r681, r13
+  Equal        r728, r548, r551
+  Index        r729, r548, r111
+  Select       730,728,574,729
+  Sub          r731, r727, r730
   // channel: "web channel",
-  Move         r738, r723
-  Move         r739, r696
+  Move         r732, r717
+  Move         r733, r690
   // id: w.wp_web_page_sk,
-  Move         r740, r724
-  Move         r741, r725
+  Move         r734, r718
+  Move         r735, r719
   // sales: w.sales,
-  Move         r742, r726
-  Move         r743, r727
+  Move         r736, r720
+  Move         r737, r721
   // returns: if r == null { 0.0 } else { r.returns },
-  Move         r744, r728
-  Move         r745, r731
+  Move         r738, r722
+  Move         r739, r725
   // profit: w.profit - (if r == null { 0.0 } else { r.profit_loss })
-  Move         r746, r732
-  Move         r747, r737
+  Move         r740, r726
+  Move         r741, r731
   // from w in ws left join r in wr on w.wp_web_page_sk == r.wp_web_page_sk select {
-  MakeMap      r748, 5, r738
-  Append       r749, r670, r748
-  Move         r670, r749
+  MakeMap      r742, 5, r732
+  Append       r743, r664, r742
+  Move         r664, r743
 L91:
-  AddInt       r684, r684, r68
+  AddInt       r678, r678, r67
   Jump         L92
 L88:
   // concat(
-  UnionAll     r750, r669, r670
+  UnionAll     r744, r663, r664
   // from p in per_channel
-  Const        r751, []
+  Const        r745, []
   // select { channel: g.key.channel, id: g.key.id, sales: sum(from x in g select x.p.sales), returns: sum(from x in g select x.p.returns), profit: sum(from x in g select x.p.profit) }
-  Const        r752, "p"
+  Const        r746, "p"
   // from p in per_channel
-  IterPrep     r753, r750
-  Len          r754, r753
-  Const        r755, 0
-  MakeMap      r756, 0, r0
-  Const        r758, []
-  Move         r757, r758
+  IterPrep     r747, r744
+  Len          r748, r747
+  Const        r749, 0
+  MakeMap      r750, 0, r0
+  Move         r751, r17
 L95:
-  LessInt      r759, r755, r754
-  JumpIfFalse  r759, L93
-  Index        r760, r753, r755
-  Move         r761, r760
+  LessInt      r752, r749, r748
+  JumpIfFalse  r752, L93
+  Index        r753, r747, r749
+  Move         r754, r753
   // group by { channel: p.channel, id: p.id } into g
-  Const        r762, "channel"
-  Index        r763, r761, r633
-  Const        r764, "id"
-  Index        r765, r761, r634
-  Move         r766, r762
-  Move         r767, r763
-  Move         r768, r764
-  Move         r769, r765
-  MakeMap      r770, 2, r766
-  Str          r771, r770
-  In           r772, r771, r756
-  JumpIfTrue   r772, L94
-  Move         r773, r770
+  Const        r755, "channel"
+  Index        r756, r754, r627
+  Const        r757, "id"
+  Index        r758, r754, r628
+  Move         r759, r755
+  Move         r760, r756
+  Move         r761, r757
+  Move         r762, r758
+  MakeMap      r763, 2, r759
+  Str          r764, r763
+  In           r765, r764, r750
+  JumpIfTrue   r765, L94
+  Move         r766, r763
   // from p in per_channel
-  Move         r774, r46
-  Move         r775, r47
-  Move         r776, r48
-  Move         r777, r9
-  Move         r778, r773
-  Move         r779, r50
-  Move         r780, r774
-  Move         r781, r52
-  Move         r782, r53
-  MakeMap      r783, 4, r775
-  SetIndex     r756, r771, r783
-  Append       r784, r757, r783
-  Move         r757, r784
+  Move         r767, r17
+  Move         r768, r46
+  Move         r769, r47
+  Move         r770, r9
+  Move         r771, r766
+  Move         r772, r49
+  Move         r773, r767
+  Move         r774, r51
+  Move         r775, r52
+  MakeMap      r776, 4, r768
+  SetIndex     r750, r764, r776
+  Append       r777, r751, r776
+  Move         r751, r777
 L94:
-  Index        r785, r756, r771
-  Index        r786, r785, r50
-  Append       r787, r786, r760
-  SetIndex     r785, r50, r787
-  Index        r788, r785, r52
-  AddInt       r789, r788, r68
-  SetIndex     r785, r52, r789
-  AddInt       r755, r755, r68
+  Index        r778, r750, r764
+  Index        r779, r778, r49
+  Append       r780, r779, r753
+  SetIndex     r778, r49, r780
+  Index        r781, r778, r51
+  AddInt       r782, r781, r67
+  SetIndex     r778, r51, r782
+  AddInt       r749, r749, r67
   Jump         L95
 L93:
-  Move         r790, r53
-  Len          r791, r757
+  Move         r783, r52
+  Len          r784, r751
 L103:
-  LessInt      r792, r790, r791
-  JumpIfFalse  r792, L96
-  Index        r793, r757, r790
-  Move         r74, r793
+  LessInt      r785, r783, r784
+  JumpIfFalse  r785, L96
+  Index        r786, r751, r783
+  Move         r73, r786
   // select { channel: g.key.channel, id: g.key.id, sales: sum(from x in g select x.p.sales), returns: sum(from x in g select x.p.returns), profit: sum(from x in g select x.p.profit) }
-  Const        r794, "channel"
-  Index        r795, r74, r9
-  Index        r796, r795, r633
-  Const        r797, "id"
-  Index        r798, r74, r9
-  Index        r799, r798, r634
-  Const        r800, "sales"
-  Const        r801, []
-  IterPrep     r802, r74
-  Len          r803, r802
-  Move         r804, r53
+  Const        r787, "channel"
+  Index        r788, r73, r9
+  Index        r789, r788, r627
+  Const        r790, "id"
+  Index        r791, r73, r9
+  Index        r792, r791, r628
+  Const        r793, "sales"
+  Const        r794, []
+  IterPrep     r795, r73
+  Len          r796, r795
+  Move         r797, r52
 L98:
-  LessInt      r805, r804, r803
-  JumpIfFalse  r805, L97
-  Index        r806, r802, r804
-  Move         r84, r806
-  Index        r807, r84, r752
-  Index        r808, r807, r10
-  Append       r809, r801, r808
-  Move         r801, r809
-  AddInt       r804, r804, r68
+  LessInt      r798, r797, r796
+  JumpIfFalse  r798, L97
+  Index        r799, r795, r797
+  Move         r83, r799
+  Index        r800, r83, r746
+  Index        r801, r800, r10
+  Append       r802, r794, r801
+  Move         r794, r802
+  AddInt       r797, r797, r67
   Jump         L98
 L97:
-  Sum          r810, r801
-  Const        r811, "returns"
-  Const        r812, []
-  IterPrep     r813, r74
-  Len          r814, r813
-  Move         r815, r53
+  Sum          r803, r794
+  Const        r804, "returns"
+  Const        r805, []
+  IterPrep     r806, r73
+  Len          r807, r806
+  Move         r808, r52
 L100:
-  LessInt      r816, r815, r814
-  JumpIfFalse  r816, L99
-  Index        r817, r813, r815
-  Move         r84, r817
-  Index        r818, r84, r752
-  Index        r819, r818, r109
-  Append       r820, r812, r819
-  Move         r812, r820
-  AddInt       r815, r815, r68
+  LessInt      r809, r808, r807
+  JumpIfFalse  r809, L99
+  Index        r810, r806, r808
+  Move         r83, r810
+  Index        r811, r83, r746
+  Index        r812, r811, r108
+  Append       r813, r805, r812
+  Move         r805, r813
+  AddInt       r808, r808, r67
   Jump         L100
 L99:
-  Sum          r821, r812
-  Const        r822, "profit"
-  Const        r823, []
-  IterPrep     r824, r74
-  Len          r825, r824
-  Move         r826, r53
+  Sum          r814, r805
+  Const        r815, "profit"
+  Const        r816, []
+  IterPrep     r817, r73
+  Len          r818, r817
+  Move         r819, r52
 L102:
-  LessInt      r827, r826, r825
-  JumpIfFalse  r827, L101
-  Index        r828, r824, r826
-  Move         r84, r828
-  Index        r829, r84, r752
-  Index        r830, r829, r13
-  Append       r831, r823, r830
-  Move         r823, r831
-  AddInt       r826, r826, r68
+  LessInt      r820, r819, r818
+  JumpIfFalse  r820, L101
+  Index        r821, r817, r819
+  Move         r83, r821
+  Index        r822, r83, r746
+  Index        r823, r822, r13
+  Append       r824, r816, r823
+  Move         r816, r824
+  AddInt       r819, r819, r67
   Jump         L102
 L101:
-  Sum          r832, r823
-  Move         r833, r794
-  Move         r834, r796
-  Move         r835, r797
-  Move         r836, r799
-  Move         r837, r800
-  Move         r838, r810
-  Move         r839, r811
-  Move         r840, r821
-  Move         r841, r822
-  Move         r842, r832
-  MakeMap      r843, 5, r833
+  Sum          r825, r816
+  Move         r826, r787
+  Move         r827, r789
+  Move         r828, r790
+  Move         r829, r792
+  Move         r830, r793
+  Move         r831, r803
+  Move         r832, r804
+  Move         r833, r814
+  Move         r834, r815
+  Move         r835, r825
+  MakeMap      r836, 5, r826
   // sort by g.key.channel
-  Index        r844, r74, r9
-  Index        r845, r844, r633
-  Move         r846, r845
+  Index        r837, r73, r9
+  Index        r838, r837, r627
+  Move         r839, r838
   // from p in per_channel
-  Move         r847, r843
-  MakeList     r848, 2, r846
-  Append       r849, r751, r848
-  Move         r751, r849
-  AddInt       r790, r790, r68
+  Move         r840, r836
+  MakeList     r841, 2, r839
+  Append       r842, r745, r841
+  Move         r745, r842
+  AddInt       r783, r783, r67
   Jump         L103
 L96:
   // sort by g.key.channel
-  Sort         r850, r751
+  Sort         r843, r745
   // from p in per_channel
-  Move         r751, r850
+  Move         r745, r843
   // json(result)
-  JSON         r751
+  JSON         r745
   // expect result == [
-  Const        r851, [{"channel": "catalog channel", "id": 1, "profit": 12, "returns": 7, "sales": 150}, {"channel": "store channel", "id": 1, "profit": 9, "returns": 5, "sales": 100}, {"channel": "web channel", "id": 1, "profit": 18, "returns": 10, "sales": 200}]
-  Equal        r852, r751, r851
-  Expect       r852
+  Const        r844, [{"channel": "catalog channel", "id": 1, "profit": 12.0, "returns": 7.0, "sales": 150.0}, {"channel": "store channel", "id": 1, "profit": 9.0, "returns": 5.0, "sales": 100.0}, {"channel": "web channel", "id": 1, "profit": 18.0, "returns": 10.0, "sales": 200.0}]
+  Equal        r845, r745, r844
+  Expect       r845
   Return       r0
-

--- a/tests/dataset/tpc-ds/out/q78.ir.out
+++ b/tests/dataset/tpc-ds/out/q78.ir.out
@@ -1,10 +1,10 @@
-func main (regs=418)
+func main (regs=415)
   // let ss = [
-  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_qty": 10, "ss_sold_year": 1998, "ss_sp": 100, "ss_wc": 50}]
+  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_qty": 10, "ss_sold_year": 1998, "ss_sp": 100.0, "ss_wc": 50.0}]
   // let ws = [
-  Const        r1, [{"ws_customer_sk": 1, "ws_item_sk": 1, "ws_qty": 5, "ws_sold_year": 1998, "ws_sp": 50, "ws_wc": 25}]
+  Const        r1, [{"ws_customer_sk": 1, "ws_item_sk": 1, "ws_qty": 5, "ws_sold_year": 1998, "ws_sp": 50.0, "ws_wc": 25.0}]
   // let cs = [
-  Const        r2, [{"cs_customer_sk": 1, "cs_item_sk": 1, "cs_qty": 3, "cs_sold_year": 1998, "cs_sp": 30, "cs_wc": 15}]
+  Const        r2, [{"cs_customer_sk": 1, "cs_item_sk": 1, "cs_qty": 3, "cs_sold_year": 1998, "cs_sp": 30.0, "cs_wc": 15.0}]
   // from s in ss
   Const        r3, []
   // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
@@ -41,7 +41,7 @@ func main (regs=418)
   Len          r24, r23
   Const        r26, 0
   Move         r25, r26
-L25:
+L22:
   LessInt      r27, r25, r24
   JumpIfFalse  r27, L0
   Index        r28, r23, r25
@@ -53,7 +53,7 @@ L25:
   Const        r33, "ws_item_sk"
   Const        r34, "ws_customer_sk"
   Move         r35, r26
-L14:
+L12:
   LessInt      r36, r35, r31
   JumpIfFalse  r36, L1
   Index        r37, r30, r35
@@ -71,555 +71,548 @@ L14:
   Move         r49, r42
   JumpIfFalse  r49, L2
   Move         r49, r45
+  JumpIfFalse  r49, L2
+  Move         r49, r48
 L2:
-  Move         r50, r49
-  JumpIfFalse  r50, L3
-  Move         r50, r48
-L3:
-  JumpIfFalse  r50, L4
+  JumpIfFalse  r49, L3
   Const        r39, true
   // left join c in cs on c.cs_sold_year == s.ss_sold_year && c.cs_item_sk == s.ss_item_sk && c.cs_customer_sk == s.ss_customer_sk
-  IterPrep     r51, r2
-  Len          r52, r51
-  Const        r53, "cs_sold_year"
-  Const        r54, "cs_item_sk"
-  Const        r55, "cs_customer_sk"
-  Move         r56, r26
-L11:
-  LessInt      r57, r56, r52
-  JumpIfFalse  r57, L5
-  Index        r58, r51, r56
-  Move         r59, r58
-  Const        r60, false
-  Index        r61, r59, r53
-  Index        r62, r29, r6
-  Equal        r63, r61, r62
-  Index        r64, r59, r54
-  Index        r65, r29, r7
-  Equal        r66, r64, r65
-  Index        r67, r59, r55
-  Index        r68, r29, r8
-  Equal        r69, r67, r68
-  Move         r70, r63
-  JumpIfFalse  r70, L6
-  Move         r70, r66
-L6:
-  Move         r71, r70
-  JumpIfFalse  r71, L7
-  Move         r71, r69
-L7:
-  JumpIfFalse  r71, L8
-  Const        r60, true
-  // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
-  Const        r72, nil
-  Equal        r73, r38, r72
-  Index        r74, r38, r4
-  Select       75,73,26,74
-  Less         r76, r26, r75
-  Equal        r77, r59, r72
-  Index        r78, r59, r5
-  Select       79,77,26,78
-  Less         r80, r26, r79
-  Move         r81, r76
-  JumpIfTrue   r81, L9
-  Move         r81, r80
+  IterPrep     r50, r2
+  Len          r51, r50
+  Const        r52, "cs_sold_year"
+  Const        r53, "cs_item_sk"
+  Const        r54, "cs_customer_sk"
+  Move         r55, r26
 L9:
-  Index        r82, r29, r6
-  Const        r83, 1998
-  Equal        r84, r82, r83
-  Move         r85, r81
-  JumpIfFalse  r85, L10
-  Move         r85, r84
-L10:
-  JumpIfFalse  r85, L8
+  LessInt      r56, r55, r51
+  JumpIfFalse  r56, L4
+  Index        r57, r50, r55
+  Move         r58, r57
+  Const        r59, false
+  Index        r60, r58, r52
+  Index        r61, r29, r6
+  Equal        r62, r60, r61
+  Index        r63, r58, r53
+  Index        r64, r29, r7
+  Equal        r65, r63, r64
+  Index        r66, r58, r54
+  Index        r67, r29, r8
+  Equal        r68, r66, r67
+  Move         r69, r62
+  JumpIfFalse  r69, L5
+  Move         r69, r65
+  JumpIfFalse  r69, L5
+  Move         r69, r68
+L5:
+  JumpIfFalse  r69, L6
+  Const        r59, true
+  // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
+  Const        r70, nil
+  Equal        r71, r38, r70
+  Index        r72, r38, r4
+  Select       73,71,26,72
+  Less         r74, r26, r73
+  Equal        r75, r58, r70
+  Index        r76, r58, r5
+  Select       77,75,26,76
+  Less         r78, r26, r77
+  Move         r79, r74
+  JumpIfTrue   r79, L7
+  Move         r79, r78
+L7:
+  Index        r80, r29, r6
+  Const        r81, 1998
+  Equal        r82, r80, r81
+  Move         r83, r79
+  JumpIfFalse  r83, L8
+  Move         r83, r82
+L8:
+  JumpIfFalse  r83, L6
   // ss_sold_year: s.ss_sold_year,
-  Const        r86, "ss_sold_year"
-  Index        r87, r29, r6
+  Const        r84, "ss_sold_year"
+  Index        r85, r29, r6
   // ss_item_sk: s.ss_item_sk,
-  Const        r88, "ss_item_sk"
-  Index        r89, r29, r7
+  Const        r86, "ss_item_sk"
+  Index        r87, r29, r7
   // ss_customer_sk: s.ss_customer_sk,
-  Const        r90, "ss_customer_sk"
-  Index        r91, r29, r8
+  Const        r88, "ss_customer_sk"
+  Index        r89, r29, r8
   // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Const        r92, "ratio"
-  Index        r93, r29, r10
-  Equal        r94, r38, r72
-  Index        r95, r38, r4
-  Select       96,94,26,95
-  Equal        r97, r59, r72
-  Index        r98, r59, r5
-  Select       99,97,26,98
-  Add          r100, r96, r99
-  Div          r101, r93, r100
+  Const        r90, "ratio"
+  Index        r91, r29, r10
+  Equal        r92, r38, r70
+  Index        r93, r38, r4
+  Select       94,92,26,93
+  Equal        r95, r58, r70
+  Index        r96, r58, r5
+  Select       97,95,26,96
+  Add          r98, r94, r97
+  Div          r99, r91, r98
   // store_qty: s.ss_qty,
-  Const        r102, "store_qty"
-  Index        r103, r29, r10
+  Const        r100, "store_qty"
+  Index        r101, r29, r10
   // store_wholesale_cost: s.ss_wc,
-  Const        r104, "store_wholesale_cost"
-  Index        r105, r29, r13
+  Const        r102, "store_wholesale_cost"
+  Index        r103, r29, r13
   // store_sales_price: s.ss_sp,
-  Const        r106, "store_sales_price"
-  Index        r107, r29, r15
+  Const        r104, "store_sales_price"
+  Index        r105, r29, r15
   // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Const        r108, "other_chan_qty"
-  Equal        r109, r38, r72
-  Index        r110, r38, r4
-  Select       111,109,26,110
-  Equal        r112, r59, r72
-  Index        r113, r59, r5
-  Select       114,112,26,113
-  Add          r115, r111, r114
+  Const        r106, "other_chan_qty"
+  Equal        r107, r38, r70
+  Index        r108, r38, r4
+  Select       109,107,26,108
+  Equal        r110, r58, r70
+  Index        r111, r58, r5
+  Select       112,110,26,111
+  Add          r113, r109, r112
   // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Const        r116, "other_chan_wholesale_cost"
-  Equal        r117, r38, r72
-  Const        r118, 0
-  Index        r119, r38, r18
-  Select       120,117,118,119
-  Equal        r121, r59, r72
-  Index        r122, r59, r19
-  Select       123,121,118,122
-  Add          r124, r120, r123
+  Const        r114, "other_chan_wholesale_cost"
+  Equal        r115, r38, r70
+  Const        r116, 0.0
+  Index        r117, r38, r18
+  Select       118,115,116,117
+  Equal        r119, r58, r70
+  Index        r120, r58, r19
+  Select       121,119,116,120
+  Add          r122, r118, r121
   // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Const        r125, "other_chan_sales_price"
-  Equal        r126, r38, r72
-  Index        r127, r38, r21
-  Select       128,126,118,127
-  Equal        r129, r59, r72
-  Index        r130, r59, r22
-  Select       131,129,118,130
-  Add          r132, r128, r131
+  Const        r123, "other_chan_sales_price"
+  Equal        r124, r38, r70
+  Index        r125, r38, r21
+  Select       126,124,116,125
+  Equal        r127, r58, r70
+  Index        r128, r58, r22
+  Select       129,127,116,128
+  Add          r130, r126, r129
   // ss_sold_year: s.ss_sold_year,
+  Move         r131, r84
+  Move         r132, r85
+  // ss_item_sk: s.ss_item_sk,
   Move         r133, r86
   Move         r134, r87
-  // ss_item_sk: s.ss_item_sk,
+  // ss_customer_sk: s.ss_customer_sk,
   Move         r135, r88
   Move         r136, r89
-  // ss_customer_sk: s.ss_customer_sk,
-  Move         r137, r90
-  Move         r138, r91
   // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Move         r139, r92
-  Move         r140, r101
+  Move         r137, r90
+  Move         r138, r99
   // store_qty: s.ss_qty,
+  Move         r139, r100
+  Move         r140, r101
+  // store_wholesale_cost: s.ss_wc,
   Move         r141, r102
   Move         r142, r103
-  // store_wholesale_cost: s.ss_wc,
+  // store_sales_price: s.ss_sp,
   Move         r143, r104
   Move         r144, r105
-  // store_sales_price: s.ss_sp,
+  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
   Move         r145, r106
-  Move         r146, r107
-  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Move         r147, r108
-  Move         r148, r115
+  Move         r146, r113
   // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Move         r149, r116
-  Move         r150, r124
+  Move         r147, r114
+  Move         r148, r122
   // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Move         r151, r125
-  Move         r152, r132
+  Move         r149, r123
+  Move         r150, r130
   // select {
-  MakeMap      r153, 10, r133
+  MakeMap      r151, 10, r131
   // from s in ss
-  Append       r154, r3, r153
-  Move         r3, r154
-L8:
+  Append       r152, r3, r151
+  Move         r3, r152
+L6:
   // left join c in cs on c.cs_sold_year == s.ss_sold_year && c.cs_item_sk == s.ss_item_sk && c.cs_customer_sk == s.ss_customer_sk
-  Const        r155, 1
-  Add          r56, r56, r155
-  Jump         L11
-L5:
-  Move         r156, r60
-  JumpIfTrue   r156, L4
-  Move         r59, r72
+  Const        r153, 1
+  Add          r55, r55, r153
+  Jump         L9
+L4:
+  Move         r154, r59
+  JumpIfTrue   r154, L3
+  Move         r58, r70
   // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
-  Equal        r157, r38, r72
-  Index        r158, r38, r4
-  Select       159,157,26,158
-  Less         r160, r26, r159
-  Equal        r161, r59, r72
-  Index        r162, r59, r5
-  Select       163,161,26,162
-  Less         r164, r26, r163
-  Move         r165, r160
-  JumpIfTrue   r165, L12
-  Move         r165, r164
-L12:
-  Index        r166, r29, r6
-  Equal        r167, r166, r83
-  Move         r168, r165
-  JumpIfFalse  r168, L13
-  Move         r168, r167
-L13:
-  JumpIfFalse  r168, L4
+  Equal        r155, r38, r70
+  Index        r156, r38, r4
+  Select       157,155,26,156
+  Less         r158, r26, r157
+  Equal        r159, r58, r70
+  Index        r160, r58, r5
+  Select       161,159,26,160
+  Less         r162, r26, r161
+  Move         r163, r158
+  JumpIfTrue   r163, L10
+  Move         r163, r162
+L10:
+  Index        r164, r29, r6
+  Equal        r165, r164, r81
+  Move         r166, r163
+  JumpIfFalse  r166, L11
+  Move         r166, r165
+L11:
+  JumpIfFalse  r166, L3
   // ss_sold_year: s.ss_sold_year,
-  Const        r169, "ss_sold_year"
-  Index        r170, r29, r6
+  Const        r167, "ss_sold_year"
+  Index        r168, r29, r6
   // ss_item_sk: s.ss_item_sk,
-  Const        r171, "ss_item_sk"
-  Index        r172, r29, r7
+  Const        r169, "ss_item_sk"
+  Index        r170, r29, r7
   // ss_customer_sk: s.ss_customer_sk,
-  Const        r173, "ss_customer_sk"
-  Index        r174, r29, r8
+  Const        r171, "ss_customer_sk"
+  Index        r172, r29, r8
   // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Const        r175, "ratio"
-  Index        r176, r29, r10
-  Equal        r177, r38, r72
-  Index        r178, r38, r4
-  Select       179,177,26,178
-  Equal        r180, r59, r72
-  Index        r181, r59, r5
-  Select       182,180,26,181
-  Add          r183, r179, r182
-  Div          r184, r176, r183
+  Const        r173, "ratio"
+  Index        r174, r29, r10
+  Equal        r175, r38, r70
+  Index        r176, r38, r4
+  Select       177,175,26,176
+  Equal        r178, r58, r70
+  Index        r179, r58, r5
+  Select       180,178,26,179
+  Add          r181, r177, r180
+  Div          r182, r174, r181
   // store_qty: s.ss_qty,
-  Const        r185, "store_qty"
-  Index        r186, r29, r10
+  Const        r183, "store_qty"
+  Index        r184, r29, r10
   // store_wholesale_cost: s.ss_wc,
-  Const        r187, "store_wholesale_cost"
-  Index        r188, r29, r13
+  Const        r185, "store_wholesale_cost"
+  Index        r186, r29, r13
   // store_sales_price: s.ss_sp,
-  Const        r189, "store_sales_price"
-  Index        r190, r29, r15
+  Const        r187, "store_sales_price"
+  Index        r188, r29, r15
   // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Const        r191, "other_chan_qty"
-  Equal        r192, r38, r72
-  Index        r193, r38, r4
-  Select       194,192,26,193
-  Equal        r195, r59, r72
-  Index        r196, r59, r5
-  Select       197,195,26,196
-  Add          r198, r194, r197
+  Const        r189, "other_chan_qty"
+  Equal        r190, r38, r70
+  Index        r191, r38, r4
+  Select       192,190,26,191
+  Equal        r193, r58, r70
+  Index        r194, r58, r5
+  Select       195,193,26,194
+  Add          r196, r192, r195
   // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Const        r199, "other_chan_wholesale_cost"
-  Equal        r200, r38, r72
-  Index        r201, r38, r18
-  Select       202,200,118,201
-  Equal        r203, r59, r72
-  Index        r204, r59, r19
-  Select       205,203,118,204
-  Add          r206, r202, r205
+  Const        r197, "other_chan_wholesale_cost"
+  Equal        r198, r38, r70
+  Index        r199, r38, r18
+  Select       200,198,116,199
+  Equal        r201, r58, r70
+  Index        r202, r58, r19
+  Select       203,201,116,202
+  Add          r204, r200, r203
   // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Const        r207, "other_chan_sales_price"
-  Equal        r208, r38, r72
-  Index        r209, r38, r21
-  Select       210,208,118,209
-  Equal        r211, r59, r72
-  Index        r212, r59, r22
-  Select       213,211,118,212
-  Add          r214, r210, r213
+  Const        r205, "other_chan_sales_price"
+  Equal        r206, r38, r70
+  Index        r207, r38, r21
+  Select       208,206,116,207
+  Equal        r209, r58, r70
+  Index        r210, r58, r22
+  Select       211,209,116,210
+  Add          r212, r208, r211
   // ss_sold_year: s.ss_sold_year,
+  Move         r213, r167
+  Move         r214, r168
+  // ss_item_sk: s.ss_item_sk,
   Move         r215, r169
   Move         r216, r170
-  // ss_item_sk: s.ss_item_sk,
+  // ss_customer_sk: s.ss_customer_sk,
   Move         r217, r171
   Move         r218, r172
-  // ss_customer_sk: s.ss_customer_sk,
-  Move         r219, r173
-  Move         r220, r174
   // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Move         r221, r175
-  Move         r222, r184
+  Move         r219, r173
+  Move         r220, r182
   // store_qty: s.ss_qty,
+  Move         r221, r183
+  Move         r222, r184
+  // store_wholesale_cost: s.ss_wc,
   Move         r223, r185
   Move         r224, r186
-  // store_wholesale_cost: s.ss_wc,
+  // store_sales_price: s.ss_sp,
   Move         r225, r187
   Move         r226, r188
-  // store_sales_price: s.ss_sp,
+  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
   Move         r227, r189
-  Move         r228, r190
-  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Move         r229, r191
-  Move         r230, r198
+  Move         r228, r196
   // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Move         r231, r199
-  Move         r232, r206
+  Move         r229, r197
+  Move         r230, r204
   // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Move         r233, r207
-  Move         r234, r214
+  Move         r231, r205
+  Move         r232, r212
   // select {
-  MakeMap      r235, 10, r215
+  MakeMap      r233, 10, r213
   // from s in ss
-  Append       r236, r3, r235
-  Move         r3, r236
-L4:
+  Append       r234, r3, r233
+  Move         r3, r234
+L3:
   // left join w in ws on w.ws_sold_year == s.ss_sold_year && w.ws_item_sk == s.ss_item_sk && w.ws_customer_sk == s.ss_customer_sk
-  Add          r35, r35, r155
-  Jump         L14
+  Add          r35, r35, r153
+  Jump         L12
 L1:
-  Move         r237, r39
-  JumpIfTrue   r237, L15
-  Move         r38, r72
+  Move         r235, r39
+  JumpIfTrue   r235, L13
+  Move         r38, r70
   // left join c in cs on c.cs_sold_year == s.ss_sold_year && c.cs_item_sk == s.ss_item_sk && c.cs_customer_sk == s.ss_customer_sk
-  IterPrep     r238, r2
-  Len          r239, r238
-  Move         r240, r26
-L22:
-  LessInt      r241, r240, r239
-  JumpIfFalse  r241, L16
-  Index        r242, r238, r240
-  Move         r59, r242
-  Const        r243, false
-  Index        r244, r59, r53
-  Index        r245, r29, r6
-  Equal        r246, r244, r245
-  Index        r247, r59, r54
-  Index        r248, r29, r7
-  Equal        r249, r247, r248
-  Index        r250, r59, r55
-  Index        r251, r29, r8
-  Equal        r252, r250, r251
-  Move         r253, r246
-  JumpIfFalse  r253, L17
-  Move         r253, r249
-L17:
-  Move         r254, r253
-  JumpIfFalse  r254, L18
-  Move         r254, r252
-L18:
-  JumpIfFalse  r254, L19
-  Const        r243, true
-  // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
-  Equal        r255, r38, r72
-  Index        r256, r38, r4
-  Select       257,255,26,256
-  Less         r258, r26, r257
-  Equal        r259, r59, r72
-  Index        r260, r59, r5
-  Select       261,259,26,260
-  Less         r262, r26, r261
-  Move         r263, r258
-  JumpIfTrue   r263, L20
-  Move         r263, r262
-L20:
-  Index        r264, r29, r6
-  Equal        r265, r264, r83
-  Move         r266, r263
-  JumpIfFalse  r266, L21
-  Move         r266, r265
-L21:
-  JumpIfFalse  r266, L19
-  // ss_sold_year: s.ss_sold_year,
-  Const        r267, "ss_sold_year"
-  Index        r268, r29, r6
-  // ss_item_sk: s.ss_item_sk,
-  Const        r269, "ss_item_sk"
-  Index        r270, r29, r7
-  // ss_customer_sk: s.ss_customer_sk,
-  Const        r271, "ss_customer_sk"
-  Index        r272, r29, r8
-  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Const        r273, "ratio"
-  Index        r274, r29, r10
-  Equal        r275, r38, r72
-  Index        r276, r38, r4
-  Select       277,275,26,276
-  Equal        r278, r59, r72
-  Index        r279, r59, r5
-  Select       280,278,26,279
-  Add          r281, r277, r280
-  Div          r282, r274, r281
-  // store_qty: s.ss_qty,
-  Const        r283, "store_qty"
-  Index        r284, r29, r10
-  // store_wholesale_cost: s.ss_wc,
-  Const        r285, "store_wholesale_cost"
-  Index        r286, r29, r13
-  // store_sales_price: s.ss_sp,
-  Const        r287, "store_sales_price"
-  Index        r288, r29, r15
-  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Const        r289, "other_chan_qty"
-  Equal        r290, r38, r72
-  Index        r291, r38, r4
-  Select       292,290,26,291
-  Equal        r293, r59, r72
-  Index        r294, r59, r5
-  Select       295,293,26,294
-  Add          r296, r292, r295
-  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Const        r297, "other_chan_wholesale_cost"
-  Equal        r298, r38, r72
-  Index        r299, r38, r18
-  Select       300,298,118,299
-  Equal        r301, r59, r72
-  Index        r302, r59, r19
-  Select       303,301,118,302
-  Add          r304, r300, r303
-  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Const        r305, "other_chan_sales_price"
-  Equal        r306, r38, r72
-  Index        r307, r38, r21
-  Select       308,306,118,307
-  Equal        r309, r59, r72
-  Index        r310, r59, r22
-  Select       311,309,118,310
-  Add          r312, r308, r311
-  // ss_sold_year: s.ss_sold_year,
-  Move         r313, r267
-  Move         r314, r268
-  // ss_item_sk: s.ss_item_sk,
-  Move         r315, r269
-  Move         r316, r270
-  // ss_customer_sk: s.ss_customer_sk,
-  Move         r317, r271
-  Move         r318, r272
-  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Move         r319, r273
-  Move         r320, r282
-  // store_qty: s.ss_qty,
-  Move         r321, r283
-  Move         r322, r284
-  // store_wholesale_cost: s.ss_wc,
-  Move         r323, r285
-  Move         r324, r286
-  // store_sales_price: s.ss_sp,
-  Move         r325, r287
-  Move         r326, r288
-  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Move         r327, r289
-  Move         r328, r296
-  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Move         r329, r297
-  Move         r330, r304
-  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Move         r331, r305
-  Move         r332, r312
-  // select {
-  MakeMap      r333, 10, r313
-  // from s in ss
-  Append       r334, r3, r333
-  Move         r3, r334
+  IterPrep     r236, r2
+  Len          r237, r236
+  Move         r238, r26
 L19:
-  // left join c in cs on c.cs_sold_year == s.ss_sold_year && c.cs_item_sk == s.ss_item_sk && c.cs_customer_sk == s.ss_customer_sk
-  Add          r240, r240, r155
-  Jump         L22
-L16:
-  Move         r335, r243
-  JumpIfTrue   r335, L15
-  Move         r59, r72
-  // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
-  Equal        r336, r38, r72
-  Index        r337, r38, r4
-  Select       338,336,26,337
-  Less         r339, r26, r338
-  Equal        r340, r59, r72
-  Index        r341, r59, r5
-  Select       342,340,26,341
-  Less         r343, r26, r342
-  Move         r344, r339
-  JumpIfTrue   r344, L23
-  Move         r344, r343
-L23:
-  Index        r345, r29, r6
-  Equal        r346, r345, r83
-  Move         r347, r344
-  JumpIfFalse  r347, L24
-  Move         r347, r346
-L24:
-  JumpIfFalse  r347, L15
-  // ss_sold_year: s.ss_sold_year,
-  Const        r348, "ss_sold_year"
-  Index        r349, r29, r6
-  // ss_item_sk: s.ss_item_sk,
-  Const        r350, "ss_item_sk"
-  Index        r351, r29, r7
-  // ss_customer_sk: s.ss_customer_sk,
-  Const        r352, "ss_customer_sk"
-  Index        r353, r29, r8
-  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Const        r354, "ratio"
-  Index        r355, r29, r10
-  Equal        r356, r38, r72
-  Index        r357, r38, r4
-  Select       358,356,26,357
-  Equal        r359, r59, r72
-  Index        r360, r59, r5
-  Select       361,359,26,360
-  Add          r362, r358, r361
-  Div          r363, r355, r362
-  // store_qty: s.ss_qty,
-  Const        r364, "store_qty"
-  Index        r365, r29, r10
-  // store_wholesale_cost: s.ss_wc,
-  Const        r366, "store_wholesale_cost"
-  Index        r367, r29, r13
-  // store_sales_price: s.ss_sp,
-  Const        r368, "store_sales_price"
-  Index        r369, r29, r15
-  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Const        r370, "other_chan_qty"
-  Equal        r371, r38, r72
-  Index        r372, r38, r4
-  Select       373,371,26,372
-  Equal        r374, r59, r72
-  Index        r375, r59, r5
-  Select       376,374,26,375
-  Add          r377, r373, r376
-  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Const        r378, "other_chan_wholesale_cost"
-  Equal        r379, r38, r72
-  Index        r380, r38, r18
-  Select       381,379,118,380
-  Equal        r382, r59, r72
-  Index        r383, r59, r19
-  Select       384,382,118,383
-  Add          r385, r381, r384
-  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Const        r386, "other_chan_sales_price"
-  Equal        r387, r38, r72
-  Index        r388, r38, r21
-  Select       389,387,118,388
-  Equal        r390, r59, r72
-  Index        r391, r59, r22
-  Select       392,390,118,391
-  Add          r393, r389, r392
-  // ss_sold_year: s.ss_sold_year,
-  Move         r394, r348
-  Move         r395, r349
-  // ss_item_sk: s.ss_item_sk,
-  Move         r396, r350
-  Move         r397, r351
-  // ss_customer_sk: s.ss_customer_sk,
-  Move         r398, r352
-  Move         r399, r353
-  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
-  Move         r400, r354
-  Move         r401, r363
-  // store_qty: s.ss_qty,
-  Move         r402, r364
-  Move         r403, r365
-  // store_wholesale_cost: s.ss_wc,
-  Move         r404, r366
-  Move         r405, r367
-  // store_sales_price: s.ss_sp,
-  Move         r406, r368
-  Move         r407, r369
-  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
-  Move         r408, r370
-  Move         r409, r377
-  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
-  Move         r410, r378
-  Move         r411, r385
-  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
-  Move         r412, r386
-  Move         r413, r393
-  // select {
-  MakeMap      r414, 10, r394
-  // from s in ss
-  Append       r415, r3, r414
-  Move         r3, r415
+  LessInt      r239, r238, r237
+  JumpIfFalse  r239, L14
+  Index        r240, r236, r238
+  Move         r58, r240
+  Const        r241, false
+  Index        r242, r58, r52
+  Index        r243, r29, r6
+  Equal        r244, r242, r243
+  Index        r245, r58, r53
+  Index        r246, r29, r7
+  Equal        r247, r245, r246
+  Index        r248, r58, r54
+  Index        r249, r29, r8
+  Equal        r250, r248, r249
+  Move         r251, r244
+  JumpIfFalse  r251, L15
+  Move         r251, r247
+  JumpIfFalse  r251, L15
+  Move         r251, r250
 L15:
-  AddInt       r25, r25, r155
-  Jump         L25
+  JumpIfFalse  r251, L16
+  Const        r241, true
+  // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
+  Equal        r252, r38, r70
+  Index        r253, r38, r4
+  Select       254,252,26,253
+  Less         r255, r26, r254
+  Equal        r256, r58, r70
+  Index        r257, r58, r5
+  Select       258,256,26,257
+  Less         r259, r26, r258
+  Move         r260, r255
+  JumpIfTrue   r260, L17
+  Move         r260, r259
+L17:
+  Index        r261, r29, r6
+  Equal        r262, r261, r81
+  Move         r263, r260
+  JumpIfFalse  r263, L18
+  Move         r263, r262
+L18:
+  JumpIfFalse  r263, L16
+  // ss_sold_year: s.ss_sold_year,
+  Const        r264, "ss_sold_year"
+  Index        r265, r29, r6
+  // ss_item_sk: s.ss_item_sk,
+  Const        r266, "ss_item_sk"
+  Index        r267, r29, r7
+  // ss_customer_sk: s.ss_customer_sk,
+  Const        r268, "ss_customer_sk"
+  Index        r269, r29, r8
+  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
+  Const        r270, "ratio"
+  Index        r271, r29, r10
+  Equal        r272, r38, r70
+  Index        r273, r38, r4
+  Select       274,272,26,273
+  Equal        r275, r58, r70
+  Index        r276, r58, r5
+  Select       277,275,26,276
+  Add          r278, r274, r277
+  Div          r279, r271, r278
+  // store_qty: s.ss_qty,
+  Const        r280, "store_qty"
+  Index        r281, r29, r10
+  // store_wholesale_cost: s.ss_wc,
+  Const        r282, "store_wholesale_cost"
+  Index        r283, r29, r13
+  // store_sales_price: s.ss_sp,
+  Const        r284, "store_sales_price"
+  Index        r285, r29, r15
+  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
+  Const        r286, "other_chan_qty"
+  Equal        r287, r38, r70
+  Index        r288, r38, r4
+  Select       289,287,26,288
+  Equal        r290, r58, r70
+  Index        r291, r58, r5
+  Select       292,290,26,291
+  Add          r293, r289, r292
+  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
+  Const        r294, "other_chan_wholesale_cost"
+  Equal        r295, r38, r70
+  Index        r296, r38, r18
+  Select       297,295,116,296
+  Equal        r298, r58, r70
+  Index        r299, r58, r19
+  Select       300,298,116,299
+  Add          r301, r297, r300
+  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
+  Const        r302, "other_chan_sales_price"
+  Equal        r303, r38, r70
+  Index        r304, r38, r21
+  Select       305,303,116,304
+  Equal        r306, r58, r70
+  Index        r307, r58, r22
+  Select       308,306,116,307
+  Add          r309, r305, r308
+  // ss_sold_year: s.ss_sold_year,
+  Move         r310, r264
+  Move         r311, r265
+  // ss_item_sk: s.ss_item_sk,
+  Move         r312, r266
+  Move         r313, r267
+  // ss_customer_sk: s.ss_customer_sk,
+  Move         r314, r268
+  Move         r315, r269
+  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
+  Move         r316, r270
+  Move         r317, r279
+  // store_qty: s.ss_qty,
+  Move         r318, r280
+  Move         r319, r281
+  // store_wholesale_cost: s.ss_wc,
+  Move         r320, r282
+  Move         r321, r283
+  // store_sales_price: s.ss_sp,
+  Move         r322, r284
+  Move         r323, r285
+  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
+  Move         r324, r286
+  Move         r325, r293
+  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
+  Move         r326, r294
+  Move         r327, r301
+  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
+  Move         r328, r302
+  Move         r329, r309
+  // select {
+  MakeMap      r330, 10, r310
+  // from s in ss
+  Append       r331, r3, r330
+  Move         r3, r331
+L16:
+  // left join c in cs on c.cs_sold_year == s.ss_sold_year && c.cs_item_sk == s.ss_item_sk && c.cs_customer_sk == s.ss_customer_sk
+  Add          r238, r238, r153
+  Jump         L19
+L14:
+  Move         r332, r241
+  JumpIfTrue   r332, L13
+  Move         r58, r70
+  // where ((if w == null { 0 } else { w.ws_qty }) > 0 || (if c == null { 0 } else { c.cs_qty }) > 0) && s.ss_sold_year == 1998
+  Equal        r333, r38, r70
+  Index        r334, r38, r4
+  Select       335,333,26,334
+  Less         r336, r26, r335
+  Equal        r337, r58, r70
+  Index        r338, r58, r5
+  Select       339,337,26,338
+  Less         r340, r26, r339
+  Move         r341, r336
+  JumpIfTrue   r341, L20
+  Move         r341, r340
+L20:
+  Index        r342, r29, r6
+  Equal        r343, r342, r81
+  Move         r344, r341
+  JumpIfFalse  r344, L21
+  Move         r344, r343
+L21:
+  JumpIfFalse  r344, L13
+  // ss_sold_year: s.ss_sold_year,
+  Const        r345, "ss_sold_year"
+  Index        r346, r29, r6
+  // ss_item_sk: s.ss_item_sk,
+  Const        r347, "ss_item_sk"
+  Index        r348, r29, r7
+  // ss_customer_sk: s.ss_customer_sk,
+  Const        r349, "ss_customer_sk"
+  Index        r350, r29, r8
+  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
+  Const        r351, "ratio"
+  Index        r352, r29, r10
+  Equal        r353, r38, r70
+  Index        r354, r38, r4
+  Select       355,353,26,354
+  Equal        r356, r58, r70
+  Index        r357, r58, r5
+  Select       358,356,26,357
+  Add          r359, r355, r358
+  Div          r360, r352, r359
+  // store_qty: s.ss_qty,
+  Const        r361, "store_qty"
+  Index        r362, r29, r10
+  // store_wholesale_cost: s.ss_wc,
+  Const        r363, "store_wholesale_cost"
+  Index        r364, r29, r13
+  // store_sales_price: s.ss_sp,
+  Const        r365, "store_sales_price"
+  Index        r366, r29, r15
+  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
+  Const        r367, "other_chan_qty"
+  Equal        r368, r38, r70
+  Index        r369, r38, r4
+  Select       370,368,26,369
+  Equal        r371, r58, r70
+  Index        r372, r58, r5
+  Select       373,371,26,372
+  Add          r374, r370, r373
+  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
+  Const        r375, "other_chan_wholesale_cost"
+  Equal        r376, r38, r70
+  Index        r377, r38, r18
+  Select       378,376,116,377
+  Equal        r379, r58, r70
+  Index        r380, r58, r19
+  Select       381,379,116,380
+  Add          r382, r378, r381
+  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
+  Const        r383, "other_chan_sales_price"
+  Equal        r384, r38, r70
+  Index        r385, r38, r21
+  Select       386,384,116,385
+  Equal        r387, r58, r70
+  Index        r388, r58, r22
+  Select       389,387,116,388
+  Add          r390, r386, r389
+  // ss_sold_year: s.ss_sold_year,
+  Move         r391, r345
+  Move         r392, r346
+  // ss_item_sk: s.ss_item_sk,
+  Move         r393, r347
+  Move         r394, r348
+  // ss_customer_sk: s.ss_customer_sk,
+  Move         r395, r349
+  Move         r396, r350
+  // ratio: s.ss_qty / ((if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty })),
+  Move         r397, r351
+  Move         r398, r360
+  // store_qty: s.ss_qty,
+  Move         r399, r361
+  Move         r400, r362
+  // store_wholesale_cost: s.ss_wc,
+  Move         r401, r363
+  Move         r402, r364
+  // store_sales_price: s.ss_sp,
+  Move         r403, r365
+  Move         r404, r366
+  // other_chan_qty: (if w == null { 0 } else { w.ws_qty }) + (if c == null { 0 } else { c.cs_qty }),
+  Move         r405, r367
+  Move         r406, r374
+  // other_chan_wholesale_cost: (if w == null { 0.0 } else { w.ws_wc }) + (if c == null { 0.0 } else { c.cs_wc }),
+  Move         r407, r375
+  Move         r408, r382
+  // other_chan_sales_price: (if w == null { 0.0 } else { w.ws_sp }) + (if c == null { 0.0 } else { c.cs_sp })
+  Move         r409, r383
+  Move         r410, r390
+  // select {
+  MakeMap      r411, 10, r391
+  // from s in ss
+  Append       r412, r3, r411
+  Move         r3, r412
+L13:
+  AddInt       r25, r25, r153
+  Jump         L22
 L0:
   // json(result)
   JSON         r3
   // expect result == [
-  Const        r416, [{"other_chan_qty": 8, "other_chan_sales_price": 80, "other_chan_wholesale_cost": 40, "ratio": 1.25, "ss_customer_sk": 1, "ss_item_sk": 1, "ss_sold_year": 1998, "store_qty": 10, "store_sales_price": 100, "store_wholesale_cost": 50}]
-  Equal        r417, r3, r416
-  Expect       r417
+  Const        r413, [{"other_chan_qty": 8, "other_chan_sales_price": 80.0, "other_chan_wholesale_cost": 40.0, "ratio": 1.25, "ss_customer_sk": 1, "ss_item_sk": 1, "ss_sold_year": 1998, "store_qty": 10, "store_sales_price": 100.0, "store_wholesale_cost": 50.0}]
+  Equal        r414, r3, r413
+  Expect       r414
   Return       r0
-

--- a/tests/dataset/tpc-ds/out/q79.ir.out
+++ b/tests/dataset/tpc-ds/out/q79.ir.out
@@ -1,4 +1,4 @@
-func main (regs=251)
+func main (regs=246)
   // let date_dim = [
   Const        r0, [{"d_date_sk": 1, "d_dow": 1, "d_year": 1999}]
   // let store = [
@@ -6,7 +6,7 @@ func main (regs=251)
   // let household_demographics = [
   Const        r2, [{"hd_demo_sk": 1, "hd_dep_count": 2, "hd_vehicle_count": 1}]
   // let store_sales = [
-  Const        r3, [{"ss_coupon_amt": 5, "ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_net_profit": 10, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}]
+  Const        r3, [{"ss_coupon_amt": 5.0, "ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_net_profit": 10.0, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}]
   // let customer = [
   Const        r4, [{"c_customer_sk": 1, "c_first_name": "Alice", "c_last_name": "Smith"}]
   // from ss in store_sales
@@ -41,7 +41,7 @@ func main (regs=251)
   IterPrep     r26, r3
   Len          r27, r26
   Const        r28, 0
-L16:
+L12:
   LessInt      r29, r28, r27
   JumpIfFalse  r29, L0
   Index        r30, r26, r28
@@ -50,7 +50,7 @@ L16:
   IterPrep     r32, r0
   Len          r33, r32
   Const        r34, 0
-L15:
+L11:
   LessInt      r35, r34, r33
   JumpIfFalse  r35, L1
   Index        r36, r32, r34
@@ -65,7 +65,7 @@ L15:
   IterPrep     r43, r1
   Len          r44, r43
   Const        r45, 0
-L14:
+L10:
   LessInt      r46, r45, r44
   JumpIfFalse  r46, L2
   Index        r47, r43, r45
@@ -80,7 +80,7 @@ L14:
   IterPrep     r54, r2
   Len          r55, r54
   Const        r56, 0
-L13:
+L9:
   LessInt      r57, r56, r55
   JumpIfFalse  r57, L3
   Index        r58, r54, r56
@@ -116,7 +116,8 @@ L5:
   Move         r80, r71
   JumpIfFalse  r80, L6
   Move         r80, r79
-L6:
+  // d.d_dow == 1 &&
+  JumpIfFalse  r80, L6
   // (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
   Index        r81, r37, r15
   Const        r82, 1998
@@ -130,262 +131,252 @@ L6:
   Move         r90, r83
   JumpIfTrue   r90, L7
   Move         r90, r86
+  JumpIfTrue   r90, L7
+  Move         r90, r89
 L7:
-  Move         r91, r90
-  JumpIfTrue   r91, L8
-  Move         r91, r89
-L8:
   // d.d_dow == 1 &&
-  Move         r92, r80
-  JumpIfFalse  r92, L9
-  Move         r92, r91
-L9:
+  Move         r80, r90
   // (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
-  Move         r93, r92
-  JumpIfFalse  r93, L10
-  Move         r93, r74
-L10:
+  JumpIfFalse  r80, L6
+  Move         r80, r74
   // s.s_number_employees >= 200 && s.s_number_employees <= 295
-  Move         r94, r93
-  JumpIfFalse  r94, L11
-  Move         r94, r77
-L11:
+  JumpIfFalse  r80, L6
+  Move         r80, r77
+L6:
   // where (hd.hd_dep_count == 2 || hd.hd_vehicle_count > 1) &&
-  JumpIfFalse  r94, L4
+  JumpIfFalse  r80, L4
   // from ss in store_sales
-  Move         r95, r31
-  Const        r96, "d"
-  Move         r97, r37
-  Const        r98, "s"
-  Move         r99, r48
-  Const        r100, "hd"
-  Move         r101, r59
-  Move         r102, r19
+  Move         r91, r31
+  Const        r92, "d"
+  Move         r93, r37
+  Const        r94, "s"
+  Move         r95, r48
+  Const        r96, "hd"
+  Move         r97, r59
+  Move         r98, r19
+  Move         r99, r91
+  Move         r100, r92
+  Move         r101, r93
+  Move         r102, r94
   Move         r103, r95
   Move         r104, r96
   Move         r105, r97
-  Move         r106, r98
-  Move         r107, r99
-  Move         r108, r100
-  Move         r109, r101
-  MakeMap      r110, 4, r102
+  MakeMap      r106, 4, r98
   // group by { ticket: ss.ss_ticket_number, customer_sk: ss.ss_customer_sk, city: s.s_city } into g
-  Const        r111, "ticket"
-  Index        r112, r31, r7
-  Const        r113, "customer_sk"
-  Index        r114, r31, r9
-  Const        r115, "city"
-  Index        r116, r48, r11
+  Const        r107, "ticket"
+  Index        r108, r31, r7
+  Const        r109, "customer_sk"
+  Index        r110, r31, r9
+  Const        r111, "city"
+  Index        r112, r48, r11
+  Move         r113, r107
+  Move         r114, r108
+  Move         r115, r109
+  Move         r116, r110
   Move         r117, r111
   Move         r118, r112
-  Move         r119, r113
-  Move         r120, r114
-  Move         r121, r115
-  Move         r122, r116
-  MakeMap      r123, 3, r117
-  Str          r124, r123
-  In           r125, r124, r23
-  JumpIfTrue   r125, L12
+  MakeMap      r119, 3, r113
+  Str          r120, r119
+  In           r121, r120, r23
+  JumpIfTrue   r121, L8
   // from ss in store_sales
-  Const        r126, []
-  Const        r127, "__group__"
-  Const        r128, true
+  Const        r122, "__group__"
+  Const        r123, true
   // group by { ticket: ss.ss_ticket_number, customer_sk: ss.ss_customer_sk, city: s.s_city } into g
-  Move         r129, r123
+  Move         r124, r119
   // from ss in store_sales
-  Const        r130, "items"
-  Move         r131, r126
-  Const        r132, "count"
-  Const        r133, 0
-  Move         r134, r127
-  Move         r135, r128
-  Move         r136, r17
-  Move         r137, r129
-  Move         r138, r130
-  Move         r139, r131
-  Move         r140, r132
-  Move         r141, r133
-  MakeMap      r142, 4, r134
-  SetIndex     r23, r124, r142
-  Append       r143, r24, r142
-  Move         r24, r143
-L12:
-  Index        r144, r23, r124
-  Index        r145, r144, r130
-  Append       r146, r145, r110
-  SetIndex     r144, r130, r146
-  Index        r147, r144, r132
-  AddInt       r148, r147, r67
-  SetIndex     r144, r132, r148
+  Const        r125, "items"
+  Move         r126, r25
+  Const        r127, "count"
+  Const        r128, 0
+  Move         r129, r122
+  Move         r130, r123
+  Move         r131, r17
+  Move         r132, r124
+  Move         r133, r125
+  Move         r134, r126
+  Move         r135, r127
+  Move         r136, r128
+  MakeMap      r137, 4, r129
+  SetIndex     r23, r120, r137
+  Append       r138, r24, r137
+  Move         r24, r138
+L8:
+  Index        r139, r23, r120
+  Index        r140, r139, r125
+  Append       r141, r140, r106
+  SetIndex     r139, r125, r141
+  Index        r142, r139, r127
+  AddInt       r143, r142, r67
+  SetIndex     r139, r127, r143
 L4:
   // join hd in household_demographics on hd.hd_demo_sk == ss.ss_hdemo_sk
   AddInt       r56, r56, r67
-  Jump         L13
+  Jump         L9
 L3:
   // join s in store on s.s_store_sk == ss.ss_store_sk
   AddInt       r45, r45, r67
-  Jump         L14
+  Jump         L10
 L2:
   // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
   AddInt       r34, r34, r67
-  Jump         L15
+  Jump         L11
 L1:
   // from ss in store_sales
   AddInt       r28, r28, r67
-  Jump         L16
+  Jump         L12
 L0:
-  Move         r149, r133
-  Len          r150, r24
-L22:
-  LessInt      r151, r149, r150
-  JumpIfFalse  r151, L17
-  Index        r152, r24, r149
-  Move         r153, r152
-  // select { key: g.key, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
-  Const        r154, "key"
-  Index        r155, r153, r17
-  Const        r156, "amt"
-  Const        r157, []
-  IterPrep     r158, r153
-  Len          r159, r158
-  Move         r160, r133
-L19:
-  LessInt      r161, r160, r159
-  JumpIfFalse  r161, L18
-  Index        r162, r158, r160
-  Move         r163, r162
-  Index        r164, r163, r19
-  Index        r165, r164, r20
-  Append       r166, r157, r165
-  Move         r157, r166
-  AddInt       r160, r160, r67
-  Jump         L19
+  Move         r144, r128
+  Len          r145, r24
 L18:
-  Sum          r167, r157
-  Const        r168, "profit"
-  Const        r169, []
-  IterPrep     r170, r153
-  Len          r171, r170
-  Move         r172, r133
-L21:
-  LessInt      r173, r172, r171
-  JumpIfFalse  r173, L20
-  Index        r174, r170, r172
-  Move         r163, r174
-  Index        r175, r163, r19
-  Index        r176, r175, r22
-  Append       r177, r169, r176
-  Move         r169, r177
-  AddInt       r172, r172, r67
-  Jump         L21
-L20:
-  Sum          r178, r169
-  Move         r179, r154
-  Move         r180, r155
-  Move         r181, r156
-  Move         r182, r167
-  Move         r183, r168
-  Move         r184, r178
-  MakeMap      r185, 3, r179
-  // from ss in store_sales
-  Append       r186, r5, r185
-  Move         r5, r186
-  AddInt       r149, r149, r67
-  Jump         L22
+  LessInt      r146, r144, r145
+  JumpIfFalse  r146, L13
+  Index        r147, r24, r144
+  Move         r148, r147
+  // select { key: g.key, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
+  Const        r149, "key"
+  Index        r150, r148, r17
+  Const        r151, "amt"
+  Const        r152, []
+  IterPrep     r153, r148
+  Len          r154, r153
+  Move         r155, r128
+L15:
+  LessInt      r156, r155, r154
+  JumpIfFalse  r156, L14
+  Index        r157, r153, r155
+  Move         r158, r157
+  Index        r159, r158, r19
+  Index        r160, r159, r20
+  Append       r161, r152, r160
+  Move         r152, r161
+  AddInt       r155, r155, r67
+  Jump         L15
+L14:
+  Sum          r162, r152
+  Const        r163, "profit"
+  Const        r164, []
+  IterPrep     r165, r148
+  Len          r166, r165
+  Move         r167, r128
 L17:
+  LessInt      r168, r167, r166
+  JumpIfFalse  r168, L16
+  Index        r169, r165, r167
+  Move         r158, r169
+  Index        r170, r158, r19
+  Index        r171, r170, r22
+  Append       r172, r164, r171
+  Move         r164, r172
+  AddInt       r167, r167, r67
+  Jump         L17
+L16:
+  Sum          r173, r164
+  Move         r174, r149
+  Move         r175, r150
+  Move         r176, r151
+  Move         r177, r162
+  Move         r178, r163
+  Move         r179, r173
+  MakeMap      r180, 3, r174
+  // from ss in store_sales
+  Append       r181, r5, r180
+  Move         r5, r181
+  AddInt       r144, r144, r67
+  Jump         L18
+L13:
   // from a in agg
-  Const        r187, []
-  IterPrep     r188, r5
-  Len          r189, r188
+  Const        r182, []
+  IterPrep     r183, r5
+  Len          r184, r183
   // join c in customer on c.c_customer_sk == a.key.customer_sk
-  IterPrep     r190, r4
-  Len          r191, r190
-  Const        r192, "c_customer_sk"
+  IterPrep     r185, r4
+  Len          r186, r185
+  Const        r187, "c_customer_sk"
   // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
-  Const        r193, "c_last_name"
-  Const        r194, "c_first_name"
+  Const        r188, "c_last_name"
+  Const        r189, "c_first_name"
   // from a in agg
-  Const        r195, 0
-L27:
-  LessInt      r196, r195, r189
-  JumpIfFalse  r196, L23
-  Index        r197, r188, r195
-  Move         r198, r197
-  // join c in customer on c.c_customer_sk == a.key.customer_sk
-  Const        r199, 0
-L26:
-  LessInt      r200, r199, r191
-  JumpIfFalse  r200, L24
-  Index        r201, r190, r199
-  Move         r202, r201
-  Index        r203, r202, r192
-  Index        r204, r198, r17
-  Index        r205, r204, r8
-  Equal        r206, r203, r205
-  JumpIfFalse  r206, L25
-  // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
-  Const        r207, "c_last_name"
-  Index        r208, r202, r193
-  Const        r209, "c_first_name"
-  Index        r210, r202, r194
-  Const        r211, "s_city"
-  Index        r212, r198, r17
-  Index        r213, r212, r10
-  Const        r214, "ss_ticket_number"
-  Index        r215, r198, r17
-  Index        r216, r215, r6
-  Const        r217, "amt"
-  Index        r218, r198, r18
-  Const        r219, "profit"
-  Index        r220, r198, r21
-  Move         r221, r207
-  Move         r222, r208
-  Move         r223, r209
-  Move         r224, r210
-  Move         r225, r211
-  Move         r226, r213
-  Move         r227, r214
-  Move         r228, r216
-  Move         r229, r217
-  Move         r230, r218
-  Move         r231, r219
-  Move         r232, r220
-  MakeMap      r233, 6, r221
-  // sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
-  Index        r234, r202, r193
-  Move         r235, r234
-  Index        r236, r202, r194
-  Move         r237, r236
-  Index        r238, r198, r17
-  Index        r239, r238, r10
-  Move         r240, r239
-  Index        r241, r198, r21
-  Move         r242, r241
-  MakeList     r243, 4, r235
-  Move         r244, r243
-  // from a in agg
-  Move         r245, r233
-  MakeList     r246, 2, r244
-  Append       r247, r187, r246
-  Move         r187, r247
-L25:
-  // join c in customer on c.c_customer_sk == a.key.customer_sk
-  AddInt       r199, r199, r67
-  Jump         L26
-L24:
-  // from a in agg
-  AddInt       r195, r195, r67
-  Jump         L27
+  Const        r190, 0
 L23:
+  LessInt      r191, r190, r184
+  JumpIfFalse  r191, L19
+  Index        r192, r183, r190
+  Move         r193, r192
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  Const        r194, 0
+L22:
+  LessInt      r195, r194, r186
+  JumpIfFalse  r195, L20
+  Index        r196, r185, r194
+  Move         r197, r196
+  Index        r198, r197, r187
+  Index        r199, r193, r17
+  Index        r200, r199, r8
+  Equal        r201, r198, r200
+  JumpIfFalse  r201, L21
+  // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
+  Const        r202, "c_last_name"
+  Index        r203, r197, r188
+  Const        r204, "c_first_name"
+  Index        r205, r197, r189
+  Const        r206, "s_city"
+  Index        r207, r193, r17
+  Index        r208, r207, r10
+  Const        r209, "ss_ticket_number"
+  Index        r210, r193, r17
+  Index        r211, r210, r6
+  Const        r212, "amt"
+  Index        r213, r193, r18
+  Const        r214, "profit"
+  Index        r215, r193, r21
+  Move         r216, r202
+  Move         r217, r203
+  Move         r218, r204
+  Move         r219, r205
+  Move         r220, r206
+  Move         r221, r208
+  Move         r222, r209
+  Move         r223, r211
+  Move         r224, r212
+  Move         r225, r213
+  Move         r226, r214
+  Move         r227, r215
+  MakeMap      r228, 6, r216
   // sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
-  Sort         r248, r187
+  Index        r229, r197, r188
+  Move         r230, r229
+  Index        r231, r197, r189
+  Move         r232, r231
+  Index        r233, r193, r17
+  Index        r234, r233, r10
+  Move         r235, r234
+  Index        r236, r193, r21
+  Move         r237, r236
+  MakeList     r238, 4, r230
+  Move         r239, r238
   // from a in agg
-  Move         r187, r248
+  Move         r240, r228
+  MakeList     r241, 2, r239
+  Append       r242, r182, r241
+  Move         r182, r242
+L21:
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  AddInt       r194, r194, r67
+  Jump         L22
+L20:
+  // from a in agg
+  AddInt       r190, r190, r67
+  Jump         L23
+L19:
+  // sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
+  Sort         r243, r182
+  // from a in agg
+  Move         r182, r243
   // json(result)
-  JSON         r187
+  JSON         r182
   // expect result == [
-  Const        r249, [{"amt": 5, "c_first_name": "Alice", "c_last_name": "Smith", "profit": 10, "s_city": "CityA", "ss_ticket_number": 1}]
-  Equal        r250, r187, r249
-  Expect       r250
+  Const        r244, [{"amt": 5.0, "c_first_name": "Alice", "c_last_name": "Smith", "profit": 10.0, "s_city": "CityA", "ss_ticket_number": 1}]
+  Equal        r245, r182, r244
+  Expect       r245
   Return       r0
-

--- a/tools/update_tpcds_ir/main.go
+++ b/tools/update_tpcds_ir/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("go.mod not found")
+}
+func main() {
+	root, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	dir := filepath.Join(root, "tests/dataset/tpc-ds")
+	pattern := filepath.Join(dir, "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	sort.Strings(files)
+	if len(os.Args) > 1 {
+		var filtered []string
+		for _, f := range files {
+			base := strings.TrimSuffix(filepath.Base(f), ".mochi")
+			for _, a := range os.Args[1:] {
+				if base == a {
+					filtered = append(filtered, f)
+				}
+			}
+		}
+		files = filtered
+	}
+	if len(files) == 0 {
+		fmt.Fprintln(os.Stderr, "no files")
+		os.Exit(1)
+	}
+	outDir := filepath.Join(dir, "out")
+	for _, src := range files {
+		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		irPath := filepath.Join(outDir, base+".ir.out")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: parse error: %v\n", src, err)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "%s: type error: %v\n", src, errs[0])
+			continue
+		}
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: compile error: %v\n", src, err)
+			continue
+		}
+		srcData, err := os.ReadFile(src)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: read src: %v\n", src, err)
+			continue
+		}
+		ir := []byte(strings.TrimSpace(p.Disassemble(string(srcData))))
+		if err := os.WriteFile(irPath, ir, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: write ir: %v\n", src, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- prevent runaway recursion in the VM by limiting call depth
- add helper `update_tpcds_ir` for updating IR goldens
- refresh TPC‑DS IR output for queries q70–q79

## Testing
- `go vet ./...`
- `go test ./runtime/vm -run TestDummy -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686331bbeda08320bb2a94fd305f6277