### PR TITLE
Add COBOL TPC-DS q1 test

### DIFF
--- a/compile/x/cobol/TASKS.md
+++ b/compile/x/cobol/TASKS.md
@@ -2,7 +2,9 @@
 
 The current COBOL backend still fails to compile the TPC-H queries. Golden tests
 now cover `q1` and `q2` but both are skipped because the generated COBOL does not
-build. The following work is required to support these queries:
+build. Query `q1` from the TPC-DS suite is also compiled under
+`tests/dataset/tpc-ds/compiler/cobol`, though the resulting program fails to
+build for the same reasons. The following work is required to support these queries:
 
 1. **Group by support** – add code generation for `group by` clauses. Queries should accumulate items by key and expose a `Group` structure similar to the Go runtime.
 2. **Aggregations** – implement built-in helpers for `sum`, `avg` and `count` that operate over lists and groups.

--- a/compile/x/cobol/tpcds_golden_test.go
+++ b/compile/x/cobol/tpcds_golden_test.go
@@ -1,0 +1,67 @@
+//go:build slow
+
+package cobolcode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	cobolcode "mochi/compile/x/cobol"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestCobolCompiler_TPCDS_Golden compiles the first TPCDS query using the COBOL backend.
+// Generated code is compared against the golden file under tests/dataset/tpc-ds/compiler/cobol.
+// If cobc fails to build or run the program, the test is skipped.
+func TestCobolCompiler_TPCDS_Golden(t *testing.T) {
+	if err := cobolcode.EnsureCOBOL(); err != nil {
+		t.Skipf("cobol not installed: %v", err)
+	}
+	os.Setenv("MOCHI_SKIP_COBFMT", "1")
+	defer os.Unsetenv("MOCHI_SKIP_COBFMT")
+	root := testutil.FindRepoRoot(t)
+	q := "q1"
+	t.Run(q, func(t *testing.T) {
+		src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Fatalf("type error: %v", errs[0])
+		}
+		code, err := cobolcode.New(env).Compile(prog)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+		wantCodePath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "cobol", q+".cob.out")
+		wantCode, err := os.ReadFile(wantCodePath)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		gotCode := bytes.TrimSpace(code)
+		if !bytes.Equal(gotCode, bytes.TrimSpace(wantCode)) {
+			t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".cob.out", gotCode, bytes.TrimSpace(wantCode))
+		}
+		tmp := t.TempDir()
+		file := filepath.Join(tmp, "main.cob")
+		if err := os.WriteFile(file, code, 0644); err != nil {
+			t.Fatalf("write error: %v", err)
+		}
+		exe := filepath.Join(tmp, "main")
+		if out, err := exec.Command("cobc", "-free", "-x", file, "-o", exe).CombinedOutput(); err != nil {
+			t.Skipf("cobc error: %v\n%s", err, out)
+		}
+		if out, err := exec.Command(exe).CombinedOutput(); err != nil {
+			t.Skipf("run error: %v\n%s", err, out)
+		} else {
+			_ = out
+		}
+	})
+}

