### PR TITLE
Add strings.ToLower support in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2612,6 +2612,13 @@ func (fc *funcCompiler) compilePostfix(p *parser.PostfixExpr) int {
 			fc.emit(p.Ops[0].Call.Pos, Instr{Op: OpUpper, A: dst, B: arg})
 			return dst
 		}
+		// strings.ToLower(x) -> lower(x)
+		if rootName == "strings" && methodName == "ToLower" {
+			arg := fc.compileExpr(p.Ops[0].Call.Args[0])
+			dst := fc.newReg()
+			fc.emit(p.Ops[0].Call.Pos, Instr{Op: OpLower, A: dst, B: arg})
+			return dst
+		}
 		if typ, err := fc.comp.env.GetVar(rootName); err == nil {
 			if st, ok := typ.(types.StructType); ok {
 				if _, ok := st.Methods[methodName]; ok {


### PR DESCRIPTION
## Summary
- handle `strings.ToLower` in the VM compiler
- no change to existing TPC-DS IR files after regeneration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68633546c5c48320a9d9238d9fae10c1