### PR TITLE
Add Lua support for first TPC-DS queries

### DIFF
--- a/compile/x/lua/runtime.go
+++ b/compile/x/lua/runtime.go
@@ -189,6 +189,45 @@ const (
 		"    end\n" +
 		"end\n"
 
+	helperMax = "function __max(v)\n" +
+		"    local items\n" +
+		"    if type(v) == 'table' and v.items ~= nil then\n" +
+		"        items = v.items\n" +
+		"    elseif type(v) == 'table' then\n" +
+		"        items = v\n" +
+		"    else\n" +
+		"        error('max() expects list or group')\n" +
+		"    end\n" +
+		"    if #items == 0 then return 0 end\n" +
+		"    local m = items[1]\n" +
+		"    if type(m) == 'string' then\n" +
+		"        for i=2,#items do\n" +
+		"            local it = items[i]\n" +
+		"            if type(it) == 'string' and it > m then m = it end\n" +
+		"        end\n" +
+		"        return m\n" +
+		"    else\n" +
+		"        m = tonumber(m)\n" +
+		"        for i=2,#items do\n" +
+		"            local n = tonumber(items[i])\n" +
+		"            if n > m then m = n end\n" +
+		"        end\n" +
+		"        return m\n" +
+		"    end\n" +
+		"end\n"
+
+	helperReverseSlice = "function __reverse_slice(t)\n" +
+		"    local out = {}\n" +
+		"    for i=#t,1,-1 do out[#out+1] = t[i] end\n" +
+		"    return out\n" +
+		"end\n"
+
+	helperReverseString = "function __reverse_string(s)\n" +
+		"    local out = {}\n" +
+		"    for i=#s,1,-1 do out[#out+1] = string.sub(s, i, i) end\n" +
+		"    return table.concat(out)\n" +
+		"end\n"
+
 	helperAppend = "function __append(lst, v)\n" +
 		"    local out = {}\n" +
 		"    if lst then for i = 1, #lst do out[#out+1] = lst[i] end end\n" +
@@ -697,38 +736,41 @@ const (
 )
 
 var helperMap = map[string]string{
-	"print":       helperPrint,
-	"run_tests":   helperRunTests,
-	"iter":        helperIter,
-	"div":         helperDiv,
-	"add":         helperAdd,
-	"eq":          helperEq,
-	"contains":    helperContains,
-	"input":       helperInput,
-	"count":       helperCount,
-	"avg":         helperAvg,
-	"sum":         helperSum,
-	"min":         helperMin,
-	"append":      helperAppend,
-	"reduce":      helperReduce,
-	"json":        helperJson,
-	"eval":        helperEval,
-	"index":       helperIndex,
-	"indexString": helperIndexString,
-	"slice":       helperSlice,
-	"union_all":   helperUnionAll,
-	"union":       helperUnion,
-	"except":      helperExcept,
-	"intersect":   helperIntersect,
-	"gen_text":    helperGenText,
-	"gen_embed":   helperGenEmbed,
-	"gen_struct":  helperGenStruct,
-	"fetch":       helperFetch,
-	"load":        helperLoad,
-	"save":        helperSave,
-	"_Group":      helperGroup,
-	"_group_by":   helperGroupBy,
-	"query":       helperQuery,
+	"print":          helperPrint,
+	"run_tests":      helperRunTests,
+	"iter":           helperIter,
+	"div":            helperDiv,
+	"add":            helperAdd,
+	"eq":             helperEq,
+	"contains":       helperContains,
+	"input":          helperInput,
+	"count":          helperCount,
+	"avg":            helperAvg,
+	"sum":            helperSum,
+	"min":            helperMin,
+	"max":            helperMax,
+	"append":         helperAppend,
+	"reduce":         helperReduce,
+	"json":           helperJson,
+	"eval":           helperEval,
+	"index":          helperIndex,
+	"indexString":    helperIndexString,
+	"slice":          helperSlice,
+	"union_all":      helperUnionAll,
+	"union":          helperUnion,
+	"except":         helperExcept,
+	"intersect":      helperIntersect,
+	"gen_text":       helperGenText,
+	"gen_embed":      helperGenEmbed,
+	"gen_struct":     helperGenStruct,
+	"fetch":          helperFetch,
+	"load":           helperLoad,
+	"save":           helperSave,
+	"_Group":         helperGroup,
+	"_group_by":      helperGroupBy,
+	"query":          helperQuery,
+	"reverse_slice":  helperReverseSlice,
+	"reverse_string": helperReverseString,
 }
 
 func (c *Compiler) use(name string) { c.helpers[name] = true }

--- a/compile/x/lua/tpcds_test.go
+++ b/compile/x/lua/tpcds_test.go
@@ -3,6 +3,7 @@ package luacode_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,58 +21,60 @@ func TestLuaCompiler_TPCDS_Golden(t *testing.T) {
 		t.Skipf("lua not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	q := "q1"
-	t.Run(q, func(t *testing.T) {
-		src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
-		prog, err := parser.Parse(src)
-		if err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			t.Fatalf("type error: %v", errs[0])
-		}
-		code, err := luacode.New(env).Compile(prog)
-		if err != nil {
-			t.Fatalf("compile error: %v", err)
-		}
-		wantCode, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "lua", q+".lua.out"))
-		if err != nil {
-			t.Fatalf("read golden: %v", err)
-		}
-		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
-			t.Errorf("generated code mismatch for %s.lua.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
-		}
-		dir := t.TempDir()
-		file := filepath.Join(dir, "main.lua")
-		if err := os.WriteFile(file, code, 0644); err != nil {
-			t.Fatalf("write error: %v", err)
-		}
-		cmd := exec.Command("lua", file)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("lua run error: %v\n%s", err, out)
-		}
-		gotLines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
-		if len(gotLines) == 0 {
-			t.Fatalf("no output")
-		}
-		gotJSON := gotLines[0]
-		wantOut, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "lua", q+".out"))
-		if err != nil {
-			t.Fatalf("read golden: %v", err)
-		}
-		wantLines := bytes.Split(bytes.TrimSpace(wantOut), []byte("\n"))
-		wantJSON := wantLines[0]
-		var gotVal, wantVal any
-		if err := json.Unmarshal(gotJSON, &gotVal); err != nil {
-			t.Fatalf("parse got json: %v", err)
-		}
-		if err := json.Unmarshal(wantJSON, &wantVal); err != nil {
-			t.Fatalf("parse want json: %v", err)
-		}
-		if !reflect.DeepEqual(gotVal, wantVal) {
-			t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, gotJSON, wantJSON)
-		}
-	})
+	for i := 1; i <= 9; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := luacode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCode, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "lua", q+".lua.out"))
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s.lua.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.lua")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("lua", file)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("lua run error: %v\n%s", err, out)
+			}
+			gotLines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+			if len(gotLines) == 0 {
+				t.Fatalf("no output")
+			}
+			gotJSON := gotLines[0]
+			wantOut, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "lua", q+".out"))
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			wantLines := bytes.Split(bytes.TrimSpace(wantOut), []byte("\n"))
+			wantJSON := wantLines[0]
+			var gotVal, wantVal any
+			if err := json.Unmarshal(gotJSON, &gotVal); err != nil {
+				t.Fatalf("parse got json: %v", err)
+			}
+			if err := json.Unmarshal(wantJSON, &wantVal); err != nil {
+				t.Fatalf("parse want json: %v", err)
+			}
+			if !reflect.DeepEqual(gotVal, wantVal) {
+				t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, gotJSON, wantJSON)
+			}
+		})
+	}
 }

