### PR TITLE
Update Haskell TPC‑DS tests

### DIFF
--- a/compile/x/hs/tpcds_golden_test.go
+++ b/compile/x/hs/tpcds_golden_test.go
@@ -18,37 +18,41 @@ func TestHSCompiler_TPCDSQueries(t *testing.T) {
 	if err := hscode.EnsureHaskell(); err != nil {
 		t.Skipf("haskell not installed: %v", err)
 	}
-    root := testutil.FindRepoRoot(t)
-    queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9"}
-    for _, q := range queries {
-            t.Run(q, func(t *testing.T) {
-                    src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
-                    prog, err := parser.Parse(src)
-                    if err != nil {
-                            t.Fatalf("parse error: %v", err)
-                    }
-                    env := types.NewEnv(nil)
-                    if errs := types.Check(prog, env); len(errs) > 0 {
-                            t.Fatalf("type error: %v", errs[0])
-                    }
-                    code, err := hscode.New(env).Compile(prog)
-                    if err != nil {
-                            t.Fatalf("compile error: %v", err)
-                    }
-                    codeWantPath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "hs", q+".hs.out")
-                    wantCode, err := os.ReadFile(codeWantPath)
-                    if err != nil {
-                            t.Fatalf("read golden: %v", err)
-                    }
-                    if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
-                            t.Errorf("generated code mismatch for %s.hs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
-                    }
-                    dir := t.TempDir()
-                    file := filepath.Join(dir, "main.hs")
-                    if err := os.WriteFile(file, code, 0644); err != nil {
-                            t.Fatalf("write error: %v", err)
-                    }
-                    t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
-            })
-    }
+	root := testutil.FindRepoRoot(t)
+	queries := []string{
+		"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9",
+		"q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
+		"q20", "q21", "q22", "q23", "q25", "q26", "q27", "q28", "q29",
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := hscode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			codeWantPath := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "hs", q+".hs.out")
+			wantCode, err := os.ReadFile(codeWantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s.hs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.hs")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
+		})
+	}
 }

