### PR TITLE
Add F# compiler support for TPC-DS queries q10-q29

### DIFF
--- a/compile/x/fs/tpcds_q1_test.go
+++ b/compile/x/fs/tpcds_q1_test.go
@@ -26,7 +26,7 @@ func TestFSCompiler_TPCDS(t *testing.T) {
 		t.Skipf("fantomas not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	for i := 1; i <= 9; i++ {
+	for i := 1; i <= 29; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")

--- a/tests/dataset/tpc-ds/compiler/fs/q10.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q10.fs.out
@@ -1,0 +1,226 @@
+open System
+
+let c_customer_sk = "c_customer_sk"
+let c_current_addr_sk = "c_current_addr_sk"
+let c_current_cdemo_sk = "c_current_cdemo_sk"
+let ca_address_sk = "ca_address_sk"
+let ca_county = "ca_county"
+let cd_demo_sk = "cd_demo_sk"
+let cd_gender = "cd_gender"
+let cd_marital_status = "cd_marital_status"
+let cd_education_status = "cd_education_status"
+let cd_purchase_estimate = "cd_purchase_estimate"
+let cd_credit_rating = "cd_credit_rating"
+let cd_dep_count = "cd_dep_count"
+let cd_dep_employed_count = "cd_dep_employed_count"
+let cd_dep_college_count = "cd_dep_college_count"
+let ss_customer_sk = "ss_customer_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let gender = "gender"
+let marital = "marital"
+let education = "education"
+let purchase = "purchase"
+let credit = "credit"
+let dep = "dep"
+let depemp = "depemp"
+let depcol = "depcol"
+let cnt1 = "cnt1"
+let cnt2 = "cnt2"
+let cnt3 = "cnt3"
+let cnt4 = "cnt4"
+let cnt5 = "cnt5"
+let cnt6 = "cnt6"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_addr_sk: int;
+        c_current_cdemo_sk: int
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_county: string
+    }
+
+type CustomerDemographics =
+    {
+        cd_demo_sk: int;
+        cd_gender: string;
+        cd_marital_status: string;
+        cd_education_status: string;
+        cd_purchase_estimate: int;
+        cd_credit_rating: string;
+        cd_dep_count: int;
+        cd_dep_employed_count: int;
+        cd_dep_college_count: int
+    }
+
+type StoreSale =
+    {
+        ss_customer_sk: int;
+        ss_sold_date_sk: int
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_addr_sk: int;
+        c_current_cdemo_sk: int
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_county: string
+    }
+type CustomerDemographics =
+    {
+        cd_demo_sk: int;
+        cd_gender: string;
+        cd_marital_status: string;
+        cd_education_status: string;
+        cd_purchase_estimate: int;
+        cd_credit_rating: string;
+        cd_dep_count: int;
+        cd_dep_employed_count: int;
+        cd_dep_college_count: int
+    }
+type StoreSale =
+    {
+        ss_customer_sk: int;
+        ss_sold_date_sk: int
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_current_addr_sk, 1); (c_current_cdemo_sk, 1)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_county, "CountyA")]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1); (cd_gender, "F"); (cd_marital_status, "M"); (cd_education_status, "College"); (cd_purchase_estimate, 5000); (cd_credit_rating, "Good"); (cd_dep_count, 1); (cd_dep_employed_count, 1); (cd_dep_college_count, 0)]|]
+let store_sales = [|Map.ofList [(ss_customer_sk, 1); (ss_sold_date_sk, 1)]|]
+let web_sales = [||]
+let catalog_sales = [||]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000); (d_moy, 2)]|]
+let active = 
+    [|
+    for c in customer do
+        for ca in customer_address do
+            if ((c.c_current_addr_sk = ca.ca_address_sk) && (ca.ca_county = "CountyA")) then
+                for cd in customer_demographics do
+                    if (c.c_current_cdemo_sk = cd.cd_demo_sk) then
+                        if exists (
+    [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                if ((((ss.ss_customer_sk = c.c_customer_sk) && (d.d_year = 2000)) && (d.d_moy >= 2)) && (d.d_moy <= 5)) then
+                    yield ss
+    |]) then
+                            yield cd
+    |]
+let result = _group_by active (fun a -> Map.ofList [(gender, a.cd_gender); (marital, a.cd_marital_status); (education, a.cd_education_status); (purchase, a.cd_purchase_estimate); (credit, a.cd_credit_rating); (dep, a.cd_dep_count); (depemp, a.cd_dep_employed_count); (depcol, a.cd_dep_college_count)]) |> List.map (fun g -> Map.ofList [(cd_gender, g.key.gender); (cd_marital_status, g.key.marital); (cd_education_status, g.key.education); (cnt1, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (cd_purchase_estimate, g.key.purchase); (cnt2, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (cd_credit_rating, g.key.credit); (cnt3, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (cd_dep_count, g.key.dep); (cnt4, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (cd_dep_employed_count, g.key.depemp); (cnt5, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (cd_dep_college_count, g.key.depcol); (cnt6, count 
+    [|
+    for _ in g do
+        yield _
+    |])])
+ignore (_json result)
+let test_TPCDS_Q10_demographics_count() =
+    if not ((result = [|Map.ofList [(cd_gender, "F"); (cd_marital_status, "M"); (cd_education_status, "College"); (cnt1, 1); (cd_purchase_estimate, 5000); (cnt2, 1); (cd_credit_rating, "Good"); (cnt3, 1); (cd_dep_count, 1); (cnt4, 1); (cd_dep_employed_count, 1); (cnt5, 1); (cd_dep_college_count, 0); (cnt6, 1)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q10 demographics count" test_TPCDS_Q10_demographics_count) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q11.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q11.fs.out
@@ -1,0 +1,136 @@
+open System
+
+let c_customer_sk = "c_customer_sk"
+let c_customer_id = "c_customer_id"
+let c_first_name = "c_first_name"
+let c_last_name = "c_last_name"
+let ss_customer_sk = "ss_customer_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_ext_list_price = "ss_ext_list_price"
+let ws_bill_customer_sk = "ws_bill_customer_sk"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_ext_list_price = "ws_ext_list_price"
+let customer_id = "customer_id"
+let customer_first_name = "customer_first_name"
+let customer_last_name = "customer_last_name"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_customer_id: string;
+        c_first_name: string;
+        c_last_name: string
+    }
+
+type StoreSale =
+    {
+        ss_customer_sk: int;
+        ss_sold_date_sk: int;
+        ss_ext_list_price: float
+    }
+
+type WebSale =
+    {
+        ws_bill_customer_sk: int;
+        ws_sold_date_sk: int;
+        ws_ext_list_price: float
+    }
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_customer_id: string;
+        c_first_name: string;
+        c_last_name: string
+    }
+type StoreSale =
+    {
+        ss_customer_sk: int;
+        ss_sold_date_sk: int;
+        ss_ext_list_price: float
+    }
+type WebSale =
+    {
+        ws_bill_customer_sk: int;
+        ws_sold_date_sk: int;
+        ws_ext_list_price: float
+    }
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_customer_id, "C1"); (c_first_name, "John"); (c_last_name, "Doe")]|]
+let store_sales = [|Map.ofList [(ss_customer_sk, 1); (ss_sold_date_sk, 1998); (ss_ext_list_price, 60.0)]; Map.ofList [(ss_customer_sk, 1); (ss_sold_date_sk, 1999); (ss_ext_list_price, 90.0)]|]
+let web_sales = [|Map.ofList [(ws_bill_customer_sk, 1); (ws_sold_date_sk, 1998); (ws_ext_list_price, 50.0)]; Map.ofList [(ws_bill_customer_sk, 1); (ws_sold_date_sk, 1999); (ws_ext_list_price, 150.0)]|]
+let ss98 = sum 
+    [|
+    for ss in store_sales do
+        if (ss.ss_sold_date_sk = 1998) then
+            yield ss.ss_ext_list_price
+    |]
+let ss99 = sum 
+    [|
+    for ss in store_sales do
+        if (ss.ss_sold_date_sk = 1999) then
+            yield ss.ss_ext_list_price
+    |]
+let ws98 = sum 
+    [|
+    for ws in web_sales do
+        if (ws.ws_sold_date_sk = 1998) then
+            yield ws.ws_ext_list_price
+    |]
+let ws99 = sum 
+    [|
+    for ws in web_sales do
+        if (ws.ws_sold_date_sk = 1999) then
+            yield ws.ws_ext_list_price
+    |]
+let growth_ok = (((ws98 > 0) && (ss98 > 0)) && (((ws99 / ws98)) > ((ss99 / ss98))))
+let result = (if growth_ok then [|Map.ofList [(customer_id, "C1"); (customer_first_name, "John"); (customer_last_name, "Doe")]|] else [||])
+ignore (_json result)
+let test_TPCDS_Q11_growth() =
+    if not ((result = [|Map.ofList [(customer_id, "C1"); (customer_first_name, "John"); (customer_last_name, "Doe")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q11 growth" test_TPCDS_Q11_growth) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q12.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q12.fs.out
@@ -1,0 +1,163 @@
+open System
+
+let ws_item_sk = "ws_item_sk"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_ext_sales_price = "ws_ext_sales_price"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let i_item_desc = "i_item_desc"
+let i_category = "i_category"
+let i_class = "i_class"
+let i_current_price = "i_current_price"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let itemrevenue = "itemrevenue"
+let id = "id"
+let desc = "desc"
+let cat = "cat"
+let _class = "class"
+let price = "price"
+let total = "total"
+let revenueratio = "revenueratio"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type WebSale =
+    {
+        ws_item_sk: int;
+        ws_sold_date_sk: int;
+        ws_ext_sales_price: float
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string;
+        i_category: string;
+        i_class: string;
+        i_current_price: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+
+type WebSale =
+    {
+        ws_item_sk: int;
+        ws_sold_date_sk: int;
+        ws_ext_sales_price: float
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string;
+        i_category: string;
+        i_class: string;
+        i_current_price: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+let web_sales = [|Map.ofList [(ws_item_sk, 1); (ws_sold_date_sk, 1); (ws_ext_sales_price, 100.0)]; Map.ofList [(ws_item_sk, 1); (ws_sold_date_sk, 2); (ws_ext_sales_price, 100.0)]; Map.ofList [(ws_item_sk, 2); (ws_sold_date_sk, 2); (ws_ext_sales_price, 200.0)]; Map.ofList [(ws_item_sk, 3); (ws_sold_date_sk, 3); (ws_ext_sales_price, 50.0)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "ITEM1"); (i_item_desc, "Item One"); (i_category, "A"); (i_class, "C1"); (i_current_price, 10.0)]; Map.ofList [(i_item_sk, 2); (i_item_id, "ITEM2"); (i_item_desc, "Item Two"); (i_category, "A"); (i_class, "C1"); (i_current_price, 20.0)]; Map.ofList [(i_item_sk, 3); (i_item_id, "ITEM3"); (i_item_desc, "Item Three"); (i_category, "B"); (i_class, "C2"); (i_current_price, 30.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2001-01-20")]; Map.ofList [(d_date_sk, 2); (d_date, "2001-02-05")]; Map.ofList [(d_date_sk, 3); (d_date, "2001-03-05")]|]
+let filtered = [| for g in _group_by [|
+    for ws in web_sales do
+        for i in item do
+            if (ws.ws_item_sk = i.i_item_sk) then
+                for d in date_dim do
+                    if (ws.ws_sold_date_sk = d.d_date_sk) then
+                        if ((Array.contains i.i_category [|"A"; "B"; "C"|] && (d.d_date >= "2001-01-15")) && (d.d_date <= "2001-02-14")) then
+                            yield (ws, i, d)
+|] (fun (ws, i, d) -> Map.ofList [(id, i.i_item_id); (desc, i.i_item_desc); (cat, i.i_category); (_class, i.i_class); (price, i.i_current_price)]) do let g = g yield Map.ofList [(i_item_id, g.key.id); (i_item_desc, g.key.desc); (i_category, g.key.cat); (i_class, g.key._class); (i_current_price, g.key.price); (itemrevenue, sum 
+    [|
+    for x in g do
+        yield x.ws_ext_sales_price
+    |])] |]
+let class_totals = _group_by filtered (fun f -> f.i_class) |> List.map (fun g -> Map.ofList [(_class, g.key); (total, sum 
+    [|
+    for x in g do
+        yield x.itemrevenue
+    |])])
+let result = 
+    [|
+    for f in filtered do
+        for t in class_totals do
+            if (f.i_class = t._class) then
+                yield ([|f.i_category; f.i_class; f.i_item_id; f.i_item_desc|], Map.ofList [(i_item_id, f.i_item_id); (i_item_desc, f.i_item_desc); (i_category, f.i_category); (i_class, f.i_class); (i_current_price, f.i_current_price); (itemrevenue, f.itemrevenue); (revenueratio, (((f.itemrevenue * 100.0)) / t.total))])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q12_revenue_ratio() =
+    if not ((result = [|Map.ofList [(i_item_id, "ITEM1"); (i_item_desc, "Item One"); (i_category, "A"); (i_class, "C1"); (i_current_price, 10.0); (itemrevenue, 200.0); (revenueratio, 50.0)]; Map.ofList [(i_item_id, "ITEM2"); (i_item_desc, "Item Two"); (i_category, "A"); (i_class, "C1"); (i_current_price, 20.0); (itemrevenue, 200.0); (revenueratio, 50.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q12 revenue ratio" test_TPCDS_Q12_revenue_ratio) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q13.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q13.fs.out
@@ -1,0 +1,237 @@
+open System
+
+let ss_store_sk = "ss_store_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_hdemo_sk = "ss_hdemo_sk"
+let ss_cdemo_sk = "ss_cdemo_sk"
+let ss_addr_sk = "ss_addr_sk"
+let ss_sales_price = "ss_sales_price"
+let ss_net_profit = "ss_net_profit"
+let ss_quantity = "ss_quantity"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let ss_ext_wholesale_cost = "ss_ext_wholesale_cost"
+let s_store_sk = "s_store_sk"
+let s_state = "s_state"
+let cd_demo_sk = "cd_demo_sk"
+let cd_marital_status = "cd_marital_status"
+let cd_education_status = "cd_education_status"
+let hd_demo_sk = "hd_demo_sk"
+let hd_dep_count = "hd_dep_count"
+let ca_address_sk = "ca_address_sk"
+let ca_country = "ca_country"
+let ca_state = "ca_state"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let avg_ss_quantity = "avg_ss_quantity"
+let avg_ss_ext_sales_price = "avg_ss_ext_sales_price"
+let avg_ss_ext_wholesale_cost = "avg_ss_ext_wholesale_cost"
+let sum_ss_ext_wholesale_cost = "sum_ss_ext_wholesale_cost"
+
+type _Group<'T>(key: obj) =
+    member val key = key with get, set
+    member val Items = System.Collections.Generic.List<'T>() with get
+    member this.size = this.Items.Count
+
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+    let groups = System.Collections.Generic.Dictionary<string, _Group<'T>>()
+    let order = System.Collections.Generic.List<string>()
+
+    for it in src do
+        let key = keyfn it
+        let ks = string key
+        let mutable g = Unchecked.defaultof<_Group<'T>>
+
+        if groups.TryGetValue(ks, &g) then
+            ()
+        else
+            g <- _Group<'T> (key)
+            groups[ks] <- g
+            order.Add(ks)
+
+        g.Items.Add(it)
+
+    [ for ks in order -> groups[ks] ]
+
+let rec _to_json (v: obj) : string =
+    match v with
+    | null -> "null"
+    | :? string as s -> "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+    | :? bool
+    | :? int
+    | :? int64
+    | :? double -> string v
+    | :? System.Collections.Generic.IDictionary<string, obj> as m ->
+        m
+        |> Seq.map (fun (KeyValue(k, v)) -> "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+        |> String.concat ","
+        |> fun s -> "{" + s + "}"
+    | :? System.Collections.IEnumerable as e ->
+        e
+        |> Seq.cast<obj>
+        |> Seq.map _to_json
+        |> String.concat ","
+        |> fun s -> "[" + s + "]"
+    | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+let _json (v: obj) : unit = printfn "%s" (_to_json v)
+
+let _run_test (name: string) (f: unit -> unit) : bool =
+    printf "%s ... " name
+
+    try
+        f ()
+        printfn "PASS"
+        true
+    with e ->
+        printfn "FAIL (%s)" e.Message
+        false
+
+let inline sum (xs: seq< ^T >) : ^T = Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T = Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T: comparison = Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T: comparison = Seq.max xs
+let count (xs: seq<'T>) : int = Seq.length xs
+
+type StoreSale =
+    { ss_store_sk: int
+      ss_sold_date_sk: int
+      ss_hdemo_sk: int
+      ss_cdemo_sk: int
+      ss_addr_sk: int
+      ss_sales_price: float
+      ss_net_profit: float
+      ss_quantity: int
+      ss_ext_sales_price: float
+      ss_ext_wholesale_cost: float }
+
+type Store = { s_store_sk: int; s_state: string }
+
+type CustomerDemographics =
+    { cd_demo_sk: int
+      cd_marital_status: string
+      cd_education_status: string }
+
+type HouseholdDemographics = { hd_demo_sk: int; hd_dep_count: int }
+
+type CustomerAddress =
+    { ca_address_sk: int
+      ca_country: string
+      ca_state: string }
+
+type DateDim = { d_date_sk: int; d_year: int }
+
+type StoreSale =
+    { ss_store_sk: int
+      ss_sold_date_sk: int
+      ss_hdemo_sk: int
+      ss_cdemo_sk: int
+      ss_addr_sk: int
+      ss_sales_price: float
+      ss_net_profit: float
+      ss_quantity: int
+      ss_ext_sales_price: float
+      ss_ext_wholesale_cost: float }
+
+type Store = { s_store_sk: int; s_state: string }
+
+type CustomerDemographics =
+    { cd_demo_sk: int
+      cd_marital_status: string
+      cd_education_status: string }
+
+type HouseholdDemographics = { hd_demo_sk: int; hd_dep_count: int }
+
+type CustomerAddress =
+    { ca_address_sk: int
+      ca_country: string
+      ca_state: string }
+
+type DateDim = { d_date_sk: int; d_year: int }
+
+let store_sales =
+    [| Map.ofList
+           [ (ss_store_sk, 1)
+             (ss_sold_date_sk, 1)
+             (ss_hdemo_sk, 1)
+             (ss_cdemo_sk, 1)
+             (ss_addr_sk, 1)
+             (ss_sales_price, 120.0)
+             (ss_net_profit, 150.0)
+             (ss_quantity, 10)
+             (ss_ext_sales_price, 100.0)
+             (ss_ext_wholesale_cost, 50.0) ] |]
+
+let store = [| Map.ofList [ (s_store_sk, 1); (s_state, "CA") ] |]
+
+let customer_demographics =
+    [| Map.ofList [ (cd_demo_sk, 1); (cd_marital_status, "M1"); (cd_education_status, "ES1") ] |]
+
+let household_demographics = [| Map.ofList [ (hd_demo_sk, 1); (hd_dep_count, 3) ] |]
+
+let customer_address =
+    [| Map.ofList [ (ca_address_sk, 1); (ca_country, "United States"); (ca_state, "CA") ] |]
+
+let date_dim = [| Map.ofList [ (d_date_sk, 1); (d_year, 2001) ] |]
+
+let filtered =
+    [| for ss in store_sales do
+           for s in store do
+               if (ss.ss_store_sk = s.s_store_sk) then
+                   for cd in customer_demographics do
+                       if
+                           (((ss.ss_cdemo_sk = cd.cd_demo_sk) && (cd.cd_marital_status = "M1"))
+                            && (cd.cd_education_status = "ES1"))
+                       then
+                           for hd in household_demographics do
+                               if ((ss.ss_hdemo_sk = hd.hd_demo_sk) && (hd.hd_dep_count = 3)) then
+                                   for ca in customer_address do
+                                       if
+                                           (((ss.ss_addr_sk = ca.ca_address_sk) && (ca.ca_country = "United States"))
+                                            && (ca.ca_state = "CA"))
+                                       then
+                                           for d in date_dim do
+                                               if ((ss.ss_sold_date_sk = d.d_date_sk) && (d.d_year = 2001)) then
+                                                   yield ss |]
+
+let result =
+    _group_by filtered (fun r -> Map.empty)
+    |> List.map (fun g ->
+        Map.ofList
+            [ (avg_ss_quantity,
+               avg
+                   [| for x in g do
+                          yield x.ss_quantity |])
+              (avg_ss_ext_sales_price,
+               avg
+                   [| for x in g do
+                          yield x.ss_ext_sales_price |])
+              (avg_ss_ext_wholesale_cost,
+               avg
+                   [| for x in g do
+                          yield x.ss_ext_wholesale_cost |])
+              (sum_ss_ext_wholesale_cost,
+               sum
+                   [| for x in g do
+                          yield x.ss_ext_wholesale_cost |]) ])
+
+ignore (_json result)
+
+let test_TPCDS_Q13_averages () =
+    if
+        not (
+            (result = [| Map.ofList
+                             [ (avg_ss_quantity, 10.0)
+                               (avg_ss_ext_sales_price, 100.0)
+                               (avg_ss_ext_wholesale_cost, 50.0)
+                               (sum_ss_ext_wholesale_cost, 50.0) ] |])
+        )
+    then
+        failwith "expect failed"
+
+let mutable failures = 0
+
+if not (_run_test "TPCDS Q13 averages" test_TPCDS_Q13_averages) then
+    failures <- failures + 1
+
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q14.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q14.fs.out
@@ -1,0 +1,201 @@
+open System
+
+let ss_item_sk = "ss_item_sk"
+let ss_list_price = "ss_list_price"
+let ss_quantity = "ss_quantity"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_list_price = "cs_list_price"
+let cs_quantity = "cs_quantity"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let ws_item_sk = "ws_item_sk"
+let ws_list_price = "ws_list_price"
+let ws_quantity = "ws_quantity"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let i_item_sk = "i_item_sk"
+let i_brand_id = "i_brand_id"
+let i_class_id = "i_class_id"
+let i_category_id = "i_category_id"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let channel = "channel"
+let sales = "sales"
+let number_sales = "number_sales"
+let brand_id = "brand_id"
+let class_id = "class_id"
+let category_id = "category_id"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_list_price: float;
+        ss_quantity: int;
+        ss_sold_date_sk: int
+    }
+
+type CatalogSale =
+    {
+        cs_item_sk: int;
+        cs_list_price: float;
+        cs_quantity: int;
+        cs_sold_date_sk: int
+    }
+
+type WebSale =
+    {
+        ws_item_sk: int;
+        ws_list_price: float;
+        ws_quantity: int;
+        ws_sold_date_sk: int
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_brand_id: int;
+        i_class_id: int;
+        i_category_id: int
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_list_price: float;
+        ss_quantity: int;
+        ss_sold_date_sk: int
+    }
+type CatalogSale =
+    {
+        cs_item_sk: int;
+        cs_list_price: float;
+        cs_quantity: int;
+        cs_sold_date_sk: int
+    }
+type WebSale =
+    {
+        ws_item_sk: int;
+        ws_list_price: float;
+        ws_quantity: int;
+        ws_sold_date_sk: int
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_brand_id: int;
+        i_class_id: int;
+        i_category_id: int
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_list_price, 10.0); (ss_quantity, 2); (ss_sold_date_sk, 1)]; Map.ofList [(ss_item_sk, 1); (ss_list_price, 20.0); (ss_quantity, 3); (ss_sold_date_sk, 2)]|]
+let catalog_sales = [|Map.ofList [(cs_item_sk, 1); (cs_list_price, 10.0); (cs_quantity, 2); (cs_sold_date_sk, 1)]|]
+let web_sales = [|Map.ofList [(ws_item_sk, 1); (ws_list_price, 30.0); (ws_quantity, 1); (ws_sold_date_sk, 1)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_brand_id, 1); (i_class_id, 1); (i_category_id, 1)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000); (d_moy, 12)]; Map.ofList [(d_date_sk, 2); (d_year, 2002); (d_moy, 11)]|]
+let cross_items = [|Map.ofList [(ss_item_sk, 1)]|]
+let avg_sales = avg [|20.0; 20.0; 30.0|]
+let store_filtered = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (((ss.ss_sold_date_sk = d.d_date_sk) && (d.d_year = 2002)) && (d.d_moy = 11)) then
+                if Array.contains ss.ss_item_sk (
+    [|
+    for ci in cross_items do
+        yield ci.ss_item_sk
+    |]) then
+                    yield (ss, d)
+|] (fun (ss, d) -> Map.ofList [(brand_id, 1); (class_id, 1); (category_id, 1)]) do let g = g yield Map.ofList [(channel, "store"); (sales, sum 
+    [|
+    for x in g do
+        yield (x.ss_quantity * x.ss_list_price)
+    |]); (number_sales, count 
+    [|
+    for _ in g do
+        yield _
+    |])] |]
+let result = 
+    [|
+    for r in store_filtered do
+        if (r.sales > avg_sales) then
+            yield Map.ofList [(channel, r.channel); (i_brand_id, 1); (i_class_id, 1); (i_category_id, 1); (sales, r.sales); (number_sales, r.number_sales)]
+    |]
+ignore (_json result)
+let test_TPCDS_Q14_cross_channel() =
+    if not ((result = [|Map.ofList [(channel, "store"); (i_brand_id, 1); (i_class_id, 1); (i_category_id, 1); (sales, 60.0); (number_sales, 1)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q14 cross channel" test_TPCDS_Q14_cross_channel) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q15.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q15.fs.out
@@ -1,0 +1,163 @@
+open System
+
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_sales_price = "cs_sales_price"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let c_customer_sk = "c_customer_sk"
+let c_current_addr_sk = "c_current_addr_sk"
+let ca_address_sk = "ca_address_sk"
+let ca_zip = "ca_zip"
+let ca_state = "ca_state"
+let d_date_sk = "d_date_sk"
+let d_qoy = "d_qoy"
+let d_year = "d_year"
+let sum_sales = "sum_sales"
+let zip = "zip"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _slice_string (s: string) (i: int) (j: int) : string =
+  let mutable start = i
+  let mutable stop = j
+  let n = s.Length
+  if start < 0 then start <- start + n
+  if stop < 0 then stop <- stop + n
+  if start < 0 then start <- 0
+  if stop > n then stop <- n
+  if stop < start then stop <- start
+  s.Substring(start, stop - start)
+
+type CatalogSale =
+    {
+        cs_bill_customer_sk: int;
+        cs_sales_price: float;
+        cs_sold_date_sk: int
+    }
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_addr_sk: int
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_zip: string;
+        ca_state: string
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_qoy: int;
+        d_year: int
+    }
+
+type CatalogSale =
+    {
+        cs_bill_customer_sk: int;
+        cs_sales_price: float;
+        cs_sold_date_sk: int
+    }
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_addr_sk: int
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_zip: string;
+        ca_state: string
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_qoy: int;
+        d_year: int
+    }
+let catalog_sales = [|Map.ofList [(cs_bill_customer_sk, 1); (cs_sales_price, 600.0); (cs_sold_date_sk, 1)]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_current_addr_sk, 1)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_zip, "85669"); (ca_state, "CA")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_qoy, 1); (d_year, 2000)]|]
+let filtered = [| for g in _group_by [|
+    for cs in catalog_sales do
+        for c in customer do
+            if (cs.cs_bill_customer_sk = c.c_customer_sk) then
+                for ca in customer_address do
+                    if (c.c_current_addr_sk = ca.ca_address_sk) then
+                        for d in date_dim do
+                            if (cs.cs_sold_date_sk = d.d_date_sk) then
+                                if (((((Array.contains _slice_string ca.ca_zip 0 5 [|"85669"; "86197"; "88274"; "83405"; "86475"; "85392"; "85460"; "80348"; "81792"|] || Array.contains ca.ca_state [|"CA"; "WA"; "GA"|]) || (cs.cs_sales_price > 500))) && (d.d_qoy = 1)) && (d.d_year = 2000)) then
+                                    yield (cs, c, ca, d)
+|] (fun (cs, c, ca, d) -> Map.ofList [(zip, ca.ca_zip)]) do let g = g yield (g.key.zip, Map.ofList [(ca_zip, g.key.zip); (sum_sales, sum 
+    [|
+    for x in g do
+        yield x.cs_sales_price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json filtered)
+let test_TPCDS_Q15_zip() =
+    if not ((filtered = [|Map.ofList [(ca_zip, "85669"); (sum_sales, 600.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q15 zip" test_TPCDS_Q15_zip) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q16.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q16.fs.out
@@ -1,0 +1,200 @@
+open System
+
+let cs_order_number = "cs_order_number"
+let cs_ship_date_sk = "cs_ship_date_sk"
+let cs_ship_addr_sk = "cs_ship_addr_sk"
+let cs_call_center_sk = "cs_call_center_sk"
+let cs_warehouse_sk = "cs_warehouse_sk"
+let cs_ext_ship_cost = "cs_ext_ship_cost"
+let cs_net_profit = "cs_net_profit"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let ca_address_sk = "ca_address_sk"
+let ca_state = "ca_state"
+let cc_call_center_sk = "cc_call_center_sk"
+let cc_county = "cc_county"
+let order_count = "order_count"
+let total_shipping_cost = "total_shipping_cost"
+let total_net_profit = "total_net_profit"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type CatalogSale =
+    {
+        cs_order_number: int;
+        cs_ship_date_sk: int;
+        cs_ship_addr_sk: int;
+        cs_call_center_sk: int;
+        cs_warehouse_sk: int;
+        cs_ext_ship_cost: float;
+        cs_net_profit: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string
+    }
+
+type CallCenter =
+    {
+        cc_call_center_sk: int;
+        cc_county: string
+    }
+
+type CatalogReturn =
+    {
+        cr_order_number: int
+    }
+
+exception Return_distinct of any[]
+let rec distinct (xs: any[]) : any[] =
+    try
+        let mutable xs = xs
+        let mutable out = [||]
+        for x in xs do
+            if (not contains out x) then
+                out <- append out x
+        raise (Return_distinct (out))
+        failwith "unreachable"
+    with Return_distinct v -> v
+
+type CatalogSale =
+    {
+        cs_order_number: int;
+        cs_ship_date_sk: int;
+        cs_ship_addr_sk: int;
+        cs_call_center_sk: int;
+        cs_warehouse_sk: int;
+        cs_ext_ship_cost: float;
+        cs_net_profit: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string
+    }
+type CallCenter =
+    {
+        cc_call_center_sk: int;
+        cc_county: string
+    }
+type CatalogReturn =
+    {
+        cr_order_number: int
+    }
+let catalog_sales = [|Map.ofList [(cs_order_number, 1); (cs_ship_date_sk, 1); (cs_ship_addr_sk, 1); (cs_call_center_sk, 1); (cs_warehouse_sk, 1); (cs_ext_ship_cost, 5.0); (cs_net_profit, 20.0)]; Map.ofList [(cs_order_number, 1); (cs_ship_date_sk, 1); (cs_ship_addr_sk, 1); (cs_call_center_sk, 1); (cs_warehouse_sk, 2); (cs_ext_ship_cost, 0.0); (cs_net_profit, 0.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2000-03-01")]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_state, "CA")]|]
+let call_center = [|Map.ofList [(cc_call_center_sk, 1); (cc_county, "CountyA")]|]
+let catalog_returns = [||]
+let filtered = [| for g in _group_by [|
+    for cs1 in catalog_sales do
+        for d in date_dim do
+            if (((cs1.cs_ship_date_sk = d.d_date_sk) && (d.d_date >= "2000-03-01")) && (d.d_date <= "2000-04-30")) then
+                for ca in customer_address do
+                    if ((cs1.cs_ship_addr_sk = ca.ca_address_sk) && (ca.ca_state = "CA")) then
+                        for cc in call_center do
+                            if ((cs1.cs_call_center_sk = cc.cc_call_center_sk) && (cc.cc_county = "CountyA")) then
+                                if (exists (
+    [|
+    for cs2 in catalog_sales do
+        if ((cs1.cs_order_number = cs2.cs_order_number) && (cs1.cs_warehouse_sk <> cs2.cs_warehouse_sk)) then
+            yield cs2
+    |]) && (exists (
+    [|
+    for cr in catalog_returns do
+        if (cs1.cs_order_number = cr.cr_order_number) then
+            yield cr
+    |]) = false)) then
+                                    yield (cs1, d, ca, cc)
+|] (fun (cs1, d, ca, cc) -> Map.empty) do let g = g yield Map.ofList [(order_count, distinct (
+    [|
+    for x in g do
+        yield x.cs_order_number
+    |]).Length); (total_shipping_cost, sum 
+    [|
+    for x in g do
+        yield x.cs_ext_ship_cost
+    |]); (total_net_profit, sum 
+    [|
+    for x in g do
+        yield x.cs_net_profit
+    |])] |]
+ignore (_json filtered)
+let test_TPCDS_Q16_shipping() =
+    if not ((filtered = [|Map.ofList [(order_count, 1); (total_shipping_cost, 5.0); (total_net_profit, 20.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q16 shipping" test_TPCDS_Q16_shipping) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q17.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q17.fs.out
@@ -1,0 +1,244 @@
+open System
+
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_item_sk = "ss_item_sk"
+let ss_customer_sk = "ss_customer_sk"
+let ss_ticket_number = "ss_ticket_number"
+let ss_quantity = "ss_quantity"
+let ss_store_sk = "ss_store_sk"
+let sr_returned_date_sk = "sr_returned_date_sk"
+let sr_customer_sk = "sr_customer_sk"
+let sr_item_sk = "sr_item_sk"
+let sr_ticket_number = "sr_ticket_number"
+let sr_return_quantity = "sr_return_quantity"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_quantity = "cs_quantity"
+let d_date_sk = "d_date_sk"
+let d_quarter_name = "d_quarter_name"
+let s_store_sk = "s_store_sk"
+let s_state = "s_state"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let i_item_desc = "i_item_desc"
+let qty = "qty"
+let ret = "ret"
+let csq = "csq"
+let store_sales_quantitycount = "store_sales_quantitycount"
+let store_sales_quantityave = "store_sales_quantityave"
+let store_sales_quantitystdev = "store_sales_quantitystdev"
+let store_sales_quantitycov = "store_sales_quantitycov"
+let store_returns_quantitycount = "store_returns_quantitycount"
+let store_returns_quantityave = "store_returns_quantityave"
+let store_returns_quantitystdev = "store_returns_quantitystdev"
+let store_returns_quantitycov = "store_returns_quantitycov"
+let catalog_sales_quantitycount = "catalog_sales_quantitycount"
+let catalog_sales_quantityave = "catalog_sales_quantityave"
+let catalog_sales_quantitystdev = "catalog_sales_quantitystdev"
+let catalog_sales_quantitycov = "catalog_sales_quantitycov"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_sold_date_sk: int;
+        ss_item_sk: int;
+        ss_customer_sk: int;
+        ss_ticket_number: int;
+        ss_quantity: int;
+        ss_store_sk: int
+    }
+
+type StoreReturn =
+    {
+        sr_returned_date_sk: int;
+        sr_customer_sk: int;
+        sr_item_sk: int;
+        sr_ticket_number: int;
+        sr_return_quantity: int
+    }
+
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_customer_sk: int;
+        cs_quantity: int
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_quarter_name: string
+    }
+
+type Store =
+    {
+        s_store_sk: int;
+        s_state: string
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string
+    }
+
+type StoreSale =
+    {
+        ss_sold_date_sk: int;
+        ss_item_sk: int;
+        ss_customer_sk: int;
+        ss_ticket_number: int;
+        ss_quantity: int;
+        ss_store_sk: int
+    }
+type StoreReturn =
+    {
+        sr_returned_date_sk: int;
+        sr_customer_sk: int;
+        sr_item_sk: int;
+        sr_ticket_number: int;
+        sr_return_quantity: int
+    }
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_customer_sk: int;
+        cs_quantity: int
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_quarter_name: string
+    }
+type Store =
+    {
+        s_store_sk: int;
+        s_state: string
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string
+    }
+let store_sales = [|Map.ofList [(ss_sold_date_sk, 1); (ss_item_sk, 1); (ss_customer_sk, 1); (ss_ticket_number, 1); (ss_quantity, 10); (ss_store_sk, 1)]|]
+let store_returns = [|Map.ofList [(sr_returned_date_sk, 2); (sr_customer_sk, 1); (sr_item_sk, 1); (sr_ticket_number, 1); (sr_return_quantity, 2)]|]
+let catalog_sales = [|Map.ofList [(cs_sold_date_sk, 3); (cs_item_sk, 1); (cs_bill_customer_sk, 1); (cs_quantity, 5)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_quarter_name, "1998Q1")]; Map.ofList [(d_date_sk, 2); (d_quarter_name, "1998Q2")]; Map.ofList [(d_date_sk, 3); (d_quarter_name, "1998Q3")]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_state, "CA")]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "I1"); (i_item_desc, "Item 1")]|]
+let joined = 
+    [|
+    for ss in store_sales do
+        for sr in store_returns do
+            if (((ss.ss_customer_sk = sr.sr_customer_sk) && (ss.ss_item_sk = sr.sr_item_sk)) && (ss.ss_ticket_number = sr.sr_ticket_number)) then
+                for cs in catalog_sales do
+                    if ((sr.sr_customer_sk = cs.cs_bill_customer_sk) && (sr.sr_item_sk = cs.cs_item_sk)) then
+                        for d1 in date_dim do
+                            if ((ss.ss_sold_date_sk = d1.d_date_sk) && (d1.d_quarter_name = "1998Q1")) then
+                                for d2 in date_dim do
+                                    if ((sr.sr_returned_date_sk = d2.d_date_sk) && Array.contains d2.d_quarter_name [|"1998Q1"; "1998Q2"; "1998Q3"|]) then
+                                        for d3 in date_dim do
+                                            if ((cs.cs_sold_date_sk = d3.d_date_sk) && Array.contains d3.d_quarter_name [|"1998Q1"; "1998Q2"; "1998Q3"|]) then
+                                                for s in store do
+                                                    if (ss.ss_store_sk = s.s_store_sk) then
+                                                        for i in item do
+                                                            if (ss.ss_item_sk = i.i_item_sk) then
+                                                                yield Map.ofList [(qty, ss.ss_quantity); (ret, sr.sr_return_quantity); (csq, cs.cs_quantity); (i_item_id, i.i_item_id); (i_item_desc, i.i_item_desc); (s_state, s.s_state)]
+    |]
+let result = _group_by joined (fun j -> Map.ofList [(i_item_id, j.i_item_id); (i_item_desc, j.i_item_desc); (s_state, j.s_state)]) |> List.map (fun g -> Map.ofList [(i_item_id, g.key.i_item_id); (i_item_desc, g.key.i_item_desc); (s_state, g.key.s_state); (store_sales_quantitycount, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (store_sales_quantityave, avg 
+    [|
+    for x in g do
+        yield x.qty
+    |]); (store_sales_quantitystdev, 0.0); (store_sales_quantitycov, 0.0); (store_returns_quantitycount, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (store_returns_quantityave, avg 
+    [|
+    for x in g do
+        yield x.ret
+    |]); (store_returns_quantitystdev, 0.0); (store_returns_quantitycov, 0.0); (catalog_sales_quantitycount, count 
+    [|
+    for _ in g do
+        yield _
+    |]); (catalog_sales_quantityave, avg 
+    [|
+    for x in g do
+        yield x.csq
+    |]); (catalog_sales_quantitystdev, 0.0); (catalog_sales_quantitycov, 0.0)])
+ignore (_json result)
+let test_TPCDS_Q17_stats() =
+    if not ((result = [|Map.ofList [(i_item_id, "I1"); (i_item_desc, "Item 1"); (s_state, "CA"); (store_sales_quantitycount, 1); (store_sales_quantityave, 10.0); (store_sales_quantitystdev, 0.0); (store_sales_quantitycov, 0.0); (store_returns_quantitycount, 1); (store_returns_quantityave, 2.0); (store_returns_quantitystdev, 0.0); (store_returns_quantitycov, 0.0); (catalog_sales_quantitycount, 1); (catalog_sales_quantityave, 5.0); (catalog_sales_quantitystdev, 0.0); (catalog_sales_quantitycov, 0.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q17 stats" test_TPCDS_Q17_stats) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q18.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q18.fs.out
@@ -1,0 +1,318 @@
+open System
+
+let cs_quantity = "cs_quantity"
+let cs_list_price = "cs_list_price"
+let cs_coupon_amt = "cs_coupon_amt"
+let cs_sales_price = "cs_sales_price"
+let cs_net_profit = "cs_net_profit"
+let cs_bill_cdemo_sk = "cs_bill_cdemo_sk"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cd_demo_sk = "cd_demo_sk"
+let cd_gender = "cd_gender"
+let cd_education_status = "cd_education_status"
+let cd_dep_count = "cd_dep_count"
+let c_customer_sk = "c_customer_sk"
+let c_current_cdemo_sk = "c_current_cdemo_sk"
+let c_current_addr_sk = "c_current_addr_sk"
+let c_birth_year = "c_birth_year"
+let c_birth_month = "c_birth_month"
+let ca_address_sk = "ca_address_sk"
+let ca_country = "ca_country"
+let ca_state = "ca_state"
+let ca_county = "ca_county"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let q = "q"
+let lp = "lp"
+let cp = "cp"
+let sp = "sp"
+let np = "np"
+let by = "by"
+let dep = "dep"
+let agg1 = "agg1"
+let agg2 = "agg2"
+let agg3 = "agg3"
+let agg4 = "agg4"
+let agg5 = "agg5"
+let agg6 = "agg6"
+let agg7 = "agg7"
+
+type _Group<'T>(key: obj) =
+    member val key = key with get, set
+    member val Items = System.Collections.Generic.List<'T>() with get
+    member this.size = this.Items.Count
+
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+    let groups = System.Collections.Generic.Dictionary<string, _Group<'T>>()
+    let order = System.Collections.Generic.List<string>()
+
+    for it in src do
+        let key = keyfn it
+        let ks = string key
+        let mutable g = Unchecked.defaultof<_Group<'T>>
+
+        if groups.TryGetValue(ks, &g) then
+            ()
+        else
+            g <- _Group<'T> (key)
+            groups[ks] <- g
+            order.Add(ks)
+
+        g.Items.Add(it)
+
+    [ for ks in order -> groups[ks] ]
+
+let rec _to_json (v: obj) : string =
+    match v with
+    | null -> "null"
+    | :? string as s -> "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+    | :? bool
+    | :? int
+    | :? int64
+    | :? double -> string v
+    | :? System.Collections.Generic.IDictionary<string, obj> as m ->
+        m
+        |> Seq.map (fun (KeyValue(k, v)) -> "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+        |> String.concat ","
+        |> fun s -> "{" + s + "}"
+    | :? System.Collections.IEnumerable as e ->
+        e
+        |> Seq.cast<obj>
+        |> Seq.map _to_json
+        |> String.concat ","
+        |> fun s -> "[" + s + "]"
+    | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+let _json (v: obj) : unit = printfn "%s" (_to_json v)
+
+let _run_test (name: string) (f: unit -> unit) : bool =
+    printf "%s ... " name
+
+    try
+        f ()
+        printfn "PASS"
+        true
+    with e ->
+        printfn "FAIL (%s)" e.Message
+        false
+
+let inline sum (xs: seq< ^T >) : ^T = Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T = Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T: comparison = Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T: comparison = Seq.max xs
+let count (xs: seq<'T>) : int = Seq.length xs
+
+type CatalogSale =
+    { cs_quantity: int
+      cs_list_price: float
+      cs_coupon_amt: float
+      cs_sales_price: float
+      cs_net_profit: float
+      cs_bill_cdemo_sk: int
+      cs_bill_customer_sk: int
+      cs_sold_date_sk: int
+      cs_item_sk: int }
+
+type CustomerDemographics =
+    { cd_demo_sk: int
+      cd_gender: string
+      cd_education_status: string
+      cd_dep_count: int }
+
+type Customer =
+    { c_customer_sk: int
+      c_current_cdemo_sk: int
+      c_current_addr_sk: int
+      c_birth_year: int
+      c_birth_month: int }
+
+type CustomerAddress =
+    { ca_address_sk: int
+      ca_country: string
+      ca_state: string
+      ca_county: string }
+
+type DateDim = { d_date_sk: int; d_year: int }
+
+type Item = { i_item_sk: int; i_item_id: string }
+
+type CatalogSale =
+    { cs_quantity: int
+      cs_list_price: float
+      cs_coupon_amt: float
+      cs_sales_price: float
+      cs_net_profit: float
+      cs_bill_cdemo_sk: int
+      cs_bill_customer_sk: int
+      cs_sold_date_sk: int
+      cs_item_sk: int }
+
+type CustomerDemographics =
+    { cd_demo_sk: int
+      cd_gender: string
+      cd_education_status: string
+      cd_dep_count: int }
+
+type Customer =
+    { c_customer_sk: int
+      c_current_cdemo_sk: int
+      c_current_addr_sk: int
+      c_birth_year: int
+      c_birth_month: int }
+
+type CustomerAddress =
+    { ca_address_sk: int
+      ca_country: string
+      ca_state: string
+      ca_county: string }
+
+type DateDim = { d_date_sk: int; d_year: int }
+type Item = { i_item_sk: int; i_item_id: string }
+
+let catalog_sales =
+    [| Map.ofList
+           [ (cs_quantity, 1)
+             (cs_list_price, 10.0)
+             (cs_coupon_amt, 1.0)
+             (cs_sales_price, 9.0)
+             (cs_net_profit, 2.0)
+             (cs_bill_cdemo_sk, 1)
+             (cs_bill_customer_sk, 1)
+             (cs_sold_date_sk, 1)
+             (cs_item_sk, 1) ] |]
+
+let customer_demographics =
+    [| Map.ofList
+           [ (cd_demo_sk, 1)
+             (cd_gender, "M")
+             (cd_education_status, "College")
+             (cd_dep_count, 2) ]
+       Map.ofList
+           [ (cd_demo_sk, 2)
+             (cd_gender, "F")
+             (cd_education_status, "College")
+             (cd_dep_count, 2) ] |]
+
+let customer =
+    [| Map.ofList
+           [ (c_customer_sk, 1)
+             (c_current_cdemo_sk, 2)
+             (c_current_addr_sk, 1)
+             (c_birth_year, 1980)
+             (c_birth_month, 1) ] |]
+
+let customer_address =
+    [| Map.ofList
+           [ (ca_address_sk, 1)
+             (ca_country, "US")
+             (ca_state, "CA")
+             (ca_county, "County1") ] |]
+
+let date_dim = [| Map.ofList [ (d_date_sk, 1); (d_year, 1999) ] |]
+let item = [| Map.ofList [ (i_item_sk, 1); (i_item_id, "I1") ] |]
+
+let joined =
+    [| for cs in catalog_sales do
+           for cd1 in customer_demographics do
+               if
+                   (((cs.cs_bill_cdemo_sk = cd1.cd_demo_sk) && (cd1.cd_gender = "M"))
+                    && (cd1.cd_education_status = "College"))
+               then
+                   for c in customer do
+                       if (cs.cs_bill_customer_sk = c.c_customer_sk) then
+                           for cd2 in customer_demographics do
+                               if (c.c_current_cdemo_sk = cd2.cd_demo_sk) then
+                                   for ca in customer_address do
+                                       if (c.c_current_addr_sk = ca.ca_address_sk) then
+                                           for d in date_dim do
+                                               if ((cs.cs_sold_date_sk = d.d_date_sk) && (d.d_year = 1999)) then
+                                                   for i in item do
+                                                       if (cs.cs_item_sk = i.i_item_sk) then
+                                                           yield
+                                                               Map.ofList
+                                                                   [ (i_item_id, i.i_item_id)
+                                                                     (ca_country, ca.ca_country)
+                                                                     (ca_state, ca.ca_state)
+                                                                     (ca_county, ca.ca_county)
+                                                                     (q, cs.cs_quantity)
+                                                                     (lp, cs.cs_list_price)
+                                                                     (cp, cs.cs_coupon_amt)
+                                                                     (sp, cs.cs_sales_price)
+                                                                     (np, cs.cs_net_profit)
+                                                                     (by, c.c_birth_year)
+                                                                     (dep, cd1.cd_dep_count) ] |]
+
+let result =
+    _group_by joined (fun j ->
+        Map.ofList
+            [ (i_item_id, j.i_item_id)
+              (ca_country, j.ca_country)
+              (ca_state, j.ca_state)
+              (ca_county, j.ca_county) ])
+    |> List.map (fun g ->
+        Map.ofList
+            [ (i_item_id, g.key.i_item_id)
+              (ca_country, g.key.ca_country)
+              (ca_state, g.key.ca_state)
+              (ca_county, g.key.ca_county)
+              (agg1,
+               avg
+                   [| for x in g do
+                          yield x.q |])
+              (agg2,
+               avg
+                   [| for x in g do
+                          yield x.lp |])
+              (agg3,
+               avg
+                   [| for x in g do
+                          yield x.cp |])
+              (agg4,
+               avg
+                   [| for x in g do
+                          yield x.sp |])
+              (agg5,
+               avg
+                   [| for x in g do
+                          yield x.np |])
+              (agg6,
+               avg
+                   [| for x in g do
+                          yield x.by |])
+              (agg7,
+               avg
+                   [| for x in g do
+                          yield x.dep |]) ])
+
+ignore (_json result)
+
+let test_TPCDS_Q18_averages () =
+    if
+        not (
+            (result = [| Map.ofList
+                             [ (i_item_id, "I1")
+                               (ca_country, "US")
+                               (ca_state, "CA")
+                               (ca_county, "County1")
+                               (agg1, 1.0)
+                               (agg2, 10.0)
+                               (agg3, 1.0)
+                               (agg4, 9.0)
+                               (agg5, 2.0)
+                               (agg6, 1980.0)
+                               (agg7, 2.0) ] |])
+        )
+    then
+        failwith "expect failed"
+
+let mutable failures = 0
+
+if not (_run_test "TPCDS Q18 averages" test_TPCDS_Q18_averages) then
+    failures <- failures + 1
+
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q19.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q19.fs.out
@@ -1,0 +1,213 @@
+open System
+
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_item_sk = "ss_item_sk"
+let ss_customer_sk = "ss_customer_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let i_item_sk = "i_item_sk"
+let i_brand_id = "i_brand_id"
+let i_brand = "i_brand"
+let i_manufact_id = "i_manufact_id"
+let i_manufact = "i_manufact"
+let i_manager_id = "i_manager_id"
+let c_customer_sk = "c_customer_sk"
+let c_current_addr_sk = "c_current_addr_sk"
+let ca_address_sk = "ca_address_sk"
+let ca_zip = "ca_zip"
+let s_store_sk = "s_store_sk"
+let s_zip = "s_zip"
+let ext_price = "ext_price"
+let brand = "brand"
+let brand_id = "brand_id"
+let man_id = "man_id"
+let man = "man"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _slice_string (s: string) (i: int) (j: int) : string =
+  let mutable start = i
+  let mutable stop = j
+  let n = s.Length
+  if start < 0 then start <- start + n
+  if stop < 0 then stop <- stop + n
+  if start < 0 then start <- 0
+  if stop > n then stop <- n
+  if stop < start then stop <- start
+  s.Substring(start, stop - start)
+
+type StoreSale =
+    {
+        ss_sold_date_sk: int;
+        ss_item_sk: int;
+        ss_customer_sk: int;
+        ss_store_sk: int;
+        ss_ext_sales_price: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_brand_id: int;
+        i_brand: string;
+        i_manufact_id: int;
+        i_manufact: string;
+        i_manager_id: int
+    }
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_addr_sk: int
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_zip: string
+    }
+
+type Store =
+    {
+        s_store_sk: int;
+        s_zip: string
+    }
+
+type StoreSale =
+    {
+        ss_sold_date_sk: int;
+        ss_item_sk: int;
+        ss_customer_sk: int;
+        ss_store_sk: int;
+        ss_ext_sales_price: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_brand_id: int;
+        i_brand: string;
+        i_manufact_id: int;
+        i_manufact: string;
+        i_manager_id: int
+    }
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_addr_sk: int
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_zip: string
+    }
+type Store =
+    {
+        s_store_sk: int;
+        s_zip: string
+    }
+let store_sales = [|Map.ofList [(ss_sold_date_sk, 1); (ss_item_sk, 1); (ss_customer_sk, 1); (ss_store_sk, 1); (ss_ext_sales_price, 100.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 1999); (d_moy, 11)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_brand_id, 1); (i_brand, "B1"); (i_manufact_id, 1); (i_manufact, "M1"); (i_manager_id, 10)]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_current_addr_sk, 1)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_zip, "11111")]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_zip, "99999")]|]
+let result = [| for g in _group_by [|
+    for d in date_dim do
+        for ss in store_sales do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                for i in item do
+                    if ((ss.ss_item_sk = i.i_item_sk) && (i.i_manager_id = 10)) then
+                        for c in customer do
+                            if (ss.ss_customer_sk = c.c_customer_sk) then
+                                for ca in customer_address do
+                                    if (c.c_current_addr_sk = ca.ca_address_sk) then
+                                        for s in store do
+                                            if ((ss.ss_store_sk = s.s_store_sk) && (_slice_string ca.ca_zip 0 5 <> _slice_string s.s_zip 0 5)) then
+                                                if ((d.d_moy = 11) && (d.d_year = 1999)) then
+                                                    yield (d, ss, i, c, ca, s)
+|] (fun (d, ss, i, c, ca, s) -> Map.ofList [(brand, i.i_brand); (brand_id, i.i_brand_id); (man_id, i.i_manufact_id); (man, i.i_manufact)]) do let g = g yield ([|g.key.brand|], Map.ofList [(i_brand, g.key.brand); (i_brand_id, g.key.brand_id); (i_manufact_id, g.key.man_id); (i_manufact, g.key.man); (ext_price, sum 
+    [|
+    for x in g do
+        yield x.ss_ext_sales_price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q19_brand() =
+    if not ((result = [|Map.ofList [(i_brand, "B1"); (i_brand_id, 1); (i_manufact_id, 1); (i_manufact, "M1"); (ext_price, 100.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q19 brand" test_TPCDS_Q19_brand) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q20.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q20.fs.out
@@ -1,0 +1,163 @@
+open System
+
+let cs_item_sk = "cs_item_sk"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_ext_sales_price = "cs_ext_sales_price"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let i_item_desc = "i_item_desc"
+let i_category = "i_category"
+let i_class = "i_class"
+let i_current_price = "i_current_price"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let itemrevenue = "itemrevenue"
+let id = "id"
+let desc = "desc"
+let cat = "cat"
+let _class = "class"
+let price = "price"
+let total = "total"
+let revenueratio = "revenueratio"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type CatalogSale =
+    {
+        cs_item_sk: int;
+        cs_sold_date_sk: int;
+        cs_ext_sales_price: float
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string;
+        i_category: string;
+        i_class: string;
+        i_current_price: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+
+type CatalogSale =
+    {
+        cs_item_sk: int;
+        cs_sold_date_sk: int;
+        cs_ext_sales_price: float
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string;
+        i_category: string;
+        i_class: string;
+        i_current_price: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+let catalog_sales = [|Map.ofList [(cs_item_sk, 1); (cs_sold_date_sk, 1); (cs_ext_sales_price, 100.0)]; Map.ofList [(cs_item_sk, 1); (cs_sold_date_sk, 1); (cs_ext_sales_price, 200.0)]; Map.ofList [(cs_item_sk, 2); (cs_sold_date_sk, 1); (cs_ext_sales_price, 150.0)]; Map.ofList [(cs_item_sk, 1); (cs_sold_date_sk, 2); (cs_ext_sales_price, 300.0)]; Map.ofList [(cs_item_sk, 2); (cs_sold_date_sk, 2); (cs_ext_sales_price, 150.0)]; Map.ofList [(cs_item_sk, 3); (cs_sold_date_sk, 1); (cs_ext_sales_price, 50.0)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "ITEM1"); (i_item_desc, "Item One"); (i_category, "A"); (i_class, "X"); (i_current_price, 10.0)]; Map.ofList [(i_item_sk, 2); (i_item_id, "ITEM2"); (i_item_desc, "Item Two"); (i_category, "A"); (i_class, "X"); (i_current_price, 20.0)]; Map.ofList [(i_item_sk, 3); (i_item_id, "ITEM3"); (i_item_desc, "Item Three"); (i_category, "D"); (i_class, "Y"); (i_current_price, 15.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2000-02-10")]; Map.ofList [(d_date_sk, 2); (d_date, "2000-02-20")]|]
+let filtered = [| for g in _group_by [|
+    for cs in catalog_sales do
+        for i in item do
+            if (cs.cs_item_sk = i.i_item_sk) then
+                for d in date_dim do
+                    if (cs.cs_sold_date_sk = d.d_date_sk) then
+                        if ((Array.contains i.i_category [|"A"; "B"; "C"|] && (d.d_date >= "2000-02-01")) && (d.d_date <= "2000-03-02")) then
+                            yield (cs, i, d)
+|] (fun (cs, i, d) -> Map.ofList [(id, i.i_item_id); (desc, i.i_item_desc); (cat, i.i_category); (_class, i.i_class); (price, i.i_current_price)]) do let g = g yield Map.ofList [(i_item_id, g.key.id); (i_item_desc, g.key.desc); (i_category, g.key.cat); (i_class, g.key._class); (i_current_price, g.key.price); (itemrevenue, sum 
+    [|
+    for x in g do
+        yield x.cs_ext_sales_price
+    |])] |]
+let class_totals = _group_by filtered (fun f -> f.i_class) |> List.map (fun g -> Map.ofList [(_class, g.key); (total, sum 
+    [|
+    for x in g do
+        yield x.itemrevenue
+    |])])
+let result = 
+    [|
+    for f in filtered do
+        for t in class_totals do
+            if (f.i_class = t._class) then
+                yield ([|f.i_category; f.i_class; f.i_item_id; f.i_item_desc|], Map.ofList [(i_item_id, f.i_item_id); (i_item_desc, f.i_item_desc); (i_category, f.i_category); (i_class, f.i_class); (i_current_price, f.i_current_price); (itemrevenue, f.itemrevenue); (revenueratio, (((f.itemrevenue * 100.0)) / t.total))])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q20_revenue_ratio() =
+    if not ((result = [|Map.ofList [(i_item_id, "ITEM1"); (i_item_desc, "Item One"); (i_category, "A"); (i_class, "X"); (i_current_price, 10.0); (itemrevenue, 600.0); (revenueratio, 66.66666666666667)]; Map.ofList [(i_item_id, "ITEM2"); (i_item_desc, "Item Two"); (i_category, "A"); (i_class, "X"); (i_current_price, 20.0); (itemrevenue, 300.0); (revenueratio, 33.333333333333336)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q20 revenue ratio" test_TPCDS_Q20_revenue_ratio) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q21.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q21.fs.out
@@ -1,0 +1,184 @@
+open System
+
+let inv_item_sk = "inv_item_sk"
+let inv_warehouse_sk = "inv_warehouse_sk"
+let inv_date_sk = "inv_date_sk"
+let inv_quantity_on_hand = "inv_quantity_on_hand"
+let w_warehouse_sk = "w_warehouse_sk"
+let w_warehouse_name = "w_warehouse_name"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let w = "w"
+let i = "i"
+let qty = "qty"
+let w_name = "w_name"
+let i_id = "i_id"
+let before_qty = "before_qty"
+let after_qty = "after_qty"
+let ratio = "ratio"
+let inv_before = "inv_before"
+let inv_after = "inv_after"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type Inventory =
+    {
+        inv_item_sk: int;
+        inv_warehouse_sk: int;
+        inv_date_sk: int;
+        inv_quantity_on_hand: int
+    }
+
+type Warehouse =
+    {
+        w_warehouse_sk: int;
+        w_warehouse_name: string
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+
+type Inventory =
+    {
+        inv_item_sk: int;
+        inv_warehouse_sk: int;
+        inv_date_sk: int;
+        inv_quantity_on_hand: int
+    }
+type Warehouse =
+    {
+        w_warehouse_sk: int;
+        w_warehouse_name: string
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+let inventory = [|Map.ofList [(inv_item_sk, 1); (inv_warehouse_sk, 1); (inv_date_sk, 1); (inv_quantity_on_hand, 30)]; Map.ofList [(inv_item_sk, 1); (inv_warehouse_sk, 1); (inv_date_sk, 2); (inv_quantity_on_hand, 40)]; Map.ofList [(inv_item_sk, 2); (inv_warehouse_sk, 2); (inv_date_sk, 1); (inv_quantity_on_hand, 20)]; Map.ofList [(inv_item_sk, 2); (inv_warehouse_sk, 2); (inv_date_sk, 2); (inv_quantity_on_hand, 20)]|]
+let warehouse = [|Map.ofList [(w_warehouse_sk, 1); (w_warehouse_name, "Main")]; Map.ofList [(w_warehouse_sk, 2); (w_warehouse_name, "Backup")]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "ITEM1")]; Map.ofList [(i_item_sk, 2); (i_item_id, "ITEM2")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2000-03-01")]; Map.ofList [(d_date_sk, 2); (d_date, "2000-03-20")]|]
+let before = [| for g in _group_by [|
+    for inv in inventory do
+        for d in date_dim do
+            if (inv.inv_date_sk = d.d_date_sk) then
+                if (d.d_date < "2000-03-15") then
+                    yield (inv, d)
+|] (fun (inv, d) -> Map.ofList [(w, inv.inv_warehouse_sk); (i, inv.inv_item_sk)]) do let g = g yield Map.ofList [(w, g.key.w); (i, g.key.i); (qty, sum 
+    [|
+    for x in g do
+        yield x.inv_quantity_on_hand
+    |])] |]
+let after = [| for g in _group_by [|
+    for inv in inventory do
+        for d in date_dim do
+            if (inv.inv_date_sk = d.d_date_sk) then
+                if (d.d_date >= "2000-03-15") then
+                    yield (inv, d)
+|] (fun (inv, d) -> Map.ofList [(w, inv.inv_warehouse_sk); (i, inv.inv_item_sk)]) do let g = g yield Map.ofList [(w, g.key.w); (i, g.key.i); (qty, sum 
+    [|
+    for x in g do
+        yield x.inv_quantity_on_hand
+    |])] |]
+let joined = 
+    [|
+    for b in before do
+        for a in after do
+            if ((b.w = a.w) && (b.i = a.i)) then
+                for w in warehouse do
+                    if (w.w_warehouse_sk = b.w) then
+                        for it in item do
+                            if (it.i_item_sk = b.i) then
+                                yield Map.ofList [(w_name, w.w_warehouse_name); (i_id, it.i_item_id); (before_qty, b.qty); (after_qty, a.qty); (ratio, (a.qty / b.qty))]
+    |]
+let result = 
+    [|
+    for r in joined do
+        if ((r.ratio >= ((2.0 / 3.0))) && (r.ratio <= ((3.0 / 2.0)))) then
+            yield ([|r.w_name; r.i_id|], Map.ofList [(w_warehouse_name, r.w_name); (i_item_id, r.i_id); (inv_before, r.before_qty); (inv_after, r.after_qty)])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q21_inventory_ratio() =
+    if not ((result = [|Map.ofList [(w_warehouse_name, "Main"); (i_item_id, "ITEM1"); (inv_before, 30); (inv_after, 40)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q21 inventory ratio" test_TPCDS_Q21_inventory_ratio) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q22.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q22.fs.out
@@ -1,0 +1,143 @@
+open System
+
+let inv_item_sk = "inv_item_sk"
+let inv_date_sk = "inv_date_sk"
+let inv_quantity_on_hand = "inv_quantity_on_hand"
+let d_date_sk = "d_date_sk"
+let d_month_seq = "d_month_seq"
+let i_item_sk = "i_item_sk"
+let i_product_name = "i_product_name"
+let i_brand = "i_brand"
+let i_class = "i_class"
+let i_category = "i_category"
+let qoh = "qoh"
+let product_name = "product_name"
+let brand = "brand"
+let _class = "class"
+let category = "category"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type Inventory =
+    {
+        inv_item_sk: int;
+        inv_date_sk: int;
+        inv_quantity_on_hand: int
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_month_seq: int
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_product_name: string;
+        i_brand: string;
+        i_class: string;
+        i_category: string
+    }
+
+type Inventory =
+    {
+        inv_item_sk: int;
+        inv_date_sk: int;
+        inv_quantity_on_hand: int
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_month_seq: int
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_product_name: string;
+        i_brand: string;
+        i_class: string;
+        i_category: string
+    }
+let inventory = [|Map.ofList [(inv_item_sk, 1); (inv_date_sk, 1); (inv_quantity_on_hand, 10)]; Map.ofList [(inv_item_sk, 1); (inv_date_sk, 2); (inv_quantity_on_hand, 20)]; Map.ofList [(inv_item_sk, 1); (inv_date_sk, 3); (inv_quantity_on_hand, 10)]; Map.ofList [(inv_item_sk, 1); (inv_date_sk, 4); (inv_quantity_on_hand, 20)]; Map.ofList [(inv_item_sk, 2); (inv_date_sk, 1); (inv_quantity_on_hand, 50)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_month_seq, 0)]; Map.ofList [(d_date_sk, 2); (d_month_seq, 1)]; Map.ofList [(d_date_sk, 3); (d_month_seq, 2)]; Map.ofList [(d_date_sk, 4); (d_month_seq, 3)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_product_name, "Prod1"); (i_brand, "Brand1"); (i_class, "Class1"); (i_category, "Cat1")]; Map.ofList [(i_item_sk, 2); (i_product_name, "Prod2"); (i_brand, "Brand2"); (i_class, "Class2"); (i_category, "Cat2")]|]
+let qoh = [| for g in _group_by [|
+    for inv in inventory do
+        for d in date_dim do
+            if (inv.inv_date_sk = d.d_date_sk) then
+                for i in item do
+                    if (inv.inv_item_sk = i.i_item_sk) then
+                        if ((d.d_month_seq >= 0) && (d.d_month_seq <= 11)) then
+                            yield (inv, d, i)
+|] (fun (inv, d, i) -> Map.ofList [(product_name, i.i_product_name); (brand, i.i_brand); (_class, i.i_class); (category, i.i_category)]) do let g = g yield Map.ofList [(i_product_name, g.key.product_name); (i_brand, g.key.brand); (i_class, g.key._class); (i_category, g.key.category); (qoh, avg 
+    [|
+    for x in g do
+        yield x.inv_quantity_on_hand
+    |])] |]
+ignore (_json qoh)
+let test_TPCDS_Q22_average_inventory() =
+    if not ((qoh = [|Map.ofList [(i_product_name, "Prod1"); (i_brand, "Brand1"); (i_class, "Class1"); (i_category, "Cat1"); (qoh, 15.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q22 average inventory" test_TPCDS_Q22_average_inventory) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q23.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q23.fs.out
@@ -1,0 +1,214 @@
+open System
+
+let ss_item_sk = "ss_item_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_customer_sk = "ss_customer_sk"
+let ss_quantity = "ss_quantity"
+let ss_sales_price = "ss_sales_price"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let i_item_sk = "i_item_sk"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_quantity = "cs_quantity"
+let cs_list_price = "cs_list_price"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_item_sk = "ws_item_sk"
+let ws_bill_customer_sk = "ws_bill_customer_sk"
+let ws_quantity = "ws_quantity"
+let ws_list_price = "ws_list_price"
+let item_sk = "item_sk"
+let date_sk = "date_sk"
+let cust = "cust"
+let sales = "sales"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_sold_date_sk: int;
+        ss_customer_sk: int;
+        ss_quantity: int;
+        ss_sales_price: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+
+type Item =
+    {
+        i_item_sk: int
+    }
+
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_customer_sk: int;
+        cs_quantity: int;
+        cs_list_price: float
+    }
+
+type WebSale =
+    {
+        ws_sold_date_sk: int;
+        ws_item_sk: int;
+        ws_bill_customer_sk: int;
+        ws_quantity: int;
+        ws_list_price: float
+    }
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_sold_date_sk: int;
+        ss_customer_sk: int;
+        ss_quantity: int;
+        ss_sales_price: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+type Item =
+    {
+        i_item_sk: int
+    }
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_customer_sk: int;
+        cs_quantity: int;
+        cs_list_price: float
+    }
+type WebSale =
+    {
+        ws_sold_date_sk: int;
+        ws_item_sk: int;
+        ws_bill_customer_sk: int;
+        ws_quantity: int;
+        ws_list_price: float
+    }
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_sold_date_sk, 1); (ss_customer_sk, 1); (ss_quantity, 1); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 1); (ss_sold_date_sk, 1); (ss_customer_sk, 1); (ss_quantity, 1); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 1); (ss_sold_date_sk, 1); (ss_customer_sk, 1); (ss_quantity, 1); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 1); (ss_sold_date_sk, 1); (ss_customer_sk, 1); (ss_quantity, 1); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 1); (ss_sold_date_sk, 1); (ss_customer_sk, 1); (ss_quantity, 1); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 2); (ss_sold_date_sk, 1); (ss_customer_sk, 2); (ss_quantity, 1); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 2); (ss_sold_date_sk, 1); (ss_customer_sk, 2); (ss_quantity, 1); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 2); (ss_sold_date_sk, 1); (ss_customer_sk, 2); (ss_quantity, 1); (ss_sales_price, 10.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000); (d_moy, 1)]|]
+let item = [|Map.ofList [(i_item_sk, 1)]; Map.ofList [(i_item_sk, 2)]|]
+let catalog_sales = [|Map.ofList [(cs_sold_date_sk, 1); (cs_item_sk, 1); (cs_bill_customer_sk, 1); (cs_quantity, 2); (cs_list_price, 10.0)]; Map.ofList [(cs_sold_date_sk, 1); (cs_item_sk, 2); (cs_bill_customer_sk, 2); (cs_quantity, 2); (cs_list_price, 10.0)]|]
+let web_sales = [|Map.ofList [(ws_sold_date_sk, 1); (ws_item_sk, 1); (ws_bill_customer_sk, 1); (ws_quantity, 3); (ws_list_price, 10.0)]; Map.ofList [(ws_sold_date_sk, 1); (ws_item_sk, 2); (ws_bill_customer_sk, 2); (ws_quantity, 1); (ws_list_price, 10.0)]|]
+let frequent_ss_items = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                for i in item do
+                    if (ss.ss_item_sk = i.i_item_sk) then
+                        if (d.d_year = 2000) then
+                            yield (ss, d, i)
+|] (fun (ss, d, i) -> Map.ofList [(item_sk, i.i_item_sk); (date_sk, d.d_date_sk)]) do let g = g if (count g > 4) then yield g.key.item_sk |]
+let customer_totals = _group_by store_sales (fun ss -> ss.ss_customer_sk) |> List.map (fun g -> Map.ofList [(cust, g.key); (sales, sum 
+    [|
+    for x in g do
+        yield (x.ss_quantity * x.ss_sales_price)
+    |])])
+let max_sales = _max 
+    [|
+    for c in customer_totals do
+        yield c.sales
+    |]
+let best_ss_customer = 
+    [|
+    for c in customer_totals do
+        if (c.sales > (0.95 * max_sales)) then
+            yield c.cust
+    |]
+let catalog = 
+    [|
+    for cs in catalog_sales do
+        for d in date_dim do
+            if (cs.cs_sold_date_sk = d.d_date_sk) then
+                if ((((d.d_year = 2000) && (d.d_moy = 1)) && Array.contains cs.cs_bill_customer_sk best_ss_customer) && Array.contains cs.cs_item_sk frequent_ss_items) then
+                    yield (cs.cs_quantity * cs.cs_list_price)
+    |]
+let web = 
+    [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (ws.ws_sold_date_sk = d.d_date_sk) then
+                if ((((d.d_year = 2000) && (d.d_moy = 1)) && Array.contains ws.ws_bill_customer_sk best_ss_customer) && Array.contains ws.ws_item_sk frequent_ss_items) then
+                    yield (ws.ws_quantity * ws.ws_list_price)
+    |]
+let result = (sum catalog + sum web)
+ignore (_json result)
+let test_TPCDS_Q23_cross_channel_sales() =
+    if not ((result = 50.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q23 cross-channel sales" test_TPCDS_Q23_cross_channel_sales) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q24.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q24.fs.out
@@ -1,0 +1,238 @@
+open System
+
+let ss_ticket_number = "ss_ticket_number"
+let ss_item_sk = "ss_item_sk"
+let ss_customer_sk = "ss_customer_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_net_paid = "ss_net_paid"
+let sr_ticket_number = "sr_ticket_number"
+let sr_item_sk = "sr_item_sk"
+let s_store_sk = "s_store_sk"
+let s_store_name = "s_store_name"
+let s_market_id = "s_market_id"
+let s_state = "s_state"
+let s_zip = "s_zip"
+let i_item_sk = "i_item_sk"
+let i_color = "i_color"
+let i_current_price = "i_current_price"
+let i_manager_id = "i_manager_id"
+let i_units = "i_units"
+let i_size = "i_size"
+let c_customer_sk = "c_customer_sk"
+let c_first_name = "c_first_name"
+let c_last_name = "c_last_name"
+let c_current_addr_sk = "c_current_addr_sk"
+let c_birth_country = "c_birth_country"
+let ca_address_sk = "ca_address_sk"
+let ca_state = "ca_state"
+let ca_country = "ca_country"
+let ca_zip = "ca_zip"
+let color = "color"
+let netpaid = "netpaid"
+let last = "last"
+let first = "first"
+let store_name = "store_name"
+let paid = "paid"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_ticket_number: int;
+        ss_item_sk: int;
+        ss_customer_sk: int;
+        ss_store_sk: int;
+        ss_net_paid: float
+    }
+
+type StoreReturn =
+    {
+        sr_ticket_number: int;
+        sr_item_sk: int
+    }
+
+type Store =
+    {
+        s_store_sk: int;
+        s_store_name: string;
+        s_market_id: int;
+        s_state: string;
+        s_zip: string
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_color: string;
+        i_current_price: float;
+        i_manager_id: int;
+        i_units: string;
+        i_size: string
+    }
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_first_name: string;
+        c_last_name: string;
+        c_current_addr_sk: int;
+        c_birth_country: string
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string;
+        ca_country: string;
+        ca_zip: string
+    }
+
+type StoreSale =
+    {
+        ss_ticket_number: int;
+        ss_item_sk: int;
+        ss_customer_sk: int;
+        ss_store_sk: int;
+        ss_net_paid: float
+    }
+type StoreReturn =
+    {
+        sr_ticket_number: int;
+        sr_item_sk: int
+    }
+type Store =
+    {
+        s_store_sk: int;
+        s_store_name: string;
+        s_market_id: int;
+        s_state: string;
+        s_zip: string
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_color: string;
+        i_current_price: float;
+        i_manager_id: int;
+        i_units: string;
+        i_size: string
+    }
+type Customer =
+    {
+        c_customer_sk: int;
+        c_first_name: string;
+        c_last_name: string;
+        c_current_addr_sk: int;
+        c_birth_country: string
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string;
+        ca_country: string;
+        ca_zip: string
+    }
+let store_sales = [|Map.ofList [(ss_ticket_number, 1); (ss_item_sk, 1); (ss_customer_sk, 1); (ss_store_sk, 1); (ss_net_paid, 100.0)]; Map.ofList [(ss_ticket_number, 2); (ss_item_sk, 2); (ss_customer_sk, 2); (ss_store_sk, 1); (ss_net_paid, 50.0)]|]
+let store_returns = [|Map.ofList [(sr_ticket_number, 1); (sr_item_sk, 1)]; Map.ofList [(sr_ticket_number, 2); (sr_item_sk, 2)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_store_name, "Store1"); (s_market_id, 5); (s_state, "CA"); (s_zip, "12345")]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_color, "RED"); (i_current_price, 10.0); (i_manager_id, 1); (i_units, "EA"); (i_size, "M")]; Map.ofList [(i_item_sk, 2); (i_color, "BLUE"); (i_current_price, 20.0); (i_manager_id, 2); (i_units, "EA"); (i_size, "L")]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_first_name, "Ann"); (c_last_name, "Smith"); (c_current_addr_sk, 1); (c_birth_country, "Canada")]; Map.ofList [(c_customer_sk, 2); (c_first_name, "Bob"); (c_last_name, "Jones"); (c_current_addr_sk, 2); (c_birth_country, "USA")]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_state, "CA"); (ca_country, "USA"); (ca_zip, "12345")]; Map.ofList [(ca_address_sk, 2); (ca_state, "CA"); (ca_country, "USA"); (ca_zip, "54321")]|]
+let ssales = [| for g in _group_by [|
+    for ss in store_sales do
+        for sr in store_returns do
+            if ((ss.ss_ticket_number = sr.sr_ticket_number) && (ss.ss_item_sk = sr.sr_item_sk)) then
+                for s in store do
+                    if (ss.ss_store_sk = s.s_store_sk) then
+                        for i in item do
+                            if (ss.ss_item_sk = i.i_item_sk) then
+                                for c in customer do
+                                    if (ss.ss_customer_sk = c.c_customer_sk) then
+                                        for ca in customer_address do
+                                            if (c.c_current_addr_sk = ca.ca_address_sk) then
+                                                if (((c.c_birth_country <> strings.ToUpper ca.ca_country) && (s.s_zip = ca.ca_zip)) && (s.s_market_id = 5)) then
+                                                    yield (ss, sr, s, i, c, ca)
+|] (fun (ss, sr, s, i, c, ca) -> Map.ofList [(last, c.c_last_name); (first, c.c_first_name); (store_name, s.s_store_name); (color, i.i_color)]) do let g = g yield Map.ofList [(c_last_name, g.key.last); (c_first_name, g.key.first); (s_store_name, g.key.store_name); (color, g.key.color); (netpaid, sum 
+    [|
+    for x in g do
+        yield x.ss_net_paid
+    |])] |]
+let avg_paid = avg 
+    [|
+    for x in ssales do
+        yield x.netpaid
+    |]
+let result = 
+    [|
+    for x in ssales do
+        if ((x.color = "RED") && (x.netpaid > (0.05 * avg_paid))) then
+            yield ([|x.c_last_name; x.c_first_name; x.s_store_name|], Map.ofList [(c_last_name, x.c_last_name); (c_first_name, x.c_first_name); (s_store_name, x.s_store_name); (paid, x.netpaid)])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q24_customer_net_paid() =
+    if not ((result = [|Map.ofList [(c_last_name, "Smith"); (c_first_name, "Ann"); (s_store_name, "Store1"); (paid, 100.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q24 customer net paid" test_TPCDS_Q24_customer_net_paid) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q25.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q25.fs.out
@@ -1,0 +1,227 @@
+open System
+
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_item_sk = "ss_item_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_customer_sk = "ss_customer_sk"
+let ss_net_profit = "ss_net_profit"
+let ss_ticket_number = "ss_ticket_number"
+let sr_returned_date_sk = "sr_returned_date_sk"
+let sr_item_sk = "sr_item_sk"
+let sr_customer_sk = "sr_customer_sk"
+let sr_ticket_number = "sr_ticket_number"
+let sr_net_loss = "sr_net_loss"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_net_profit = "cs_net_profit"
+let d_date_sk = "d_date_sk"
+let d_moy = "d_moy"
+let d_year = "d_year"
+let s_store_sk = "s_store_sk"
+let s_store_id = "s_store_id"
+let s_store_name = "s_store_name"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let i_item_desc = "i_item_desc"
+let store_sales_profit = "store_sales_profit"
+let store_returns_loss = "store_returns_loss"
+let catalog_sales_profit = "catalog_sales_profit"
+let item_id = "item_id"
+let item_desc = "item_desc"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_sold_date_sk: int;
+        ss_item_sk: int;
+        ss_store_sk: int;
+        ss_customer_sk: int;
+        ss_net_profit: float;
+        ss_ticket_number: int
+    }
+
+type StoreReturn =
+    {
+        sr_returned_date_sk: int;
+        sr_item_sk: int;
+        sr_customer_sk: int;
+        sr_ticket_number: int;
+        sr_net_loss: float
+    }
+
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_customer_sk: int;
+        cs_net_profit: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_moy: int;
+        d_year: int
+    }
+
+type Store =
+    {
+        s_store_sk: int;
+        s_store_id: string;
+        s_store_name: string
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string
+    }
+
+type StoreSale =
+    {
+        ss_sold_date_sk: int;
+        ss_item_sk: int;
+        ss_store_sk: int;
+        ss_customer_sk: int;
+        ss_net_profit: float;
+        ss_ticket_number: int
+    }
+type StoreReturn =
+    {
+        sr_returned_date_sk: int;
+        sr_item_sk: int;
+        sr_customer_sk: int;
+        sr_ticket_number: int;
+        sr_net_loss: float
+    }
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_customer_sk: int;
+        cs_net_profit: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_moy: int;
+        d_year: int
+    }
+type Store =
+    {
+        s_store_sk: int;
+        s_store_id: string;
+        s_store_name: string
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string
+    }
+let store_sales = [|Map.ofList [(ss_sold_date_sk, 1); (ss_item_sk, 1); (ss_store_sk, 1); (ss_customer_sk, 1); (ss_net_profit, 50.0); (ss_ticket_number, 1)]; Map.ofList [(ss_sold_date_sk, 1); (ss_item_sk, 2); (ss_store_sk, 1); (ss_customer_sk, 2); (ss_net_profit, 20.0); (ss_ticket_number, 2)]|]
+let store_returns = [|Map.ofList [(sr_returned_date_sk, 2); (sr_item_sk, 1); (sr_customer_sk, 1); (sr_ticket_number, 1); (sr_net_loss, 10.0)]; Map.ofList [(sr_returned_date_sk, 2); (sr_item_sk, 2); (sr_customer_sk, 2); (sr_ticket_number, 2); (sr_net_loss, 5.0)]|]
+let catalog_sales = [|Map.ofList [(cs_sold_date_sk, 3); (cs_item_sk, 1); (cs_bill_customer_sk, 1); (cs_net_profit, 30.0)]; Map.ofList [(cs_sold_date_sk, 3); (cs_item_sk, 2); (cs_bill_customer_sk, 2); (cs_net_profit, 15.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_moy, 4); (d_year, 2000)]; Map.ofList [(d_date_sk, 2); (d_moy, 5); (d_year, 2000)]; Map.ofList [(d_date_sk, 3); (d_moy, 6); (d_year, 2000)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_store_id, "S1"); (s_store_name, "Store1")]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "ITEM1"); (i_item_desc, "Desc1")]; Map.ofList [(i_item_sk, 2); (i_item_id, "ITEM2"); (i_item_desc, "Desc2")]|]
+let result = [| for g in _group_by [|
+    for ss in store_sales do
+        for sr in store_returns do
+            if ((ss.ss_ticket_number = sr.sr_ticket_number) && (ss.ss_item_sk = sr.sr_item_sk)) then
+                for cs in catalog_sales do
+                    if ((sr.sr_customer_sk = cs.cs_bill_customer_sk) && (sr.sr_item_sk = cs.cs_item_sk)) then
+                        for d1 in date_dim do
+                            if (d1.d_date_sk = ss.ss_sold_date_sk) then
+                                for d2 in date_dim do
+                                    if (d2.d_date_sk = sr.sr_returned_date_sk) then
+                                        for d3 in date_dim do
+                                            if (d3.d_date_sk = cs.cs_sold_date_sk) then
+                                                for s in store do
+                                                    if (s.s_store_sk = ss.ss_store_sk) then
+                                                        for i in item do
+                                                            if (i.i_item_sk = ss.ss_item_sk) then
+                                                                if ((((((d1.d_moy = 4) && (d1.d_year = 2000)) && (d2.d_moy >= 4)) && (d2.d_moy <= 10)) && (d3.d_moy >= 4)) && (d3.d_moy <= 10)) then
+                                                                    yield (ss, sr, cs, d1, d2, d3, s, i)
+|] (fun (ss, sr, cs, d1, d2, d3, s, i) -> Map.ofList [(item_id, i.i_item_id); (item_desc, i.i_item_desc); (s_store_id, s.s_store_id); (s_store_name, s.s_store_name)]) do let g = g yield Map.ofList [(i_item_id, g.key.item_id); (i_item_desc, g.key.item_desc); (s_store_id, g.key.s_store_id); (s_store_name, g.key.s_store_name); (store_sales_profit, sum 
+    [|
+    for x in g do
+        yield x.ss_net_profit
+    |]); (store_returns_loss, sum 
+    [|
+    for x in g do
+        yield x.sr_net_loss
+    |]); (catalog_sales_profit, sum 
+    [|
+    for x in g do
+        yield x.cs_net_profit
+    |])] |]
+ignore (_json result)
+let test_TPCDS_Q25_aggregated_profit() =
+    if not ((result = [|Map.ofList [(i_item_id, "ITEM1"); (i_item_desc, "Desc1"); (s_store_id, "S1"); (s_store_name, "Store1"); (store_sales_profit, 50.0); (store_returns_loss, 10.0); (catalog_sales_profit, 30.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q25 aggregated profit" test_TPCDS_Q25_aggregated_profit) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q26.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q26.fs.out
@@ -1,0 +1,201 @@
+open System
+
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_bill_cdemo_sk = "cs_bill_cdemo_sk"
+let cs_promo_sk = "cs_promo_sk"
+let cs_quantity = "cs_quantity"
+let cs_list_price = "cs_list_price"
+let cs_coupon_amt = "cs_coupon_amt"
+let cs_sales_price = "cs_sales_price"
+let cd_demo_sk = "cd_demo_sk"
+let cd_gender = "cd_gender"
+let cd_marital_status = "cd_marital_status"
+let cd_education_status = "cd_education_status"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let p_promo_sk = "p_promo_sk"
+let p_channel_email = "p_channel_email"
+let p_channel_event = "p_channel_event"
+let agg1 = "agg1"
+let agg2 = "agg2"
+let agg3 = "agg3"
+let agg4 = "agg4"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_cdemo_sk: int;
+        cs_promo_sk: int;
+        cs_quantity: int;
+        cs_list_price: float;
+        cs_coupon_amt: float;
+        cs_sales_price: float
+    }
+
+type CustomerDemo =
+    {
+        cd_demo_sk: int;
+        cd_gender: string;
+        cd_marital_status: string;
+        cd_education_status: string
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string
+    }
+
+type Promotion =
+    {
+        p_promo_sk: int;
+        p_channel_email: string;
+        p_channel_event: string
+    }
+
+type CatalogSale =
+    {
+        cs_sold_date_sk: int;
+        cs_item_sk: int;
+        cs_bill_cdemo_sk: int;
+        cs_promo_sk: int;
+        cs_quantity: int;
+        cs_list_price: float;
+        cs_coupon_amt: float;
+        cs_sales_price: float
+    }
+type CustomerDemo =
+    {
+        cd_demo_sk: int;
+        cd_gender: string;
+        cd_marital_status: string;
+        cd_education_status: string
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string
+    }
+type Promotion =
+    {
+        p_promo_sk: int;
+        p_channel_email: string;
+        p_channel_event: string
+    }
+let catalog_sales = [|Map.ofList [(cs_sold_date_sk, 1); (cs_item_sk, 1); (cs_bill_cdemo_sk, 1); (cs_promo_sk, 1); (cs_quantity, 10); (cs_list_price, 100.0); (cs_coupon_amt, 5.0); (cs_sales_price, 95.0)]; Map.ofList [(cs_sold_date_sk, 1); (cs_item_sk, 2); (cs_bill_cdemo_sk, 2); (cs_promo_sk, 2); (cs_quantity, 5); (cs_list_price, 50.0); (cs_coupon_amt, 2.0); (cs_sales_price, 48.0)]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1); (cd_gender, "M"); (cd_marital_status, "S"); (cd_education_status, "College")]; Map.ofList [(cd_demo_sk, 2); (cd_gender, "F"); (cd_marital_status, "M"); (cd_education_status, "High School")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "ITEM1")]; Map.ofList [(i_item_sk, 2); (i_item_id, "ITEM2")]|]
+let promotion = [|Map.ofList [(p_promo_sk, 1); (p_channel_email, "N"); (p_channel_event, "Y")]; Map.ofList [(p_promo_sk, 2); (p_channel_email, "Y"); (p_channel_event, "N")]|]
+let result = [| for g in _group_by [|
+    for cs in catalog_sales do
+        for cd in customer_demographics do
+            if (cs.cs_bill_cdemo_sk = cd.cd_demo_sk) then
+                for d in date_dim do
+                    if (cs.cs_sold_date_sk = d.d_date_sk) then
+                        for i in item do
+                            if (cs.cs_item_sk = i.i_item_sk) then
+                                for p in promotion do
+                                    if (cs.cs_promo_sk = p.p_promo_sk) then
+                                        if (((((cd.cd_gender = "M") && (cd.cd_marital_status = "S")) && (cd.cd_education_status = "College")) && (((p.p_channel_email = "N") || (p.p_channel_event = "N")))) && (d.d_year = 2000)) then
+                                            yield (cs, cd, d, i, p)
+|] (fun (cs, cd, d, i, p) -> i.i_item_id) do let g = g yield Map.ofList [(i_item_id, g.key); (agg1, avg 
+    [|
+    for x in g do
+        yield x.cs_quantity
+    |]); (agg2, avg 
+    [|
+    for x in g do
+        yield x.cs_list_price
+    |]); (agg3, avg 
+    [|
+    for x in g do
+        yield x.cs_coupon_amt
+    |]); (agg4, avg 
+    [|
+    for x in g do
+        yield x.cs_sales_price
+    |])] |]
+ignore (_json result)
+let test_TPCDS_Q26_demographic_averages() =
+    if not ((result = [|Map.ofList [(i_item_id, "ITEM1"); (agg1, 10.0); (agg2, 100.0); (agg3, 5.0); (agg4, 95.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q26 demographic averages" test_TPCDS_Q26_demographic_averages) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q27.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q27.fs.out
@@ -1,0 +1,200 @@
+open System
+
+let ss_item_sk = "ss_item_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_cdemo_sk = "ss_cdemo_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_quantity = "ss_quantity"
+let ss_list_price = "ss_list_price"
+let ss_coupon_amt = "ss_coupon_amt"
+let ss_sales_price = "ss_sales_price"
+let cd_demo_sk = "cd_demo_sk"
+let cd_gender = "cd_gender"
+let cd_marital_status = "cd_marital_status"
+let cd_education_status = "cd_education_status"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let s_store_sk = "s_store_sk"
+let s_state = "s_state"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let agg1 = "agg1"
+let agg2 = "agg2"
+let agg3 = "agg3"
+let agg4 = "agg4"
+let item_id = "item_id"
+let state = "state"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_store_sk: int;
+        ss_cdemo_sk: int;
+        ss_sold_date_sk: int;
+        ss_quantity: int;
+        ss_list_price: float;
+        ss_coupon_amt: float;
+        ss_sales_price: float
+    }
+
+type CustomerDemo =
+    {
+        cd_demo_sk: int;
+        cd_gender: string;
+        cd_marital_status: string;
+        cd_education_status: string
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int
+    }
+
+type Store =
+    {
+        s_store_sk: int;
+        s_state: string
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string
+    }
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_store_sk: int;
+        ss_cdemo_sk: int;
+        ss_sold_date_sk: int;
+        ss_quantity: int;
+        ss_list_price: float;
+        ss_coupon_amt: float;
+        ss_sales_price: float
+    }
+type CustomerDemo =
+    {
+        cd_demo_sk: int;
+        cd_gender: string;
+        cd_marital_status: string;
+        cd_education_status: string
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int
+    }
+type Store =
+    {
+        s_store_sk: int;
+        s_state: string
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string
+    }
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_store_sk, 1); (ss_cdemo_sk, 1); (ss_sold_date_sk, 1); (ss_quantity, 5); (ss_list_price, 100.0); (ss_coupon_amt, 10.0); (ss_sales_price, 90.0)]; Map.ofList [(ss_item_sk, 2); (ss_store_sk, 2); (ss_cdemo_sk, 2); (ss_sold_date_sk, 1); (ss_quantity, 2); (ss_list_price, 50.0); (ss_coupon_amt, 5.0); (ss_sales_price, 45.0)]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1); (cd_gender, "F"); (cd_marital_status, "M"); (cd_education_status, "College")]; Map.ofList [(cd_demo_sk, 2); (cd_gender, "M"); (cd_marital_status, "S"); (cd_education_status, "College")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_state, "CA")]; Map.ofList [(s_store_sk, 2); (s_state, "TX")]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "ITEM1")]; Map.ofList [(i_item_sk, 2); (i_item_id, "ITEM2")]|]
+let result = [| for g in _group_by [|
+    for ss in store_sales do
+        for cd in customer_demographics do
+            if (ss.ss_cdemo_sk = cd.cd_demo_sk) then
+                for d in date_dim do
+                    if (ss.ss_sold_date_sk = d.d_date_sk) then
+                        for s in store do
+                            if (ss.ss_store_sk = s.s_store_sk) then
+                                for i in item do
+                                    if (ss.ss_item_sk = i.i_item_sk) then
+                                        if (((((cd.cd_gender = "F") && (cd.cd_marital_status = "M")) && (cd.cd_education_status = "College")) && (d.d_year = 2000)) && Array.contains s.s_state [|"CA"|]) then
+                                            yield (ss, cd, d, s, i)
+|] (fun (ss, cd, d, s, i) -> Map.ofList [(item_id, i.i_item_id); (state, s.s_state)]) do let g = g yield ([|g.key.item_id; g.key.state|], Map.ofList [(i_item_id, g.key.item_id); (s_state, g.key.state); (agg1, avg 
+    [|
+    for x in g do
+        yield x.ss_quantity
+    |]); (agg2, avg 
+    [|
+    for x in g do
+        yield x.ss_list_price
+    |]); (agg3, avg 
+    [|
+    for x in g do
+        yield x.ss_coupon_amt
+    |]); (agg4, avg 
+    [|
+    for x in g do
+        yield x.ss_sales_price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q27_averages_by_state() =
+    if not ((result = [|Map.ofList [(i_item_id, "ITEM1"); (s_state, "CA"); (agg1, 5.0); (agg2, 100.0); (agg3, 10.0); (agg4, 90.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q27 averages by state" test_TPCDS_Q27_averages_by_state) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q28.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q28.fs.out
@@ -1,0 +1,165 @@
+open System
+
+let ss_quantity = "ss_quantity"
+let ss_list_price = "ss_list_price"
+let ss_coupon_amt = "ss_coupon_amt"
+let ss_wholesale_cost = "ss_wholesale_cost"
+let B1_LP = "B1_LP"
+let B1_CNT = "B1_CNT"
+let B1_CNTD = "B1_CNTD"
+let B2_LP = "B2_LP"
+let B2_CNT = "B2_CNT"
+let B2_CNTD = "B2_CNTD"
+
+type _Group<'T>(key: obj) =
+    member val key = key with get, set
+    member val Items = System.Collections.Generic.List<'T>() with get
+    member this.size = this.Items.Count
+
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+    let groups = System.Collections.Generic.Dictionary<string, _Group<'T>>()
+    let order = System.Collections.Generic.List<string>()
+
+    for it in src do
+        let key = keyfn it
+        let ks = string key
+        let mutable g = Unchecked.defaultof<_Group<'T>>
+
+        if groups.TryGetValue(ks, &g) then
+            ()
+        else
+            g <- _Group<'T> (key)
+            groups[ks] <- g
+            order.Add(ks)
+
+        g.Items.Add(it)
+
+    [ for ks in order -> groups[ks] ]
+
+let rec _to_json (v: obj) : string =
+    match v with
+    | null -> "null"
+    | :? string as s -> "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+    | :? bool
+    | :? int
+    | :? int64
+    | :? double -> string v
+    | :? System.Collections.Generic.IDictionary<string, obj> as m ->
+        m
+        |> Seq.map (fun (KeyValue(k, v)) -> "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+        |> String.concat ","
+        |> fun s -> "{" + s + "}"
+    | :? System.Collections.IEnumerable as e ->
+        e
+        |> Seq.cast<obj>
+        |> Seq.map _to_json
+        |> String.concat ","
+        |> fun s -> "[" + s + "]"
+    | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+let _json (v: obj) : unit = printfn "%s" (_to_json v)
+
+let _run_test (name: string) (f: unit -> unit) : bool =
+    printf "%s ... " name
+
+    try
+        f ()
+        printfn "PASS"
+        true
+    with e ->
+        printfn "FAIL (%s)" e.Message
+        false
+
+let inline sum (xs: seq< ^T >) : ^T = Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T = Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T: comparison = Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T: comparison = Seq.max xs
+let count (xs: seq<'T>) : int = Seq.length xs
+
+type StoreSale =
+    { ss_quantity: int
+      ss_list_price: float
+      ss_coupon_amt: float
+      ss_wholesale_cost: float }
+
+type StoreSale =
+    { ss_quantity: int
+      ss_list_price: float
+      ss_coupon_amt: float
+      ss_wholesale_cost: float }
+
+let store_sales =
+    [| Map.ofList
+           [ (ss_quantity, 3)
+             (ss_list_price, 100.0)
+             (ss_coupon_amt, 50.0)
+             (ss_wholesale_cost, 30.0) ]
+       Map.ofList
+           [ (ss_quantity, 8)
+             (ss_list_price, 80.0)
+             (ss_coupon_amt, 10.0)
+             (ss_wholesale_cost, 20.0) ]
+       Map.ofList
+           [ (ss_quantity, 12)
+             (ss_list_price, 60.0)
+             (ss_coupon_amt, 5.0)
+             (ss_wholesale_cost, 15.0) ] |]
+
+let bucket1 =
+    [| for ss in store_sales do
+           if
+               (((ss.ss_quantity >= 0) && (ss.ss_quantity <= 5))
+                && ((((((ss.ss_list_price >= 0) && (ss.ss_list_price <= 110)))
+                      || (((ss.ss_coupon_amt >= 0) && (ss.ss_coupon_amt <= 1000))))
+                     || (((ss.ss_wholesale_cost >= 0) && (ss.ss_wholesale_cost <= 50))))))
+           then
+               yield ss |]
+
+let bucket2 =
+    [| for ss in store_sales do
+           if
+               (((ss.ss_quantity >= 6) && (ss.ss_quantity <= 10))
+                && ((((((ss.ss_list_price >= 0) && (ss.ss_list_price <= 110)))
+                      || (((ss.ss_coupon_amt >= 0) && (ss.ss_coupon_amt <= 1000))))
+                     || (((ss.ss_wholesale_cost >= 0) && (ss.ss_wholesale_cost <= 50))))))
+           then
+               yield ss |]
+
+let result =
+    Map.ofList
+        [ (B1_LP,
+           avg
+               [| for x in bucket1 do
+                      yield x.ss_list_price |])
+          (B1_CNT, count bucket1)
+          (B1_CNTD, count _group_by bucket1 (fun x -> x.ss_list_price) |> List.map (fun g -> g.key))
+          (B2_LP,
+           avg
+               [| for x in bucket2 do
+                      yield x.ss_list_price |])
+          (B2_CNT, count bucket2)
+          (B2_CNTD, count _group_by bucket2 (fun x -> x.ss_list_price) |> List.map (fun g -> g.key)) ]
+
+ignore (_json result)
+
+let test_TPCDS_Q28_buckets () =
+    if
+        not (
+            (result = Map.ofList
+                [ (B1_LP, 100.0)
+                  (B1_CNT, 1)
+                  (B1_CNTD, 1)
+                  (B2_LP, 80.0)
+                  (B2_CNT, 1)
+                  (B2_CNTD, 1) ])
+        )
+    then
+        failwith "expect failed"
+
+let mutable failures = 0
+
+if not (_run_test "TPCDS Q28 buckets" test_TPCDS_Q28_buckets) then
+    failures <- failures + 1
+
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q29.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q29.fs.out
@@ -1,0 +1,289 @@
+open System
+
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_item_sk = "ss_item_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_customer_sk = "ss_customer_sk"
+let ss_quantity = "ss_quantity"
+let ss_ticket_number = "ss_ticket_number"
+let sr_returned_date_sk = "sr_returned_date_sk"
+let sr_item_sk = "sr_item_sk"
+let sr_customer_sk = "sr_customer_sk"
+let sr_ticket_number = "sr_ticket_number"
+let sr_return_quantity = "sr_return_quantity"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_quantity = "cs_quantity"
+let d_date_sk = "d_date_sk"
+let d_moy = "d_moy"
+let d_year = "d_year"
+let s_store_sk = "s_store_sk"
+let s_store_id = "s_store_id"
+let s_store_name = "s_store_name"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let i_item_desc = "i_item_desc"
+let item_id = "item_id"
+let item_desc = "item_desc"
+let store_sales_quantity = "store_sales_quantity"
+let store_returns_quantity = "store_returns_quantity"
+let catalog_sales_quantity = "catalog_sales_quantity"
+
+type _Group<'T>(key: obj) =
+    member val key = key with get, set
+    member val Items = System.Collections.Generic.List<'T>() with get
+    member this.size = this.Items.Count
+
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+    let groups = System.Collections.Generic.Dictionary<string, _Group<'T>>()
+    let order = System.Collections.Generic.List<string>()
+
+    for it in src do
+        let key = keyfn it
+        let ks = string key
+        let mutable g = Unchecked.defaultof<_Group<'T>>
+
+        if groups.TryGetValue(ks, &g) then
+            ()
+        else
+            g <- _Group<'T> (key)
+            groups[ks] <- g
+            order.Add(ks)
+
+        g.Items.Add(it)
+
+    [ for ks in order -> groups[ks] ]
+
+let rec _to_json (v: obj) : string =
+    match v with
+    | null -> "null"
+    | :? string as s -> "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+    | :? bool
+    | :? int
+    | :? int64
+    | :? double -> string v
+    | :? System.Collections.Generic.IDictionary<string, obj> as m ->
+        m
+        |> Seq.map (fun (KeyValue(k, v)) -> "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+        |> String.concat ","
+        |> fun s -> "{" + s + "}"
+    | :? System.Collections.IEnumerable as e ->
+        e
+        |> Seq.cast<obj>
+        |> Seq.map _to_json
+        |> String.concat ","
+        |> fun s -> "[" + s + "]"
+    | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+let _json (v: obj) : unit = printfn "%s" (_to_json v)
+
+let _run_test (name: string) (f: unit -> unit) : bool =
+    printf "%s ... " name
+
+    try
+        f ()
+        printfn "PASS"
+        true
+    with e ->
+        printfn "FAIL (%s)" e.Message
+        false
+
+let inline sum (xs: seq< ^T >) : ^T = Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T = Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T: comparison = Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T: comparison = Seq.max xs
+let count (xs: seq<'T>) : int = Seq.length xs
+
+type StoreSale =
+    { ss_sold_date_sk: int
+      ss_item_sk: int
+      ss_store_sk: int
+      ss_customer_sk: int
+      ss_quantity: int
+      ss_ticket_number: int }
+
+type StoreReturn =
+    { sr_returned_date_sk: int
+      sr_item_sk: int
+      sr_customer_sk: int
+      sr_ticket_number: int
+      sr_return_quantity: int }
+
+type CatalogSale =
+    { cs_sold_date_sk: int
+      cs_item_sk: int
+      cs_bill_customer_sk: int
+      cs_quantity: int }
+
+type DateDim =
+    { d_date_sk: int
+      d_moy: int
+      d_year: int }
+
+type Store =
+    { s_store_sk: int
+      s_store_id: string
+      s_store_name: string }
+
+type Item =
+    { i_item_sk: int
+      i_item_id: string
+      i_item_desc: string }
+
+type StoreSale =
+    { ss_sold_date_sk: int
+      ss_item_sk: int
+      ss_store_sk: int
+      ss_customer_sk: int
+      ss_quantity: int
+      ss_ticket_number: int }
+
+type StoreReturn =
+    { sr_returned_date_sk: int
+      sr_item_sk: int
+      sr_customer_sk: int
+      sr_ticket_number: int
+      sr_return_quantity: int }
+
+type CatalogSale =
+    { cs_sold_date_sk: int
+      cs_item_sk: int
+      cs_bill_customer_sk: int
+      cs_quantity: int }
+
+type DateDim =
+    { d_date_sk: int
+      d_moy: int
+      d_year: int }
+
+type Store =
+    { s_store_sk: int
+      s_store_id: string
+      s_store_name: string }
+
+type Item =
+    { i_item_sk: int
+      i_item_id: string
+      i_item_desc: string }
+
+let store_sales =
+    [| Map.ofList
+           [ (ss_sold_date_sk, 1)
+             (ss_item_sk, 1)
+             (ss_store_sk, 1)
+             (ss_customer_sk, 1)
+             (ss_quantity, 10)
+             (ss_ticket_number, 1) ] |]
+
+let store_returns =
+    [| Map.ofList
+           [ (sr_returned_date_sk, 2)
+             (sr_item_sk, 1)
+             (sr_customer_sk, 1)
+             (sr_ticket_number, 1)
+             (sr_return_quantity, 2) ] |]
+
+let catalog_sales =
+    [| Map.ofList
+           [ (cs_sold_date_sk, 3)
+             (cs_item_sk, 1)
+             (cs_bill_customer_sk, 1)
+             (cs_quantity, 5) ] |]
+
+let date_dim =
+    [| Map.ofList [ (d_date_sk, 1); (d_moy, 4); (d_year, 1999) ]
+       Map.ofList [ (d_date_sk, 2); (d_moy, 5); (d_year, 1999) ]
+       Map.ofList [ (d_date_sk, 3); (d_moy, 5); (d_year, 2000) ] |]
+
+let store =
+    [| Map.ofList [ (s_store_sk, 1); (s_store_id, "S1"); (s_store_name, "Store1") ] |]
+
+let item =
+    [| Map.ofList [ (i_item_sk, 1); (i_item_id, "ITEM1"); (i_item_desc, "Desc1") ] |]
+
+let _base =
+    [| for ss in store_sales do
+           for sr in store_returns do
+               if ((ss.ss_ticket_number = sr.sr_ticket_number) && (ss.ss_item_sk = sr.sr_item_sk)) then
+                   for cs in catalog_sales do
+                       if ((sr.sr_customer_sk = cs.cs_bill_customer_sk) && (sr.sr_item_sk = cs.cs_item_sk)) then
+                           for d1 in date_dim do
+                               if (d1.d_date_sk = ss.ss_sold_date_sk) then
+                                   for d2 in date_dim do
+                                       if (d2.d_date_sk = sr.sr_returned_date_sk) then
+                                           for d3 in date_dim do
+                                               if (d3.d_date_sk = cs.cs_sold_date_sk) then
+                                                   for s in store do
+                                                       if (s.s_store_sk = ss.ss_store_sk) then
+                                                           for i in item do
+                                                               if (i.i_item_sk = ss.ss_item_sk) then
+                                                                   if
+                                                                       (((((d1.d_moy = 4) && (d1.d_year = 1999))
+                                                                          && (d2.d_moy >= 4))
+                                                                         && (d2.d_moy <= 7))
+                                                                        && Array.contains
+                                                                            d3.d_year
+                                                                            [| 1999; 2000; 2001 |])
+                                                                   then
+                                                                       yield
+                                                                           Map.ofList
+                                                                               [ (ss_quantity, ss.ss_quantity)
+                                                                                 (sr_return_quantity,
+                                                                                  sr.sr_return_quantity)
+                                                                                 (cs_quantity, cs.cs_quantity)
+                                                                                 (i_item_id, i.i_item_id)
+                                                                                 (i_item_desc, i.i_item_desc)
+                                                                                 (s_store_id, s.s_store_id)
+                                                                                 (s_store_name, s.s_store_name) ] |]
+
+let result =
+    _group_by _base (fun b ->
+        Map.ofList
+            [ (item_id, b.i_item_id)
+              (item_desc, b.i_item_desc)
+              (s_store_id, b.s_store_id)
+              (s_store_name, b.s_store_name) ])
+    |> List.map (fun g ->
+        Map.ofList
+            [ (i_item_id, g.key.item_id)
+              (i_item_desc, g.key.item_desc)
+              (s_store_id, g.key.s_store_id)
+              (s_store_name, g.key.s_store_name)
+              (store_sales_quantity,
+               sum
+                   [| for x in g do
+                          yield x.ss_quantity |])
+              (store_returns_quantity,
+               sum
+                   [| for x in g do
+                          yield x.sr_return_quantity |])
+              (catalog_sales_quantity,
+               sum
+                   [| for x in g do
+                          yield x.cs_quantity |]) ])
+
+ignore (_json result)
+
+let test_TPCDS_Q29_quantity_summary () =
+    if
+        not (
+            (result = [| Map.ofList
+                             [ (i_item_id, "ITEM1")
+                               (i_item_desc, "Desc1")
+                               (s_store_id, "S1")
+                               (s_store_name, "Store1")
+                               (store_sales_quantity, 10)
+                               (store_returns_quantity, 2)
+                               (catalog_sales_quantity, 5) ] |])
+        )
+    then
+        failwith "expect failed"
+
+let mutable failures = 0
+
+if not (_run_test "TPCDS Q29 quantity summary" test_TPCDS_Q29_quantity_summary) then
+    failures <- failures + 1
+
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures


### PR DESCRIPTION
## Summary
- extend F# TPC-DS tests to cover queries q1–q29
- add generated F# code for TPC-DS queries q10–q29

## Testing
- `go test ./compile/x/fs -run TPCDS -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68640ccf1f388320815926c441f74906