### PR TITLE
Extend Smalltalk backend for TPC‑DS queries

### DIFF
--- a/compile/x/st/tpcds_golden_test.go
+++ b/compile/x/st/tpcds_golden_test.go
@@ -4,6 +4,7 @@ package stcode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,28 +17,30 @@ import (
 
 func TestSTCompiler_TPCDS_Golden(t *testing.T) {
 	root := testutil.FindRepoRoot(t)
-	q := "q1"
-	t.Run(q, func(t *testing.T) {
-		src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
-		prog, err := parser.Parse(src)
-		if err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			t.Fatalf("type error: %v", errs[0])
-		}
-		code, err := stcode.New(env).Compile(prog)
-		if err != nil {
-			t.Fatalf("compile error: %v", err)
-		}
-		wantPath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "st", q+".st.out")
-		want, err := os.ReadFile(wantPath)
-		if err != nil {
-			t.Fatalf("read golden: %v", err)
-		}
-		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
-			t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".st.out", got, bytes.TrimSpace(want))
-		}
-	})
+	for i := 1; i <= 9; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := stcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantPath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "st", q+".st.out")
+			want, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".st.out", got, bytes.TrimSpace(want))
+			}
+		})
+	}
 }

--- a/tests/dataset/tpc-ds/compiler/st/q1.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q1.st.out
@@ -8,86 +8,86 @@ Smalltalk at: #store_returns put: nil.
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
-test_TPCDS_Q1_empty
-    (((result) size = 0)) ifFalse: [ self error: 'expect failed' ]
+test_TPCDS_Q1_result
+	((result = Array with: (Dictionary from: {'c_customer_id' -> 'C2'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !_Group class methodsFor: 'instance creation'!
 key: k | g |
-    g := self new.
-    g key: k.
-    g initialize.
-    ^ g
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
 !
 !_Group methodsFor: 'initialization'!
 initialize
-    items := OrderedCollection new.
-    ^ self
+	items := OrderedCollection new.
+	^ self
 !
 !_Group methodsFor: 'accessing'!
 key
-    ^ key
+	^ key
 !
 key: k
-    key := k
+	key := k
 !
 add: it
-    items add: it
+	items add: it
 !
 do: blk
-    items do: blk
+	items do: blk
 !
 size
-    ^ items size
+	^ items size
 !
 !Main class methodsFor: 'runtime'!
 __avg: v
-    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
-    v size = 0 ifTrue: [ ^ 0 ]
-    | sum |
-    sum := 0.
-    v do: [:it | sum := sum + it].
-    ^ sum / v size
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+	v size = 0 ifTrue: [ ^ 0 ]
+	| sum |
+	sum := 0.
+	v do: [:it | sum := sum + it].
+	^ sum / v size
 !
 __sum: v
-    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
-    | s |
-    s := 0.
-    v do: [:it | s := s + it].
-    ^ s
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
 !
 _group_by: src keyFn: blk
-    | groups order |
-    groups := Dictionary new.
-    order := OrderedCollection new.
-    src do: [:it |
-        | key ks g |
-        key := blk value: it.
-        ks := key printString.
-        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
-        g add: it.
-    ]
-    ^ order collect: [:k | groups at: k ]
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
 !
 !!
-store_returns := Array new.
-date_dim := Array new.
-store := Array new.
-customer := Array new.
+store_returns := Array with: (Dictionary from: {'sr_returned_date_sk' -> 1. 'sr_customer_sk' -> 1. 'sr_store_sk' -> 10. 'sr_return_amt' -> 20.000000}) with: (Dictionary from: {'sr_returned_date_sk' -> 1. 'sr_customer_sk' -> 2. 'sr_store_sk' -> 10. 'sr_return_amt' -> 50.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1998}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 10. 's_state' -> 'TN'}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_customer_id' -> 'C1'}) with: (Dictionary from: {'c_customer_sk' -> 2. 'c_customer_id' -> 'C2'}).
 customer_total_return := ((| rows groups |
 rows := OrderedCollection new.
 (store_returns) do: [:sr |
-    ((d at: 'd_year' = 1998)) ifTrue: [ rows add: sr ].
+	rows add: sr.
 ]
 groups := (Main _group_by: rows keyFn: [:sr | Dictionary from: {'customer_sk' -> sr at: 'sr_customer_sk'. 'store_sk' -> sr at: 'sr_store_sk'}]).
 rows := OrderedCollection new.
 (groups) do: [:g |
-    rows add: Dictionary from: {'ctr_customer_sk' -> g at: 'key' at: 'customer_sk'. 'ctr_store_sk' -> g at: 'key' at: 'store_sk'. 'ctr_total_return' -> (Main __sum: ((| res |
+	rows add: Dictionary from: {'ctr_customer_sk' -> g at: 'key' at: 'customer_sk'. 'ctr_store_sk' -> g at: 'key' at: 'store_sk'. 'ctr_total_return' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-    res add: x at: 'sr_return_amt'.
+	res add: x at: 'sr_return_amt'.
 ]
 res := res asArray.
 res)))}.
@@ -99,19 +99,19 @@ res := OrderedCollection new.
 ((customer_total_return) select: [:ctr1 | ((((((ctr1 at: 'ctr_total_return' > (Main __avg: ((| res |
 res := OrderedCollection new.
 ((customer_total_return) select: [:ctr2 | (ctr1 at: 'ctr_store_sk' = ctr2 at: 'ctr_store_sk')]) do: [:ctr2 |
-    res add: ctr2 at: 'ctr_total_return'.
+	res add: ctr2 at: 'ctr_total_return'.
 ]
 res := res asArray.
 res)))) * 1.200000) and: [s at: 's_state']) = 'TN') and: [(ctr1 at: 'ctr_store_sk' = s at: 's_store_sk')]) and: [(ctr1 at: 'ctr_customer_sk' = c at: 'c_customer_sk')])]) do: [:ctr1 |
-    (store) do: [:s |
-        (customer) do: [:c |
-            res add: { c at: 'c_customer_id' . Dictionary from: {'c_customer_id' -> c at: 'c_customer_id'} }.
-        ]
-    ]
+	(store) do: [:s |
+		(customer) do: [:c |
+			res add: { c at: 'c_customer_id' . Dictionary from: {'c_customer_id' -> c at: 'c_customer_id'} }.
+		]
+	]
 ]
 res := res asArray.
 res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
 res := res collect: [:p | p second].
 res)).
 (result toJSON) displayOn: Transcript. Transcript cr.
-Main test_TPCDS_Q1_empty.
+Main test_TPCDS_Q1_result.

--- a/tests/dataset/tpc-ds/compiler/st/q2.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q2.st.out
@@ -1,0 +1,170 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #wscs put: nil.
+Smalltalk at: #wswscs put: nil.
+Smalltalk at: #year1 put: nil.
+Smalltalk at: #year2 put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q2_result
+	((result = Array with: (Dictionary from: {'d_week_seq1' -> 1. 'sun_ratio' -> 0.500000. 'mon_ratio' -> 0.500000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__union_all: a with: b
+	| out |
+	out := OrderedCollection new.
+	a ifNotNil: [ a do: [:v | out add: v ] ].
+	b ifNotNil: [ b do: [:v | out add: v ] ].
+	^ out asArray
+!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+web_sales := Array with: (Dictionary from: {'ws_sold_date_sk' -> 1. 'ws_ext_sales_price' -> 5.000000. 'ws_sold_date_name' -> 'Sunday'}) with: (Dictionary from: {'ws_sold_date_sk' -> 2. 'ws_ext_sales_price' -> 5.000000. 'ws_sold_date_name' -> 'Monday'}) with: (Dictionary from: {'ws_sold_date_sk' -> 8. 'ws_ext_sales_price' -> 10.000000. 'ws_sold_date_name' -> 'Sunday'}) with: (Dictionary from: {'ws_sold_date_sk' -> 9. 'ws_ext_sales_price' -> 10.000000. 'ws_sold_date_name' -> 'Monday'}).
+catalog_sales := Array with: (Dictionary from: {'cs_sold_date_sk' -> 1. 'cs_ext_sales_price' -> 5.000000. 'cs_sold_date_name' -> 'Sunday'}) with: (Dictionary from: {'cs_sold_date_sk' -> 2. 'cs_ext_sales_price' -> 5.000000. 'cs_sold_date_name' -> 'Monday'}) with: (Dictionary from: {'cs_sold_date_sk' -> 8. 'cs_ext_sales_price' -> 10.000000. 'cs_sold_date_name' -> 'Sunday'}) with: (Dictionary from: {'cs_sold_date_sk' -> 9. 'cs_ext_sales_price' -> 10.000000. 'cs_sold_date_name' -> 'Monday'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_week_seq' -> 1. 'd_day_name' -> 'Sunday'. 'd_year' -> 1998}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_week_seq' -> 1. 'd_day_name' -> 'Monday'. 'd_year' -> 1998}) with: (Dictionary from: {'d_date_sk' -> 8. 'd_week_seq' -> 54. 'd_day_name' -> 'Sunday'. 'd_year' -> 1999}) with: (Dictionary from: {'d_date_sk' -> 9. 'd_week_seq' -> 54. 'd_day_name' -> 'Monday'. 'd_year' -> 1999}).
+wscs := (Main __union_all: ((((| res |
+res := OrderedCollection new.
+(web_sales) do: [:ws |
+	res add: Dictionary from: {'sold_date_sk' -> ws at: 'ws_sold_date_sk'. 'sales_price' -> ws at: 'ws_ext_sales_price'. 'day' -> ws at: 'ws_sold_date_name'}.
+]
+res := res asArray.
+res)))) with: ((((| res |
+res := OrderedCollection new.
+(catalog_sales) do: [:cs |
+	res add: Dictionary from: {'sold_date_sk' -> cs at: 'cs_sold_date_sk'. 'sales_price' -> cs at: 'cs_ext_sales_price'. 'day' -> cs at: 'cs_sold_date_name'}.
+]
+res := res asArray.
+res))))).
+wswscs := ((| rows groups |
+rows := OrderedCollection new.
+(wscs) do: [:w |
+	rows add: w.
+]
+groups := (Main _group_by: rows keyFn: [:w | Dictionary from: {'week_seq' -> d at: 'd_week_seq'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'d_week_seq' -> g at: 'key' at: 'week_seq'. 'sun_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'day' = 'Sunday')]) do: [:x |
+	res add: x at: 'sales_price'.
+]
+res := res asArray.
+res))). 'mon_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'day' = 'Monday')]) do: [:x |
+	res add: x at: 'sales_price'.
+]
+res := res asArray.
+res))). 'tue_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'day' = 'Tuesday')]) do: [:x |
+	res add: x at: 'sales_price'.
+]
+res := res asArray.
+res))). 'wed_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'day' = 'Wednesday')]) do: [:x |
+	res add: x at: 'sales_price'.
+]
+res := res asArray.
+res))). 'thu_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'day' = 'Thursday')]) do: [:x |
+	res add: x at: 'sales_price'.
+]
+res := res asArray.
+res))). 'fri_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'day' = 'Friday')]) do: [:x |
+	res add: x at: 'sales_price'.
+]
+res := res asArray.
+res))). 'sat_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'day' = 'Saturday')]) do: [:x |
+	res add: x at: 'sales_price'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+year1 := ((| res |
+res := OrderedCollection new.
+((wswscs) select: [:w | (w at: 'd_week_seq' = 1)]) do: [:w |
+	res add: w.
+]
+res := res asArray.
+res)).
+year2 := ((| res |
+res := OrderedCollection new.
+((wswscs) select: [:w | (w at: 'd_week_seq' = 54)]) do: [:w |
+	res add: w.
+]
+res := res asArray.
+res)).
+result := ((| res |
+res := OrderedCollection new.
+((year1) select: [:y | ((y at: 'd_week_seq' = z at: 'd_week_seq') - 53)]) do: [:y |
+	(year2) do: [:z |
+		res add: Dictionary from: {'d_week_seq1' -> y at: 'd_week_seq'. 'sun_ratio' -> (y at: 'sun_sales' / z at: 'sun_sales'). 'mon_ratio' -> (y at: 'mon_sales' / z at: 'mon_sales')}.
+	]
+]
+res := res asArray.
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q2_result.

--- a/tests/dataset/tpc-ds/compiler/st/q3.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q3.st.out
@@ -1,0 +1,51 @@
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q3_result
+	((result = Array with: (Dictionary from: {'d_year' -> 1998. 'brand_id' -> 1. 'brand' -> 'Brand1'. 'sum_agg' -> 10.000000}) with: (Dictionary from: {'d_year' -> 1998. 'brand_id' -> 2. 'brand' -> 'Brand2'. 'sum_agg' -> 20.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1998. 'd_moy' -> 12}).
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1. 'ss_ext_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 2. 'ss_ext_sales_price' -> 20.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_manufact_id' -> 100. 'i_brand_id' -> 1. 'i_brand' -> 'Brand1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_manufact_id' -> 100. 'i_brand_id' -> 2. 'i_brand' -> 'Brand2'}).
+result := ((| res |
+res := OrderedCollection new.
+((date_dim) select: [:dt | (((((i at: 'i_manufact_id' = 100) and: [dt at: 'd_moy']) = 12) and: [(dt at: 'd_date_sk' = ss at: 'ss_sold_date_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')])]) do: [:dt |
+	(store_sales) do: [:ss |
+		(item) do: [:i |
+			res add: { Array with: (g at: 'key' at: 'd_year') with: (((Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res))) negated)) with: (g at: 'key' at: 'brand_id') . Dictionary from: {'d_year' -> g at: 'key' at: 'd_year'. 'brand_id' -> g at: 'key' at: 'brand_id'. 'brand' -> g at: 'key' at: 'brand'. 'sum_agg' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res)))} }.
+		]
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q3_result.

--- a/tests/dataset/tpc-ds/compiler/st/q4.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q4.st.out
@@ -1,0 +1,152 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #year_total put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q4_result
+	((result = Array with: (Dictionary from: {'customer_id' -> 'C1'. 'customer_first_name' -> 'Alice'. 'customer_last_name' -> 'A'. 'customer_login' -> 'alice'}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__union_all: a with: b
+	| out |
+	out := OrderedCollection new.
+	a ifNotNil: [ a do: [:v | out add: v ] ].
+	b ifNotNil: [ b do: [:v | out add: v ] ].
+	^ out asArray
+!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_customer_id' -> 'C1'. 'c_first_name' -> 'Alice'. 'c_last_name' -> 'A'. 'c_login' -> 'alice'}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_ext_list_price' -> 10.000000. 'ss_ext_wholesale_cost' -> 5.000000. 'ss_ext_discount_amt' -> 0.000000. 'ss_ext_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 2. 'ss_ext_list_price' -> 20.000000. 'ss_ext_wholesale_cost' -> 5.000000. 'ss_ext_discount_amt' -> 0.000000. 'ss_ext_sales_price' -> 20.000000}).
+catalog_sales := Array with: (Dictionary from: {'cs_bill_customer_sk' -> 1. 'cs_sold_date_sk' -> 1. 'cs_ext_list_price' -> 10.000000. 'cs_ext_wholesale_cost' -> 2.000000. 'cs_ext_discount_amt' -> 0.000000. 'cs_ext_sales_price' -> 10.000000}) with: (Dictionary from: {'cs_bill_customer_sk' -> 1. 'cs_sold_date_sk' -> 2. 'cs_ext_list_price' -> 30.000000. 'cs_ext_wholesale_cost' -> 2.000000. 'cs_ext_discount_amt' -> 0.000000. 'cs_ext_sales_price' -> 30.000000}).
+web_sales := Array with: (Dictionary from: {'ws_bill_customer_sk' -> 1. 'ws_sold_date_sk' -> 1. 'ws_ext_list_price' -> 10.000000. 'ws_ext_wholesale_cost' -> 5.000000. 'ws_ext_discount_amt' -> 0.000000. 'ws_ext_sales_price' -> 10.000000}) with: (Dictionary from: {'ws_bill_customer_sk' -> 1. 'ws_sold_date_sk' -> 2. 'ws_ext_list_price' -> 12.000000. 'ws_ext_wholesale_cost' -> 5.000000. 'ws_ext_discount_amt' -> 0.000000. 'ws_ext_sales_price' -> 12.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2001}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_year' -> 2002}).
+year_total := (Main __union_all: ((Main __union_all: ((((| rows groups |
+rows := OrderedCollection new.
+(customer) do: [:c |
+	rows add: c.
+]
+groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'login' -> c at: 'c_login'. 'year' -> d at: 'd_year'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: ((((((x at: 'ss_ext_list_price' - x at: 'ss_ext_wholesale_cost') - x at: 'ss_ext_discount_amt')) + x at: 'ss_ext_sales_price')) / 2).
+]
+res := res asArray.
+res))). 'sale_type' -> 's'}.
+]
+rows := rows asArray.
+rows)))) with: ((((| rows groups |
+rows := OrderedCollection new.
+(customer) do: [:c |
+	rows add: c.
+]
+groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'login' -> c at: 'c_login'. 'year' -> d at: 'd_year'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: ((((((x at: 'cs_ext_list_price' - x at: 'cs_ext_wholesale_cost') - x at: 'cs_ext_discount_amt')) + x at: 'cs_ext_sales_price')) / 2).
+]
+res := res asArray.
+res))). 'sale_type' -> 'c'}.
+]
+rows := rows asArray.
+rows)))))) with: ((((| rows groups |
+rows := OrderedCollection new.
+(customer) do: [:c |
+	rows add: c.
+]
+groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'login' -> c at: 'c_login'. 'year' -> d at: 'd_year'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: ((((((x at: 'ws_ext_list_price' - x at: 'ws_ext_wholesale_cost') - x at: 'ws_ext_discount_amt')) + x at: 'ws_ext_sales_price')) / 2).
+]
+res := res asArray.
+res))). 'sale_type' -> 'w'}.
+]
+rows := rows asArray.
+rows))))).
+result := ((| res |
+res := OrderedCollection new.
+((year_total) select: [:s1 | ((((((((((((((((((((((((((((((((((((((s1 at: 'sale_type' = 's') and: [c1 at: 'sale_type']) = 'c') and: [w1 at: 'sale_type']) = 'w') and: [s2 at: 'sale_type']) = 's') and: [c2 at: 'sale_type']) = 'c') and: [w2 at: 'sale_type']) = 'w') and: [s1 at: 'dyear']) = 2001) and: [s2 at: 'dyear']) = 2002) and: [c1 at: 'dyear']) = 2001) and: [c2 at: 'dyear']) = 2002) and: [w1 at: 'dyear']) = 2001) and: [w2 at: 'dyear']) = 2002) and: [s1 at: 'year_total']) > 0) and: [c1 at: 'year_total']) > 0) and: [w1 at: 'year_total']) > 0) and: [((((c1 at: 'year_total' > 0)) ifTrue: [(c2 at: 'year_total' / c1 at: 'year_total')] ifFalse: [nil]))]) > ((((s1 at: 'year_total' > 0)) ifTrue: [(s2 at: 'year_total' / s1 at: 'year_total')] ifFalse: [nil]))) and: [((((c1 at: 'year_total' > 0)) ifTrue: [(c2 at: 'year_total' / c1 at: 'year_total')] ifFalse: [nil]))]) > ((((w1 at: 'year_total' > 0)) ifTrue: [(w2 at: 'year_total' / w1 at: 'year_total')] ifFalse: [nil]))) and: [(s2 at: 'customer_id' = s1 at: 'customer_id')]) and: [(c1 at: 'customer_id' = s1 at: 'customer_id')]) and: [(c2 at: 'customer_id' = s1 at: 'customer_id')]) and: [(w1 at: 'customer_id' = s1 at: 'customer_id')]) and: [(w2 at: 'customer_id' = s1 at: 'customer_id')])]) do: [:s1 |
+	(year_total) do: [:s2 |
+		(year_total) do: [:c1 |
+			(year_total) do: [:c2 |
+				(year_total) do: [:w1 |
+					(year_total) do: [:w2 |
+						res add: { Array with: (s2 at: 'customer_id') with: (s2 at: 'customer_first_name') with: (s2 at: 'customer_last_name') with: (s2 at: 'customer_login') . Dictionary from: {'customer_id' -> s2 at: 'customer_id'. 'customer_first_name' -> s2 at: 'customer_first_name'. 'customer_last_name' -> s2 at: 'customer_last_name'. 'customer_login' -> s2 at: 'customer_login'} }.
+					]
+				]
+			]
+		]
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q4_result.

--- a/tests/dataset/tpc-ds/compiler/st/q5.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q5.st.out
@@ -1,0 +1,13 @@
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q5_result
+	(((result) size = 3)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+result := Array with: (Dictionary from: {'channel' -> 'catalog channel'. 'id' -> 'catalog_page100'. 'sales' -> 30.000000. 'returns' -> 3.000000. 'profit' -> 8.000000}) with: (Dictionary from: {'channel' -> 'store channel'. 'id' -> 'store10'. 'sales' -> 20.000000. 'returns' -> 2.000000. 'profit' -> 4.000000}) with: (Dictionary from: {'channel' -> 'web channel'. 'id' -> 'web_site200'. 'sales' -> 40.000000. 'returns' -> 4.000000. 'profit' -> 10.000000}).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q5_result.

--- a/tests/dataset/tpc-ds/compiler/st/q6.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q6.st.out
@@ -1,0 +1,82 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #target_month_seq put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q6_result
+	((result = Array with: (Dictionary from: {'state' -> 'CA'. 'cnt' -> 10}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+__avg: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+	v size = 0 ifTrue: [ ^ 0 ]
+	| sum |
+	sum := 0.
+	v do: [:it | sum := sum + it].
+	^ sum / v size
+!
+__max: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'max() expects collection' ]
+	| m first |
+	first := true.
+	v do: [:it | first ifTrue: [ m := it. first := false ] ifFalse: [ (it > m) ifTrue: [ m := it ] ] ].
+	^ first ifTrue: [ 0 ] ifFalse: [ m ]
+!
+_paginate: items skip: s take: t
+	| out start |
+	out := items asArray.
+	start := s ifNil: [ 0 ] ifNotNil: [ s ].
+	start > 0 ifTrue: [ out := out copyFrom: start + 1 to: out size ].
+	t notNil ifTrue: [ out := out copyFrom: 1 to: (t min: out size) ].
+	^ out
+!
+!!
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'. 'ca_zip' -> '12345'}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_addr_sk' -> 1}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1999. 'd_moy' -> 5. 'd_month_seq' -> 120}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_category' -> 'A'. 'i_current_price' -> 100.000000}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_category' -> 'A'. 'i_current_price' -> 50.000000}).
+target_month_seq := (Main __max: ((| res |
+res := OrderedCollection new.
+((date_dim) select: [:d | (((d at: 'd_year' = 1999) and: [d at: 'd_moy']) = 5)]) do: [:d |
+	res add: d at: 'd_month_seq'.
+]
+res := res asArray.
+res))).
+result := ((| res |
+res := OrderedCollection new.
+((customer_address) select: [:a | ((((((((d at: 'd_month_seq' = target_month_seq) and: [i at: 'i_current_price']) > 1.200000) * (Main __avg: ((| res |
+res := OrderedCollection new.
+((item) select: [:j | (j at: 'i_category' = i at: 'i_category')]) do: [:j |
+	res add: j at: 'i_current_price'.
+]
+res := res asArray.
+res)))) and: [(a at: 'ca_address_sk' = c at: 'c_current_addr_sk')]) and: [(c at: 'c_customer_sk' = s at: 'ss_customer_sk')]) and: [(s at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(s at: 'ss_item_sk' = i at: 'i_item_sk')])]) do: [:a |
+	(customer) do: [:c |
+		(store_sales) do: [:s |
+			(date_dim) do: [:d |
+				(item) do: [:i |
+					res add: { Array with: ((Main __count: g)) with: (g at: 'key') . Dictionary from: {'state' -> g at: 'key'. 'cnt' -> (Main __count: g)} }.
+				]
+			]
+		]
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res := (Main _paginate: res skip: 0 take: 100).
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q6_result.

--- a/tests/dataset/tpc-ds/compiler/st/q7.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q7.st.out
@@ -1,0 +1,72 @@
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #promotion put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q7_result
+	((result = Array with: (Dictionary from: {'i_item_id' -> 'I1'. 'agg1' -> 5.000000. 'agg2' -> 10.000000. 'agg3' -> 2.000000. 'agg4' -> 8.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__avg: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+	v size = 0 ifTrue: [ ^ 0 ]
+	| sum |
+	sum := 0.
+	v do: [:it | sum := sum + it].
+	^ sum / v size
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_cdemo_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1. 'ss_promo_sk' -> 1. 'ss_quantity' -> 5. 'ss_list_price' -> 10.000000. 'ss_coupon_amt' -> 2.000000. 'ss_sales_price' -> 8.000000}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_gender' -> 'M'. 'cd_marital_status' -> 'S'. 'cd_education_status' -> 'College'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1998}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'I1'}).
+promotion := Array with: (Dictionary from: {'p_promo_sk' -> 1. 'p_channel_email' -> 'N'. 'p_channel_event' -> 'Y'}).
+result := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((((((((((cd at: 'cd_gender' = 'M') and: [cd at: 'cd_marital_status']) = 'S') and: [cd at: 'cd_education_status']) = 'College') and: [((((p at: 'p_channel_email' = 'N') or: [p at: 'p_channel_event']) = 'N'))]) and: [d at: 'd_year']) = 1998) and: [(ss at: 'ss_cdemo_sk' = cd at: 'cd_demo_sk')]) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')]) and: [(ss at: 'ss_promo_sk' = p at: 'p_promo_sk')])]) do: [:ss |
+	(customer_demographics) do: [:cd |
+		(date_dim) do: [:d |
+			(item) do: [:i |
+				(promotion) do: [:p |
+					res add: { g at: 'key' at: 'i_item_id' . Dictionary from: {'i_item_id' -> g at: 'key' at: 'i_item_id'. 'agg1' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_quantity'.
+]
+res := res asArray.
+res))). 'agg2' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_list_price'.
+]
+res := res asArray.
+res))). 'agg3' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_coupon_amt'.
+]
+res := res asArray.
+res))). 'agg4' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_sales_price'.
+]
+res := res asArray.
+res)))} }.
+				]
+			]
+		]
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q7_result.

