### PR TITLE
Mark compiler tests as slow

### DIFF
--- a/compile/x/c/cosmo_test.go
+++ b/compile/x/c/cosmo_test.go
@@ -1,4 +1,4 @@
-//go:build cosmo && libcosmo
+//go:build cosmo && libcosmo && slow
 
 package ccode_test
 

--- a/compile/x/c/tpch_golden_test.go
+++ b/compile/x/c/tpch_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode_test
 
 import (

--- a/compile/x/ex/tpcds_test.go
+++ b/compile/x/ex/tpcds_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package excode_test
 
 import (

--- a/compile/x/php/leetcode_test.go
+++ b/compile/x/php/leetcode_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode_test
 
 import (

--- a/compile/x/php/tpcds_test.go
+++ b/compile/x/php/tpcds_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode_test
 
 import (

--- a/compile/x/rkt/tpcds_golden_test.go
+++ b/compile/x/rkt/tpcds_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rktcode_test
 
 import (

--- a/compile/x/swift/job_test.go
+++ b/compile/x/swift/job_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swiftcode_test
 
 import (

--- a/compile/x/swift/leetcode_test.go
+++ b/compile/x/swift/leetcode_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swiftcode_test
 
 import (


### PR DESCRIPTION
## Summary
- ensure that all compiler tests require the `slow` build tag

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6863bc4cab708320a44dab3ea2cc2f85