### PR TITLE
Add Go compiler support for TPC-DS q1

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -380,6 +380,54 @@ func TestGoCompiler_JOBQueries(t *testing.T) {
 	}
 }
 
+func TestGoCompiler_TPCDSQueries(t *testing.T) {
+	root := findRepoRoot(t)
+	q := "q1"
+	t.Run(q, func(t *testing.T) {
+		src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Fatalf("type error: %v", errs[0])
+		}
+		code, err := gocode.New(env).Compile(prog)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+		codeWantPath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "go", q+".go.out")
+		wantCode, err := os.ReadFile(codeWantPath)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+			t.Errorf("generated code mismatch for %s.go.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
+		}
+		dir := t.TempDir()
+		file := filepath.Join(dir, "main.go")
+		if err := os.WriteFile(file, code, 0644); err != nil {
+			t.Fatalf("write error: %v", err)
+		}
+		cmd := exec.Command("go", "run", file)
+		cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("go run error: %v\n%s", err, out)
+		}
+		gotOut := bytes.TrimSpace(out)
+		outWantPath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "go", q+".out")
+		wantOut, err := os.ReadFile(outWantPath)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		if !bytes.Equal(normalizeOutput(root, gotOut), normalizeOutput(root, bytes.TrimSpace(wantOut))) {
+			t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, gotOut, bytes.TrimSpace(wantOut))
+		}
+	})
+}
+
 func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/tests/dataset/tpc-ds/compiler/go/q1.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q1.go.out
@@ -1,0 +1,533 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q1_empty() {
+	expect((len(result) == 0))
+}
+
+var store_returns []any
+var date_dim []any
+var store []any
+var customer []any
+var customer_total_return []map[string]any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	store_returns = []any{}
+	date_dim = []any{}
+	store = []any{}
+	customer = []any{}
+	customer_total_return = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, sr := range store_returns {
+			for _, d := range date_dim {
+				if !(_equal(_cast[map[string]any](sr)["sr_returned_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+					continue
+				}
+				if _equal(_cast[map[string]any](d)["d_year"], 1998) {
+					key := map[string]any{"customer_sk": _cast[map[string]any](sr)["sr_customer_sk"], "store_sk": _cast[map[string]any](sr)["sr_store_sk"]}
+					ks := fmt.Sprint(key)
+					g, ok := groups[ks]
+					if !ok {
+						g = &data.Group{Key: key}
+						groups[ks] = g
+						order = append(order, ks)
+					}
+					g.Items = append(g.Items, sr)
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"ctr_customer_sk": _cast[map[string]any](g.Key)["customer_sk"],
+				"ctr_store_sk":    _cast[map[string]any](g.Key)["store_sk"],
+				"ctr_total_return": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["sr_return_amt"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	result = func() []map[string]any {
+		src := _toAnySlice(customer_total_return)
+		resAny := _query(src, []_joinSpec{
+			{items: store, on: func(_a ...any) bool {
+				ctr1 := _cast[map[string]any](_a[0])
+				_ = ctr1
+				s := _a[1]
+				_ = s
+				return _equal(ctr1["ctr_store_sk"], _cast[map[string]any](s)["s_store_sk"])
+			}},
+			{items: customer, on: func(_a ...any) bool {
+				ctr1 := _cast[map[string]any](_a[0])
+				_ = ctr1
+				s := _a[1]
+				_ = s
+				c := _a[2]
+				_ = c
+				return _equal(ctr1["ctr_customer_sk"], _cast[map[string]any](c)["c_customer_sk"])
+			}},
+		}, _queryOpts{selectFn: func(_a ...any) any {
+			ctr1 := _cast[map[string]any](_a[0])
+			_ = ctr1
+			s := _a[1]
+			_ = s
+			c := _a[2]
+			_ = c
+			return map[string]any{"c_customer_id": _cast[map[string]any](c)["c_customer_id"]}
+		}, where: func(_a ...any) bool {
+			ctr1 := _cast[map[string]any](_a[0])
+			_ = ctr1
+			s := _a[1]
+			_ = s
+			c := _a[2]
+			_ = c
+			return ((_cast[float64](ctr1["ctr_total_return"]) > (_avg(func() []any {
+				_res := []any{}
+				for _, ctr2 := range customer_total_return {
+					if _equal(ctr1["ctr_store_sk"], ctr2["ctr_store_sk"]) {
+						if _equal(ctr1["ctr_store_sk"], ctr2["ctr_store_sk"]) {
+							_res = append(_res, ctr2["ctr_total_return"])
+						}
+					}
+				}
+				return _res
+			}()) * 1.2)) && _equal(_cast[map[string]any](s)["s_state"], "TN"))
+		}, sortKey: func(_a ...any) any {
+			ctr1 := _cast[map[string]any](_a[0])
+			_ = ctr1
+			s := _a[1]
+			_ = s
+			c := _a[2]
+			_ = c
+			return _cast[map[string]any](c)["c_customer_id"]
+		}, skip: -1, take: -1})
+		out := make([]map[string]any, len(resAny))
+		for i, v := range resAny {
+			out[i] = _cast[map[string]any](v)
+		}
+		return out
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q1 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q1_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+type _joinSpec struct {
+	items []any
+	on    func(...any) bool
+	left  bool
+	right bool
+}
+type _queryOpts struct {
+	selectFn func(...any) any
+	where    func(...any) bool
+	sortKey  func(...any) any
+	skip     int
+	take     int
+}
+
+func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
+	items := make([][]any, len(src))
+	for i, v := range src {
+		items[i] = []any{v}
+	}
+	for _, j := range joins {
+		joined := [][]any{}
+		if j.right && j.left {
+			matched := make([]bool, len(j.items))
+			for _, left := range items {
+				m := false
+				for ri, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					matched[ri] = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+			for ri, right := range j.items {
+				if !matched[ri] {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else if j.right {
+			for _, right := range j.items {
+				m := false
+				for _, left := range items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else {
+			for _, left := range items {
+				m := false
+				for _, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if j.left && !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+		}
+		items = joined
+	}
+	if opts.where != nil {
+		filtered := [][]any{}
+		for _, r := range items {
+			if opts.where(r...) {
+				filtered = append(filtered, r)
+			}
+		}
+		items = filtered
+	}
+	if opts.sortKey != nil {
+		type pair struct {
+			item []any
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for i, it := range items {
+			pairs[i] = pair{it, opts.sortKey(it...)}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for i, p := range pairs {
+			items[i] = p.item
+		}
+	}
+	if opts.skip >= 0 {
+		if opts.skip < len(items) {
+			items = items[opts.skip:]
+		} else {
+			items = [][]any{}
+		}
+	}
+	if opts.take >= 0 {
+		if opts.take < len(items) {
+			items = items[:opts.take]
+		}
+	}
+	res := make([]any, len(items))
+	for i, r := range items {
+		res[i] = opts.selectFn(r...)
+	}
+	return res
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q1.out
+++ b/tests/dataset/tpc-ds/compiler/go/q1.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q1 empty                 ... ok (624ns)


### PR DESCRIPTION
## Summary
- support sorting in query compilation via runtime helper
- normalize parameters for runtime `_query`
- add golden files for TPC-DS q1 Go backend
- exercise TPC-DS q1 in Go compiler tests

## Testing
- `go test ./compile/go -run TPCDS -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68634459cbc48320be27f4dc599e1012