--- a/tests/dataset/tpc-ds/compiler/st/q8.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q8.st.out
@@ -1,0 +1,73 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #zip_list put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q8_result
+	((result = Array with: (Dictionary from: {'s_store_name' -> 'Store1'. 'net_profit' -> 10.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__slice_string: s start: i end: j
+	| start end n |
+	start := i.
+	end := j.
+	n := s size.
+	start < 0 ifTrue: [ start := start + n ].
+	end < 0 ifTrue: [ end := end + n ].
+	start < 0 ifTrue: [ start := 0 ].
+	end > n ifTrue: [ end := n ].
+	end < start ifTrue: [ end := start ].
+	^ (s copyFrom: start + 1 to: end)
+!
+__reverse: obj
+	(obj isKindOf: Array) ifTrue: [ ^ obj reverse ]
+	(obj isString) ifTrue: [ ^ obj reverse ]
+	^ self error: 'reverse expects list or string'
+!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_store_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_net_profit' -> 10.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_qoy' -> 1. 'd_year' -> 1998}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_store_name' -> 'Store1'. 's_zip' -> '12345'}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_zip' -> '12345'}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_addr_sk' -> 1. 'c_preferred_cust_flag' -> 'Y'}).
+(Main __reverse: (Main __slice_string: 'zip' start: 0 end: 0 + 2)).
+zip_list := Array with: '12345'.
+result := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (((((zip_list includes: (Main __slice_string: ca at: 'ca_zip' start: 0 end: 0 + 5)) and: [(((((ss at: 'ss_sold_date_sk' = d at: 'd_date_sk') and: [d at: 'd_qoy']) = 1) and: [d at: 'd_year']) = 1998)]) and: [(ss at: 'ss_store_sk' = s at: 's_store_sk')]) and: [((Main __slice_string: s at: 's_zip' start: 0 end: 0 + 2) = (Main __slice_string: ca at: 'ca_zip' start: 0 end: 0 + 2))]) and: [(((ca at: 'ca_address_sk' = c at: 'c_current_addr_sk') and: [c at: 'c_preferred_cust_flag']) = 'Y')])]) do: [:ss |
+	(date_dim) do: [:d |
+		(store) do: [:s |
+			(customer_address) do: [:ca |
+				(customer) do: [:c |
+					res add: { g at: 'key' . Dictionary from: {'s_store_name' -> g at: 'key'. 'net_profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_net_profit'.
+]
+res := res asArray.
+res)))} }.
+				]
+			]
+		]
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q8_result.

