### PR TITLE
Enable Go backend for TPC‑DS q1‑q9

### DIFF
--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -379,6 +379,29 @@ const (
 		"    return res\n" +
 		"}\n"
 
+	helperConcat = "func _concat[T any](a, b []T) []T {\n" +
+		"    res := make([]T, 0, len(a)+len(b))\n" +
+		"    res = append(res, a...)\n" +
+		"    res = append(res, b...)\n" +
+		"    return res\n" +
+		"}\n"
+
+	helperReverseSlice = "func _reverseSlice[T any](s []T) []T {\n" +
+		"    out := append([]T{}, s...)\n" +
+		"    for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {\n" +
+		"        out[i], out[j] = out[j], out[i]\n" +
+		"    }\n" +
+		"    return out\n" +
+		"}\n"
+
+	helperReverseString = "func _reverseString(s string) string {\n" +
+		"    r := []rune(s)\n" +
+		"    for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {\n" +
+		"        r[i], r[j] = r[j], r[i]\n" +
+		"    }\n" +
+		"    return string(r)\n" +
+		"}\n"
+
 	helperExcept = "func _except[T any](a, b []T) []T {\n" +
 		"    res := []T{}\n" +
 		"    for _, x := range a {\n" +
@@ -675,6 +698,9 @@ var helperMap = map[string]string{
 	"_contains":      helperContains,
 	"_union_all":     helperUnionAll,
 	"_union":         helperUnion,
+	"_concat":        helperConcat,
+	"_reverseSlice":  helperReverseSlice,
+	"_reverseString": helperReverseString,
 	"_except":        helperExcept,
 	"_intersect":     helperIntersect,
 	"_cast":          helperCast,

--- a/tests/dataset/tpc-ds/compiler/go/q3.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q3.go.out
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q3_empty() {
+	expect((len(result) == 0))
+}
+
+var date_dim []any
+var store_sales []any
+var item []any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	date_dim = []any{}
+	store_sales = []any{}
+	item = []any{}
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, dt := range date_dim {
+			for _, ss := range store_sales {
+				if !(_equal(_cast[map[string]any](dt)["d_date_sk"], _cast[map[string]any](ss)["ss_sold_date_sk"])) {
+					continue
+				}
+				for _, i := range item {
+					if !(_equal(_cast[map[string]any](ss)["ss_item_sk"], _cast[map[string]any](i)["i_item_sk"])) {
+						continue
+					}
+					if _equal(_cast[map[string]any](i)["i_manufact_id"], 100) && _equal(_cast[map[string]any](dt)["d_moy"], 12) {
+						key := map[string]any{
+							"d_year":   _cast[map[string]any](dt)["d_year"],
+							"brand_id": _cast[map[string]any](i)["i_brand_id"],
+							"brand":    _cast[map[string]any](i)["i_brand"],
+						}
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, dt)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _toAnySlice([]any{_cast[map[string]any](g.Key)["d_year"], -_sum(func() []any {
+				_res := []any{}
+				for _, x := range g.Items {
+					_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_ext_sales_price"])
+				}
+				return _res
+			}()), _cast[map[string]any](g.Key)["brand_id"]})}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"d_year":   _cast[map[string]any](g.Key)["d_year"],
+				"brand_id": _cast[map[string]any](g.Key)["brand_id"],
+				"brand":    _cast[map[string]any](g.Key)["brand"],
+				"sum_agg": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_ext_sales_price"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q3 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q3_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q3.out
+++ b/tests/dataset/tpc-ds/compiler/go/q3.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q3 empty                 ... ok (400ns)

--- a/tests/dataset/tpc-ds/compiler/go/q4.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q4.go.out
@@ -1,0 +1,701 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q4_empty() {
+	expect((len(result) == 0))
+}
+
+var customer []any
+var store_sales []any
+var catalog_sales []any
+var web_sales []any
+var date_dim []any
+var year_total []map[string]any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	customer = []any{}
+	store_sales = []any{}
+	catalog_sales = []any{}
+	web_sales = []any{}
+	date_dim = []any{}
+	year_total = _union[map[string]any](_union[map[string]any]((func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, c := range customer {
+			for _, s := range store_sales {
+				if !(_equal(_cast[map[string]any](c)["c_customer_sk"], _cast[map[string]any](s)["ss_customer_sk"])) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(_equal(_cast[map[string]any](s)["ss_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+						continue
+					}
+					key := map[string]any{
+						"id":    _cast[map[string]any](c)["c_customer_id"],
+						"first": _cast[map[string]any](c)["c_first_name"],
+						"last":  _cast[map[string]any](c)["c_last_name"],
+						"login": _cast[map[string]any](c)["c_login"],
+						"year":  _cast[map[string]any](d)["d_year"],
+					}
+					ks := fmt.Sprint(key)
+					g, ok := groups[ks]
+					if !ok {
+						g = &data.Group{Key: key}
+						groups[ks] = g
+						order = append(order, ks)
+					}
+					g.Items = append(g.Items, c)
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"customer_id":         _cast[map[string]any](g.Key)["id"],
+				"customer_first_name": _cast[map[string]any](g.Key)["first"],
+				"customer_last_name":  _cast[map[string]any](g.Key)["last"],
+				"customer_login":      _cast[map[string]any](g.Key)["login"],
+				"dyear":               _cast[map[string]any](g.Key)["year"],
+				"year_total": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, (_cast[float64]((_cast[float64]((_cast[float64]((_cast[float64](_cast[map[string]any](x)["ss_ext_list_price"]) - _cast[float64](_cast[map[string]any](x)["ss_ext_wholesale_cost"]))) - _cast[float64](_cast[map[string]any](x)["ss_ext_discount_amt"]))) + _cast[float64](_cast[map[string]any](x)["ss_ext_sales_price"]))) / _cast[float64](2)))
+					}
+					return _res
+				}()),
+				"sale_type": "s",
+			})
+		}
+		return _res
+	}()), (func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, c := range customer {
+			for _, cs := range catalog_sales {
+				if !(_equal(_cast[map[string]any](c)["c_customer_sk"], _cast[map[string]any](cs)["cs_bill_customer_sk"])) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(_equal(_cast[map[string]any](cs)["cs_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+						continue
+					}
+					key := map[string]any{
+						"id":    _cast[map[string]any](c)["c_customer_id"],
+						"first": _cast[map[string]any](c)["c_first_name"],
+						"last":  _cast[map[string]any](c)["c_last_name"],
+						"login": _cast[map[string]any](c)["c_login"],
+						"year":  _cast[map[string]any](d)["d_year"],
+					}
+					ks := fmt.Sprint(key)
+					g, ok := groups[ks]
+					if !ok {
+						g = &data.Group{Key: key}
+						groups[ks] = g
+						order = append(order, ks)
+					}
+					g.Items = append(g.Items, c)
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"customer_id":         _cast[map[string]any](g.Key)["id"],
+				"customer_first_name": _cast[map[string]any](g.Key)["first"],
+				"customer_last_name":  _cast[map[string]any](g.Key)["last"],
+				"customer_login":      _cast[map[string]any](g.Key)["login"],
+				"dyear":               _cast[map[string]any](g.Key)["year"],
+				"year_total": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, (_cast[float64]((_cast[float64]((_cast[float64]((_cast[float64](_cast[map[string]any](x)["cs_ext_list_price"]) - _cast[float64](_cast[map[string]any](x)["cs_ext_wholesale_cost"]))) - _cast[float64](_cast[map[string]any](x)["cs_ext_discount_amt"]))) + _cast[float64](_cast[map[string]any](x)["cs_ext_sales_price"]))) / _cast[float64](2)))
+					}
+					return _res
+				}()),
+				"sale_type": "c",
+			})
+		}
+		return _res
+	}())), (func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, c := range customer {
+			for _, ws := range web_sales {
+				if !(_equal(_cast[map[string]any](c)["c_customer_sk"], _cast[map[string]any](ws)["ws_bill_customer_sk"])) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(_equal(_cast[map[string]any](ws)["ws_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+						continue
+					}
+					key := map[string]any{
+						"id":    _cast[map[string]any](c)["c_customer_id"],
+						"first": _cast[map[string]any](c)["c_first_name"],
+						"last":  _cast[map[string]any](c)["c_last_name"],
+						"login": _cast[map[string]any](c)["c_login"],
+						"year":  _cast[map[string]any](d)["d_year"],
+					}
+					ks := fmt.Sprint(key)
+					g, ok := groups[ks]
+					if !ok {
+						g = &data.Group{Key: key}
+						groups[ks] = g
+						order = append(order, ks)
+					}
+					g.Items = append(g.Items, c)
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"customer_id":         _cast[map[string]any](g.Key)["id"],
+				"customer_first_name": _cast[map[string]any](g.Key)["first"],
+				"customer_last_name":  _cast[map[string]any](g.Key)["last"],
+				"customer_login":      _cast[map[string]any](g.Key)["login"],
+				"dyear":               _cast[map[string]any](g.Key)["year"],
+				"year_total": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, (_cast[float64]((_cast[float64]((_cast[float64]((_cast[float64](_cast[map[string]any](x)["ws_ext_list_price"]) - _cast[float64](_cast[map[string]any](x)["ws_ext_wholesale_cost"]))) - _cast[float64](_cast[map[string]any](x)["ws_ext_discount_amt"]))) + _cast[float64](_cast[map[string]any](x)["ws_ext_sales_price"]))) / _cast[float64](2)))
+					}
+					return _res
+				}()),
+				"sale_type": "w",
+			})
+		}
+		return _res
+	}()))
+	result = func() []map[string]any {
+		src := _toAnySlice(year_total)
+		resAny := _query(src, []_joinSpec{
+			{items: _toAnySlice(year_total), on: func(_a ...any) bool {
+				s1 := _cast[map[string]any](_a[0])
+				_ = s1
+				s2 := _cast[map[string]any](_a[1])
+				_ = s2
+				return _equal(s2["customer_id"], s1["customer_id"])
+			}},
+			{items: _toAnySlice(year_total), on: func(_a ...any) bool {
+				s1 := _cast[map[string]any](_a[0])
+				_ = s1
+				s2 := _cast[map[string]any](_a[1])
+				_ = s2
+				c1 := _cast[map[string]any](_a[2])
+				_ = c1
+				return _equal(c1["customer_id"], s1["customer_id"])
+			}},
+			{items: _toAnySlice(year_total), on: func(_a ...any) bool {
+				s1 := _cast[map[string]any](_a[0])
+				_ = s1
+				s2 := _cast[map[string]any](_a[1])
+				_ = s2
+				c1 := _cast[map[string]any](_a[2])
+				_ = c1
+				c2 := _cast[map[string]any](_a[3])
+				_ = c2
+				return _equal(c2["customer_id"], s1["customer_id"])
+			}},
+			{items: _toAnySlice(year_total), on: func(_a ...any) bool {
+				s1 := _cast[map[string]any](_a[0])
+				_ = s1
+				s2 := _cast[map[string]any](_a[1])
+				_ = s2
+				c1 := _cast[map[string]any](_a[2])
+				_ = c1
+				c2 := _cast[map[string]any](_a[3])
+				_ = c2
+				w1 := _cast[map[string]any](_a[4])
+				_ = w1
+				return _equal(w1["customer_id"], s1["customer_id"])
+			}},
+			{items: _toAnySlice(year_total), on: func(_a ...any) bool {
+				s1 := _cast[map[string]any](_a[0])
+				_ = s1
+				s2 := _cast[map[string]any](_a[1])
+				_ = s2
+				c1 := _cast[map[string]any](_a[2])
+				_ = c1
+				c2 := _cast[map[string]any](_a[3])
+				_ = c2
+				w1 := _cast[map[string]any](_a[4])
+				_ = w1
+				w2 := _cast[map[string]any](_a[5])
+				_ = w2
+				return _equal(w2["customer_id"], s1["customer_id"])
+			}},
+		}, _queryOpts{selectFn: func(_a ...any) any {
+			s1 := _cast[map[string]any](_a[0])
+			_ = s1
+			s2 := _cast[map[string]any](_a[1])
+			_ = s2
+			c1 := _cast[map[string]any](_a[2])
+			_ = c1
+			c2 := _cast[map[string]any](_a[3])
+			_ = c2
+			w1 := _cast[map[string]any](_a[4])
+			_ = w1
+			w2 := _cast[map[string]any](_a[5])
+			_ = w2
+			return map[string]any{
+				"customer_id":         s2["customer_id"],
+				"customer_first_name": s2["customer_first_name"],
+				"customer_last_name":  s2["customer_last_name"],
+				"customer_login":      s2["customer_login"],
+			}
+		}, where: func(_a ...any) bool {
+			s1 := _cast[map[string]any](_a[0])
+			_ = s1
+			s2 := _cast[map[string]any](_a[1])
+			_ = s2
+			c1 := _cast[map[string]any](_a[2])
+			_ = c1
+			c2 := _cast[map[string]any](_a[3])
+			_ = c2
+			w1 := _cast[map[string]any](_a[4])
+			_ = w1
+			w2 := _cast[map[string]any](_a[5])
+			_ = w2
+			return ((((((((((((((((_equal(s1["sale_type"], "s") && _equal(c1["sale_type"], "c")) && _equal(w1["sale_type"], "w")) && _equal(s2["sale_type"], "s")) && _equal(c2["sale_type"], "c")) && _equal(w2["sale_type"], "w")) && _equal(s1["dyear"], 2001)) && _equal(s2["dyear"], 2002)) && _equal(c1["dyear"], 2001)) && _equal(c2["dyear"], 2002)) && _equal(w1["dyear"], 2001)) && _equal(w2["dyear"], 2002)) && (_cast[int](s1["year_total"]) > 0)) && (_cast[int](c1["year_total"]) > 0)) && (_cast[int](w1["year_total"]) > 0)) && (_cast[float64]((func() any {
+				if _cast[int](c1["year_total"]) > 0 {
+					return (_cast[float64](c2["year_total"]) / _cast[float64](c1["year_total"]))
+				} else {
+					return nil
+				}
+			}())) > _cast[float64]((func() any {
+				if _cast[int](s1["year_total"]) > 0 {
+					return (_cast[float64](s2["year_total"]) / _cast[float64](s1["year_total"]))
+				} else {
+					return nil
+				}
+			}())))) && (_cast[float64]((func() any {
+				if _cast[int](c1["year_total"]) > 0 {
+					return (_cast[float64](c2["year_total"]) / _cast[float64](c1["year_total"]))
+				} else {
+					return nil
+				}
+			}())) > _cast[float64]((func() any {
+				if _cast[int](w1["year_total"]) > 0 {
+					return (_cast[float64](w2["year_total"]) / _cast[float64](w1["year_total"]))
+				} else {
+					return nil
+				}
+			}()))))
+		}, sortKey: func(_a ...any) any {
+			s1 := _cast[map[string]any](_a[0])
+			_ = s1
+			s2 := _cast[map[string]any](_a[1])
+			_ = s2
+			c1 := _cast[map[string]any](_a[2])
+			_ = c1
+			c2 := _cast[map[string]any](_a[3])
+			_ = c2
+			w1 := _cast[map[string]any](_a[4])
+			_ = w1
+			w2 := _cast[map[string]any](_a[5])
+			_ = w2
+			return []any{
+				s2["customer_id"],
+				s2["customer_first_name"],
+				s2["customer_last_name"],
+				s2["customer_login"],
+			}
+		}, skip: -1, take: -1})
+		out := make([]map[string]any, len(resAny))
+		for i, v := range resAny {
+			out[i] = _cast[map[string]any](v)
+		}
+		return out
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q4 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q4_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+type _joinSpec struct {
+	items []any
+	on    func(...any) bool
+	left  bool
+	right bool
+}
+type _queryOpts struct {
+	selectFn func(...any) any
+	where    func(...any) bool
+	sortKey  func(...any) any
+	skip     int
+	take     int
+}
+
+func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
+	items := make([][]any, len(src))
+	for i, v := range src {
+		items[i] = []any{v}
+	}
+	for _, j := range joins {
+		joined := [][]any{}
+		if j.right && j.left {
+			matched := make([]bool, len(j.items))
+			for _, left := range items {
+				m := false
+				for ri, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					matched[ri] = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+			for ri, right := range j.items {
+				if !matched[ri] {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else if j.right {
+			for _, right := range j.items {
+				m := false
+				for _, left := range items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else {
+			for _, left := range items {
+				m := false
+				for _, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if j.left && !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+		}
+		items = joined
+	}
+	if opts.where != nil {
+		filtered := [][]any{}
+		for _, r := range items {
+			if opts.where(r...) {
+				filtered = append(filtered, r)
+			}
+		}
+		items = filtered
+	}
+	if opts.sortKey != nil {
+		type pair struct {
+			item []any
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for i, it := range items {
+			pairs[i] = pair{it, opts.sortKey(it...)}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for i, p := range pairs {
+			items[i] = p.item
+		}
+	}
+	if opts.skip >= 0 {
+		if opts.skip < len(items) {
+			items = items[opts.skip:]
+		} else {
+			items = [][]any{}
+		}
+	}
+	if opts.take >= 0 {
+		if opts.take < len(items) {
+			items = items[:opts.take]
+		}
+	}
+	res := make([]any, len(items))
+	for i, r := range items {
+		res[i] = opts.selectFn(r...)
+	}
+	return res
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
+func _union[T any](a, b []T) []T {
+	res := append([]T{}, a...)
+	for _, it := range b {
+		found := false
+		for _, v := range res {
+			if _equal(v, it) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			res = append(res, it)
+		}
+	}
+	return res
+}

--- a/tests/dataset/tpc-ds/compiler/go/q4.out
+++ b/tests/dataset/tpc-ds/compiler/go/q4.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q4 empty                 ... ok (377ns)

--- a/tests/dataset/tpc-ds/compiler/go/q5.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q5.go.out
@@ -1,0 +1,702 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q5_empty() {
+	expect((len(result) == 0))
+}
+
+var store_sales []any
+var store_returns []any
+var store []any
+var catalog_sales []any
+var catalog_returns []any
+var catalog_page []any
+var web_sales []any
+var web_returns []any
+var web_site []any
+var date_dim []any
+var ss []map[string]any
+var sr []map[string]any
+var cs []map[string]any
+var cr []map[string]any
+var ws []map[string]any
+var wr []map[string]any
+var per_channel []any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	store_sales = []any{}
+	store_returns = []any{}
+	store = []any{}
+	catalog_sales = []any{}
+	catalog_returns = []any{}
+	catalog_page = []any{}
+	web_sales = []any{}
+	web_returns = []any{}
+	web_site = []any{}
+	date_dim = []any{}
+	ss = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ss := range store_sales {
+			for _, d := range date_dim {
+				if !(_equal(_cast[map[string]any](ss)["ss_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+					continue
+				}
+				for _, s := range store {
+					if !(_equal(_cast[map[string]any](ss)["ss_store_sk"], _cast[map[string]any](s)["s_store_sk"])) {
+						continue
+					}
+					if (_cast[string](_cast[map[string]any](d)["d_date"]) >= "1998-12-01") && (_cast[string](_cast[map[string]any](d)["d_date"]) <= "1998-12-15") {
+						key := _cast[map[string]any](s)["s_store_id"]
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, ss)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": "store channel",
+				"id":      "store" + fmt.Sprint(g.Key),
+				"sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_ext_sales_price"])
+					}
+					return _res
+				}()),
+				"returns": 0.0,
+				"profit": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_net_profit"])
+					}
+					return _res
+				}()),
+				"profit_loss": 0.0,
+			})
+		}
+		return _res
+	}()
+	sr = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, sr := range store_returns {
+			for _, d := range date_dim {
+				if !(_equal(_cast[map[string]any](sr)["sr_returned_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+					continue
+				}
+				for _, s := range store {
+					if !(_equal(_cast[map[string]any](sr)["sr_store_sk"], _cast[map[string]any](s)["s_store_sk"])) {
+						continue
+					}
+					if (_cast[string](_cast[map[string]any](d)["d_date"]) >= "1998-12-01") && (_cast[string](_cast[map[string]any](d)["d_date"]) <= "1998-12-15") {
+						key := _cast[map[string]any](s)["s_store_id"]
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, sr)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": "store channel",
+				"id":      "store" + fmt.Sprint(g.Key),
+				"sales":   0.0,
+				"returns": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["sr"])["sr_return_amt"])
+					}
+					return _res
+				}()),
+				"profit": 0.0,
+				"profit_loss": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["sr"])["sr_net_loss"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	cs = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, cs := range catalog_sales {
+			for _, d := range date_dim {
+				if !(_equal(_cast[map[string]any](cs)["cs_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+					continue
+				}
+				for _, cp := range catalog_page {
+					if !(_equal(_cast[map[string]any](cs)["cs_catalog_page_sk"], _cast[map[string]any](cp)["cp_catalog_page_sk"])) {
+						continue
+					}
+					if (_cast[string](_cast[map[string]any](d)["d_date"]) >= "1998-12-01") && (_cast[string](_cast[map[string]any](d)["d_date"]) <= "1998-12-15") {
+						key := _cast[map[string]any](cp)["cp_catalog_page_id"]
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, cs)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": "catalog channel",
+				"id":      "catalog_page" + fmt.Sprint(g.Key),
+				"sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["cs"])["cs_ext_sales_price"])
+					}
+					return _res
+				}()),
+				"returns": 0.0,
+				"profit": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["cs"])["cs_net_profit"])
+					}
+					return _res
+				}()),
+				"profit_loss": 0.0,
+			})
+		}
+		return _res
+	}()
+	cr = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, cr := range catalog_returns {
+			for _, d := range date_dim {
+				if !(_equal(_cast[map[string]any](cr)["cr_returned_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+					continue
+				}
+				for _, cp := range catalog_page {
+					if !(_equal(_cast[map[string]any](cr)["cr_catalog_page_sk"], _cast[map[string]any](cp)["cp_catalog_page_sk"])) {
+						continue
+					}
+					if (_cast[string](_cast[map[string]any](d)["d_date"]) >= "1998-12-01") && (_cast[string](_cast[map[string]any](d)["d_date"]) <= "1998-12-15") {
+						key := _cast[map[string]any](cp)["cp_catalog_page_id"]
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, cr)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": "catalog channel",
+				"id":      "catalog_page" + fmt.Sprint(g.Key),
+				"sales":   0.0,
+				"returns": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["cr"])["cr_return_amount"])
+					}
+					return _res
+				}()),
+				"profit": 0.0,
+				"profit_loss": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["cr"])["cr_net_loss"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	ws = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ws := range web_sales {
+			for _, d := range date_dim {
+				if !(_equal(_cast[map[string]any](ws)["ws_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+					continue
+				}
+				for _, w := range web_site {
+					if !(_equal(_cast[map[string]any](ws)["ws_web_site_sk"], _cast[map[string]any](w)["web_site_sk"])) {
+						continue
+					}
+					if (_cast[string](_cast[map[string]any](d)["d_date"]) >= "1998-12-01") && (_cast[string](_cast[map[string]any](d)["d_date"]) <= "1998-12-15") {
+						key := _cast[map[string]any](w)["web_site_id"]
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, ws)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": "web channel",
+				"id":      "web_site" + fmt.Sprint(g.Key),
+				"sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ws"])["ws_ext_sales_price"])
+					}
+					return _res
+				}()),
+				"returns": 0.0,
+				"profit": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ws"])["ws_net_profit"])
+					}
+					return _res
+				}()),
+				"profit_loss": 0.0,
+			})
+		}
+		return _res
+	}()
+	wr = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, wr := range web_returns {
+			for _, ws := range web_sales {
+				if !(_equal(_cast[map[string]any](wr)["wr_item_sk"], _cast[map[string]any](ws)["ws_item_sk"]) && _equal(_cast[map[string]any](wr)["wr_order_number"], _cast[map[string]any](ws)["ws_order_number"])) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(_equal(_cast[map[string]any](wr)["wr_returned_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+						continue
+					}
+					for _, w := range web_site {
+						if !(_equal(_cast[map[string]any](ws)["ws_web_site_sk"], _cast[map[string]any](w)["web_site_sk"])) {
+							continue
+						}
+						if (_cast[string](_cast[map[string]any](d)["d_date"]) >= "1998-12-01") && (_cast[string](_cast[map[string]any](d)["d_date"]) <= "1998-12-15") {
+							key := _cast[map[string]any](w)["web_site_id"]
+							ks := fmt.Sprint(key)
+							g, ok := groups[ks]
+							if !ok {
+								g = &data.Group{Key: key}
+								groups[ks] = g
+								order = append(order, ks)
+							}
+							g.Items = append(g.Items, wr)
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": "web channel",
+				"id":      "web_site" + fmt.Sprint(g.Key),
+				"sales":   0.0,
+				"returns": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["wr"])["wr_return_amt"])
+					}
+					return _res
+				}()),
+				"profit": 0.0,
+				"profit_loss": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["wr"])["wr_net_loss"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	per_channel = _concat[any](_concat[any](_toAnySlice(_convSlice[map[string]any, any](_union[map[string]any](ss, sr))), _toAnySlice(_union[map[string]any](cs, cr))), _toAnySlice(_union[map[string]any](ws, wr)))
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, p := range per_channel {
+			key := map[string]any{"channel": _cast[map[string]any](p)["channel"], "id": _cast[map[string]any](p)["id"]}
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, p)
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _cast[[]any](_cast[map[string]any](g.Key)["channel"])}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": _cast[map[string]any](g.Key)["channel"],
+				"id":      _cast[map[string]any](g.Key)["id"],
+				"sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["p"])["sales"])
+					}
+					return _res
+				}()),
+				"returns": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["p"])["returns"])
+					}
+					return _res
+				}()),
+				"profit": (_sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["p"])["profit"])
+					}
+					return _res
+				}()) - _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["p"])["profit_loss"])
+					}
+					return _res
+				}())),
+			})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q5 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q5_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _concat[T any](a, b []T) []T {
+	res := make([]T, 0, len(a)+len(b))
+	res = append(res, a...)
+	res = append(res, b...)
+	return res
+}
+
+func _convSlice[T any, U any](s []T) []U {
+	out := make([]U, len(s))
+	for i, v := range s {
+		out[i] = any(v).(U)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
+func _union[T any](a, b []T) []T {
+	res := append([]T{}, a...)
+	for _, it := range b {
+		found := false
+		for _, v := range res {
+			if _equal(v, it) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			res = append(res, it)
+		}
+	}
+	return res
+}

--- a/tests/dataset/tpc-ds/compiler/go/q5.out
+++ b/tests/dataset/tpc-ds/compiler/go/q5.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q5 empty                 ... ok (582ns)

--- a/tests/dataset/tpc-ds/compiler/go/q6.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q6.go.out
@@ -1,0 +1,473 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q6_empty() {
+	expect((len(result) == 0))
+}
+
+var customer_address []any
+var customer []any
+var store_sales []any
+var date_dim []any
+var item []any
+var target_month_seq any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	customer_address = []any{}
+	customer = []any{}
+	store_sales = []any{}
+	date_dim = []any{}
+	item = []any{}
+	target_month_seq = _max(func() []any {
+		_res := []any{}
+		for _, d := range date_dim {
+			if _equal(_cast[map[string]any](d)["d_year"], 1999) && _equal(_cast[map[string]any](d)["d_moy"], 5) {
+				if _equal(_cast[map[string]any](d)["d_year"], 1999) && _equal(_cast[map[string]any](d)["d_moy"], 5) {
+					_res = append(_res, _cast[map[string]any](d)["d_month_seq"])
+				}
+			}
+		}
+		return _res
+	}())
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, a := range customer_address {
+			for _, c := range customer {
+				if !(_equal(_cast[map[string]any](a)["ca_address_sk"], _cast[map[string]any](c)["c_current_addr_sk"])) {
+					continue
+				}
+				for _, s := range store_sales {
+					if !(_equal(_cast[map[string]any](c)["c_customer_sk"], _cast[map[string]any](s)["ss_customer_sk"])) {
+						continue
+					}
+					for _, d := range date_dim {
+						if !(_equal(_cast[map[string]any](s)["ss_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+							continue
+						}
+						for _, i := range item {
+							if !(_equal(_cast[map[string]any](s)["ss_item_sk"], _cast[map[string]any](i)["i_item_sk"])) {
+								continue
+							}
+							if _equal(_cast[map[string]any](d)["d_month_seq"], target_month_seq) && (_cast[float64](_cast[map[string]any](i)["i_current_price"]) > (1.2 * _avg(func() []any {
+								_res := []any{}
+								for _, j := range item {
+									if _equal(_cast[map[string]any](j)["i_category"], _cast[map[string]any](i)["i_category"]) {
+										if _equal(_cast[map[string]any](j)["i_category"], _cast[map[string]any](i)["i_category"]) {
+											_res = append(_res, _cast[map[string]any](j)["i_current_price"])
+										}
+									}
+								}
+								return _res
+							}()))) {
+								key := _cast[map[string]any](a)["ca_state"]
+								ks := fmt.Sprint(key)
+								g, ok := groups[ks]
+								if !ok {
+									g = &data.Group{Key: key}
+									groups[ks] = g
+									order = append(order, ks)
+								}
+								g.Items = append(g.Items, a)
+							}
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _toAnySlice([]any{_count(g), g.Key})}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		items = _paginate[*data.Group](items, -1, 100)
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{"state": g.Key, "cnt": _count(g)})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q6 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q6_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _count(v any) int {
+	if g, ok := v.(*data.Group); ok {
+		return len(g.Items)
+	}
+	switch s := v.(type) {
+	case []any:
+		return len(s)
+	case []int:
+		return len(s)
+	case []float64:
+		return len(s)
+	case []string:
+		return len(s)
+	case []bool:
+		return len(s)
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	case string:
+		return len([]rune(s))
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len()
+	}
+	panic("count() expects list or group")
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _max(v any) any {
+	if g, ok := v.(*data.Group); ok {
+		v = g.Items
+	}
+	switch s := v.(type) {
+	case []int:
+		if len(s) == 0 {
+			return 0
+		}
+		m := s[0]
+		for _, n := range s[1:] {
+			if n > m {
+				m = n
+			}
+		}
+		return m
+	case []float64:
+		if len(s) == 0 {
+			return 0.0
+		}
+		m := s[0]
+		for _, n := range s[1:] {
+			if n > m {
+				m = n
+			}
+		}
+		return m
+	case []any:
+		if len(s) == 0 {
+			return 0
+		}
+		var m float64
+		var isFloat bool
+		switch n := s[0].(type) {
+		case int:
+			m = float64(n)
+		case int64:
+			m = float64(n)
+		case float64:
+			m = n
+			isFloat = true
+		default:
+			panic("max() expects numbers")
+		}
+		for _, it := range s[1:] {
+			switch v := it.(type) {
+			case int:
+				if float64(v) > m {
+					m = float64(v)
+				}
+			case int64:
+				if float64(v) > m {
+					m = float64(v)
+				}
+			case float64:
+				if v > m {
+					m = v
+				}
+				isFloat = true
+			default:
+				panic("max() expects numbers")
+			}
+		}
+		if isFloat {
+			return m
+		}
+		return int(m)
+	default:
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Slice {
+			if rv.Len() == 0 {
+				return 0
+			}
+			m := rv.Index(0).Interface()
+			switch m.(type) {
+			case int, int64, float64:
+				items := make([]any, rv.Len())
+				for i := 0; i < rv.Len(); i++ {
+					items[i] = rv.Index(i).Interface()
+				}
+				return _max(items)
+			}
+		}
+		panic("max() expects list or group")
+	}
+}
+
+func _paginate[T any](src []T, skip, take int) []T {
+	if skip > 0 {
+		if skip < len(src) {
+			src = src[skip:]
+		} else {
+			return []T{}
+		}
+	}
+	if take >= 0 && take < len(src) {
+		src = src[:take]
+	}
+	return src
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q6.out
+++ b/tests/dataset/tpc-ds/compiler/go/q6.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q6 empty                 ... ok (396ns)

--- a/tests/dataset/tpc-ds/compiler/go/q7.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q7.go.out
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q7_empty() {
+	expect((len(result) == 0))
+}
+
+var store_sales []any
+var customer_demographics []any
+var date_dim []any
+var item []any
+var promotion []any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	store_sales = []any{}
+	customer_demographics = []any{}
+	date_dim = []any{}
+	item = []any{}
+	promotion = []any{}
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ss := range store_sales {
+			for _, cd := range customer_demographics {
+				if !(_equal(_cast[map[string]any](ss)["ss_cdemo_sk"], _cast[map[string]any](cd)["cd_demo_sk"])) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(_equal(_cast[map[string]any](ss)["ss_sold_date_sk"], _cast[map[string]any](d)["d_date_sk"])) {
+						continue
+					}
+					for _, i := range item {
+						if !(_equal(_cast[map[string]any](ss)["ss_item_sk"], _cast[map[string]any](i)["i_item_sk"])) {
+							continue
+						}
+						for _, p := range promotion {
+							if !(_equal(_cast[map[string]any](ss)["ss_promo_sk"], _cast[map[string]any](p)["p_promo_sk"])) {
+								continue
+							}
+							if (((_equal(_cast[map[string]any](cd)["cd_gender"], "M") && _equal(_cast[map[string]any](cd)["cd_marital_status"], "S")) && _equal(_cast[map[string]any](cd)["cd_education_status"], "College")) && (_equal(_cast[map[string]any](p)["p_channel_email"], "N") || _equal(_cast[map[string]any](p)["p_channel_event"], "N"))) && _equal(_cast[map[string]any](d)["d_year"], 1998) {
+								key := map[string]any{"i_item_id": _cast[map[string]any](i)["i_item_id"]}
+								ks := fmt.Sprint(key)
+								g, ok := groups[ks]
+								if !ok {
+									g = &data.Group{Key: key}
+									groups[ks] = g
+									order = append(order, ks)
+								}
+								g.Items = append(g.Items, ss)
+							}
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _cast[[]any](_cast[map[string]any](g.Key)["i_item_id"])}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"i_item_id": _cast[map[string]any](g.Key)["i_item_id"],
+				"agg1": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_quantity"])
+					}
+					return _res
+				}()),
+				"agg2": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_list_price"])
+					}
+					return _res
+				}()),
+				"agg3": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_coupon_amt"])
+					}
+					return _res
+				}()),
+				"agg4": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](_cast[map[string]any](x)["ss"])["ss_sales_price"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q7 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q7_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}

--- a/tests/dataset/tpc-ds/compiler/go/q7.out
+++ b/tests/dataset/tpc-ds/compiler/go/q7.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q7 empty                 ... ok (390ns)

--- a/tests/dataset/tpc-ds/compiler/go/q8.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q8.go.out
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q8_empty() {
+	expect((len(result) == 0))
+}
+
+var store_sales []any
+var date_dim []any
+var store []any
+var customer_address []any
+var customer []any
+var result []any
+
+func main() {
+	failures := 0
+	store_sales = []any{}
+	date_dim = []any{}
+	store = []any{}
+	customer_address = []any{}
+	customer = []any{}
+	result = []any{}
+	_reverseString("zi")
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q8 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q8_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _reverseString(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}

--- a/tests/dataset/tpc-ds/compiler/go/q8.out
+++ b/tests/dataset/tpc-ds/compiler/go/q8.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q8 empty                 ... ok (285ns)

--- a/tests/dataset/tpc-ds/compiler/go/q9.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q9.go.out
@@ -1,0 +1,460 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q9_empty() {
+	expect((len(result) == 0))
+}
+
+var store_sales []any
+var reason []any
+var bucket1 float64
+var bucket2 float64
+var bucket3 float64
+var bucket4 float64
+var bucket5 float64
+var result []map[string]float64
+
+func main() {
+	failures := 0
+	store_sales = []any{}
+	reason = []any{}
+	bucket1 = func() float64 {
+		if _count(func() []any {
+			_res := []any{}
+			for _, s := range store_sales {
+				if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 1) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 20) {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 1) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 20) {
+						_res = append(_res, s)
+					}
+				}
+			}
+			return _res
+		}()) > 10 {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 1) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 20) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 1) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 20) {
+							_res = append(_res, _cast[map[string]any](s)["ss_ext_discount_amt"])
+						}
+					}
+				}
+				return _res
+			}())
+		} else {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 1) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 20) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 1) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 20) {
+							_res = append(_res, _cast[map[string]any](s)["ss_net_paid"])
+						}
+					}
+				}
+				return _res
+			}())
+		}
+	}()
+	bucket2 = func() float64 {
+		if _count(func() []any {
+			_res := []any{}
+			for _, s := range store_sales {
+				if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 21) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 40) {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 21) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 40) {
+						_res = append(_res, s)
+					}
+				}
+			}
+			return _res
+		}()) > 20 {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 21) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 40) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 21) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 40) {
+							_res = append(_res, _cast[map[string]any](s)["ss_ext_discount_amt"])
+						}
+					}
+				}
+				return _res
+			}())
+		} else {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 21) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 40) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 21) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 40) {
+							_res = append(_res, _cast[map[string]any](s)["ss_net_paid"])
+						}
+					}
+				}
+				return _res
+			}())
+		}
+	}()
+	bucket3 = func() float64 {
+		if _count(func() []any {
+			_res := []any{}
+			for _, s := range store_sales {
+				if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 41) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 60) {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 41) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 60) {
+						_res = append(_res, s)
+					}
+				}
+			}
+			return _res
+		}()) > 30 {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 41) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 60) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 41) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 60) {
+							_res = append(_res, _cast[map[string]any](s)["ss_ext_discount_amt"])
+						}
+					}
+				}
+				return _res
+			}())
+		} else {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 41) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 60) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 41) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 60) {
+							_res = append(_res, _cast[map[string]any](s)["ss_net_paid"])
+						}
+					}
+				}
+				return _res
+			}())
+		}
+	}()
+	bucket4 = func() float64 {
+		if _count(func() []any {
+			_res := []any{}
+			for _, s := range store_sales {
+				if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 61) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 80) {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 61) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 80) {
+						_res = append(_res, s)
+					}
+				}
+			}
+			return _res
+		}()) > 40 {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 61) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 80) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 61) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 80) {
+							_res = append(_res, _cast[map[string]any](s)["ss_ext_discount_amt"])
+						}
+					}
+				}
+				return _res
+			}())
+		} else {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 61) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 80) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 61) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 80) {
+							_res = append(_res, _cast[map[string]any](s)["ss_net_paid"])
+						}
+					}
+				}
+				return _res
+			}())
+		}
+	}()
+	bucket5 = func() float64 {
+		if _count(func() []any {
+			_res := []any{}
+			for _, s := range store_sales {
+				if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 81) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 100) {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 81) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 100) {
+						_res = append(_res, s)
+					}
+				}
+			}
+			return _res
+		}()) > 50 {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 81) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 100) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 81) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 100) {
+							_res = append(_res, _cast[map[string]any](s)["ss_ext_discount_amt"])
+						}
+					}
+				}
+				return _res
+			}())
+		} else {
+			return _avg(func() []any {
+				_res := []any{}
+				for _, s := range store_sales {
+					if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 81) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 100) {
+						if (_cast[int](_cast[map[string]any](s)["ss_quantity"]) >= 81) && (_cast[int](_cast[map[string]any](s)["ss_quantity"]) <= 100) {
+							_res = append(_res, _cast[map[string]any](s)["ss_net_paid"])
+						}
+					}
+				}
+				return _res
+			}())
+		}
+	}()
+	result = func() []map[string]float64 {
+		_res := []map[string]float64{}
+		for _, r := range reason {
+			if _equal(_cast[map[string]any](r)["r_reason_sk"], 1) {
+				if _equal(_cast[map[string]any](r)["r_reason_sk"], 1) {
+					_res = append(_res, map[string]float64{
+						"bucket1": bucket1,
+						"bucket2": bucket2,
+						"bucket3": bucket3,
+						"bucket4": bucket4,
+						"bucket5": bucket5,
+					})
+				}
+			}
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q9 empty")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q9_empty()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _count(v any) int {
+	if g, ok := v.(*data.Group); ok {
+		return len(g.Items)
+	}
+	switch s := v.(type) {
+	case []any:
+		return len(s)
+	case []int:
+		return len(s)
+	case []float64:
+		return len(s)
+	case []string:
+		return len(s)
+	case []bool:
+		return len(s)
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	case string:
+		return len([]rune(s))
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len()
+	}
+	panic("count() expects list or group")
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}

--- a/tests/dataset/tpc-ds/compiler/go/q9.out
+++ b/tests/dataset/tpc-ds/compiler/go/q9.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q9 empty                 ... ok (906ns)


### PR DESCRIPTION
## Summary
- add if-expression support to the Go compiler
- handle `null` literals
- implement `concat`, `substr` and `reverse` built-ins for Go
- update query compilation to type hint sort keys
- add runtime helpers `_concat`, `_reverseSlice` and `_reverseString`
- provide golden Go outputs for TPC-DS queries q3‒q9

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68637edf80808320ad8279579f9234c6