### PR TITLE
Add numeric comparisons with AnyType in Go compiler

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -1476,6 +1476,12 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 				case isString(leftType) && isAny(rightType):
 					c.use("_cast")
 					right = fmt.Sprintf("_cast[string](%s)", right)
+				case isAny(leftType) && isNumeric(rightType):
+					c.use("_cast")
+					left = fmt.Sprintf("_cast[%s](%s)", goType(rightType), left)
+				case isNumeric(leftType) && isAny(rightType):
+					c.use("_cast")
+					right = fmt.Sprintf("_cast[%s](%s)", goType(leftType), right)
 				default:
 					return "", types.AnyType{}, fmt.Errorf("incompatible types in comparison: %s and %s", leftType, rightType)
 				}

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -187,6 +187,10 @@ func isFloat(t types.Type) bool {
 	return ok
 }
 
+func isNumeric(t types.Type) bool {
+	return isInt(t) || isInt64(t) || isFloat(t)
+}
+
 func isBool(t types.Type) bool {
 	_, ok := t.(types.BoolType)
 	return ok


### PR DESCRIPTION
## Summary
- expand Go codegen helper utilities with `isNumeric`
- allow comparisons between `any` and numeric types in the Go backend

## Testing
- `go test ./compile/go -run TPCHQ1 -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68633f3bba4883208007efd4b0be748b