--- a/tests/dataset/tpc-ds/compiler/lua/q1.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q1.out
@@ -1,2 +1,2 @@
 []
-   test TPCDS Q1 empty ... ok (3.0µs)
+   test TPCDS Q1 empty ... ok (97.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q2.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q2.lua.out
@@ -1,0 +1,379 @@
+_Group = {}
+function _Group.new(k)
+    return {key = k, items = {}}
+end
+function __group_by(src, keyfn)
+    local groups = {}
+    local order = {}
+    for _, it in ipairs(src) do
+        local key = keyfn(it)
+        local ks
+        if type(key) == 'table' then
+            local fields = {}
+            for k,_ in pairs(key) do fields[#fields+1] = k end
+            table.sort(fields)
+            local parts = {}
+            for _,k in ipairs(fields) do parts[#parts+1] = tostring(k)..'='..tostring(key[k]) end
+            ks = table.concat(parts, ',')
+        else
+            ks = tostring(key)
+        end
+        local g = groups[ks]
+        if not g then
+            g = _Group.new(key)
+            groups[ks] = g
+            order[#order+1] = ks
+        end
+        table.insert(g.items, it)
+    end
+    local res = {}
+    for _, ks in ipairs(order) do
+        res[#res+1] = groups[ks]
+    end
+    return res
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function __sum(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('sum() expects list or group')
+    end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum
+end
+function __union_all(a, b)
+    local res = {}
+    if a then for _, v in ipairs(a) do res[#res+1] = v end end
+    if b then for _, v in ipairs(b) do res[#res+1] = v end end
+    return res
+end
+function test_TPCDS_Q2_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+web_sales = {}
+catalog_sales = {}
+date_dim = {}
+wscs = __union_all(((function()
+    local _res = {}
+    for _, ws in ipairs(web_sales) do
+        _res[#_res+1] = {["sold_date_sk"]=ws.ws_sold_date_sk, ["sales_price"]=ws.ws_ext_sales_price, ["day"]=ws.ws_sold_date_name}
+    end
+    return _res
+end)()), ((function()
+    local _res = {}
+    for _, cs in ipairs(catalog_sales) do
+        _res[#_res+1] = {["sold_date_sk"]=cs.cs_sold_date_sk, ["sales_price"]=cs.cs_ext_sales_price, ["day"]=cs.cs_sold_date_name}
+    end
+    return _res
+end)()))
+wswscs = (function()
+    local _src = wscs
+    local _rows = __query(_src, {
+        { items = date_dim, on = function(w, d) return __eq(w.sold_date_sk, d.d_date_sk) end }
+    }, { selectFn = function(w, d) return w end })
+    local _groups = __group_by(_rows, function(w) return {["week_seq"]=d.d_week_seq} end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["d_week_seq"]=g.key.week_seq, ["sun_sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        if __eq(x.day, "Sunday") then
+            _res[#_res+1] = x.sales_price
+        end
+    end
+    return _res
+end)()), ["mon_sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        if __eq(x.day, "Monday") then
+            _res[#_res+1] = x.sales_price
+        end
+    end
+    return _res
+end)()), ["tue_sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        if __eq(x.day, "Tuesday") then
+            _res[#_res+1] = x.sales_price
+        end
+    end
+    return _res
+end)()), ["wed_sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        if __eq(x.day, "Wednesday") then
+            _res[#_res+1] = x.sales_price
+        end
+    end
+    return _res
+end)()), ["thu_sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        if __eq(x.day, "Thursday") then
+            _res[#_res+1] = x.sales_price
+        end
+    end
+    return _res
+end)()), ["fri_sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        if __eq(x.day, "Friday") then
+            _res[#_res+1] = x.sales_price
+        end
+    end
+    return _res
+end)()), ["sat_sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        if __eq(x.day, "Saturday") then
+            _res[#_res+1] = x.sales_price
+        end
+    end
+    return _res
+end)())}
+    end
+    return _res
+end)()
+result = {}
+__json(result)
+local __tests = {
+    {name="TPCDS Q2 empty", fn=test_TPCDS_Q2_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q2.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q2.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q2 empty ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q3.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q3.lua.out
@@ -1,0 +1,310 @@
+_Group = {}
+function _Group.new(k)
+    return {key = k, items = {}}
+end
+function __group_by(src, keyfn)
+    local groups = {}
+    local order = {}
+    for _, it in ipairs(src) do
+        local key = keyfn(it)
+        local ks
+        if type(key) == 'table' then
+            local fields = {}
+            for k,_ in pairs(key) do fields[#fields+1] = k end
+            table.sort(fields)
+            local parts = {}
+            for _,k in ipairs(fields) do parts[#parts+1] = tostring(k)..'='..tostring(key[k]) end
+            ks = table.concat(parts, ',')
+        else
+            ks = tostring(key)
+        end
+        local g = groups[ks]
+        if not g then
+            g = _Group.new(key)
+            groups[ks] = g
+            order[#order+1] = ks
+        end
+        table.insert(g.items, it)
+    end
+    local res = {}
+    for _, ks in ipairs(order) do
+        res[#res+1] = groups[ks]
+    end
+    return res
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function __sum(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('sum() expects list or group')
+    end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum
+end
+function test_TPCDS_Q3_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+date_dim = {}
+store_sales = {}
+item = {}
+result = (function()
+    local _src = date_dim
+    local _rows = __query(_src, {
+        { items = store_sales, on = function(dt, ss) return __eq(dt.d_date_sk, ss.ss_sold_date_sk) end },
+        { items = item, on = function(dt, ss, i) return __eq(ss.ss_item_sk, i.i_item_sk) end }
+    }, { selectFn = function(dt, ss, i) return dt end, where = function(dt, ss, i) return ((__eq(i.i_manufact_id, 100) and __eq(dt.d_moy, 12))) end })
+    local _groups = __group_by(_rows, function(dt) return {["d_year"]=dt.d_year, ["brand_id"]=i.i_brand_id, ["brand"]=i.i_brand} end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["d_year"]=g.key.d_year, ["brand_id"]=g.key.brand_id, ["brand"]=g.key.brand, ["sum_agg"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ss.ss_ext_sales_price
+    end
+    return _res
+end)())}
+    end
+    return _res
+end)()
+__json(result)
+local __tests = {
+    {name="TPCDS Q3 empty", fn=test_TPCDS_Q3_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q3.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q3.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q3 empty ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q4.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q4.lua.out
@@ -1,0 +1,406 @@
+_Group = {}
+function _Group.new(k)
+    return {key = k, items = {}}
+end
+function __group_by(src, keyfn)
+    local groups = {}
+    local order = {}
+    for _, it in ipairs(src) do
+        local key = keyfn(it)
+        local ks
+        if type(key) == 'table' then
+            local fields = {}
+            for k,_ in pairs(key) do fields[#fields+1] = k end
+            table.sort(fields)
+            local parts = {}
+            for _,k in ipairs(fields) do parts[#parts+1] = tostring(k)..'='..tostring(key[k]) end
+            ks = table.concat(parts, ',')
+        else
+            ks = tostring(key)
+        end
+        local g = groups[ks]
+        if not g then
+            g = _Group.new(key)
+            groups[ks] = g
+            order[#order+1] = ks
+        end
+        table.insert(g.items, it)
+    end
+    local res = {}
+    for _, ks in ipairs(order) do
+        res[#res+1] = groups[ks]
+    end
+    return res
+end
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function __sum(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('sum() expects list or group')
+    end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum
+end
+function __union_all(a, b)
+    local res = {}
+    if a then for _, v in ipairs(a) do res[#res+1] = v end end
+    if b then for _, v in ipairs(b) do res[#res+1] = v end end
+    return res
+end
+function test_TPCDS_Q4_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+customer = {}
+store_sales = {}
+catalog_sales = {}
+web_sales = {}
+date_dim = {}
+year_total = __union_all(__union_all(((function()
+    local _src = customer
+    local _rows = __query(_src, {
+        { items = store_sales, on = function(c, s) return __eq(c.c_customer_sk, s.ss_customer_sk) end },
+        { items = date_dim, on = function(c, s, d) return __eq(s.ss_sold_date_sk, d.d_date_sk) end }
+    }, { selectFn = function(c, s, d) return c end })
+    local _groups = __group_by(_rows, function(c) return {["id"]=c.c_customer_id, ["first"]=c.c_first_name, ["last"]=c.c_last_name, ["login"]=c.c_login, ["year"]=d.d_year} end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["customer_id"]=g.key.id, ["customer_first_name"]=g.key.first, ["customer_last_name"]=g.key.last, ["customer_login"]=g.key.login, ["dyear"]=g.key.year, ["year_total"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = __div((__add((((x.ss_ext_list_price - x.ss_ext_wholesale_cost) - x.ss_ext_discount_amt)), x.ss_ext_sales_price)), 2)
+    end
+    return _res
+end)()), ["sale_type"]="s"}
+    end
+    return _res
+end)()), ((function()
+    local _src = customer
+    local _rows = __query(_src, {
+        { items = catalog_sales, on = function(c, cs) return __eq(c.c_customer_sk, cs.cs_bill_customer_sk) end },
+        { items = date_dim, on = function(c, cs, d) return __eq(cs.cs_sold_date_sk, d.d_date_sk) end }
+    }, { selectFn = function(c, cs, d) return c end })
+    local _groups = __group_by(_rows, function(c) return {["id"]=c.c_customer_id, ["first"]=c.c_first_name, ["last"]=c.c_last_name, ["login"]=c.c_login, ["year"]=d.d_year} end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["customer_id"]=g.key.id, ["customer_first_name"]=g.key.first, ["customer_last_name"]=g.key.last, ["customer_login"]=g.key.login, ["dyear"]=g.key.year, ["year_total"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = __div((__add((((x.cs_ext_list_price - x.cs_ext_wholesale_cost) - x.cs_ext_discount_amt)), x.cs_ext_sales_price)), 2)
+    end
+    return _res
+end)()), ["sale_type"]="c"}
+    end
+    return _res
+end)())), ((function()
+    local _src = customer
+    local _rows = __query(_src, {
+        { items = web_sales, on = function(c, ws) return __eq(c.c_customer_sk, ws.ws_bill_customer_sk) end },
+        { items = date_dim, on = function(c, ws, d) return __eq(ws.ws_sold_date_sk, d.d_date_sk) end }
+    }, { selectFn = function(c, ws, d) return c end })
+    local _groups = __group_by(_rows, function(c) return {["id"]=c.c_customer_id, ["first"]=c.c_first_name, ["last"]=c.c_last_name, ["login"]=c.c_login, ["year"]=d.d_year} end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["customer_id"]=g.key.id, ["customer_first_name"]=g.key.first, ["customer_last_name"]=g.key.last, ["customer_login"]=g.key.login, ["dyear"]=g.key.year, ["year_total"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = __div((__add((((x.ws_ext_list_price - x.ws_ext_wholesale_cost) - x.ws_ext_discount_amt)), x.ws_ext_sales_price)), 2)
+    end
+    return _res
+end)()), ["sale_type"]="w"}
+    end
+    return _res
+end)()))
+result = (function()
+    local _src = year_total
+    return __query(_src, {
+        { items = year_total, on = function(s1, s2) return __eq(s2.customer_id, s1.customer_id) end },
+        { items = year_total, on = function(s1, s2, c1) return __eq(c1.customer_id, s1.customer_id) end },
+        { items = year_total, on = function(s1, s2, c1, c2) return __eq(c2.customer_id, s1.customer_id) end },
+        { items = year_total, on = function(s1, s2, c1, c2, w1) return __eq(w1.customer_id, s1.customer_id) end },
+        { items = year_total, on = function(s1, s2, c1, c2, w1, w2) return __eq(w2.customer_id, s1.customer_id) end }
+    }, { selectFn = function(s1, s2, c1, c2, w1, w2) return {["customer_id"]=s2.customer_id, ["customer_first_name"]=s2.customer_first_name, ["customer_last_name"]=s2.customer_last_name, ["customer_login"]=s2.customer_login} end, where = function(s1, s2, c1, c2, w1, w2) return (((((((((((((((((__eq(s1.sale_type, "s") and __eq(c1.sale_type, "c")) and __eq(w1.sale_type, "w")) and __eq(s2.sale_type, "s")) and __eq(c2.sale_type, "c")) and __eq(w2.sale_type, "w")) and __eq(s1.dyear, 2001)) and __eq(s2.dyear, 2002)) and __eq(c1.dyear, 2001)) and __eq(c2.dyear, 2002)) and __eq(w1.dyear, 2001)) and __eq(w2.dyear, 2002)) and (s1.year_total > 0)) and (c1.year_total > 0)) and (w1.year_total > 0)) and (((function()
+    if (c1.year_total > 0) then
+        return __div(c2.year_total, c1.year_total)
+    else
+        return nil
+    end
+end)()) > ((function()
+    if (s1.year_total > 0) then
+        return __div(s2.year_total, s1.year_total)
+    else
+        return nil
+    end
+end)()))) and (((function()
+    if (c1.year_total > 0) then
+        return __div(c2.year_total, c1.year_total)
+    else
+        return nil
+    end
+end)()) > ((function()
+    if (w1.year_total > 0) then
+        return __div(w2.year_total, w1.year_total)
+    else
+        return nil
+    end
+end)())))) end, sortKey = function(s1, s2, c1, c2, w1, w2) return ({s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login}) end })
+end)()
+__json(result)
+local __tests = {
+    {name="TPCDS Q4 empty", fn=test_TPCDS_Q4_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q4.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q4.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q4 empty ... ok (3.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q5.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q5.lua.out
@@ -1,0 +1,491 @@
+_Group = {}
+function _Group.new(k)
+    return {key = k, items = {}}
+end
+function __group_by(src, keyfn)
+    local groups = {}
+    local order = {}
+    for _, it in ipairs(src) do
+        local key = keyfn(it)
+        local ks
+        if type(key) == 'table' then
+            local fields = {}
+            for k,_ in pairs(key) do fields[#fields+1] = k end
+            table.sort(fields)
+            local parts = {}
+            for _,k in ipairs(fields) do parts[#parts+1] = tostring(k)..'='..tostring(key[k]) end
+            ks = table.concat(parts, ',')
+        else
+            ks = tostring(key)
+        end
+        local g = groups[ks]
+        if not g then
+            g = _Group.new(key)
+            groups[ks] = g
+            order[#order+1] = ks
+        end
+        table.insert(g.items, it)
+    end
+    local res = {}
+    for _, ks in ipairs(order) do
+        res[#res+1] = groups[ks]
+    end
+    return res
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function __sum(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('sum() expects list or group')
+    end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum
+end
+function __union_all(a, b)
+    local res = {}
+    if a then for _, v in ipairs(a) do res[#res+1] = v end end
+    if b then for _, v in ipairs(b) do res[#res+1] = v end end
+    return res
+end
+function test_TPCDS_Q5_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+store_sales = {}
+store_returns = {}
+store = {}
+catalog_sales = {}
+catalog_returns = {}
+catalog_page = {}
+web_sales = {}
+web_returns = {}
+web_site = {}
+date_dim = {}
+ss = (function()
+    local _src = store_sales
+    local _rows = __query(_src, {
+        { items = date_dim, on = function(ss, d) return __eq(ss.ss_sold_date_sk, d.d_date_sk) end },
+        { items = store, on = function(ss, d, s) return __eq(ss.ss_store_sk, s.s_store_sk) end }
+    }, { selectFn = function(ss, d, s) return ss end, where = function(ss, d, s) return (((d.d_date >= "1998-12-01") and (d.d_date <= "1998-12-15"))) end })
+    local _groups = __group_by(_rows, function(ss) return s.s_store_id end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["channel"]="store channel", ["id"]=("store" .. tostring(g.key)), ["sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ss.ss_ext_sales_price
+    end
+    return _res
+end)()), ["returns"]=0.0, ["profit"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ss.ss_net_profit
+    end
+    return _res
+end)()), ["profit_loss"]=0.0}
+    end
+    return _res
+end)()
+sr = (function()
+    local _src = store_returns
+    local _rows = __query(_src, {
+        { items = date_dim, on = function(sr, d) return __eq(sr.sr_returned_date_sk, d.d_date_sk) end },
+        { items = store, on = function(sr, d, s) return __eq(sr.sr_store_sk, s.s_store_sk) end }
+    }, { selectFn = function(sr, d, s) return sr end, where = function(sr, d, s) return (((d.d_date >= "1998-12-01") and (d.d_date <= "1998-12-15"))) end })
+    local _groups = __group_by(_rows, function(sr) return s.s_store_id end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["channel"]="store channel", ["id"]=("store" .. tostring(g.key)), ["sales"]=0.0, ["returns"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.sr.sr_return_amt
+    end
+    return _res
+end)()), ["profit"]=0.0, ["profit_loss"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.sr.sr_net_loss
+    end
+    return _res
+end)())}
+    end
+    return _res
+end)()
+cs = (function()
+    local _src = catalog_sales
+    local _rows = __query(_src, {
+        { items = date_dim, on = function(cs, d) return __eq(cs.cs_sold_date_sk, d.d_date_sk) end },
+        { items = catalog_page, on = function(cs, d, cp) return __eq(cs.cs_catalog_page_sk, cp.cp_catalog_page_sk) end }
+    }, { selectFn = function(cs, d, cp) return cs end, where = function(cs, d, cp) return (((d.d_date >= "1998-12-01") and (d.d_date <= "1998-12-15"))) end })
+    local _groups = __group_by(_rows, function(cs) return cp.cp_catalog_page_id end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["channel"]="catalog channel", ["id"]=("catalog_page" .. tostring(g.key)), ["sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.cs.cs_ext_sales_price
+    end
+    return _res
+end)()), ["returns"]=0.0, ["profit"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.cs.cs_net_profit
+    end
+    return _res
+end)()), ["profit_loss"]=0.0}
+    end
+    return _res
+end)()
+cr = (function()
+    local _src = catalog_returns
+    local _rows = __query(_src, {
+        { items = date_dim, on = function(cr, d) return __eq(cr.cr_returned_date_sk, d.d_date_sk) end },
+        { items = catalog_page, on = function(cr, d, cp) return __eq(cr.cr_catalog_page_sk, cp.cp_catalog_page_sk) end }
+    }, { selectFn = function(cr, d, cp) return cr end, where = function(cr, d, cp) return (((d.d_date >= "1998-12-01") and (d.d_date <= "1998-12-15"))) end })
+    local _groups = __group_by(_rows, function(cr) return cp.cp_catalog_page_id end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["channel"]="catalog channel", ["id"]=("catalog_page" .. tostring(g.key)), ["sales"]=0.0, ["returns"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.cr.cr_return_amount
+    end
+    return _res
+end)()), ["profit"]=0.0, ["profit_loss"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.cr.cr_net_loss
+    end
+    return _res
+end)())}
+    end
+    return _res
+end)()
+ws = (function()
+    local _src = web_sales
+    local _rows = __query(_src, {
+        { items = date_dim, on = function(ws, d) return __eq(ws.ws_sold_date_sk, d.d_date_sk) end },
+        { items = web_site, on = function(ws, d, w) return __eq(ws.ws_web_site_sk, w.web_site_sk) end }
+    }, { selectFn = function(ws, d, w) return ws end, where = function(ws, d, w) return (((d.d_date >= "1998-12-01") and (d.d_date <= "1998-12-15"))) end })
+    local _groups = __group_by(_rows, function(ws) return w.web_site_id end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["channel"]="web channel", ["id"]=("web_site" .. tostring(g.key)), ["sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ws.ws_ext_sales_price
+    end
+    return _res
+end)()), ["returns"]=0.0, ["profit"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ws.ws_net_profit
+    end
+    return _res
+end)()), ["profit_loss"]=0.0}
+    end
+    return _res
+end)()
+wr = (function()
+    local _src = web_returns
+    local _rows = __query(_src, {
+        { items = web_sales, on = function(wr, ws) return (__eq(wr.wr_item_sk, ws.ws_item_sk) and __eq(wr.wr_order_number, ws.ws_order_number)) end },
+        { items = date_dim, on = function(wr, ws, d) return __eq(wr.wr_returned_date_sk, d.d_date_sk) end },
+        { items = web_site, on = function(wr, ws, d, w) return __eq(ws.ws_web_site_sk, w.web_site_sk) end }
+    }, { selectFn = function(wr, ws, d, w) return wr end, where = function(wr, ws, d, w) return (((d.d_date >= "1998-12-01") and (d.d_date <= "1998-12-15"))) end })
+    local _groups = __group_by(_rows, function(wr) return w.web_site_id end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["channel"]="web channel", ["id"]=("web_site" .. tostring(g.key)), ["sales"]=0.0, ["returns"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.wr.wr_return_amt
+    end
+    return _res
+end)()), ["profit"]=0.0, ["profit_loss"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.wr.wr_net_loss
+    end
+    return _res
+end)())}
+    end
+    return _res
+end)()
+per_channel = __union_all(__union_all(__union_all(ss, sr), __union_all(cs, cr)), __union_all(ws, wr))
+result = (function()
+    local _src = per_channel
+    local _rows = __query(_src, {
+    }, { selectFn = function(p) return p end })
+    local _groups = __group_by(_rows, function(p) return {["channel"]=p.channel, ["id"]=p.id} end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["channel"]=g.key.channel, ["id"]=g.key.id, ["sales"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.p.sales
+    end
+    return _res
+end)()), ["returns"]=__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.p.returns
+    end
+    return _res
+end)()), ["profit"]=(__sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.p.profit
+    end
+    return _res
+end)()) - __sum((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.p.profit_loss
+    end
+    return _res
+end)()))}
+    end
+    return _res
+end)()
+__json(result)
+local __tests = {
+    {name="TPCDS Q5 empty", fn=test_TPCDS_Q5_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q5.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q5.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q5 empty ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q6.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q6.lua.out
@@ -1,0 +1,370 @@
+_Group = {}
+function _Group.new(k)
+    return {key = k, items = {}}
+end
+function __group_by(src, keyfn)
+    local groups = {}
+    local order = {}
+    for _, it in ipairs(src) do
+        local key = keyfn(it)
+        local ks
+        if type(key) == 'table' then
+            local fields = {}
+            for k,_ in pairs(key) do fields[#fields+1] = k end
+            table.sort(fields)
+            local parts = {}
+            for _,k in ipairs(fields) do parts[#parts+1] = tostring(k)..'='..tostring(key[k]) end
+            ks = table.concat(parts, ',')
+        else
+            ks = tostring(key)
+        end
+        local g = groups[ks]
+        if not g then
+            g = _Group.new(key)
+            groups[ks] = g
+            order[#order+1] = ks
+        end
+        table.insert(g.items, it)
+    end
+    local res = {}
+    for _, ks in ipairs(order) do
+        res[#res+1] = groups[ks]
+    end
+    return res
+end
+function __avg(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('avg() expects list or group')
+    end
+    if #items == 0 then return 0 end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum / #items
+end
+function __count(v)
+    if type(v) == 'table' then
+        if v.items ~= nil then return #v.items end
+        if v[1] ~= nil or #v > 0 then return #v end
+        local n = 0
+        for _ in pairs(v) do n = n + 1 end
+        return n
+    elseif type(v) == 'string' then
+        return #v
+    else
+        error('count() expects list or group')
+    end
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __max(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('max() expects list or group')
+    end
+    if #items == 0 then return 0 end
+    local m = items[1]
+    if type(m) == 'string' then
+        for i=2,#items do
+            local it = items[i]
+            if type(it) == 'string' and it > m then m = it end
+        end
+        return m
+    else
+        m = tonumber(m)
+        for i=2,#items do
+            local n = tonumber(items[i])
+            if n > m then m = n end
+        end
+        return m
+    end
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function test_TPCDS_Q6_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+customer_address = {}
+customer = {}
+store_sales = {}
+date_dim = {}
+item = {}
+target_month_seq = __max((function()
+    local _res = {}
+    for _, d in ipairs(date_dim) do
+        if (__eq(d.d_year, 1999) and __eq(d.d_moy, 5)) then
+            _res[#_res+1] = d.d_month_seq
+        end
+    end
+    return _res
+end)())
+result = (function()
+    local _src = customer_address
+    local _rows = __query(_src, {
+        { items = customer, on = function(a, c) return __eq(a.ca_address_sk, c.c_current_addr_sk) end },
+        { items = store_sales, on = function(a, c, s) return __eq(c.c_customer_sk, s.ss_customer_sk) end },
+        { items = date_dim, on = function(a, c, s, d) return __eq(s.ss_sold_date_sk, d.d_date_sk) end },
+        { items = item, on = function(a, c, s, d, i) return __eq(s.ss_item_sk, i.i_item_sk) end }
+    }, { selectFn = function(a, c, s, d, i) return a end, where = function(a, c, s, d, i) return ((__eq(d.d_month_seq, target_month_seq) and (i.i_current_price > (1.2 * __avg((function()
+    local _res = {}
+    for _, j in ipairs(item) do
+        if __eq(j.i_category, i.i_category) then
+            _res[#_res+1] = j.i_current_price
+        end
+    end
+    return _res
+end)()))))) end })
+    local _groups = __group_by(_rows, function(a) return a.ca_state end)
+    local _filtered = {}
+    for _, g in ipairs(_groups) do
+        if (__count(g) >= 10) then _filtered[#_filtered+1] = g end
+    end
+    _groups = _filtered
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["state"]=g.key, ["cnt"]=__count(g)}
+    end
+    return _res
+end)()
+__json(result)
+local __tests = {
+    {name="TPCDS Q6 empty", fn=test_TPCDS_Q6_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q6.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q6.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q6 empty ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q7.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q7.lua.out
@@ -1,0 +1,333 @@
+_Group = {}
+function _Group.new(k)
+    return {key = k, items = {}}
+end
+function __group_by(src, keyfn)
+    local groups = {}
+    local order = {}
+    for _, it in ipairs(src) do
+        local key = keyfn(it)
+        local ks
+        if type(key) == 'table' then
+            local fields = {}
+            for k,_ in pairs(key) do fields[#fields+1] = k end
+            table.sort(fields)
+            local parts = {}
+            for _,k in ipairs(fields) do parts[#parts+1] = tostring(k)..'='..tostring(key[k]) end
+            ks = table.concat(parts, ',')
+        else
+            ks = tostring(key)
+        end
+        local g = groups[ks]
+        if not g then
+            g = _Group.new(key)
+            groups[ks] = g
+            order[#order+1] = ks
+        end
+        table.insert(g.items, it)
+    end
+    local res = {}
+    for _, ks in ipairs(order) do
+        res[#res+1] = groups[ks]
+    end
+    return res
+end
+function __avg(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('avg() expects list or group')
+    end
+    if #items == 0 then return 0 end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum / #items
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function test_TPCDS_Q7_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+store_sales = {}
+customer_demographics = {}
+date_dim = {}
+item = {}
+promotion = {}
+result = (function()
+    local _src = store_sales
+    local _rows = __query(_src, {
+        { items = customer_demographics, on = function(ss, cd) return __eq(ss.ss_cdemo_sk, cd.cd_demo_sk) end },
+        { items = date_dim, on = function(ss, cd, d) return __eq(ss.ss_sold_date_sk, d.d_date_sk) end },
+        { items = item, on = function(ss, cd, d, i) return __eq(ss.ss_item_sk, i.i_item_sk) end },
+        { items = promotion, on = function(ss, cd, d, i, p) return __eq(ss.ss_promo_sk, p.p_promo_sk) end }
+    }, { selectFn = function(ss, cd, d, i, p) return ss end, where = function(ss, cd, d, i, p) return (((((__eq(cd.cd_gender, "M") and __eq(cd.cd_marital_status, "S")) and __eq(cd.cd_education_status, "College")) and ((__eq(p.p_channel_email, "N") or __eq(p.p_channel_event, "N")))) and __eq(d.d_year, 1998))) end })
+    local _groups = __group_by(_rows, function(ss) return {["i_item_id"]=i.i_item_id} end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["i_item_id"]=g.key.i_item_id, ["agg1"]=__avg((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ss.ss_quantity
+    end
+    return _res
+end)()), ["agg2"]=__avg((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ss.ss_list_price
+    end
+    return _res
+end)()), ["agg3"]=__avg((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ss.ss_coupon_amt
+    end
+    return _res
+end)()), ["agg4"]=__avg((function()
+    local _res = {}
+    for _, x in ipairs(g.items) do
+        _res[#_res+1] = x.ss.ss_sales_price
+    end
+    return _res
+end)())}
+    end
+    return _res
+end)()
+__json(result)
+local __tests = {
+    {name="TPCDS Q7 empty", fn=test_TPCDS_Q7_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q7.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q7.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q7 empty ... ok (3.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q8.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q8.lua.out
@@ -1,0 +1,133 @@
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __reverse_string(s)
+    local out = {}
+    for i=#s,1,-1 do out[#out+1] = string.sub(s, i, i) end
+    return table.concat(out)
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function __slice(obj, i, j)
+    if i == nil then i = 0 end
+    if type(obj) == 'string' then
+        local len = #obj
+        if j == nil then j = len end
+        if i < 0 then i = len + i end
+        if j < 0 then j = len + j end
+        if i < 0 then i = 0 end
+        if j > len then j = len end
+        return string.sub(obj, i+1, j)
+    elseif type(obj) == 'table' then
+        local len = #obj
+        if j == nil then j = len end
+        if i < 0 then i = len + i end
+        if j < 0 then j = len + j end
+        if i < 0 then i = 0 end
+        if j > len then j = len end
+        local out = {}
+        for k = i+1, j do
+            out[#out+1] = obj[k]
+        end
+        return out
+    else
+        return {}
+    end
+end
+function test_TPCDS_Q8_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+store_sales = {}
+date_dim = {}
+store = {}
+customer_address = {}
+customer = {}
+__reverse_string(__slice("zip", 0, 2))
+result = {}
+__json(result)
+local __tests = {
+    {name="TPCDS Q8 empty", fn=test_TPCDS_Q8_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q8.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q8.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q8 empty ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/lua/q9.lua.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q9.lua.out
@@ -1,0 +1,288 @@
+function __avg(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('avg() expects list or group')
+    end
+    if #items == 0 then return 0 end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum / #items
+end
+function __count(v)
+    if type(v) == 'table' then
+        if v.items ~= nil then return #v.items end
+        if v[1] ~= nil or #v > 0 then return #v end
+        local n = 0
+        for _ in pairs(v) do n = n + 1 end
+        return n
+    elseif type(v) == 'string' then
+        return #v
+    else
+        error('count() expects list or group')
+    end
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function test_TPCDS_Q9_empty()
+    if not (__eq(#result, 0)) then error('expect failed') end
+end
+
+store_sales = {}
+reason = {}
+bucket1 = (function()
+    if (__count((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 1) and (s.ss_quantity <= 20)) then
+            _res[#_res+1] = s
+        end
+    end
+    return _res
+end)()) > 10) then
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 1) and (s.ss_quantity <= 20)) then
+            _res[#_res+1] = s.ss_ext_discount_amt
+        end
+    end
+    return _res
+end)())
+    else
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 1) and (s.ss_quantity <= 20)) then
+            _res[#_res+1] = s.ss_net_paid
+        end
+    end
+    return _res
+end)())
+    end
+end)()
+bucket2 = (function()
+    if (__count((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 21) and (s.ss_quantity <= 40)) then
+            _res[#_res+1] = s
+        end
+    end
+    return _res
+end)()) > 20) then
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 21) and (s.ss_quantity <= 40)) then
+            _res[#_res+1] = s.ss_ext_discount_amt
+        end
+    end
+    return _res
+end)())
+    else
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 21) and (s.ss_quantity <= 40)) then
+            _res[#_res+1] = s.ss_net_paid
+        end
+    end
+    return _res
+end)())
+    end
+end)()
+bucket3 = (function()
+    if (__count((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 41) and (s.ss_quantity <= 60)) then
+            _res[#_res+1] = s
+        end
+    end
+    return _res
+end)()) > 30) then
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 41) and (s.ss_quantity <= 60)) then
+            _res[#_res+1] = s.ss_ext_discount_amt
+        end
+    end
+    return _res
+end)())
+    else
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 41) and (s.ss_quantity <= 60)) then
+            _res[#_res+1] = s.ss_net_paid
+        end
+    end
+    return _res
+end)())
+    end
+end)()
+bucket4 = (function()
+    if (__count((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 61) and (s.ss_quantity <= 80)) then
+            _res[#_res+1] = s
+        end
+    end
+    return _res
+end)()) > 40) then
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 61) and (s.ss_quantity <= 80)) then
+            _res[#_res+1] = s.ss_ext_discount_amt
+        end
+    end
+    return _res
+end)())
+    else
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 61) and (s.ss_quantity <= 80)) then
+            _res[#_res+1] = s.ss_net_paid
+        end
+    end
+    return _res
+end)())
+    end
+end)()
+bucket5 = (function()
+    if (__count((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 81) and (s.ss_quantity <= 100)) then
+            _res[#_res+1] = s
+        end
+    end
+    return _res
+end)()) > 50) then
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 81) and (s.ss_quantity <= 100)) then
+            _res[#_res+1] = s.ss_ext_discount_amt
+        end
+    end
+    return _res
+end)())
+    else
+        return __avg((function()
+    local _res = {}
+    for _, s in ipairs(store_sales) do
+        if ((s.ss_quantity >= 81) and (s.ss_quantity <= 100)) then
+            _res[#_res+1] = s.ss_net_paid
+        end
+    end
+    return _res
+end)())
+    end
+end)()
+result = (function()
+    local _res = {}
+    for _, r in ipairs(reason) do
+        if __eq(r.r_reason_sk, 1) then
+            _res[#_res+1] = {["bucket1"]=bucket1, ["bucket2"]=bucket2, ["bucket3"]=bucket3, ["bucket4"]=bucket4, ["bucket5"]=bucket5}
+        end
+    end
+    return _res
+end)()
+__json(result)
+local __tests = {
+    {name="TPCDS Q9 empty", fn=test_TPCDS_Q9_empty},
+}
+__run_tests(__tests)

--- a/tests/dataset/tpc-ds/compiler/lua/q9.out
+++ b/tests/dataset/tpc-ds/compiler/lua/q9.out
@@ -1,0 +1,2 @@
+[]
+   test TPCDS Q9 empty ... ok (2.0µs)


### PR DESCRIPTION
## Summary
- extend Lua runtime with `max` and reverse helpers
- support more built-ins and `if` expressions in Lua backend
- handle `having` groups in Lua compiler
- test Lua compiler on TPC-DS queries q1–q9
- add generated Lua code and output for q1–q9

## Testing
- `go test ./compile/x/lua -run TestLuaCompiler_TPCDS_Golden -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68638762674c83209c0740439889fd73