--- a/tests/dataset/tpc-ds/compiler/st/q9.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q9.st.out
@@ -1,0 +1,136 @@
+Smalltalk at: #bucket1 put: nil.
+Smalltalk at: #bucket2 put: nil.
+Smalltalk at: #bucket3 put: nil.
+Smalltalk at: #bucket4 put: nil.
+Smalltalk at: #bucket5 put: nil.
+Smalltalk at: #reason put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q9_result
+	((result = Array with: (Dictionary from: {'bucket1' -> 7.000000. 'bucket2' -> 15.000000. 'bucket3' -> 30.000000. 'bucket4' -> 35.000000. 'bucket5' -> 50.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+__avg: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+	v size = 0 ifTrue: [ ^ 0 ]
+	| sum |
+	sum := 0.
+	v do: [:it | sum := sum + it].
+	^ sum / v size
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_quantity' -> 5. 'ss_ext_discount_amt' -> 5.000000. 'ss_net_paid' -> 7.000000}) with: (Dictionary from: {'ss_quantity' -> 30. 'ss_ext_discount_amt' -> 10.000000. 'ss_net_paid' -> 15.000000}) with: (Dictionary from: {'ss_quantity' -> 50. 'ss_ext_discount_amt' -> 20.000000. 'ss_net_paid' -> 30.000000}) with: (Dictionary from: {'ss_quantity' -> 70. 'ss_ext_discount_amt' -> 25.000000. 'ss_net_paid' -> 35.000000}) with: (Dictionary from: {'ss_quantity' -> 90. 'ss_ext_discount_amt' -> 40.000000. 'ss_net_paid' -> 50.000000}).
+reason := Array with: (Dictionary from: {'r_reason_sk' -> 1}).
+bucket1 := ((((Main __count: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 1) and: [s at: 'ss_quantity']) <= 20)]) do: [:s |
+	res add: s.
+]
+res := res asArray.
+res))) > 10)) ifTrue: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 1) and: [s at: 'ss_quantity']) <= 20)]) do: [:s |
+	res add: s at: 'ss_ext_discount_amt'.
+]
+res := res asArray.
+res)))] ifFalse: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 1) and: [s at: 'ss_quantity']) <= 20)]) do: [:s |
+	res add: s at: 'ss_net_paid'.
+]
+res := res asArray.
+res)))]).
+bucket2 := ((((Main __count: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 21) and: [s at: 'ss_quantity']) <= 40)]) do: [:s |
+	res add: s.
+]
+res := res asArray.
+res))) > 20)) ifTrue: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 21) and: [s at: 'ss_quantity']) <= 40)]) do: [:s |
+	res add: s at: 'ss_ext_discount_amt'.
+]
+res := res asArray.
+res)))] ifFalse: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 21) and: [s at: 'ss_quantity']) <= 40)]) do: [:s |
+	res add: s at: 'ss_net_paid'.
+]
+res := res asArray.
+res)))]).
+bucket3 := ((((Main __count: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 41) and: [s at: 'ss_quantity']) <= 60)]) do: [:s |
+	res add: s.
+]
+res := res asArray.
+res))) > 30)) ifTrue: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 41) and: [s at: 'ss_quantity']) <= 60)]) do: [:s |
+	res add: s at: 'ss_ext_discount_amt'.
+]
+res := res asArray.
+res)))] ifFalse: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 41) and: [s at: 'ss_quantity']) <= 60)]) do: [:s |
+	res add: s at: 'ss_net_paid'.
+]
+res := res asArray.
+res)))]).
+bucket4 := ((((Main __count: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 61) and: [s at: 'ss_quantity']) <= 80)]) do: [:s |
+	res add: s.
+]
+res := res asArray.
+res))) > 40)) ifTrue: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 61) and: [s at: 'ss_quantity']) <= 80)]) do: [:s |
+	res add: s at: 'ss_ext_discount_amt'.
+]
+res := res asArray.
+res)))] ifFalse: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 61) and: [s at: 'ss_quantity']) <= 80)]) do: [:s |
+	res add: s at: 'ss_net_paid'.
+]
+res := res asArray.
+res)))]).
+bucket5 := ((((Main __count: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 81) and: [s at: 'ss_quantity']) <= 100)]) do: [:s |
+	res add: s.
+]
+res := res asArray.
+res))) > 50)) ifTrue: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 81) and: [s at: 'ss_quantity']) <= 100)]) do: [:s |
+	res add: s at: 'ss_ext_discount_amt'.
+]
+res := res asArray.
+res)))] ifFalse: [(Main __avg: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ss_quantity' >= 81) and: [s at: 'ss_quantity']) <= 100)]) do: [:s |
+	res add: s at: 'ss_net_paid'.
+]
+res := res asArray.
+res)))]).
+result := ((| res |
+res := OrderedCollection new.
+((reason) select: [:r | (r at: 'r_reason_sk' = 1)]) do: [:r |
+	res add: Dictionary from: {'bucket1' -> bucket1. 'bucket2' -> bucket2. 'bucket3' -> bucket3. 'bucket4' -> bucket4. 'bucket5' -> bucket5}.
+]
+res := res asArray.
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q9_result.


### PR DESCRIPTION
## Summary
- support new builtin functions in the Smalltalk compiler
- handle `null` literals and `having` clauses
- add smalltalk golden tests for TPC‑DS q1‑q9
- update generated `.st.out` fixtures

## Testing
- `go test ./compile/x/st -tags slow -run TestSTCompiler_TPCDS_Golden`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6863c6520da483208c82c99737de6fd1