--- a/tests/dataset/tpc-ds/compiler/cobol/q1.cob.out
+++ b/tests/dataset/tpc-ds/compiler/cobol/q1.cob.out
@@ -1,0 +1,108 @@
+>>SOURCE FORMAT FREE
+IDENTIFICATION DIVISION.
+PROGRAM-ID. MAIN.
+
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+01 STORE_RETURNS OCCURS 0 TIMES PIC 9.
+01 DATE_DIM OCCURS 0 TIMES PIC 9.
+01 STORE OCCURS 0 TIMES PIC 9.
+01 CUSTOMER OCCURS 0 TIMES PIC 9.
+01 SR PIC 9.
+01 D PIC 9.
+01 CUSTOMER_TOTAL_RETURN OCCURS 0 TIMES PIC 9.
+01 TMP0 PIC 9.
+01 TMP1 PIC 9.
+01 IDX PIC 9.
+01 IDX2 PIC 9.
+01 CTR1 PIC 9.
+01 S PIC 9.
+01 C PIC 9.
+01 RESULT OCCURS 0 TIMES PIC 9.
+01 TMP2 PIC 9.
+01 TMP3 PIC 9.
+01 IDX3 PIC 9.
+01 TMP4 PIC 9.
+01 TMP5 PIC 9.
+01 CTR2 PIC 9.
+01 TMP6 OCCURS 0 TIMES PIC 9.
+01 TMP7 PIC 9.
+01 TMP8 PIC 9.
+01 TMP9 PIC 9(4)V9(4).
+01 TMP10 PIC 9.
+
+PROCEDURE DIVISION.
+    MOVE 0 TO TMP0
+    MOVE 0 TO TMP1
+    MOVE 0 TO IDX
+    PERFORM VARYING IDX FROM 0 BY 1 UNTIL IDX >= 0
+    MOVE STORE_RETURNS(IDX + 1) TO SR
+        MOVE 0 TO IDX2
+        PERFORM VARYING IDX2 FROM 0 BY 1 UNTIL IDX2 >= 0
+        MOVE DATE_DIM(IDX2 + 1) TO D
+        IF D_D_YEAR = 1998 * SR_SR_RETURNED_DATE_SK = D_D_DATE_SK
+            ADD 1 TO TMP1
+            IF TMP1 > 0
+                IF 0 = 0 OR TMP0 < 0
+                    ADD 1 TO TMP0
+                    COMPUTE CUSTOMER_TOTAL_RETURN(TMP0) = 0
+                END-IF
+            END-IF
+        END-IF
+        END-PERFORM
+    END-PERFORM
+    MOVE 0 TO TMP2
+    MOVE 0 TO TMP3
+    MOVE 0 TO IDX
+    PERFORM VARYING IDX FROM 0 BY 1 UNTIL IDX >= 0
+    MOVE CUSTOMER_TOTAL_RETURN(IDX + 1) TO CTR1
+        MOVE 0 TO IDX2
+        PERFORM VARYING IDX2 FROM 0 BY 1 UNTIL IDX2 >= 0
+        MOVE STORE(IDX2 + 1) TO S
+            MOVE 0 TO IDX3
+            PERFORM VARYING IDX3 FROM 0 BY 1 UNTIL IDX3 >= 0
+            MOVE CUSTOMER(IDX3 + 1) TO C
+                *> unsupported reduce
+                COMPUTE TMP4 = 0
+                MOVE 0 TO TMP7
+                MOVE 0 TO TMP8
+                MOVE 0 TO IDX
+                PERFORM VARYING IDX FROM 0 BY 1 UNTIL IDX >= 0
+                MOVE CUSTOMER_TOTAL_RETURN(IDX + 1) TO CTR2
+                IF CTR1_CTR_STORE_SK = CTR2_CTR_STORE_SK
+                    ADD 1 TO TMP8
+                    IF TMP8 > 0
+                        IF 0 = 0 OR TMP7 < 0
+                            ADD 1 TO TMP7
+                            COMPUTE TMP6(TMP7) = CTR2_CTR_TOTAL_RETURN
+                        END-IF
+                    END-IF
+                END-IF
+                END-PERFORM
+                COMPUTE TMP5 = FUNCTION LENGTH(TMP6)
+                IF TMP5 = 0
+                MOVE 0 TO TMP9
+                ELSE
+                COMPUTE TMP9 = TMP4 / TMP5
+                END-IF
+            IF CTR1_CTR_TOTAL_RETURN > TMP9 * 1.2 * S_S_STATE = "TN" * CTR1_CTR_STORE_SK = S_S_STORE_SK * CTR1_CTR_CUSTOMER_SK = C_C_CUSTOMER_SK
+                ADD 1 TO TMP3
+                IF TMP3 > 0
+                    IF 0 = 0 OR TMP2 < 0
+                        ADD 1 TO TMP2
+                        COMPUTE RESULT(TMP2) = 0
+                    END-IF
+                END-IF
+            END-IF
+            END-PERFORM
+        END-PERFORM
+    END-PERFORM
+DISPLAY "-- TEST TPCDS Q1 empty --"
+    COMPUTE TMP10 = FUNCTION LENGTH(RESULT)
+IF NOT (TMP10 = 0)
+    DISPLAY "expect failed"
+    STOP RUN
+END-IF
+DISPLAY "-- END TPCDS Q1 empty --"
+    STOP RUN.
+


### PR DESCRIPTION
## Summary
- add TPC‑DS q1 golden for the COBOL backend
- create tpcds_golden_test to compile and run q1
- note tpcds coverage in COBOL TASKS.md

## Testing
- `go test ./compile/x/cobol -run TestCobolCompiler_TPCDS_Golden -tags slow -count=1`
- `go test ./compile/x/cobol -run TestCobolCompiler_TPCH_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686351d7399883209919294d218a9bda