### PR TITLE
Add v0.10.10 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # 📦 CHANGELOG.md
 
+## [0.10.10] – 2025-07-01T18:41:01+07:00
+
+### Added
+
+* Sample TPC-DS dataset with queries 1–19 across languages
+* `first` builtin in Python, TypeScript and Go
+* `union` and `union_all` operations in Go and Python
+* `matrix_mul` builtin in the C backend and `if` expressions for C++
+* Typed map elements and join-group support in C#
+
+### Changed
+
+* Compiler tests marked slow with optional golden skips
+* Updated golden outputs for F#, Java, Rust and Zig compilers
+
+### Fixed
+
+* Kotlin query argument casting bug
+* Zig backend grouping issue with joins
+* Elixir TPC-DS query 1 test case
+* Miscellaneous fixes after helper additions
+
 ## [0.10.8] – 2025-06-30
 
 ### Added

--- a/releases/v0.10.10.md
+++ b/releases/v0.10.10.md
@@ -1,0 +1,22 @@
+# Jul 2025 (v0.10.10)
+
+Released on Tue Jul 1 18:41:01 2025 +0700.
+
+Mochi v0.10.10 expands the dataset suite with full TPC-DS coverage, new builtins and improved compiler support across languages.
+
+## Runtime
+
+- `first` builtin added for Python, TypeScript and Go
+- Union and union_all operations supported in Go and Python
+- `matrix_mul` builtin available in the C backend
+- C++ now handles `if` expressions with typed map queries in C#
+
+## Datasets
+
+- Sample TPC-DS data with queries 1–19 for all languages
+- Updated golden outputs for F#, Java, Rust and Zig
+
+## Tooling
+
+- Compiler tests marked slow with optional golden skips
+- Miscellaneous fixes for dataset helpers and examples


### PR DESCRIPTION
## Summary
- document v0.10.10 release in CHANGELOG
- add `releases/v0.10.10.md`

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6863d45ead8c8320a80b9f9f1fc70396