--- a/tests/dataset/tpc-ds/compiler/hs/q10.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q10.hs.out
@@ -1,0 +1,258 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data Customer = Customer
+  { c_customer_sk :: Int,
+    c_current_addr_sk :: Int,
+    c_current_cdemo_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Customer
+
+data CustomerAddress = CustomerAddress
+  { ca_address_sk :: Int,
+    ca_county :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerAddress
+
+data CustomerDemographics = CustomerDemographics
+  { cd_demo_sk :: Int,
+    cd_gender :: String,
+    cd_marital_status :: String,
+    cd_education_status :: String,
+    cd_purchase_estimate :: Int,
+    cd_credit_rating :: String,
+    cd_dep_count :: Int,
+    cd_dep_employed_count :: Int,
+    cd_dep_college_count :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerDemographics
+
+data StoreSale = StoreSale
+  { ss_customer_sk :: Int,
+    ss_sold_date_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int,
+    d_moy :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+customer = [Map.fromList [("c_customer_sk", 1), ("c_current_addr_sk", 1), ("c_current_cdemo_sk", 1)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_county", VString ("CountyA"))]]
+
+customer_demographics = [Map.fromList [("cd_demo_sk", VInt (1)), ("cd_gender", VString ("F")), ("cd_marital_status", VString ("M")), ("cd_education_status", VString ("College")), ("cd_purchase_estimate", VInt (5000)), ("cd_credit_rating", VString ("Good")), ("cd_dep_count", VInt (1)), ("cd_dep_employed_count", VInt (1)), ("cd_dep_college_count", VInt (0))]]
+
+store_sales = [Map.fromList [("ss_customer_sk", 1), ("ss_sold_date_sk", 1)]]
+
+web_sales = []
+
+catalog_sales = []
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000), ("d_moy", 2)]]
+
+active = [cd | c <- customer, ca <- customer_address, cd <- customer_demographics, (((fromMaybe (error "missing") (Map.lookup "c_current_addr_sk" (c)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))) && fromMaybe (error "missing") (Map.lookup "ca_county" (ca))) == "CountyA"), (fromMaybe (error "missing") (Map.lookup "c_current_cdemo_sk" (c)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd))), exists [ss | ss <- store_sales, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (((((((fromMaybe (error "missing") (Map.lookup "ss_customer_sk" ss) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" c)) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == 2000) && fromMaybe (error "missing") (Map.lookup "d_moy" d)) >= 2) && fromMaybe (error "missing") (Map.lookup "d_moy" d)) <= 5)]]
+
+result = [Map.fromList [("cd_gender", VString (fromMaybe (error "missing") (Map.lookup "gender" (key (g))))), ("cd_marital_status", VString (fromMaybe (error "missing") (Map.lookup "marital" (key (g))))), ("cd_education_status", VString (fromMaybe (error "missing") (Map.lookup "education" (key (g))))), ("cnt1", VInt (length [_ | _ <- g])), ("cd_purchase_estimate", VString (fromMaybe (error "missing") (Map.lookup "purchase" (key (g))))), ("cnt2", VInt (length [_ | _ <- g])), ("cd_credit_rating", VString (fromMaybe (error "missing") (Map.lookup "credit" (key (g))))), ("cnt3", VInt (length [_ | _ <- g])), ("cd_dep_count", VString (fromMaybe (error "missing") (Map.lookup "dep" (key (g))))), ("cnt4", VInt (length [_ | _ <- g])), ("cd_dep_employed_count", VString (fromMaybe (error "missing") (Map.lookup "depemp" (key (g))))), ("cnt5", VInt (length [_ | _ <- g])), ("cd_dep_college_count", VString (fromMaybe (error "missing") (Map.lookup "depcol" (key (g))))), ("cnt6", VInt (length [_ | _ <- g]))] | g <- _group_by active (\a -> Map.fromList [("gender", VString (fromMaybe (error "missing") (Map.lookup "cd_gender" a))), ("marital", VString (fromMaybe (error "missing") (Map.lookup "cd_marital_status" a))), ("education", VString (fromMaybe (error "missing") (Map.lookup "cd_education_status" a))), ("purchase", VString (fromMaybe (error "missing") (Map.lookup "cd_purchase_estimate" a))), ("credit", VString (fromMaybe (error "missing") (Map.lookup "cd_credit_rating" a))), ("dep", VString (fromMaybe (error "missing") (Map.lookup "cd_dep_count" a))), ("depemp", VString (fromMaybe (error "missing") (Map.lookup "cd_dep_employed_count" a))), ("depcol", VString (fromMaybe (error "missing") (Map.lookup "cd_dep_college_count" a)))]), let g = g]
+
+test_TPCDS_Q10_demographics_count :: IO ()
+test_TPCDS_Q10_demographics_count = do
+  expect ((result == [Map.fromList [("cd_gender", VString ("F")), ("cd_marital_status", VString ("M")), ("cd_education_status", VString ("College")), ("cnt1", VInt (1)), ("cd_purchase_estimate", VInt (5000)), ("cnt2", VInt (1)), ("cd_credit_rating", VString ("Good")), ("cnt3", VInt (1)), ("cd_dep_count", VInt (1)), ("cnt4", VInt (1)), ("cd_dep_employed_count", VInt (1)), ("cnt5", VInt (1)), ("cd_dep_college_count", VInt (0)), ("cnt6", VInt (1))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q10_demographics_count

--- a/tests/dataset/tpc-ds/compiler/hs/q11.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q11.hs.out
@@ -1,0 +1,237 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data Customer = Customer
+  { c_customer_sk :: Int,
+    c_customer_id :: String,
+    c_first_name :: String,
+    c_last_name :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Customer
+
+data StoreSale = StoreSale
+  { ss_customer_sk :: Int,
+    ss_sold_date_sk :: Int,
+    ss_ext_list_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data WebSale = WebSale
+  { ws_bill_customer_sk :: Int,
+    ws_sold_date_sk :: Int,
+    ws_ext_list_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON WebSale
+
+customer = [Map.fromList [("c_customer_sk", VInt (1)), ("c_customer_id", VString ("C1")), ("c_first_name", VString ("John")), ("c_last_name", VString ("Doe"))]]
+
+store_sales = [Map.fromList [("ss_customer_sk", VInt (1)), ("ss_sold_date_sk", VInt (1998)), ("ss_ext_list_price", VDouble (60.0))], Map.fromList [("ss_customer_sk", VInt (1)), ("ss_sold_date_sk", VInt (1999)), ("ss_ext_list_price", VDouble (90.0))]]
+
+web_sales = [Map.fromList [("ws_bill_customer_sk", VInt (1)), ("ws_sold_date_sk", VInt (1998)), ("ws_ext_list_price", VDouble (50.0))], Map.fromList [("ws_bill_customer_sk", VInt (1)), ("ws_sold_date_sk", VInt (1999)), ("ws_ext_list_price", VDouble (150.0))]]
+
+ss98 = sum [fromMaybe (error "missing") (Map.lookup "ss_ext_list_price" ss) | ss <- filter (\ss -> (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" ss) == 1998)) store_sales]
+
+ss99 = sum [fromMaybe (error "missing") (Map.lookup "ss_ext_list_price" ss) | ss <- filter (\ss -> (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" ss) == 1999)) store_sales]
+
+ws98 = sum [fromMaybe (error "missing") (Map.lookup "ws_ext_list_price" ws) | ws <- filter (\ws -> (fromMaybe (error "missing") (Map.lookup "ws_sold_date_sk" ws) == 1998)) web_sales]
+
+ws99 = sum [fromMaybe (error "missing") (Map.lookup "ws_ext_list_price" ws) | ws <- filter (\ws -> (fromMaybe (error "missing") (Map.lookup "ws_sold_date_sk" ws) == 1999)) web_sales]
+
+growth_ok = (((((ws98 > 0) && ss98) > 0) && ((ws99 / ws98))) > ((ss99 / ss98)))
+
+result = 0
+
+test_TPCDS_Q11_growth :: IO ()
+test_TPCDS_Q11_growth = do
+  expect ((result == [Map.fromList [("customer_id", "C1"), ("customer_first_name", "John"), ("customer_last_name", "Doe")]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q11_growth

--- a/tests/dataset/tpc-ds/compiler/hs/q12.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q12.hs.out
@@ -1,0 +1,232 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data WebSale = WebSale
+  { ws_item_sk :: Int,
+    ws_sold_date_sk :: Int,
+    ws_ext_sales_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON WebSale
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String,
+    i_item_desc :: String,
+    i_category :: String,
+    i_class :: String,
+    i_current_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_date :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+web_sales = [Map.fromList [("ws_item_sk", VInt (1)), ("ws_sold_date_sk", VInt (1)), ("ws_ext_sales_price", VDouble (100.0))], Map.fromList [("ws_item_sk", VInt (1)), ("ws_sold_date_sk", VInt (2)), ("ws_ext_sales_price", VDouble (100.0))], Map.fromList [("ws_item_sk", VInt (2)), ("ws_sold_date_sk", VInt (2)), ("ws_ext_sales_price", VDouble (200.0))], Map.fromList [("ws_item_sk", VInt (3)), ("ws_sold_date_sk", VInt (3)), ("ws_ext_sales_price", VDouble (50.0))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Item One")), ("i_category", VString ("A")), ("i_class", VString ("C1")), ("i_current_price", VDouble (10.0))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("ITEM2")), ("i_item_desc", VString ("Item Two")), ("i_category", VString ("A")), ("i_class", VString ("C1")), ("i_current_price", VDouble (20.0))], Map.fromList [("i_item_sk", VInt (3)), ("i_item_id", VString ("ITEM3")), ("i_item_desc", VString ("Item Three")), ("i_category", VString ("B")), ("i_class", VString ("C2")), ("i_current_price", VDouble (30.0))]]
+
+date_dim = [Map.fromList [("d_date_sk", VInt (1)), ("d_date", VString ("2001-01-20"))], Map.fromList [("d_date_sk", VInt (2)), ("d_date", VString ("2001-02-05"))], Map.fromList [("d_date_sk", VInt (3)), ("d_date", VString ("2001-03-05"))]]
+
+filtered = [Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "id" (key (g))))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "desc" (key (g))))), ("i_category", VString (fromMaybe (error "missing") (Map.lookup "cat" (key (g))))), ("i_class", VString (fromMaybe (error "missing") (Map.lookup "class" (key (g))))), ("i_current_price", VString (fromMaybe (error "missing") (Map.lookup "price" (key (g))))), ("itemrevenue", VDouble (sum [fromMaybe (error "missing") (Map.lookup "ws_ext_sales_price" (x)) | x <- g]))] | g <- _group_by [(ws, i, d) | ws <- web_sales, i <- item, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "ws_item_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "ws_sold_date_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), ((((elem fromMaybe (error "missing") (Map.lookup "i_category" i) ["A", "B", "C"] && fromMaybe (error "missing") (Map.lookup "d_date" d)) >= "2001-01-15") && fromMaybe (error "missing") (Map.lookup "d_date" d)) <= "2001-02-14")] (\(ws, i, d) -> Map.fromList [("id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" i))), ("desc", VString (fromMaybe (error "missing") (Map.lookup "i_item_desc" i))), ("cat", VString (fromMaybe (error "missing") (Map.lookup "i_category" i))), ("class", VString (fromMaybe (error "missing") (Map.lookup "i_class" i))), ("price", VString (fromMaybe (error "missing") (Map.lookup "i_current_price" i)))]), let g = g]
+
+class_totals = [Map.fromList [("class", VString (key (g))), ("total", VDouble (sum [fromMaybe (error "missing") (Map.lookup "itemrevenue" (x)) | x <- g]))] | g <- _group_by filtered (\f -> fromMaybe (error "missing") (Map.lookup "i_class" f)), let g = g]
+
+result = map snd (List.sortOn fst [([fromMaybe (error "missing") (Map.lookup "i_category" (f)), fromMaybe (error "missing") (Map.lookup "i_class" (f)), fromMaybe (error "missing") (Map.lookup "i_item_id" (f)), fromMaybe (error "missing") (Map.lookup "i_item_desc" (f))], Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" f))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "i_item_desc" f))), ("i_category", VString (fromMaybe (error "missing") (Map.lookup "i_category" f))), ("i_class", VString (fromMaybe (error "missing") (Map.lookup "i_class" f))), ("i_current_price", VString (fromMaybe (error "missing") (Map.lookup "i_current_price" f))), ("itemrevenue", VString (fromMaybe (error "missing") (Map.lookup "itemrevenue" f))), ("revenueratio", VString ((((fromMaybe (error "missing") (Map.lookup "itemrevenue" f) * 100.0)) / fromMaybe (error "missing") (Map.lookup "total" t))))]) | f <- filtered, t <- class_totals, (fromMaybe (error "missing") (Map.lookup "i_class" (f)) == fromMaybe (error "missing") (Map.lookup "class" (t)))])
+
+test_TPCDS_Q12_revenue_ratio :: IO ()
+test_TPCDS_Q12_revenue_ratio = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Item One")), ("i_category", VString ("A")), ("i_class", VString ("C1")), ("i_current_price", VDouble (10.0)), ("itemrevenue", VDouble (200.0)), ("revenueratio", VDouble (50.0))], Map.fromList [("i_item_id", VString ("ITEM2")), ("i_item_desc", VString ("Item Two")), ("i_category", VString ("A")), ("i_class", VString ("C1")), ("i_current_price", VDouble (20.0)), ("itemrevenue", VDouble (200.0)), ("revenueratio", VDouble (50.0))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q12_revenue_ratio

--- a/tests/dataset/tpc-ds/compiler/hs/q13.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q13.hs.out
@@ -1,0 +1,265 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_store_sk :: Int,
+    ss_sold_date_sk :: Int,
+    ss_hdemo_sk :: Int,
+    ss_cdemo_sk :: Int,
+    ss_addr_sk :: Int,
+    ss_sales_price :: Double,
+    ss_net_profit :: Double,
+    ss_quantity :: Int,
+    ss_ext_sales_price :: Double,
+    ss_ext_wholesale_cost :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data Store = Store
+  { s_store_sk :: Int,
+    s_state :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Store
+
+data CustomerDemographics = CustomerDemographics
+  { cd_demo_sk :: Int,
+    cd_marital_status :: String,
+    cd_education_status :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerDemographics
+
+data HouseholdDemographics = HouseholdDemographics
+  { hd_demo_sk :: Int,
+    hd_dep_count :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON HouseholdDemographics
+
+data CustomerAddress = CustomerAddress
+  { ca_address_sk :: Int,
+    ca_country :: String,
+    ca_state :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerAddress
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+store_sales = [Map.fromList [("ss_store_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_hdemo_sk", VInt (1)), ("ss_cdemo_sk", VInt (1)), ("ss_addr_sk", VInt (1)), ("ss_sales_price", VDouble (120.0)), ("ss_net_profit", VDouble (150.0)), ("ss_quantity", VInt (10)), ("ss_ext_sales_price", VDouble (100.0)), ("ss_ext_wholesale_cost", VDouble (50.0))]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_state", VString ("CA"))]]
+
+customer_demographics = [Map.fromList [("cd_demo_sk", VInt (1)), ("cd_marital_status", VString ("M1")), ("cd_education_status", VString ("ES1"))]]
+
+household_demographics = [Map.fromList [("hd_demo_sk", 1), ("hd_dep_count", 3)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_country", VString ("United States")), ("ca_state", VString ("CA"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2001)]]
+
+filtered = [ss | ss <- store_sales, s <- store, cd <- customer_demographics, hd <- household_demographics, ca <- customer_address, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "s_store_sk" (s))), (((((fromMaybe (error "missing") (Map.lookup "ss_cdemo_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd))) && fromMaybe (error "missing") (Map.lookup "cd_marital_status" (cd))) == "M1") && fromMaybe (error "missing") (Map.lookup "cd_education_status" (cd))) == "ES1"), (((fromMaybe (error "missing") (Map.lookup "ss_hdemo_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "hd_demo_sk" (hd))) && fromMaybe (error "missing") (Map.lookup "hd_dep_count" (hd))) == 3), (((((fromMaybe (error "missing") (Map.lookup "ss_addr_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))) && fromMaybe (error "missing") (Map.lookup "ca_country" (ca))) == "United States") && fromMaybe (error "missing") (Map.lookup "ca_state" (ca))) == "CA"), (((fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))) && fromMaybe (error "missing") (Map.lookup "d_year" (d))) == 2001)]
+
+result = [Map.fromList [("avg_ss_quantity", avg [fromMaybe (error "missing") (Map.lookup "ss_quantity" (x)) | x <- g]), ("avg_ss_ext_sales_price", avg [fromMaybe (error "missing") (Map.lookup "ss_ext_sales_price" (x)) | x <- g]), ("avg_ss_ext_wholesale_cost", avg [fromMaybe (error "missing") (Map.lookup "ss_ext_wholesale_cost" (x)) | x <- g]), ("sum_ss_ext_wholesale_cost", sum [fromMaybe (error "missing") (Map.lookup "ss_ext_wholesale_cost" (x)) | x <- g])] | g <- _group_by filtered (\r -> Map.fromList []), let g = g]
+
+test_TPCDS_Q13_averages :: IO ()
+test_TPCDS_Q13_averages = do
+  expect ((result == [Map.fromList [("avg_ss_quantity", 10.0), ("avg_ss_ext_sales_price", 100.0), ("avg_ss_ext_wholesale_cost", 50.0), ("sum_ss_ext_wholesale_cost", 50.0)]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q13_averages

--- a/tests/dataset/tpc-ds/compiler/hs/q14.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q14.hs.out
@@ -1,0 +1,258 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_item_sk :: Int,
+    ss_list_price :: Double,
+    ss_quantity :: Int,
+    ss_sold_date_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data CatalogSale = CatalogSale
+  { cs_item_sk :: Int,
+    cs_list_price :: Double,
+    cs_quantity :: Int,
+    cs_sold_date_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data WebSale = WebSale
+  { ws_item_sk :: Int,
+    ws_list_price :: Double,
+    ws_quantity :: Int,
+    ws_sold_date_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON WebSale
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_brand_id :: Int,
+    i_class_id :: Int,
+    i_category_id :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int,
+    d_moy :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+store_sales = [Map.fromList [("ss_item_sk", VInt (1)), ("ss_list_price", VDouble (10.0)), ("ss_quantity", VInt (2)), ("ss_sold_date_sk", VInt (1))], Map.fromList [("ss_item_sk", VInt (1)), ("ss_list_price", VDouble (20.0)), ("ss_quantity", VInt (3)), ("ss_sold_date_sk", VInt (2))]]
+
+catalog_sales = [Map.fromList [("cs_item_sk", VInt (1)), ("cs_list_price", VDouble (10.0)), ("cs_quantity", VInt (2)), ("cs_sold_date_sk", VInt (1))]]
+
+web_sales = [Map.fromList [("ws_item_sk", VInt (1)), ("ws_list_price", VDouble (30.0)), ("ws_quantity", VInt (1)), ("ws_sold_date_sk", VInt (1))]]
+
+item = [Map.fromList [("i_item_sk", 1), ("i_brand_id", 1), ("i_class_id", 1), ("i_category_id", 1)]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000), ("d_moy", 12)], Map.fromList [("d_date_sk", 2), ("d_year", 2002), ("d_moy", 11)]]
+
+cross_items = [Map.fromList [("ss_item_sk", 1)]]
+
+avg_sales = avg [20.0, 20.0, 30.0]
+
+store_filtered = [Map.fromList [("channel", VString ("store")), ("sales", VDouble (sum [(fromMaybe (error "missing") (Map.lookup "ss_quantity" (x)) * fromMaybe (error "missing") (Map.lookup "ss_list_price" (x))) | x <- g])), ("number_sales", VInt (length [_ | _ <- g]))] | g <- _group_by [(ss, d) | ss <- store_sales, d <- date_dim, (((((fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))) && fromMaybe (error "missing") (Map.lookup "d_year" (d))) == 2002) && fromMaybe (error "missing") (Map.lookup "d_moy" (d))) == 11), elem fromMaybe (error "missing") (Map.lookup "ss_item_sk" ss) ([fromMaybe (error "missing") (Map.lookup "ss_item_sk" ci) | ci <- cross_items])] (\(ss, d) -> Map.fromList [("brand_id", 1), ("class_id", 1), ("category_id", 1)]), let g = g]
+
+result = [Map.fromList [("channel", VString (fromMaybe (error "missing") (Map.lookup "channel" r))), ("i_brand_id", VInt (1)), ("i_class_id", VInt (1)), ("i_category_id", VInt (1)), ("sales", VString (fromMaybe (error "missing") (Map.lookup "sales" r))), ("number_sales", VString (fromMaybe (error "missing") (Map.lookup "number_sales" r)))] | r <- filter (\r -> (fromMaybe (error "missing") (Map.lookup "sales" r) > avg_sales)) store_filtered]
+
+test_TPCDS_Q14_cross_channel :: IO ()
+test_TPCDS_Q14_cross_channel = do
+  expect ((result == [Map.fromList [("channel", VString ("store")), ("i_brand_id", VInt (1)), ("i_class_id", VInt (1)), ("i_category_id", VInt (1)), ("sales", VDouble (60.0)), ("number_sales", VInt (1))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q14_cross_channel

--- a/tests/dataset/tpc-ds/compiler/hs/q15.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q15.hs.out
@@ -1,0 +1,236 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data CatalogSale = CatalogSale
+  { cs_bill_customer_sk :: Int,
+    cs_sales_price :: Double,
+    cs_sold_date_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data Customer = Customer
+  { c_customer_sk :: Int,
+    c_current_addr_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Customer
+
+data CustomerAddress = CustomerAddress
+  { ca_address_sk :: Int,
+    ca_zip :: String,
+    ca_state :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerAddress
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_qoy :: Int,
+    d_year :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+catalog_sales = [Map.fromList [("cs_bill_customer_sk", VInt (1)), ("cs_sales_price", VDouble (600.0)), ("cs_sold_date_sk", VInt (1))]]
+
+customer = [Map.fromList [("c_customer_sk", 1), ("c_current_addr_sk", 1)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_zip", VString ("85669")), ("ca_state", VString ("CA"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_qoy", 1), ("d_year", 2000)]]
+
+filtered = map snd (List.sortOn fst [(fromMaybe (error "missing") (Map.lookup "zip" (key (g))), Map.fromList [("ca_zip", VString (fromMaybe (error "missing") (Map.lookup "zip" (key (g))))), ("sum_sales", VDouble (sum [fromMaybe (error "missing") (Map.lookup "cs_sales_price" (x)) | x <- g]))]) | g <- _group_by [(cs, c, ca, d) | cs <- catalog_sales, c <- customer, ca <- customer_address, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "cs_bill_customer_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" (c))), (fromMaybe (error "missing") (Map.lookup "c_current_addr_sk" (c)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (((((((elem (elem substr fromMaybe (error "missing") (Map.lookup "ca_zip" ca) 0 5 ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"] || fromMaybe (error "missing") (Map.lookup "ca_state" ca)) ["CA", "WA", "GA"] || fromMaybe (error "missing") (Map.lookup "cs_sales_price" cs)) > 500)) && fromMaybe (error "missing") (Map.lookup "d_qoy" d)) == 1) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == 2000)] (\(cs, c, ca, d) -> Map.fromList [("zip", VString (fromMaybe (error "missing") (Map.lookup "ca_zip" ca)))])])
+
+test_TPCDS_Q15_zip :: IO ()
+test_TPCDS_Q15_zip = do
+  expect ((filtered == [Map.fromList [("ca_zip", VString ("85669")), ("sum_sales", VDouble (600.0))]]))
+
+main :: IO ()
+main = do
+  _json filtered
+  test_TPCDS_Q15_zip

--- a/tests/dataset/tpc-ds/compiler/hs/q16.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q16.hs.out
@@ -1,0 +1,252 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data CatalogSale = CatalogSale
+  { cs_order_number :: Int,
+    cs_ship_date_sk :: Int,
+    cs_ship_addr_sk :: Int,
+    cs_call_center_sk :: Int,
+    cs_warehouse_sk :: Int,
+    cs_ext_ship_cost :: Double,
+    cs_net_profit :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_date :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data CustomerAddress = CustomerAddress
+  { ca_address_sk :: Int,
+    ca_state :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerAddress
+
+data CallCenter = CallCenter
+  { cc_call_center_sk :: Int,
+    cc_county :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CallCenter
+
+data CatalogReturn = CatalogReturn
+  { cr_order_number :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogReturn
+
+distinct :: [()] -> [()]
+distinct xs =
+  fromMaybe ([]) $
+    (let out = [] in case foldr (\x acc -> case if not contains out x then (let out = append out x in Nothing) else Nothing of Just v -> Just v; Nothing -> acc) Nothing xs of Just v -> Just v; Nothing -> Just (out))
+
+catalog_sales = [Map.fromList [("cs_order_number", VInt (1)), ("cs_ship_date_sk", VInt (1)), ("cs_ship_addr_sk", VInt (1)), ("cs_call_center_sk", VInt (1)), ("cs_warehouse_sk", VInt (1)), ("cs_ext_ship_cost", VDouble (5.0)), ("cs_net_profit", VDouble (20.0))], Map.fromList [("cs_order_number", VInt (1)), ("cs_ship_date_sk", VInt (1)), ("cs_ship_addr_sk", VInt (1)), ("cs_call_center_sk", VInt (1)), ("cs_warehouse_sk", VInt (2)), ("cs_ext_ship_cost", VDouble (0.0)), ("cs_net_profit", VDouble (0.0))]]
+
+date_dim = [Map.fromList [("d_date_sk", VInt (1)), ("d_date", VString ("2000-03-01"))]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_state", VString ("CA"))]]
+
+call_center = [Map.fromList [("cc_call_center_sk", VInt (1)), ("cc_county", VString ("CountyA"))]]
+
+catalog_returns = []
+
+filtered = [Map.fromList [("order_count", VInt (length distinct [fromMaybe (error "missing") (Map.lookup "cs_order_number" (x)) | x <- g])), ("total_shipping_cost", VDouble (sum [fromMaybe (error "missing") (Map.lookup "cs_ext_ship_cost" (x)) | x <- g])), ("total_net_profit", VDouble (sum [fromMaybe (error "missing") (Map.lookup "cs_net_profit" (x)) | x <- g]))] | g <- _group_by [(cs1, d, ca, cc) | cs1 <- catalog_sales, d <- date_dim, ca <- customer_address, cc <- call_center, (((((fromMaybe (error "missing") (Map.lookup "cs_ship_date_sk" (cs1)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))) && fromMaybe (error "missing") (Map.lookup "d_date" (d))) >= "2000-03-01") && fromMaybe (error "missing") (Map.lookup "d_date" (d))) <= "2000-04-30"), (((fromMaybe (error "missing") (Map.lookup "cs_ship_addr_sk" (cs1)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))) && fromMaybe (error "missing") (Map.lookup "ca_state" (ca))) == "CA"), (((fromMaybe (error "missing") (Map.lookup "cs_call_center_sk" (cs1)) == fromMaybe (error "missing") (Map.lookup "cc_call_center_sk" (cc))) && fromMaybe (error "missing") (Map.lookup "cc_county" (cc))) == "CountyA"), ((exists [cs2 | cs2 <- filter (\cs2 -> (((fromMaybe (error "missing") (Map.lookup "cs_order_number" cs1) == fromMaybe (error "missing") (Map.lookup "cs_order_number" cs2)) && fromMaybe (error "missing") (Map.lookup "cs_warehouse_sk" cs1)) /= fromMaybe (error "missing") (Map.lookup "cs_warehouse_sk" cs2))) catalog_sales] && exists [cr | cr <- filter (\cr -> (fromMaybe (error "missing") (Map.lookup "cs_order_number" cs1) == fromMaybe (error "missing") (Map.lookup "cr_order_number" (cr)))) catalog_returns]) == False)] (\(cs1, d, ca, cc) -> Map.fromList []), let g = g]
+
+test_TPCDS_Q16_shipping :: IO ()
+test_TPCDS_Q16_shipping = do
+  expect ((filtered == [Map.fromList [("order_count", VInt (1)), ("total_shipping_cost", VDouble (5.0)), ("total_net_profit", VDouble (20.0))]]))
+
+main :: IO ()
+main = do
+  _json filtered
+  test_TPCDS_Q16_shipping

--- a/tests/dataset/tpc-ds/compiler/hs/q17.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q17.hs.out
@@ -1,0 +1,265 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_sold_date_sk :: Int,
+    ss_item_sk :: Int,
+    ss_customer_sk :: Int,
+    ss_ticket_number :: Int,
+    ss_quantity :: Int,
+    ss_store_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data StoreReturn = StoreReturn
+  { sr_returned_date_sk :: Int,
+    sr_customer_sk :: Int,
+    sr_item_sk :: Int,
+    sr_ticket_number :: Int,
+    sr_return_quantity :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreReturn
+
+data CatalogSale = CatalogSale
+  { cs_sold_date_sk :: Int,
+    cs_item_sk :: Int,
+    cs_bill_customer_sk :: Int,
+    cs_quantity :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_quarter_name :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Store = Store
+  { s_store_sk :: Int,
+    s_state :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Store
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String,
+    i_item_desc :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+store_sales = [Map.fromList [("ss_sold_date_sk", 1), ("ss_item_sk", 1), ("ss_customer_sk", 1), ("ss_ticket_number", 1), ("ss_quantity", 10), ("ss_store_sk", 1)]]
+
+store_returns = [Map.fromList [("sr_returned_date_sk", 2), ("sr_customer_sk", 1), ("sr_item_sk", 1), ("sr_ticket_number", 1), ("sr_return_quantity", 2)]]
+
+catalog_sales = [Map.fromList [("cs_sold_date_sk", 3), ("cs_item_sk", 1), ("cs_bill_customer_sk", 1), ("cs_quantity", 5)]]
+
+date_dim = [Map.fromList [("d_date_sk", VInt (1)), ("d_quarter_name", VString ("1998Q1"))], Map.fromList [("d_date_sk", VInt (2)), ("d_quarter_name", VString ("1998Q2"))], Map.fromList [("d_date_sk", VInt (3)), ("d_quarter_name", VString ("1998Q3"))]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_state", VString ("CA"))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("I1")), ("i_item_desc", VString ("Item 1"))]]
+
+joined = [Map.fromList [("qty", fromMaybe (error "missing") (Map.lookup "ss_quantity" ss)), ("ret", fromMaybe (error "missing") (Map.lookup "sr_return_quantity" sr)), ("csq", fromMaybe (error "missing") (Map.lookup "cs_quantity" cs)), ("i_item_id", fromMaybe (error "missing") (Map.lookup "i_item_id" i)), ("i_item_desc", fromMaybe (error "missing") (Map.lookup "i_item_desc" i)), ("s_state", fromMaybe (error "missing") (Map.lookup "s_state" s))] | ss <- store_sales, sr <- store_returns, cs <- catalog_sales, d1 <- date_dim, d2 <- date_dim, d3 <- date_dim, s <- store, i <- item, (((((fromMaybe (error "missing") (Map.lookup "ss_customer_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "sr_customer_sk" (sr))) && fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss))) == fromMaybe (error "missing") (Map.lookup "sr_item_sk" (sr))) && fromMaybe (error "missing") (Map.lookup "ss_ticket_number" (ss))) == fromMaybe (error "missing") (Map.lookup "sr_ticket_number" (sr))), (((fromMaybe (error "missing") (Map.lookup "sr_customer_sk" (sr)) == fromMaybe (error "missing") (Map.lookup "cs_bill_customer_sk" (cs))) && fromMaybe (error "missing") (Map.lookup "sr_item_sk" (sr))) == fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs))), (((fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d1))) && fromMaybe (error "missing") (Map.lookup "d_quarter_name" (d1))) == "1998Q1"), elem ((fromMaybe (error "missing") (Map.lookup "sr_returned_date_sk" (sr)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d2))) && fromMaybe (error "missing") (Map.lookup "d_quarter_name" (d2))) ["1998Q1", "1998Q2", "1998Q3"], elem ((fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d3))) && fromMaybe (error "missing") (Map.lookup "d_quarter_name" (d3))) ["1998Q1", "1998Q2", "1998Q3"], (fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "s_store_sk" (s))), (fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i)))]
+
+result = [Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" (key (g))))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "i_item_desc" (key (g))))), ("s_state", VString (fromMaybe (error "missing") (Map.lookup "s_state" (key (g))))), ("store_sales_quantitycount", VInt (length [_ | _ <- g])), ("store_sales_quantityave", VDouble (avg [fromMaybe (error "missing") (Map.lookup "qty" (x)) | x <- g])), ("store_sales_quantitystdev", VDouble (0.0)), ("store_sales_quantitycov", VDouble (0.0)), ("store_returns_quantitycount", VInt (length [_ | _ <- g])), ("store_returns_quantityave", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ret" (x)) | x <- g])), ("store_returns_quantitystdev", VDouble (0.0)), ("store_returns_quantitycov", VDouble (0.0)), ("catalog_sales_quantitycount", VInt (length [_ | _ <- g])), ("catalog_sales_quantityave", VDouble (avg [fromMaybe (error "missing") (Map.lookup "csq" (x)) | x <- g])), ("catalog_sales_quantitystdev", VDouble (0.0)), ("catalog_sales_quantitycov", VDouble (0.0))] | g <- _group_by joined (\j -> Map.fromList [("i_item_id", fromMaybe (error "missing") (Map.lookup "i_item_id" j)), ("i_item_desc", fromMaybe (error "missing") (Map.lookup "i_item_desc" j)), ("s_state", fromMaybe (error "missing") (Map.lookup "s_state" j))]), let g = g]
+
+test_TPCDS_Q17_stats :: IO ()
+test_TPCDS_Q17_stats = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("I1")), ("i_item_desc", VString ("Item 1")), ("s_state", VString ("CA")), ("store_sales_quantitycount", VInt (1)), ("store_sales_quantityave", VDouble (10.0)), ("store_sales_quantitystdev", VDouble (0.0)), ("store_sales_quantitycov", VDouble (0.0)), ("store_returns_quantitycount", VInt (1)), ("store_returns_quantityave", VDouble (2.0)), ("store_returns_quantitystdev", VDouble (0.0)), ("store_returns_quantitycov", VDouble (0.0)), ("catalog_sales_quantitycount", VInt (1)), ("catalog_sales_quantityave", VDouble (5.0)), ("catalog_sales_quantitystdev", VDouble (0.0)), ("catalog_sales_quantitycov", VDouble (0.0))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q17_stats

--- a/tests/dataset/tpc-ds/compiler/hs/q18.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q18.hs.out
@@ -1,0 +1,269 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data CatalogSale = CatalogSale
+  { cs_quantity :: Int,
+    cs_list_price :: Double,
+    cs_coupon_amt :: Double,
+    cs_sales_price :: Double,
+    cs_net_profit :: Double,
+    cs_bill_cdemo_sk :: Int,
+    cs_bill_customer_sk :: Int,
+    cs_sold_date_sk :: Int,
+    cs_item_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data CustomerDemographics = CustomerDemographics
+  { cd_demo_sk :: Int,
+    cd_gender :: String,
+    cd_education_status :: String,
+    cd_dep_count :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerDemographics
+
+data Customer = Customer
+  { c_customer_sk :: Int,
+    c_current_cdemo_sk :: Int,
+    c_current_addr_sk :: Int,
+    c_birth_year :: Int,
+    c_birth_month :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Customer
+
+data CustomerAddress = CustomerAddress
+  { ca_address_sk :: Int,
+    ca_country :: String,
+    ca_state :: String,
+    ca_county :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerAddress
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+catalog_sales = [Map.fromList [("cs_quantity", VInt (1)), ("cs_list_price", VDouble (10.0)), ("cs_coupon_amt", VDouble (1.0)), ("cs_sales_price", VDouble (9.0)), ("cs_net_profit", VDouble (2.0)), ("cs_bill_cdemo_sk", VInt (1)), ("cs_bill_customer_sk", VInt (1)), ("cs_sold_date_sk", VInt (1)), ("cs_item_sk", VInt (1))]]
+
+customer_demographics = [Map.fromList [("cd_demo_sk", VInt (1)), ("cd_gender", VString ("M")), ("cd_education_status", VString ("College")), ("cd_dep_count", VInt (2))], Map.fromList [("cd_demo_sk", VInt (2)), ("cd_gender", VString ("F")), ("cd_education_status", VString ("College")), ("cd_dep_count", VInt (2))]]
+
+customer = [Map.fromList [("c_customer_sk", 1), ("c_current_cdemo_sk", 2), ("c_current_addr_sk", 1), ("c_birth_year", 1980), ("c_birth_month", 1)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_country", VString ("US")), ("ca_state", VString ("CA")), ("ca_county", VString ("County1"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 1999)]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("I1"))]]
+
+joined = [Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" i))), ("ca_country", VString (fromMaybe (error "missing") (Map.lookup "ca_country" ca))), ("ca_state", VString (fromMaybe (error "missing") (Map.lookup "ca_state" ca))), ("ca_county", VString (fromMaybe (error "missing") (Map.lookup "ca_county" ca))), ("q", VString (fromMaybe (error "missing") (Map.lookup "cs_quantity" cs))), ("lp", VString (fromMaybe (error "missing") (Map.lookup "cs_list_price" cs))), ("cp", VString (fromMaybe (error "missing") (Map.lookup "cs_coupon_amt" cs))), ("sp", VString (fromMaybe (error "missing") (Map.lookup "cs_sales_price" cs))), ("np", VString (fromMaybe (error "missing") (Map.lookup "cs_net_profit" cs))), ("by", VInt (fromMaybe (error "missing") (Map.lookup "c_birth_year" c))), ("dep", VString (fromMaybe (error "missing") (Map.lookup "cd_dep_count" cd1)))] | cs <- catalog_sales, cd1 <- customer_demographics, c <- customer, cd2 <- customer_demographics, ca <- customer_address, d <- date_dim, i <- item, (((((fromMaybe (error "missing") (Map.lookup "cs_bill_cdemo_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd1))) && fromMaybe (error "missing") (Map.lookup "cd_gender" (cd1))) == "M") && fromMaybe (error "missing") (Map.lookup "cd_education_status" (cd1))) == "College"), (fromMaybe (error "missing") (Map.lookup "cs_bill_customer_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" (c))), (fromMaybe (error "missing") (Map.lookup "c_current_cdemo_sk" (c)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd2))), (fromMaybe (error "missing") (Map.lookup "c_current_addr_sk" (c)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (((fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))) && fromMaybe (error "missing") (Map.lookup "d_year" (d))) == 1999), (fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i)))]
+
+result = [Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" (key (g))))), ("ca_country", VString (fromMaybe (error "missing") (Map.lookup "ca_country" (key (g))))), ("ca_state", VString (fromMaybe (error "missing") (Map.lookup "ca_state" (key (g))))), ("ca_county", VString (fromMaybe (error "missing") (Map.lookup "ca_county" (key (g))))), ("agg1", VDouble (avg [fromMaybe (error "missing") (Map.lookup "q" (x)) | x <- g])), ("agg2", VDouble (avg [fromMaybe (error "missing") (Map.lookup "lp" (x)) | x <- g])), ("agg3", VDouble (avg [fromMaybe (error "missing") (Map.lookup "cp" (x)) | x <- g])), ("agg4", VDouble (avg [fromMaybe (error "missing") (Map.lookup "sp" (x)) | x <- g])), ("agg5", VDouble (avg [fromMaybe (error "missing") (Map.lookup "np" (x)) | x <- g])), ("agg6", VDouble (avg [fromMaybe (error "missing") (Map.lookup "by" (x)) | x <- g])), ("agg7", VDouble (avg [fromMaybe (error "missing") (Map.lookup "dep" (x)) | x <- g]))] | g <- _group_by joined (\j -> Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" j))), ("ca_country", VString (fromMaybe (error "missing") (Map.lookup "ca_country" j))), ("ca_state", VString (fromMaybe (error "missing") (Map.lookup "ca_state" j))), ("ca_county", VString (fromMaybe (error "missing") (Map.lookup "ca_county" j)))]), let g = g]
+
+test_TPCDS_Q18_averages :: IO ()
+test_TPCDS_Q18_averages = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("I1")), ("ca_country", VString ("US")), ("ca_state", VString ("CA")), ("ca_county", VString ("County1")), ("agg1", VDouble (1.0)), ("agg2", VDouble (10.0)), ("agg3", VDouble (1.0)), ("agg4", VDouble (9.0)), ("agg5", VDouble (2.0)), ("agg6", VDouble (1980.0)), ("agg7", VDouble (2.0))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q18_averages

--- a/tests/dataset/tpc-ds/compiler/hs/q19.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q19.hs.out
@@ -1,0 +1,261 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_sold_date_sk :: Int,
+    ss_item_sk :: Int,
+    ss_customer_sk :: Int,
+    ss_store_sk :: Int,
+    ss_ext_sales_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int,
+    d_moy :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_brand_id :: Int,
+    i_brand :: String,
+    i_manufact_id :: Int,
+    i_manufact :: String,
+    i_manager_id :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+data Customer = Customer
+  { c_customer_sk :: Int,
+    c_current_addr_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Customer
+
+data CustomerAddress = CustomerAddress
+  { ca_address_sk :: Int,
+    ca_zip :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerAddress
+
+data Store = Store
+  { s_store_sk :: Int,
+    s_zip :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Store
+
+store_sales = [Map.fromList [("ss_sold_date_sk", VInt (1)), ("ss_item_sk", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_store_sk", VInt (1)), ("ss_ext_sales_price", VDouble (100.0))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 1999), ("d_moy", 11)]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_brand_id", VInt (1)), ("i_brand", VString ("B1")), ("i_manufact_id", VInt (1)), ("i_manufact", VString ("M1")), ("i_manager_id", VInt (10))]]
+
+customer = [Map.fromList [("c_customer_sk", 1), ("c_current_addr_sk", 1)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_zip", VString ("11111"))]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_zip", VString ("99999"))]]
+
+result = map snd (List.sortOn fst [([fromMaybe (error "missing") (Map.lookup "brand" (key (g)))], Map.fromList [("i_brand", VString (fromMaybe (error "missing") (Map.lookup "brand" (key (g))))), ("i_brand_id", VString (fromMaybe (error "missing") (Map.lookup "brand_id" (key (g))))), ("i_manufact_id", VString (fromMaybe (error "missing") (Map.lookup "man_id" (key (g))))), ("i_manufact", VString (fromMaybe (error "missing") (Map.lookup "man" (key (g))))), ("ext_price", VDouble (sum [fromMaybe (error "missing") (Map.lookup "ss_ext_sales_price" (x)) | x <- g]))]) | g <- _group_by [(d, ss, i, c, ca, s) | d <- date_dim, ss <- store_sales, i <- item, c <- customer, ca <- customer_address, s <- store, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (((fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))) && fromMaybe (error "missing") (Map.lookup "i_manager_id" (i))) == 10), (fromMaybe (error "missing") (Map.lookup "ss_customer_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" (c))), (fromMaybe (error "missing") (Map.lookup "c_current_addr_sk" (c)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (((fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "s_store_sk" (s))) && substr fromMaybe (error "missing") (Map.lookup "ca_zip" (ca)) 0 5) /= substr fromMaybe (error "missing") (Map.lookup "s_zip" (s)) 0 5), (((fromMaybe (error "missing") (Map.lookup "d_moy" d) == 11) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == 1999)] (\(d, ss, i, c, ca, s) -> Map.fromList [("brand", VString (fromMaybe (error "missing") (Map.lookup "i_brand" i))), ("brand_id", VString (fromMaybe (error "missing") (Map.lookup "i_brand_id" i))), ("man_id", VString (fromMaybe (error "missing") (Map.lookup "i_manufact_id" i))), ("man", VString (fromMaybe (error "missing") (Map.lookup "i_manufact" i)))])])
+
+test_TPCDS_Q19_brand :: IO ()
+test_TPCDS_Q19_brand = do
+  expect ((result == [Map.fromList [("i_brand", VString ("B1")), ("i_brand_id", VInt (1)), ("i_manufact_id", VInt (1)), ("i_manufact", VString ("M1")), ("ext_price", VDouble (100.0))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q19_brand

--- a/tests/dataset/tpc-ds/compiler/hs/q20.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q20.hs.out
@@ -1,0 +1,232 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data CatalogSale = CatalogSale
+  { cs_item_sk :: Int,
+    cs_sold_date_sk :: Int,
+    cs_ext_sales_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String,
+    i_item_desc :: String,
+    i_category :: String,
+    i_class :: String,
+    i_current_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_date :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+catalog_sales = [Map.fromList [("cs_item_sk", VInt (1)), ("cs_sold_date_sk", VInt (1)), ("cs_ext_sales_price", VDouble (100.0))], Map.fromList [("cs_item_sk", VInt (1)), ("cs_sold_date_sk", VInt (1)), ("cs_ext_sales_price", VDouble (200.0))], Map.fromList [("cs_item_sk", VInt (2)), ("cs_sold_date_sk", VInt (1)), ("cs_ext_sales_price", VDouble (150.0))], Map.fromList [("cs_item_sk", VInt (1)), ("cs_sold_date_sk", VInt (2)), ("cs_ext_sales_price", VDouble (300.0))], Map.fromList [("cs_item_sk", VInt (2)), ("cs_sold_date_sk", VInt (2)), ("cs_ext_sales_price", VDouble (150.0))], Map.fromList [("cs_item_sk", VInt (3)), ("cs_sold_date_sk", VInt (1)), ("cs_ext_sales_price", VDouble (50.0))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Item One")), ("i_category", VString ("A")), ("i_class", VString ("X")), ("i_current_price", VDouble (10.0))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("ITEM2")), ("i_item_desc", VString ("Item Two")), ("i_category", VString ("A")), ("i_class", VString ("X")), ("i_current_price", VDouble (20.0))], Map.fromList [("i_item_sk", VInt (3)), ("i_item_id", VString ("ITEM3")), ("i_item_desc", VString ("Item Three")), ("i_category", VString ("D")), ("i_class", VString ("Y")), ("i_current_price", VDouble (15.0))]]
+
+date_dim = [Map.fromList [("d_date_sk", VInt (1)), ("d_date", VString ("2000-02-10"))], Map.fromList [("d_date_sk", VInt (2)), ("d_date", VString ("2000-02-20"))]]
+
+filtered = [Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "id" (key (g))))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "desc" (key (g))))), ("i_category", VString (fromMaybe (error "missing") (Map.lookup "cat" (key (g))))), ("i_class", VString (fromMaybe (error "missing") (Map.lookup "class" (key (g))))), ("i_current_price", VString (fromMaybe (error "missing") (Map.lookup "price" (key (g))))), ("itemrevenue", VDouble (sum [fromMaybe (error "missing") (Map.lookup "cs_ext_sales_price" (x)) | x <- g]))] | g <- _group_by [(cs, i, d) | cs <- catalog_sales, i <- item, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), ((((elem fromMaybe (error "missing") (Map.lookup "i_category" i) ["A", "B", "C"] && fromMaybe (error "missing") (Map.lookup "d_date" d)) >= "2000-02-01") && fromMaybe (error "missing") (Map.lookup "d_date" d)) <= "2000-03-02")] (\(cs, i, d) -> Map.fromList [("id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" i))), ("desc", VString (fromMaybe (error "missing") (Map.lookup "i_item_desc" i))), ("cat", VString (fromMaybe (error "missing") (Map.lookup "i_category" i))), ("class", VString (fromMaybe (error "missing") (Map.lookup "i_class" i))), ("price", VString (fromMaybe (error "missing") (Map.lookup "i_current_price" i)))]), let g = g]
+
+class_totals = [Map.fromList [("class", VString (key (g))), ("total", VDouble (sum [fromMaybe (error "missing") (Map.lookup "itemrevenue" (x)) | x <- g]))] | g <- _group_by filtered (\f -> fromMaybe (error "missing") (Map.lookup "i_class" f)), let g = g]
+
+result = map snd (List.sortOn fst [([fromMaybe (error "missing") (Map.lookup "i_category" (f)), fromMaybe (error "missing") (Map.lookup "i_class" (f)), fromMaybe (error "missing") (Map.lookup "i_item_id" (f)), fromMaybe (error "missing") (Map.lookup "i_item_desc" (f))], Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" f))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "i_item_desc" f))), ("i_category", VString (fromMaybe (error "missing") (Map.lookup "i_category" f))), ("i_class", VString (fromMaybe (error "missing") (Map.lookup "i_class" f))), ("i_current_price", VString (fromMaybe (error "missing") (Map.lookup "i_current_price" f))), ("itemrevenue", VString (fromMaybe (error "missing") (Map.lookup "itemrevenue" f))), ("revenueratio", VString ((((fromMaybe (error "missing") (Map.lookup "itemrevenue" f) * 100.0)) / fromMaybe (error "missing") (Map.lookup "total" t))))]) | f <- filtered, t <- class_totals, (fromMaybe (error "missing") (Map.lookup "i_class" (f)) == fromMaybe (error "missing") (Map.lookup "class" (t)))])
+
+test_TPCDS_Q20_revenue_ratio :: IO ()
+test_TPCDS_Q20_revenue_ratio = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Item One")), ("i_category", VString ("A")), ("i_class", VString ("X")), ("i_current_price", VDouble (10.0)), ("itemrevenue", VDouble (600.0)), ("revenueratio", VDouble (66.66666666666667))], Map.fromList [("i_item_id", VString ("ITEM2")), ("i_item_desc", VString ("Item Two")), ("i_category", VString ("A")), ("i_class", VString ("X")), ("i_current_price", VDouble (20.0)), ("itemrevenue", VDouble (300.0)), ("revenueratio", VDouble (33.333333333333336))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q20_revenue_ratio

--- a/tests/dataset/tpc-ds/compiler/hs/q21.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q21.hs.out
@@ -1,0 +1,241 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data Inventory = Inventory
+  { inv_item_sk :: Int,
+    inv_warehouse_sk :: Int,
+    inv_date_sk :: Int,
+    inv_quantity_on_hand :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Inventory
+
+data Warehouse = Warehouse
+  { w_warehouse_sk :: Int,
+    w_warehouse_name :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Warehouse
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_date :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+inventory = [Map.fromList [("inv_item_sk", 1), ("inv_warehouse_sk", 1), ("inv_date_sk", 1), ("inv_quantity_on_hand", 30)], Map.fromList [("inv_item_sk", 1), ("inv_warehouse_sk", 1), ("inv_date_sk", 2), ("inv_quantity_on_hand", 40)], Map.fromList [("inv_item_sk", 2), ("inv_warehouse_sk", 2), ("inv_date_sk", 1), ("inv_quantity_on_hand", 20)], Map.fromList [("inv_item_sk", 2), ("inv_warehouse_sk", 2), ("inv_date_sk", 2), ("inv_quantity_on_hand", 20)]]
+
+warehouse = [Map.fromList [("w_warehouse_sk", VInt (1)), ("w_warehouse_name", VString ("Main"))], Map.fromList [("w_warehouse_sk", VInt (2)), ("w_warehouse_name", VString ("Backup"))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("ITEM1"))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("ITEM2"))]]
+
+date_dim = [Map.fromList [("d_date_sk", VInt (1)), ("d_date", VString ("2000-03-01"))], Map.fromList [("d_date_sk", VInt (2)), ("d_date", VString ("2000-03-20"))]]
+
+before = [Map.fromList [("w", VString (fromMaybe (error "missing") (Map.lookup "w" (key (g))))), ("i", VString (fromMaybe (error "missing") (Map.lookup "i" (key (g))))), ("qty", VDouble (sum [fromMaybe (error "missing") (Map.lookup "inv_quantity_on_hand" (x)) | x <- g]))] | g <- _group_by [(inv, d) | inv <- inventory, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "inv_date_sk" (inv)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "d_date" d) < "2000-03-15")] (\(inv, d) -> Map.fromList [("w", fromMaybe (error "missing") (Map.lookup "inv_warehouse_sk" inv)), ("i", fromMaybe (error "missing") (Map.lookup "inv_item_sk" inv))]), let g = g]
+
+after = [Map.fromList [("w", VString (fromMaybe (error "missing") (Map.lookup "w" (key (g))))), ("i", VString (fromMaybe (error "missing") (Map.lookup "i" (key (g))))), ("qty", VDouble (sum [fromMaybe (error "missing") (Map.lookup "inv_quantity_on_hand" (x)) | x <- g]))] | g <- _group_by [(inv, d) | inv <- inventory, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "inv_date_sk" (inv)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "d_date" d) >= "2000-03-15")] (\(inv, d) -> Map.fromList [("w", fromMaybe (error "missing") (Map.lookup "inv_warehouse_sk" inv)), ("i", fromMaybe (error "missing") (Map.lookup "inv_item_sk" inv))]), let g = g]
+
+joined = [Map.fromList [("w_name", VString (fromMaybe (error "missing") (Map.lookup "w_warehouse_name" w))), ("i_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" it))), ("before_qty", VString (fromMaybe (error "missing") (Map.lookup "qty" b))), ("after_qty", VString (fromMaybe (error "missing") (Map.lookup "qty" a))), ("ratio", VString ((fromMaybe (error "missing") (Map.lookup "qty" a) / fromMaybe (error "missing") (Map.lookup "qty" b))))] | b <- before, a <- after, w <- warehouse, it <- item, (((fromMaybe (error "missing") (Map.lookup "w" (b)) == fromMaybe (error "missing") (Map.lookup "w" (a))) && fromMaybe (error "missing") (Map.lookup "i" (b))) == fromMaybe (error "missing") (Map.lookup "i" (a))), (fromMaybe (error "missing") (Map.lookup "w_warehouse_sk" (w)) == fromMaybe (error "missing") (Map.lookup "w" (b))), (fromMaybe (error "missing") (Map.lookup "i_item_sk" (it)) == fromMaybe (error "missing") (Map.lookup "i" (b)))]
+
+result = map snd (List.sortOn fst [([fromMaybe (error "missing") (Map.lookup "w_name" (r)), fromMaybe (error "missing") (Map.lookup "i_id" (r))], Map.fromList [("w_warehouse_name", VString (fromMaybe (error "missing") (Map.lookup "w_name" r))), ("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_id" r))), ("inv_before", VString (fromMaybe (error "missing") (Map.lookup "before_qty" r))), ("inv_after", VString (fromMaybe (error "missing") (Map.lookup "after_qty" r)))]) | r <- joined, (((fromMaybe (error "missing") (Map.lookup "ratio" r) >= ((2.0 / 3.0))) && fromMaybe (error "missing") (Map.lookup "ratio" r)) <= ((3.0 / 2.0)))])
+
+test_TPCDS_Q21_inventory_ratio :: IO ()
+test_TPCDS_Q21_inventory_ratio = do
+  expect ((result == [Map.fromList [("w_warehouse_name", VString ("Main")), ("i_item_id", VString ("ITEM1")), ("inv_before", VInt (30)), ("inv_after", VInt (40))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q21_inventory_ratio

--- a/tests/dataset/tpc-ds/compiler/hs/q22.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q22.hs.out
@@ -1,0 +1,227 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data Inventory = Inventory
+  { inv_item_sk :: Int,
+    inv_date_sk :: Int,
+    inv_quantity_on_hand :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Inventory
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_month_seq :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_product_name :: String,
+    i_brand :: String,
+    i_class :: String,
+    i_category :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+inventory = [Map.fromList [("inv_item_sk", 1), ("inv_date_sk", 1), ("inv_quantity_on_hand", 10)], Map.fromList [("inv_item_sk", 1), ("inv_date_sk", 2), ("inv_quantity_on_hand", 20)], Map.fromList [("inv_item_sk", 1), ("inv_date_sk", 3), ("inv_quantity_on_hand", 10)], Map.fromList [("inv_item_sk", 1), ("inv_date_sk", 4), ("inv_quantity_on_hand", 20)], Map.fromList [("inv_item_sk", 2), ("inv_date_sk", 1), ("inv_quantity_on_hand", 50)]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_month_seq", 0)], Map.fromList [("d_date_sk", 2), ("d_month_seq", 1)], Map.fromList [("d_date_sk", 3), ("d_month_seq", 2)], Map.fromList [("d_date_sk", 4), ("d_month_seq", 3)]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_product_name", VString ("Prod1")), ("i_brand", VString ("Brand1")), ("i_class", VString ("Class1")), ("i_category", VString ("Cat1"))], Map.fromList [("i_item_sk", VInt (2)), ("i_product_name", VString ("Prod2")), ("i_brand", VString ("Brand2")), ("i_class", VString ("Class2")), ("i_category", VString ("Cat2"))]]
+
+qoh = [Map.fromList [("i_product_name", VString (fromMaybe (error "missing") (Map.lookup "product_name" (key (g))))), ("i_brand", VString (fromMaybe (error "missing") (Map.lookup "brand" (key (g))))), ("i_class", VString (fromMaybe (error "missing") (Map.lookup "class" (key (g))))), ("i_category", VString (fromMaybe (error "missing") (Map.lookup "category" (key (g))))), ("qoh", VDouble (avg [fromMaybe (error "missing") (Map.lookup "inv_quantity_on_hand" (x)) | x <- g]))] | g <- _group_by [(inv, d, i) | inv <- inventory, d <- date_dim, i <- item, (fromMaybe (error "missing") (Map.lookup "inv_date_sk" (inv)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "inv_item_sk" (inv)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (((fromMaybe (error "missing") (Map.lookup "d_month_seq" d) >= 0) && fromMaybe (error "missing") (Map.lookup "d_month_seq" d)) <= 11)] (\(inv, d, i) -> Map.fromList [("product_name", VString (fromMaybe (error "missing") (Map.lookup "i_product_name" i))), ("brand", VString (fromMaybe (error "missing") (Map.lookup "i_brand" i))), ("class", VString (fromMaybe (error "missing") (Map.lookup "i_class" i))), ("category", VString (fromMaybe (error "missing") (Map.lookup "i_category" i)))]), let g = g]
+
+test_TPCDS_Q22_average_inventory :: IO ()
+test_TPCDS_Q22_average_inventory = do
+  expect ((qoh == [Map.fromList [("i_product_name", VString ("Prod1")), ("i_brand", VString ("Brand1")), ("i_class", VString ("Class1")), ("i_category", VString ("Cat1")), ("qoh", VDouble (15.0))]]))
+
+main :: IO ()
+main = do
+  _json qoh
+  test_TPCDS_Q22_average_inventory

--- a/tests/dataset/tpc-ds/compiler/hs/q23.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q23.hs.out
@@ -1,0 +1,264 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_item_sk :: Int,
+    ss_sold_date_sk :: Int,
+    ss_customer_sk :: Int,
+    ss_quantity :: Int,
+    ss_sales_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int,
+    d_moy :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Item = Item
+  { i_item_sk :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+data CatalogSale = CatalogSale
+  { cs_sold_date_sk :: Int,
+    cs_item_sk :: Int,
+    cs_bill_customer_sk :: Int,
+    cs_quantity :: Int,
+    cs_list_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data WebSale = WebSale
+  { ws_sold_date_sk :: Int,
+    ws_item_sk :: Int,
+    ws_bill_customer_sk :: Int,
+    ws_quantity :: Int,
+    ws_list_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON WebSale
+
+store_sales = [Map.fromList [("ss_item_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))], Map.fromList [("ss_item_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))], Map.fromList [("ss_item_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))], Map.fromList [("ss_item_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))], Map.fromList [("ss_item_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))], Map.fromList [("ss_item_sk", VInt (2)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (2)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))], Map.fromList [("ss_item_sk", VInt (2)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (2)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))], Map.fromList [("ss_item_sk", VInt (2)), ("ss_sold_date_sk", VInt (1)), ("ss_customer_sk", VInt (2)), ("ss_quantity", VInt (1)), ("ss_sales_price", VDouble (10.0))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000), ("d_moy", 1)]]
+
+item = [Map.fromList [("i_item_sk", 1)], Map.fromList [("i_item_sk", 2)]]
+
+catalog_sales = [Map.fromList [("cs_sold_date_sk", VInt (1)), ("cs_item_sk", VInt (1)), ("cs_bill_customer_sk", VInt (1)), ("cs_quantity", VInt (2)), ("cs_list_price", VDouble (10.0))], Map.fromList [("cs_sold_date_sk", VInt (1)), ("cs_item_sk", VInt (2)), ("cs_bill_customer_sk", VInt (2)), ("cs_quantity", VInt (2)), ("cs_list_price", VDouble (10.0))]]
+
+web_sales = [Map.fromList [("ws_sold_date_sk", VInt (1)), ("ws_item_sk", VInt (1)), ("ws_bill_customer_sk", VInt (1)), ("ws_quantity", VInt (3)), ("ws_list_price", VDouble (10.0))], Map.fromList [("ws_sold_date_sk", VInt (1)), ("ws_item_sk", VInt (2)), ("ws_bill_customer_sk", VInt (2)), ("ws_quantity", VInt (1)), ("ws_list_price", VDouble (10.0))]]
+
+frequent_ss_items = [fromMaybe (error "missing") (Map.lookup "item_sk" (key (g))) | g <- _group_by [(ss, d, i) | ss <- store_sales, d <- date_dim, i <- item, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "d_year" d) == 2000)] (\(ss, d, i) -> Map.fromList [("item_sk", fromMaybe (error "missing") (Map.lookup "i_item_sk" i)), ("date_sk", fromMaybe (error "missing") (Map.lookup "d_date_sk" d))]), let g = g]
+
+customer_totals = [Map.fromList [("cust", VString (key (g))), ("sales", VDouble (sum [(fromMaybe (error "missing") (Map.lookup "ss_quantity" (x)) * fromMaybe (error "missing") (Map.lookup "ss_sales_price" (x))) | x <- g]))] | g <- _group_by store_sales (\ss -> fromMaybe (error "missing") (Map.lookup "ss_customer_sk" ss)), let g = g]
+
+max_sales = max [fromMaybe (error "missing") (Map.lookup "sales" c) | c <- customer_totals]
+
+best_ss_customer = [fromMaybe (error "missing") (Map.lookup "cust" c) | c <- filter (\c -> ((fromMaybe (error "missing") (Map.lookup "sales" c) > 0.95) * max_sales)) customer_totals]
+
+catalog = [(fromMaybe (error "missing") (Map.lookup "cs_quantity" cs) * fromMaybe (error "missing") (Map.lookup "cs_list_price" cs)) | cs <- catalog_sales, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), elem (elem ((((fromMaybe (error "missing") (Map.lookup "d_year" d) == 2000) && fromMaybe (error "missing") (Map.lookup "d_moy" d)) == 1) && fromMaybe (error "missing") (Map.lookup "cs_bill_customer_sk" cs)) best_ss_customer && fromMaybe (error "missing") (Map.lookup "cs_item_sk" cs)) frequent_ss_items]
+
+web = [(fromMaybe (error "missing") (Map.lookup "ws_quantity" ws) * fromMaybe (error "missing") (Map.lookup "ws_list_price" ws)) | ws <- web_sales, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "ws_sold_date_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), elem (elem ((((fromMaybe (error "missing") (Map.lookup "d_year" d) == 2000) && fromMaybe (error "missing") (Map.lookup "d_moy" d)) == 1) && fromMaybe (error "missing") (Map.lookup "ws_bill_customer_sk" ws)) best_ss_customer && fromMaybe (error "missing") (Map.lookup "ws_item_sk" ws)) frequent_ss_items]
+
+result = (sum catalog + sum web)
+
+test_TPCDS_Q23_cross_channel_sales :: IO ()
+test_TPCDS_Q23_cross_channel_sales = do
+  expect ((result == 50.0))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q23_cross_channel_sales

--- a/tests/dataset/tpc-ds/compiler/hs/q25.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q25.hs.out
@@ -1,0 +1,265 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_sold_date_sk :: Int,
+    ss_item_sk :: Int,
+    ss_store_sk :: Int,
+    ss_customer_sk :: Int,
+    ss_net_profit :: Double,
+    ss_ticket_number :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data StoreReturn = StoreReturn
+  { sr_returned_date_sk :: Int,
+    sr_item_sk :: Int,
+    sr_customer_sk :: Int,
+    sr_ticket_number :: Int,
+    sr_net_loss :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreReturn
+
+data CatalogSale = CatalogSale
+  { cs_sold_date_sk :: Int,
+    cs_item_sk :: Int,
+    cs_bill_customer_sk :: Int,
+    cs_net_profit :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_moy :: Int,
+    d_year :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Store = Store
+  { s_store_sk :: Int,
+    s_store_id :: String,
+    s_store_name :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Store
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String,
+    i_item_desc :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+store_sales = [Map.fromList [("ss_sold_date_sk", VInt (1)), ("ss_item_sk", VInt (1)), ("ss_store_sk", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_net_profit", VDouble (50.0)), ("ss_ticket_number", VInt (1))], Map.fromList [("ss_sold_date_sk", VInt (1)), ("ss_item_sk", VInt (2)), ("ss_store_sk", VInt (1)), ("ss_customer_sk", VInt (2)), ("ss_net_profit", VDouble (20.0)), ("ss_ticket_number", VInt (2))]]
+
+store_returns = [Map.fromList [("sr_returned_date_sk", VInt (2)), ("sr_item_sk", VInt (1)), ("sr_customer_sk", VInt (1)), ("sr_ticket_number", VInt (1)), ("sr_net_loss", VDouble (10.0))], Map.fromList [("sr_returned_date_sk", VInt (2)), ("sr_item_sk", VInt (2)), ("sr_customer_sk", VInt (2)), ("sr_ticket_number", VInt (2)), ("sr_net_loss", VDouble (5.0))]]
+
+catalog_sales = [Map.fromList [("cs_sold_date_sk", VInt (3)), ("cs_item_sk", VInt (1)), ("cs_bill_customer_sk", VInt (1)), ("cs_net_profit", VDouble (30.0))], Map.fromList [("cs_sold_date_sk", VInt (3)), ("cs_item_sk", VInt (2)), ("cs_bill_customer_sk", VInt (2)), ("cs_net_profit", VDouble (15.0))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_moy", 4), ("d_year", 2000)], Map.fromList [("d_date_sk", 2), ("d_moy", 5), ("d_year", 2000)], Map.fromList [("d_date_sk", 3), ("d_moy", 6), ("d_year", 2000)]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_store_id", VString ("S1")), ("s_store_name", VString ("Store1"))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Desc1"))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("ITEM2")), ("i_item_desc", VString ("Desc2"))]]
+
+result = [Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "item_id" (key (g))))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "item_desc" (key (g))))), ("s_store_id", VString (fromMaybe (error "missing") (Map.lookup "s_store_id" (key (g))))), ("s_store_name", VString (fromMaybe (error "missing") (Map.lookup "s_store_name" (key (g))))), ("store_sales_profit", VDouble (sum [fromMaybe (error "missing") (Map.lookup "ss_net_profit" (x)) | x <- g])), ("store_returns_loss", VDouble (sum [fromMaybe (error "missing") (Map.lookup "sr_net_loss" (x)) | x <- g])), ("catalog_sales_profit", VDouble (sum [fromMaybe (error "missing") (Map.lookup "cs_net_profit" (x)) | x <- g]))] | g <- _group_by [(ss, sr, cs, d1, d2, d3, s, i) | ss <- store_sales, sr <- store_returns, cs <- catalog_sales, d1 <- date_dim, d2 <- date_dim, d3 <- date_dim, s <- store, i <- item, (((fromMaybe (error "missing") (Map.lookup "ss_ticket_number" (ss)) == fromMaybe (error "missing") (Map.lookup "sr_ticket_number" (sr))) && fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss))) == fromMaybe (error "missing") (Map.lookup "sr_item_sk" (sr))), (((fromMaybe (error "missing") (Map.lookup "sr_customer_sk" (sr)) == fromMaybe (error "missing") (Map.lookup "cs_bill_customer_sk" (cs))) && fromMaybe (error "missing") (Map.lookup "sr_item_sk" (sr))) == fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs))), (fromMaybe (error "missing") (Map.lookup "d_date_sk" (d1)) == fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss))), (fromMaybe (error "missing") (Map.lookup "d_date_sk" (d2)) == fromMaybe (error "missing") (Map.lookup "sr_returned_date_sk" (sr))), (fromMaybe (error "missing") (Map.lookup "d_date_sk" (d3)) == fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs))), (fromMaybe (error "missing") (Map.lookup "s_store_sk" (s)) == fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss))), (fromMaybe (error "missing") (Map.lookup "i_item_sk" (i)) == fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss))), (((((((((((fromMaybe (error "missing") (Map.lookup "d_moy" d1) == 4) && fromMaybe (error "missing") (Map.lookup "d_year" d1)) == 2000) && fromMaybe (error "missing") (Map.lookup "d_moy" d2)) >= 4) && fromMaybe (error "missing") (Map.lookup "d_moy" d2)) <= 10) && fromMaybe (error "missing") (Map.lookup "d_moy" d3)) >= 4) && fromMaybe (error "missing") (Map.lookup "d_moy" d3)) <= 10)] (\(ss, sr, cs, d1, d2, d3, s, i) -> Map.fromList [("item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" i))), ("item_desc", VString (fromMaybe (error "missing") (Map.lookup "i_item_desc" i))), ("s_store_id", VString (fromMaybe (error "missing") (Map.lookup "s_store_id" s))), ("s_store_name", VString (fromMaybe (error "missing") (Map.lookup "s_store_name" s)))]), let g = g]
+
+test_TPCDS_Q25_aggregated_profit :: IO ()
+test_TPCDS_Q25_aggregated_profit = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Desc1")), ("s_store_id", VString ("S1")), ("s_store_name", VString ("Store1")), ("store_sales_profit", VDouble (50.0)), ("store_returns_loss", VDouble (10.0)), ("catalog_sales_profit", VDouble (30.0))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q25_aggregated_profit

--- a/tests/dataset/tpc-ds/compiler/hs/q26.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q26.hs.out
@@ -1,0 +1,252 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data CatalogSale = CatalogSale
+  { cs_sold_date_sk :: Int,
+    cs_item_sk :: Int,
+    cs_bill_cdemo_sk :: Int,
+    cs_promo_sk :: Int,
+    cs_quantity :: Int,
+    cs_list_price :: Double,
+    cs_coupon_amt :: Double,
+    cs_sales_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data CustomerDemo = CustomerDemo
+  { cd_demo_sk :: Int,
+    cd_gender :: String,
+    cd_marital_status :: String,
+    cd_education_status :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerDemo
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+data Promotion = Promotion
+  { p_promo_sk :: Int,
+    p_channel_email :: String,
+    p_channel_event :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Promotion
+
+catalog_sales = [Map.fromList [("cs_sold_date_sk", VInt (1)), ("cs_item_sk", VInt (1)), ("cs_bill_cdemo_sk", VInt (1)), ("cs_promo_sk", VInt (1)), ("cs_quantity", VInt (10)), ("cs_list_price", VDouble (100.0)), ("cs_coupon_amt", VDouble (5.0)), ("cs_sales_price", VDouble (95.0))], Map.fromList [("cs_sold_date_sk", VInt (1)), ("cs_item_sk", VInt (2)), ("cs_bill_cdemo_sk", VInt (2)), ("cs_promo_sk", VInt (2)), ("cs_quantity", VInt (5)), ("cs_list_price", VDouble (50.0)), ("cs_coupon_amt", VDouble (2.0)), ("cs_sales_price", VDouble (48.0))]]
+
+customer_demographics = [Map.fromList [("cd_demo_sk", VInt (1)), ("cd_gender", VString ("M")), ("cd_marital_status", VString ("S")), ("cd_education_status", VString ("College"))], Map.fromList [("cd_demo_sk", VInt (2)), ("cd_gender", VString ("F")), ("cd_marital_status", VString ("M")), ("cd_education_status", VString ("High School"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000)]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("ITEM1"))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("ITEM2"))]]
+
+promotion = [Map.fromList [("p_promo_sk", VInt (1)), ("p_channel_email", VString ("N")), ("p_channel_event", VString ("Y"))], Map.fromList [("p_promo_sk", VInt (2)), ("p_channel_email", VString ("Y")), ("p_channel_event", VString ("N"))]]
+
+result = [Map.fromList [("i_item_id", VString (key (g))), ("agg1", VDouble (avg [fromMaybe (error "missing") (Map.lookup "cs_quantity" (x)) | x <- g])), ("agg2", VDouble (avg [fromMaybe (error "missing") (Map.lookup "cs_list_price" (x)) | x <- g])), ("agg3", VDouble (avg [fromMaybe (error "missing") (Map.lookup "cs_coupon_amt" (x)) | x <- g])), ("agg4", VDouble (avg [fromMaybe (error "missing") (Map.lookup "cs_sales_price" (x)) | x <- g]))] | g <- _group_by [(cs, cd, d, i, p) | cs <- catalog_sales, cd <- customer_demographics, d <- date_dim, i <- item, p <- promotion, (fromMaybe (error "missing") (Map.lookup "cs_bill_cdemo_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd))), (fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "cs_promo_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "p_promo_sk" (p))), ((((((((fromMaybe (error "missing") (Map.lookup "cd_gender" cd) == "M") && fromMaybe (error "missing") (Map.lookup "cd_marital_status" cd)) == "S") && fromMaybe (error "missing") (Map.lookup "cd_education_status" cd)) == "College") && ((((fromMaybe (error "missing") (Map.lookup "p_channel_email" p) == "N") || fromMaybe (error "missing") (Map.lookup "p_channel_event" p)) == "N"))) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == 2000)] (\(cs, cd, d, i, p) -> fromMaybe (error "missing") (Map.lookup "i_item_id" i)), let g = g]
+
+test_TPCDS_Q26_demographic_averages :: IO ()
+test_TPCDS_Q26_demographic_averages = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("ITEM1")), ("agg1", VDouble (10.0)), ("agg2", VDouble (100.0)), ("agg3", VDouble (5.0)), ("agg4", VDouble (95.0))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q26_demographic_averages

--- a/tests/dataset/tpc-ds/compiler/hs/q27.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q27.hs.out
@@ -1,0 +1,251 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_item_sk :: Int,
+    ss_store_sk :: Int,
+    ss_cdemo_sk :: Int,
+    ss_sold_date_sk :: Int,
+    ss_quantity :: Int,
+    ss_list_price :: Double,
+    ss_coupon_amt :: Double,
+    ss_sales_price :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data CustomerDemo = CustomerDemo
+  { cd_demo_sk :: Int,
+    cd_gender :: String,
+    cd_marital_status :: String,
+    cd_education_status :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CustomerDemo
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_year :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Store = Store
+  { s_store_sk :: Int,
+    s_state :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Store
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+store_sales = [Map.fromList [("ss_item_sk", VInt (1)), ("ss_store_sk", VInt (1)), ("ss_cdemo_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_quantity", VInt (5)), ("ss_list_price", VDouble (100.0)), ("ss_coupon_amt", VDouble (10.0)), ("ss_sales_price", VDouble (90.0))], Map.fromList [("ss_item_sk", VInt (2)), ("ss_store_sk", VInt (2)), ("ss_cdemo_sk", VInt (2)), ("ss_sold_date_sk", VInt (1)), ("ss_quantity", VInt (2)), ("ss_list_price", VDouble (50.0)), ("ss_coupon_amt", VDouble (5.0)), ("ss_sales_price", VDouble (45.0))]]
+
+customer_demographics = [Map.fromList [("cd_demo_sk", VInt (1)), ("cd_gender", VString ("F")), ("cd_marital_status", VString ("M")), ("cd_education_status", VString ("College"))], Map.fromList [("cd_demo_sk", VInt (2)), ("cd_gender", VString ("M")), ("cd_marital_status", VString ("S")), ("cd_education_status", VString ("College"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000)]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_state", VString ("CA"))], Map.fromList [("s_store_sk", VInt (2)), ("s_state", VString ("TX"))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("ITEM1"))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("ITEM2"))]]
+
+result = map snd (List.sortOn fst [([fromMaybe (error "missing") (Map.lookup "item_id" (key (g))), fromMaybe (error "missing") (Map.lookup "state" (key (g)))], Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "item_id" (key (g))))), ("s_state", VString (fromMaybe (error "missing") (Map.lookup "state" (key (g))))), ("agg1", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ss_quantity" (x)) | x <- g])), ("agg2", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ss_list_price" (x)) | x <- g])), ("agg3", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ss_coupon_amt" (x)) | x <- g])), ("agg4", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ss_sales_price" (x)) | x <- g]))]) | g <- _group_by [(ss, cd, d, s, i) | ss <- store_sales, cd <- customer_demographics, d <- date_dim, s <- store, i <- item, (fromMaybe (error "missing") (Map.lookup "ss_cdemo_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd))), (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "s_store_sk" (s))), (fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), elem ((((((((fromMaybe (error "missing") (Map.lookup "cd_gender" cd) == "F") && fromMaybe (error "missing") (Map.lookup "cd_marital_status" cd)) == "M") && fromMaybe (error "missing") (Map.lookup "cd_education_status" cd)) == "College") && fromMaybe (error "missing") (Map.lookup "d_year" d)) == 2000) && fromMaybe (error "missing") (Map.lookup "s_state" s)) ["CA"]] (\(ss, cd, d, s, i) -> Map.fromList [("item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" i))), ("state", VString (fromMaybe (error "missing") (Map.lookup "s_state" s)))])])
+
+test_TPCDS_Q27_averages_by_state :: IO ()
+test_TPCDS_Q27_averages_by_state = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("ITEM1")), ("s_state", VString ("CA")), ("agg1", VDouble (5.0)), ("agg2", VDouble (100.0)), ("agg3", VDouble (10.0)), ("agg4", VDouble (90.0))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q27_averages_by_state

--- a/tests/dataset/tpc-ds/compiler/hs/q28.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q28.hs.out
@@ -1,0 +1,209 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_quantity :: Int,
+    ss_list_price :: Double,
+    ss_coupon_amt :: Double,
+    ss_wholesale_cost :: Double
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+store_sales = [Map.fromList [("ss_quantity", VInt (3)), ("ss_list_price", VDouble (100.0)), ("ss_coupon_amt", VDouble (50.0)), ("ss_wholesale_cost", VDouble (30.0))], Map.fromList [("ss_quantity", VInt (8)), ("ss_list_price", VDouble (80.0)), ("ss_coupon_amt", VDouble (10.0)), ("ss_wholesale_cost", VDouble (20.0))], Map.fromList [("ss_quantity", VInt (12)), ("ss_list_price", VDouble (60.0)), ("ss_coupon_amt", VDouble (5.0)), ("ss_wholesale_cost", VDouble (15.0))]]
+
+bucket1 = [ss | ss <- filter (\ss -> ((((fromMaybe (error "missing") (Map.lookup "ss_quantity" ss) >= 0) && fromMaybe (error "missing") (Map.lookup "ss_quantity" ss)) <= 5) && (((((((fromMaybe (error "missing") (Map.lookup "ss_list_price" ss) >= 0) && fromMaybe (error "missing") (Map.lookup "ss_list_price" ss)) <= 110)) || ((((fromMaybe (error "missing") (Map.lookup "ss_coupon_amt" ss) >= 0) && fromMaybe (error "missing") (Map.lookup "ss_coupon_amt" ss)) <= 1000))) || ((((fromMaybe (error "missing") (Map.lookup "ss_wholesale_cost" ss) >= 0) && fromMaybe (error "missing") (Map.lookup "ss_wholesale_cost" ss)) <= 50)))))) store_sales]
+
+bucket2 = [ss | ss <- filter (\ss -> ((((fromMaybe (error "missing") (Map.lookup "ss_quantity" ss) >= 6) && fromMaybe (error "missing") (Map.lookup "ss_quantity" ss)) <= 10) && (((((((fromMaybe (error "missing") (Map.lookup "ss_list_price" ss) >= 0) && fromMaybe (error "missing") (Map.lookup "ss_list_price" ss)) <= 110)) || ((((fromMaybe (error "missing") (Map.lookup "ss_coupon_amt" ss) >= 0) && fromMaybe (error "missing") (Map.lookup "ss_coupon_amt" ss)) <= 1000))) || ((((fromMaybe (error "missing") (Map.lookup "ss_wholesale_cost" ss) >= 0) && fromMaybe (error "missing") (Map.lookup "ss_wholesale_cost" ss)) <= 50)))))) store_sales]
+
+result = Map.fromList [("B1_LP", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ss_list_price" x) | x <- bucket1])), ("B1_CNT", VInt (length bucket1)), ("B1_CNTD", VInt (length [key (g) | g <- _group_by bucket1 (\x -> fromMaybe (error "missing") (Map.lookup "ss_list_price" x)), let g = g])), ("B2_LP", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ss_list_price" x) | x <- bucket2])), ("B2_CNT", VInt (length bucket2)), ("B2_CNTD", VInt (length [key (g) | g <- _group_by bucket2 (\x -> fromMaybe (error "missing") (Map.lookup "ss_list_price" x)), let g = g]))]
+
+test_TPCDS_Q28_buckets :: IO ()
+test_TPCDS_Q28_buckets = do
+  expect ((result == Map.fromList [("B1_LP", VDouble (100.0)), ("B1_CNT", VInt (1)), ("B1_CNTD", VInt (1)), ("B2_LP", VDouble (80.0)), ("B2_CNT", VInt (1)), ("B2_CNTD", VInt (1))]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q28_buckets

--- a/tests/dataset/tpc-ds/compiler/hs/q29.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q29.hs.out
@@ -1,0 +1,267 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+data StoreSale = StoreSale
+  { ss_sold_date_sk :: Int,
+    ss_item_sk :: Int,
+    ss_store_sk :: Int,
+    ss_customer_sk :: Int,
+    ss_quantity :: Int,
+    ss_ticket_number :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreSale
+
+data StoreReturn = StoreReturn
+  { sr_returned_date_sk :: Int,
+    sr_item_sk :: Int,
+    sr_customer_sk :: Int,
+    sr_ticket_number :: Int,
+    sr_return_quantity :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON StoreReturn
+
+data CatalogSale = CatalogSale
+  { cs_sold_date_sk :: Int,
+    cs_item_sk :: Int,
+    cs_bill_customer_sk :: Int,
+    cs_quantity :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON CatalogSale
+
+data DateDim = DateDim
+  { d_date_sk :: Int,
+    d_moy :: Int,
+    d_year :: Int
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON DateDim
+
+data Store = Store
+  { s_store_sk :: Int,
+    s_store_id :: String,
+    s_store_name :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Store
+
+data Item = Item
+  { i_item_sk :: Int,
+    i_item_id :: String,
+    i_item_desc :: String
+  }
+  deriving (Show, Generic)
+
+instance Aeson.FromJSON Item
+
+store_sales = [Map.fromList [("ss_sold_date_sk", 1), ("ss_item_sk", 1), ("ss_store_sk", 1), ("ss_customer_sk", 1), ("ss_quantity", 10), ("ss_ticket_number", 1)]]
+
+store_returns = [Map.fromList [("sr_returned_date_sk", 2), ("sr_item_sk", 1), ("sr_customer_sk", 1), ("sr_ticket_number", 1), ("sr_return_quantity", 2)]]
+
+catalog_sales = [Map.fromList [("cs_sold_date_sk", 3), ("cs_item_sk", 1), ("cs_bill_customer_sk", 1), ("cs_quantity", 5)]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_moy", 4), ("d_year", 1999)], Map.fromList [("d_date_sk", 2), ("d_moy", 5), ("d_year", 1999)], Map.fromList [("d_date_sk", 3), ("d_moy", 5), ("d_year", 2000)]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_store_id", VString ("S1")), ("s_store_name", VString ("Store1"))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Desc1"))]]
+
+base = [Map.fromList [("ss_quantity", fromMaybe (error "missing") (Map.lookup "ss_quantity" ss)), ("sr_return_quantity", fromMaybe (error "missing") (Map.lookup "sr_return_quantity" sr)), ("cs_quantity", fromMaybe (error "missing") (Map.lookup "cs_quantity" cs)), ("i_item_id", fromMaybe (error "missing") (Map.lookup "i_item_id" i)), ("i_item_desc", fromMaybe (error "missing") (Map.lookup "i_item_desc" i)), ("s_store_id", fromMaybe (error "missing") (Map.lookup "s_store_id" s)), ("s_store_name", fromMaybe (error "missing") (Map.lookup "s_store_name" s))] | ss <- store_sales, sr <- store_returns, cs <- catalog_sales, d1 <- date_dim, d2 <- date_dim, d3 <- date_dim, s <- store, i <- item, (((fromMaybe (error "missing") (Map.lookup "ss_ticket_number" (ss)) == fromMaybe (error "missing") (Map.lookup "sr_ticket_number" (sr))) && fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss))) == fromMaybe (error "missing") (Map.lookup "sr_item_sk" (sr))), (((fromMaybe (error "missing") (Map.lookup "sr_customer_sk" (sr)) == fromMaybe (error "missing") (Map.lookup "cs_bill_customer_sk" (cs))) && fromMaybe (error "missing") (Map.lookup "sr_item_sk" (sr))) == fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs))), (fromMaybe (error "missing") (Map.lookup "d_date_sk" (d1)) == fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss))), (fromMaybe (error "missing") (Map.lookup "d_date_sk" (d2)) == fromMaybe (error "missing") (Map.lookup "sr_returned_date_sk" (sr))), (fromMaybe (error "missing") (Map.lookup "d_date_sk" (d3)) == fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs))), (fromMaybe (error "missing") (Map.lookup "s_store_sk" (s)) == fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss))), (fromMaybe (error "missing") (Map.lookup "i_item_sk" (i)) == fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss))), elem ((((((((fromMaybe (error "missing") (Map.lookup "d_moy" d1) == 4) && fromMaybe (error "missing") (Map.lookup "d_year" d1)) == 1999) && fromMaybe (error "missing") (Map.lookup "d_moy" d2)) >= 4) && fromMaybe (error "missing") (Map.lookup "d_moy" d2)) <= 7) && fromMaybe (error "missing") (Map.lookup "d_year" d3)) [1999, 2000, 2001]]
+
+result = [Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "item_id" (key (g))))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "item_desc" (key (g))))), ("s_store_id", VString (fromMaybe (error "missing") (Map.lookup "s_store_id" (key (g))))), ("s_store_name", VString (fromMaybe (error "missing") (Map.lookup "s_store_name" (key (g))))), ("store_sales_quantity", VDouble (sum [fromMaybe (error "missing") (Map.lookup "ss_quantity" (x)) | x <- g])), ("store_returns_quantity", VDouble (sum [fromMaybe (error "missing") (Map.lookup "sr_return_quantity" (x)) | x <- g])), ("catalog_sales_quantity", VDouble (sum [fromMaybe (error "missing") (Map.lookup "cs_quantity" (x)) | x <- g]))] | g <- _group_by base (\b -> Map.fromList [("item_id", fromMaybe (error "missing") (Map.lookup "i_item_id" b)), ("item_desc", fromMaybe (error "missing") (Map.lookup "i_item_desc" b)), ("s_store_id", fromMaybe (error "missing") (Map.lookup "s_store_id" b)), ("s_store_name", fromMaybe (error "missing") (Map.lookup "s_store_name" b))]), let g = g]
+
+test_TPCDS_Q29_quantity_summary :: IO ()
+test_TPCDS_Q29_quantity_summary = do
+  expect ((result == [Map.fromList [("i_item_id", VString ("ITEM1")), ("i_item_desc", VString ("Desc1")), ("s_store_id", VString ("S1")), ("s_store_name", VString ("Store1")), ("store_sales_quantity", VInt (10)), ("store_returns_quantity", VInt (2)), ("catalog_sales_quantity", VInt (5))]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_TPCDS_Q29_quantity_summary

--- a/tools/update_tpcds_hs/main.go
+++ b/tools/update_tpcds_hs/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	hscode "mochi/compile/x/hs"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("go.mod not found")
+}
+
+func main() {
+	root, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	queries := []string{}
+	for i := 1; i <= 29; i++ {
+		queries = append(queries, fmt.Sprintf("q%d", i))
+	}
+	dir := filepath.Join(root, "tests", "dataset", "tpc-ds")
+	outDir := filepath.Join(dir, "compiler", "hs")
+	os.MkdirAll(outDir, 0755)
+	for _, q := range queries {
+		src := filepath.Join(dir, q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: parse error: %v\n", src, err)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "%s: type error: %v\n", src, errs[0])
+			continue
+		}
+		code, err := hscode.New(env).Compile(prog)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: compile error: %v\n", src, err)
+			continue
+		}
+		codePath := filepath.Join(outDir, q+".hs.out")
+		if err := os.WriteFile(codePath, code, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: write code: %v\n", q, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- extend Haskell TPC‑DS golden test coverage
- add generated Haskell code for queries q10–q29 (except unsupported q24)
- provide a helper script to regenerate these files

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68640cfbd54483209f4698a0560c4a4d