### PR TITLE
Improve Pascal compiler features

### DIFF
--- a/compile/x/pas/README.md
+++ b/compile/x/pas/README.md
@@ -146,6 +146,8 @@ constructs:
 - Function definitions and calls
  - List and map literals with indexing and slicing
  - Dataset helpers `fetch`, `load` and `save`
+ - List set operations using `union all`
+ - Built-in string helpers `substr` and `reverse`
  - Dataset queries with `from`/`where`/`select`, joins, sorting and pagination
  - Simple `group by` queries without filters or joins
 - Package declarations and importing of local packages

--- a/compile/x/pas/TASKS.md
+++ b/compile/x/pas/TASKS.md
@@ -9,6 +9,12 @@ Work is ongoing to extend coverage to further TPCH queries and to improve
 runtime error handling. Query `q2` currently fails to compile due to missing
 support for complex record field accesses.
 
+## TPCDS dataset
+
+Queries `q1` through `q9` from the TPCDS suite now compile. The generated
+sources are stored under `tests/dataset/tpc-ds/compiler/pas` and executed as
+part of the slow test suite when `fpc` is available.
+
 ## JOB dataset
 
 The JOB benchmark programs up to `q10.mochi` now compile and the generated


### PR DESCRIPTION
## Summary
- add Pascal helper functions for `substr` and `reverse`
- support the `union_all` list operation
- document new abilities in README and TASKS

## Testing
- `go test ./compile/x/pas -run TPCH -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68639b3e9468832083b49795755c93b0