### PR TITLE
Enhance fs compiler for TPC‑DS Q1–Q9

### DIFF
--- a/compile/x/fs/runtime.go
+++ b/compile/x/fs/runtime.go
@@ -178,6 +178,26 @@ const (
   let dt = new System.Data.DataTable()
   dt.Compute(code, "")`
 
+	helperSliceString = `let _slice_string (s: string) (i: int) (j: int) : string =
+  let mutable start = i
+  let mutable stop = j
+  let n = s.Length
+  if start < 0 then start <- start + n
+  if stop < 0 then stop <- stop + n
+  if start < 0 then start <- 0
+  if stop > n then stop <- n
+  if stop < start then stop <- start
+  s.Substring(start, stop - start)`
+
+	helperReverseArray = `let _reverse_array (xs: 'T[]) : 'T[] =
+  Array.rev xs`
+
+	helperReverseString = `let _reverse_string (s: string) : string =
+  s.ToCharArray() |> Array.rev |> System.String`
+
+	helperConcat = `let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b`
+
 	helperUnionAll = `let _union_all (a: 'T[]) (b: 'T[]) : 'T[] =
   Array.append a b`
 
@@ -256,24 +276,28 @@ let _extern_get (name: string) : obj =
 )
 
 var helperMap = map[string]string{
-	"_load":         helperLoad,
-	"_save":         helperSave,
-	"_run_test":     helperRunTest,
-	"_input":        helperInput,
-	"_fetch":        helperFetch,
-	"_fetch_json":   helperFetchTyped,
-	"_cast":         helperCast,
-	"_eval":         helperEval,
-	"_genText":      helperGenText,
-	"_genEmbed":     helperGenEmbed,
-	"_genStruct":    helperGenStruct,
-	"_json_helpers": helperToJson,
-	"_extern":       helperExtern,
-	"_union_all":    helperUnionAll,
-	"_union":        helperUnion,
-	"_except":       helperExcept,
-	"_intersect":    helperIntersect,
-	"_seq_helpers":  helperSeq,
-	"_Group":        helperGroup,
-	"_group_by":     helperGroupBy,
+	"_load":           helperLoad,
+	"_save":           helperSave,
+	"_run_test":       helperRunTest,
+	"_input":          helperInput,
+	"_fetch":          helperFetch,
+	"_fetch_json":     helperFetchTyped,
+	"_cast":           helperCast,
+	"_eval":           helperEval,
+	"_slice_string":   helperSliceString,
+	"_reverse_array":  helperReverseArray,
+	"_reverse_string": helperReverseString,
+	"_concat":         helperConcat,
+	"_genText":        helperGenText,
+	"_genEmbed":       helperGenEmbed,
+	"_genStruct":      helperGenStruct,
+	"_json_helpers":   helperToJson,
+	"_extern":         helperExtern,
+	"_union_all":      helperUnionAll,
+	"_union":          helperUnion,
+	"_except":         helperExcept,
+	"_intersect":      helperIntersect,
+	"_seq_helpers":    helperSeq,
+	"_Group":          helperGroup,
+	"_group_by":       helperGroupBy,
 }

--- a/compile/x/fs/tpcds_q1_test.go
+++ b/compile/x/fs/tpcds_q1_test.go
@@ -4,6 +4,7 @@ package fscode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +15,7 @@ import (
 	"mochi/types"
 )
 
-func TestFSCompiler_TPCDSQ1(t *testing.T) {
+func TestFSCompiler_TPCDS(t *testing.T) {
 	if err := fscode.EnsureDotnet(); err != nil {
 		t.Skipf("dotnet not installed: %v", err)
 	}
@@ -25,23 +26,28 @@ func TestFSCompiler_TPCDSQ1(t *testing.T) {
 		t.Skipf("fantomas not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	src := filepath.Join(root, "tests", "dataset", "tpc-ds", "q1.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := fscode.New(env).Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	wantCodePath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "fs", "q1.fs.out")
-	if want, err := os.ReadFile(wantCodePath); err == nil {
-		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
-			t.Errorf("generated code mismatch for q1.fs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(want))
-		}
+	for i := 1; i <= 9; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := fscode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCodePath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "fs", q+".fs.out")
+			if want, err := os.ReadFile(wantCodePath); err == nil {
+				if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+					t.Errorf("generated code mismatch for %s.fs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(want))
+				}
+			}
+		})
 	}
 }

--- a/tests/dataset/tpc-ds/compiler/fs/q2.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q2.fs.out
@@ -1,0 +1,139 @@
+open System
+
+let sold_date_sk = "sold_date_sk"
+let sales_price = "sales_price"
+let day = "day"
+let d_week_seq = "d_week_seq"
+let sun_sales = "sun_sales"
+let mon_sales = "mon_sales"
+let tue_sales = "tue_sales"
+let wed_sales = "wed_sales"
+let thu_sales = "thu_sales"
+let fri_sales = "fri_sales"
+let sat_sales = "sat_sales"
+let week_seq = "week_seq"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _union_all (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+
+let web_sales = [||]
+let catalog_sales = [||]
+let date_dim = [||]
+let wscs = _union_all (
+    [|
+    for ws in web_sales do
+        yield Map.ofList [(sold_date_sk, ws.ws_sold_date_sk); (sales_price, ws.ws_ext_sales_price); (day, ws.ws_sold_date_name)]
+    |]) (
+    [|
+    for cs in catalog_sales do
+        yield Map.ofList [(sold_date_sk, cs.cs_sold_date_sk); (sales_price, cs.cs_ext_sales_price); (day, cs.cs_sold_date_name)]
+    |])
+let wswscs = [| for g in _group_by [|
+    for w in wscs do
+        for d in date_dim do
+            if (w.sold_date_sk = d.d_date_sk) then
+                yield (w, d)
+|] (fun (w, d) -> Map.ofList [(week_seq, d.d_week_seq)]) do let g = g yield Map.ofList [(d_week_seq, g.key.week_seq); (sun_sales, sum 
+    [|
+    for x in g do
+        if (x.day = "Sunday") then
+            yield x.sales_price
+    |]); (mon_sales, sum 
+    [|
+    for x in g do
+        if (x.day = "Monday") then
+            yield x.sales_price
+    |]); (tue_sales, sum 
+    [|
+    for x in g do
+        if (x.day = "Tuesday") then
+            yield x.sales_price
+    |]); (wed_sales, sum 
+    [|
+    for x in g do
+        if (x.day = "Wednesday") then
+            yield x.sales_price
+    |]); (thu_sales, sum 
+    [|
+    for x in g do
+        if (x.day = "Thursday") then
+            yield x.sales_price
+    |]); (fri_sales, sum 
+    [|
+    for x in g do
+        if (x.day = "Friday") then
+            yield x.sales_price
+    |]); (sat_sales, sum 
+    [|
+    for x in g do
+        if (x.day = "Saturday") then
+            yield x.sales_price
+    |])] |]
+let result = [||]
+ignore (_json result)
+let test_TPCDS_Q2_empty() =
+    if not ((result.Length = 0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q2 empty" test_TPCDS_Q2_empty) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q3.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q3.fs.out
@@ -1,0 +1,95 @@
+open System
+
+let d_year = "d_year"
+let brand_id = "brand_id"
+let brand = "brand"
+let sum_agg = "sum_agg"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let date_dim = [||]
+let store_sales = [||]
+let item = [||]
+let result = [| for g in _group_by [|
+    for dt in date_dim do
+        for ss in store_sales do
+            if (dt.d_date_sk = ss.ss_sold_date_sk) then
+                for i in item do
+                    if (ss.ss_item_sk = i.i_item_sk) then
+                        if ((i.i_manufact_id = 100) && (dt.d_moy = 12)) then
+                            yield (dt, ss, i)
+|] (fun (dt, ss, i) -> Map.ofList [(d_year, dt.d_year); (brand_id, i.i_brand_id); (brand, i.i_brand)]) do let g = g yield ([|g.key.d_year; (-sum 
+    [|
+    for x in g do
+        yield x.ss.ss_ext_sales_price
+    |]); g.key.brand_id|], Map.ofList [(d_year, g.key.d_year); (brand_id, g.key.brand_id); (brand, g.key.brand); (sum_agg, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_ext_sales_price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q3_empty() =
+    if not ((result.Length = 0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q3 empty" test_TPCDS_Q3_empty) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q4.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q4.fs.out
@@ -1,0 +1,142 @@
+open System
+
+let customer_id = "customer_id"
+let customer_first_name = "customer_first_name"
+let customer_last_name = "customer_last_name"
+let customer_login = "customer_login"
+let dyear = "dyear"
+let year_total = "year_total"
+let sale_type = "sale_type"
+let id = "id"
+let first = "first"
+let last = "last"
+let login = "login"
+let year = "year"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _union_all (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+
+let customer = [||]
+let store_sales = [||]
+let catalog_sales = [||]
+let web_sales = [||]
+let date_dim = [||]
+let year_total = _union_all _union_all ([| for g in _group_by [|
+    for c in customer do
+        for s in store_sales do
+            if (c.c_customer_sk = s.ss_customer_sk) then
+                for d in date_dim do
+                    if (s.ss_sold_date_sk = d.d_date_sk) then
+                        yield (c, s, d)
+|] (fun (c, s, d) -> Map.ofList [(id, c.c_customer_id); (first, c.c_first_name); (last, c.c_last_name); (login, c.c_login); (year, d.d_year)]) do let g = g yield Map.ofList [(customer_id, g.key.id); (customer_first_name, g.key.first); (customer_last_name, g.key.last); (customer_login, g.key.login); (dyear, g.key.year); (year_total, sum 
+    [|
+    for x in g do
+        yield ((((((x.ss_ext_list_price - x.ss_ext_wholesale_cost) - x.ss_ext_discount_amt)) + x.ss_ext_sales_price)) / 2)
+    |]); (sale_type, "s")] |]) ([| for g in _group_by [|
+    for c in customer do
+        for cs in catalog_sales do
+            if (c.c_customer_sk = cs.cs_bill_customer_sk) then
+                for d in date_dim do
+                    if (cs.cs_sold_date_sk = d.d_date_sk) then
+                        yield (c, cs, d)
+|] (fun (c, cs, d) -> Map.ofList [(id, c.c_customer_id); (first, c.c_first_name); (last, c.c_last_name); (login, c.c_login); (year, d.d_year)]) do let g = g yield Map.ofList [(customer_id, g.key.id); (customer_first_name, g.key.first); (customer_last_name, g.key.last); (customer_login, g.key.login); (dyear, g.key.year); (year_total, sum 
+    [|
+    for x in g do
+        yield ((((((x.cs_ext_list_price - x.cs_ext_wholesale_cost) - x.cs_ext_discount_amt)) + x.cs_ext_sales_price)) / 2)
+    |]); (sale_type, "c")] |]) ([| for g in _group_by [|
+    for c in customer do
+        for ws in web_sales do
+            if (c.c_customer_sk = ws.ws_bill_customer_sk) then
+                for d in date_dim do
+                    if (ws.ws_sold_date_sk = d.d_date_sk) then
+                        yield (c, ws, d)
+|] (fun (c, ws, d) -> Map.ofList [(id, c.c_customer_id); (first, c.c_first_name); (last, c.c_last_name); (login, c.c_login); (year, d.d_year)]) do let g = g yield Map.ofList [(customer_id, g.key.id); (customer_first_name, g.key.first); (customer_last_name, g.key.last); (customer_login, g.key.login); (dyear, g.key.year); (year_total, sum 
+    [|
+    for x in g do
+        yield ((((((x.ws_ext_list_price - x.ws_ext_wholesale_cost) - x.ws_ext_discount_amt)) + x.ws_ext_sales_price)) / 2)
+    |]); (sale_type, "w")] |])
+let result = 
+    [|
+    for s1 in year_total do
+        for s2 in year_total do
+            if (s2.customer_id = s1.customer_id) then
+                for c1 in year_total do
+                    if (c1.customer_id = s1.customer_id) then
+                        for c2 in year_total do
+                            if (c2.customer_id = s1.customer_id) then
+                                for w1 in year_total do
+                                    if (w1.customer_id = s1.customer_id) then
+                                        for w2 in year_total do
+                                            if (w2.customer_id = s1.customer_id) then
+                                                if (((((((((((((((((s1.sale_type = "s") && (c1.sale_type = "c")) && (w1.sale_type = "w")) && (s2.sale_type = "s")) && (c2.sale_type = "c")) && (w2.sale_type = "w")) && (s1.dyear = 2001)) && (s2.dyear = 2002)) && (c1.dyear = 2001)) && (c2.dyear = 2002)) && (w1.dyear = 2001)) && (w2.dyear = 2002)) && (s1.year_total > 0)) && (c1.year_total > 0)) && (w1.year_total > 0)) && (((if (c1.year_total > 0) then (c2.year_total / c1.year_total) else null)) > ((if (s1.year_total > 0) then (s2.year_total / s1.year_total) else null)))) && (((if (c1.year_total > 0) then (c2.year_total / c1.year_total) else null)) > ((if (w1.year_total > 0) then (w2.year_total / w1.year_total) else null)))) then
+                                                    yield ([|s2.customer_id; s2.customer_first_name; s2.customer_last_name; s2.customer_login|], Map.ofList [(customer_id, s2.customer_id); (customer_first_name, s2.customer_first_name); (customer_last_name, s2.customer_last_name); (customer_login, s2.customer_login)])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q4_empty() =
+    if not ((result.Length = 0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q4 empty" test_TPCDS_Q4_empty) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q5.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q5.fs.out
@@ -1,0 +1,216 @@
+open System
+
+let channel = "channel"
+let id = "id"
+let sales = "sales"
+let returns = "returns"
+let profit = "profit"
+let profit_loss = "profit_loss"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _union_all (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+
+let store_sales = [||]
+let store_returns = [||]
+let store = [||]
+let catalog_sales = [||]
+let catalog_returns = [||]
+let catalog_page = [||]
+let web_sales = [||]
+let web_returns = [||]
+let web_site = [||]
+let date_dim = [||]
+let ss = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                for s in store do
+                    if (ss.ss_store_sk = s.s_store_sk) then
+                        if ((d.d_date >= "1998-12-01") && (d.d_date <= "1998-12-15")) then
+                            yield (ss, d, s)
+|] (fun (ss, d, s) -> s.s_store_id) do let g = g yield Map.ofList [(channel, "store channel"); (id, ("store" + (string g.key))); (sales, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_ext_sales_price
+    |]); (returns, 0.0); (profit, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_net_profit
+    |]); (profit_loss, 0.0)] |]
+let sr = [| for g in _group_by [|
+    for sr in store_returns do
+        for d in date_dim do
+            if (sr.sr_returned_date_sk = d.d_date_sk) then
+                for s in store do
+                    if (sr.sr_store_sk = s.s_store_sk) then
+                        if ((d.d_date >= "1998-12-01") && (d.d_date <= "1998-12-15")) then
+                            yield (sr, d, s)
+|] (fun (sr, d, s) -> s.s_store_id) do let g = g yield Map.ofList [(channel, "store channel"); (id, ("store" + (string g.key))); (sales, 0.0); (returns, sum 
+    [|
+    for x in g do
+        yield x.sr.sr_return_amt
+    |]); (profit, 0.0); (profit_loss, sum 
+    [|
+    for x in g do
+        yield x.sr.sr_net_loss
+    |])] |]
+let cs = [| for g in _group_by [|
+    for cs in catalog_sales do
+        for d in date_dim do
+            if (cs.cs_sold_date_sk = d.d_date_sk) then
+                for cp in catalog_page do
+                    if (cs.cs_catalog_page_sk = cp.cp_catalog_page_sk) then
+                        if ((d.d_date >= "1998-12-01") && (d.d_date <= "1998-12-15")) then
+                            yield (cs, d, cp)
+|] (fun (cs, d, cp) -> cp.cp_catalog_page_id) do let g = g yield Map.ofList [(channel, "catalog channel"); (id, ("catalog_page" + (string g.key))); (sales, sum 
+    [|
+    for x in g do
+        yield x.cs.cs_ext_sales_price
+    |]); (returns, 0.0); (profit, sum 
+    [|
+    for x in g do
+        yield x.cs.cs_net_profit
+    |]); (profit_loss, 0.0)] |]
+let cr = [| for g in _group_by [|
+    for cr in catalog_returns do
+        for d in date_dim do
+            if (cr.cr_returned_date_sk = d.d_date_sk) then
+                for cp in catalog_page do
+                    if (cr.cr_catalog_page_sk = cp.cp_catalog_page_sk) then
+                        if ((d.d_date >= "1998-12-01") && (d.d_date <= "1998-12-15")) then
+                            yield (cr, d, cp)
+|] (fun (cr, d, cp) -> cp.cp_catalog_page_id) do let g = g yield Map.ofList [(channel, "catalog channel"); (id, ("catalog_page" + (string g.key))); (sales, 0.0); (returns, sum 
+    [|
+    for x in g do
+        yield x.cr.cr_return_amount
+    |]); (profit, 0.0); (profit_loss, sum 
+    [|
+    for x in g do
+        yield x.cr.cr_net_loss
+    |])] |]
+let ws = [| for g in _group_by [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (ws.ws_sold_date_sk = d.d_date_sk) then
+                for w in web_site do
+                    if (ws.ws_web_site_sk = w.web_site_sk) then
+                        if ((d.d_date >= "1998-12-01") && (d.d_date <= "1998-12-15")) then
+                            yield (ws, d, w)
+|] (fun (ws, d, w) -> w.web_site_id) do let g = g yield Map.ofList [(channel, "web channel"); (id, ("web_site" + (string g.key))); (sales, sum 
+    [|
+    for x in g do
+        yield x.ws.ws_ext_sales_price
+    |]); (returns, 0.0); (profit, sum 
+    [|
+    for x in g do
+        yield x.ws.ws_net_profit
+    |]); (profit_loss, 0.0)] |]
+let wr = [| for g in _group_by [|
+    for wr in web_returns do
+        for ws in web_sales do
+            if ((wr.wr_item_sk = ws.ws_item_sk) && (wr.wr_order_number = ws.ws_order_number)) then
+                for d in date_dim do
+                    if (wr.wr_returned_date_sk = d.d_date_sk) then
+                        for w in web_site do
+                            if (ws.ws_web_site_sk = w.web_site_sk) then
+                                if ((d.d_date >= "1998-12-01") && (d.d_date <= "1998-12-15")) then
+                                    yield (wr, ws, d, w)
+|] (fun (wr, ws, d, w) -> w.web_site_id) do let g = g yield Map.ofList [(channel, "web channel"); (id, ("web_site" + (string g.key))); (sales, 0.0); (returns, sum 
+    [|
+    for x in g do
+        yield x.wr.wr_return_amt
+    |]); (profit, 0.0); (profit_loss, sum 
+    [|
+    for x in g do
+        yield x.wr.wr_net_loss
+    |])] |]
+let per_channel = _concat _concat _union_all ss sr _union_all cs cr _union_all ws wr
+let result = [| for g in _group_by [|
+    for p in per_channel do
+        yield p
+|] (fun p -> Map.ofList [(channel, p.channel); (id, p.id)]) do let g = g yield (g.key.channel, Map.ofList [(channel, g.key.channel); (id, g.key.id); (sales, sum 
+    [|
+    for x in g do
+        yield x.p.sales
+    |]); (returns, sum 
+    [|
+    for x in g do
+        yield x.p.returns
+    |]); (profit, (sum 
+    [|
+    for x in g do
+        yield x.p.profit
+    |] - sum 
+    [|
+    for x in g do
+        yield x.p.profit_loss
+    |]))]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q5_empty() =
+    if not ((result.Length = 0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q5 empty" test_TPCDS_Q5_empty) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q6.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q6.fs.out
@@ -1,0 +1,102 @@
+open System
+
+let state = "state"
+let cnt = "cnt"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let customer_address = [||]
+let customer = [||]
+let store_sales = [||]
+let date_dim = [||]
+let item = [||]
+let target_month_seq = _max 
+    [|
+    for d in date_dim do
+        if ((d.d_year = 1999) && (d.d_moy = 5)) then
+            yield d.d_month_seq
+    |]
+let result = [| for g in _group_by [|
+    for a in customer_address do
+        for c in customer do
+            if (a.ca_address_sk = c.c_current_addr_sk) then
+                for s in store_sales do
+                    if (c.c_customer_sk = s.ss_customer_sk) then
+                        for d in date_dim do
+                            if (s.ss_sold_date_sk = d.d_date_sk) then
+                                for i in item do
+                                    if (s.ss_item_sk = i.i_item_sk) then
+                                        if ((d.d_month_seq = target_month_seq) && (i.i_current_price > (1.2 * avg 
+    [|
+    for j in item do
+        if (j.i_category = i.i_category) then
+            yield j.i_current_price
+    |]))) then
+                                            yield (a, c, s, d, i)
+|] (fun (a, c, s, d, i) -> a.ca_state) do let g = g if (count g >= 10) then yield ([|count g; g.key|], Map.ofList [(state, g.key); (cnt, count g)]) |] |> Array.sortBy fst |> Array.map snd |> Array.take 100
+ignore (_json result)
+let test_TPCDS_Q6_empty() =
+    if not ((result.Length = 0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q6 empty" test_TPCDS_Q6_empty) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q7.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q7.fs.out
@@ -1,0 +1,110 @@
+open System
+
+let i_item_id = "i_item_id"
+let agg1 = "agg1"
+let agg2 = "agg2"
+let agg3 = "agg3"
+let agg4 = "agg4"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [||]
+let customer_demographics = [||]
+let date_dim = [||]
+let item = [||]
+let promotion = [||]
+let result = [| for g in _group_by [|
+    for ss in store_sales do
+        for cd in customer_demographics do
+            if (ss.ss_cdemo_sk = cd.cd_demo_sk) then
+                for d in date_dim do
+                    if (ss.ss_sold_date_sk = d.d_date_sk) then
+                        for i in item do
+                            if (ss.ss_item_sk = i.i_item_sk) then
+                                for p in promotion do
+                                    if (ss.ss_promo_sk = p.p_promo_sk) then
+                                        if (((((cd.cd_gender = "M") && (cd.cd_marital_status = "S")) && (cd.cd_education_status = "College")) && (((p.p_channel_email = "N") || (p.p_channel_event = "N")))) && (d.d_year = 1998)) then
+                                            yield (ss, cd, d, i, p)
+|] (fun (ss, cd, d, i, p) -> Map.ofList [(i_item_id, i.i_item_id)]) do let g = g yield (g.key.i_item_id, Map.ofList [(i_item_id, g.key.i_item_id); (agg1, avg 
+    [|
+    for x in g do
+        yield x.ss.ss_quantity
+    |]); (agg2, avg 
+    [|
+    for x in g do
+        yield x.ss.ss_list_price
+    |]); (agg3, avg 
+    [|
+    for x in g do
+        yield x.ss.ss_coupon_amt
+    |]); (agg4, avg 
+    [|
+    for x in g do
+        yield x.ss.ss_sales_price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q7_empty() =
+    if not ((result.Length = 0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q7 empty" test_TPCDS_Q7_empty) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q8.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q8.fs.out
@@ -1,0 +1,81 @@
+open System
+
+let rec _to_json (v: obj) : string =
+    match v with
+    | null -> "null"
+    | :? string as s -> "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+    | :? bool
+    | :? int
+    | :? int64
+    | :? double -> string v
+    | :? System.Collections.Generic.IDictionary<string, obj> as m ->
+        m
+        |> Seq.map (fun (KeyValue(k, v)) -> "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+        |> String.concat ","
+        |> fun s -> "{" + s + "}"
+    | :? System.Collections.IEnumerable as e ->
+        e
+        |> Seq.cast<obj>
+        |> Seq.map _to_json
+        |> String.concat ","
+        |> fun s -> "[" + s + "]"
+    | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+let _json (v: obj) : unit = printfn "%s" (_to_json v)
+
+let _reverse_string (s: string) : string =
+    s.ToCharArray() |> Array.rev |> System.String
+
+let _run_test (name: string) (f: unit -> unit) : bool =
+    printf "%s ... " name
+
+    try
+        f ()
+        printfn "PASS"
+        true
+    with e ->
+        printfn "FAIL (%s)" e.Message
+        false
+
+let _slice_string (s: string) (i: int) (j: int) : string =
+    let mutable start = i
+    let mutable stop = j
+    let n = s.Length
+
+    if start < 0 then
+        start <- start + n
+
+    if stop < 0 then
+        stop <- stop + n
+
+    if start < 0 then
+        start <- 0
+
+    if stop > n then
+        stop <- n
+
+    if stop < start then
+        stop <- start
+
+    s.Substring(start, stop - start)
+
+let store_sales = [||]
+let date_dim = [||]
+let store = [||]
+let customer_address = [||]
+let customer = [||]
+ignore (_reverse_string _slice_string "zip" 0 2)
+let result = [||]
+ignore (_json result)
+
+let test_TPCDS_Q8_empty () =
+    if not ((result.Length = 0)) then
+        failwith "expect failed"
+
+let mutable failures = 0
+
+if not (_run_test "TPCDS Q8 empty" test_TPCDS_Q8_empty) then
+    failures <- failures + 1
+
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q9.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q9.fs.out
@@ -1,0 +1,146 @@
+open System
+
+let bucket1 = "bucket1"
+let bucket2 = "bucket2"
+let bucket3 = "bucket3"
+let bucket4 = "bucket4"
+let bucket5 = "bucket5"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [||]
+let reason = [||]
+let bucket1 = (if (count 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 1) && (s.ss_quantity <= 20)) then
+            yield s
+    |] > 10) then avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 1) && (s.ss_quantity <= 20)) then
+            yield s.ss_ext_discount_amt
+    |] else avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 1) && (s.ss_quantity <= 20)) then
+            yield s.ss_net_paid
+    |])
+let bucket2 = (if (count 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 21) && (s.ss_quantity <= 40)) then
+            yield s
+    |] > 20) then avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 21) && (s.ss_quantity <= 40)) then
+            yield s.ss_ext_discount_amt
+    |] else avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 21) && (s.ss_quantity <= 40)) then
+            yield s.ss_net_paid
+    |])
+let bucket3 = (if (count 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 41) && (s.ss_quantity <= 60)) then
+            yield s
+    |] > 30) then avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 41) && (s.ss_quantity <= 60)) then
+            yield s.ss_ext_discount_amt
+    |] else avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 41) && (s.ss_quantity <= 60)) then
+            yield s.ss_net_paid
+    |])
+let bucket4 = (if (count 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 61) && (s.ss_quantity <= 80)) then
+            yield s
+    |] > 40) then avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 61) && (s.ss_quantity <= 80)) then
+            yield s.ss_ext_discount_amt
+    |] else avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 61) && (s.ss_quantity <= 80)) then
+            yield s.ss_net_paid
+    |])
+let bucket5 = (if (count 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 81) && (s.ss_quantity <= 100)) then
+            yield s
+    |] > 50) then avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 81) && (s.ss_quantity <= 100)) then
+            yield s.ss_ext_discount_amt
+    |] else avg 
+    [|
+    for s in store_sales do
+        if ((s.ss_quantity >= 81) && (s.ss_quantity <= 100)) then
+            yield s.ss_net_paid
+    |])
+let result = 
+    [|
+    for r in reason do
+        if (r.r_reason_sk = 1) then
+            yield Map.ofList [(bucket1, bucket1); (bucket2, bucket2); (bucket3, bucket3); (bucket4, bucket4); (bucket5, bucket5)]
+    |]
+ignore (_json result)
+let test_TPCDS_Q9_empty() =
+    if not ((result.Length = 0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q9 empty" test_TPCDS_Q9_empty) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures


### PR DESCRIPTION
## Summary
- implement `substr`, `reverse` and `concat` builtins in F# backend
- add support for `null` literals and `if` expressions
- handle `having` in query expressions
- provide runtime helpers for new builtins
- extend TPC‑DS test to compile queries q1–q9
- add formatted F# outputs for queries q1–q9

## Testing
- `go test ./compile/x/fs -run TestFSCompiler_TPCDS -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6863871a327c8320990056775a1a97fb