### PR TITLE
Support lowercase conversion on non-string values

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -780,16 +780,11 @@ func evalUnaryConst(op Op, v Value) (Value, bool) {
 			return Value{Tag: ValueBool, Bool: !v.Bool}, true
 		}
 	case OpStr:
-		return Value{Tag: ValueStr, Str: fmt.Sprint(valueToAny(v))}, true
+		return Value{Tag: ValueStr, Str: valueToText(v)}, true
 	case OpUpper:
-		if v.Tag == ValueStr {
-			return Value{Tag: ValueStr, Str: strings.ToUpper(v.Str)}, true
-		}
+		return Value{Tag: ValueStr, Str: strings.ToUpper(valueToText(v))}, true
 	case OpLower:
-		if v.Tag == ValueStr {
-			return Value{Tag: ValueStr, Str: strings.ToLower(v.Str)}, true
-		}
-		return Value{Tag: ValueStr, Str: strings.ToLower(fmt.Sprint(valueToAny(v)))}, true
+		return Value{Tag: ValueStr, Str: strings.ToLower(valueToText(v))}, true
 	case OpFirst:
 		if lst, ok := toList(v); ok {
 			if len(lst) > 0 {


### PR DESCRIPTION
## Summary
- allow VM string builtins to accept non-string values
- return `null` via `valueToText` when converting `ValueNull`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6863386358008320bff545b30192da1b