### PR TITLE
Add F# codegen tests for TPCDS q30-49

### DIFF
--- a/compile/x/fs/tpcds_q1_test.go
+++ b/compile/x/fs/tpcds_q1_test.go
@@ -26,7 +26,7 @@ func TestFSCompiler_TPCDS(t *testing.T) {
 		t.Skipf("fantomas not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	for i := 1; i <= 29; i++ {
+	for i := 1; i <= 49; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")

--- a/tests/dataset/tpc-ds/compiler/fs/q30.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q30.fs.out
@@ -1,0 +1,122 @@
+open System
+
+let wr_returning_customer_sk = "wr_returning_customer_sk"
+let wr_returned_date_sk = "wr_returned_date_sk"
+let wr_return_amt = "wr_return_amt"
+let wr_returning_addr_sk = "wr_returning_addr_sk"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let ca_address_sk = "ca_address_sk"
+let ca_state = "ca_state"
+let c_customer_sk = "c_customer_sk"
+let c_customer_id = "c_customer_id"
+let c_first_name = "c_first_name"
+let c_last_name = "c_last_name"
+let c_current_addr_sk = "c_current_addr_sk"
+let ctr_customer_sk = "ctr_customer_sk"
+let ctr_state = "ctr_state"
+let ctr_total_return = "ctr_total_return"
+let cust = "cust"
+let state = "state"
+let avg_return = "avg_return"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let web_returns = [|Map.ofList [(wr_returning_customer_sk, 1); (wr_returned_date_sk, 1); (wr_return_amt, 100.0); (wr_returning_addr_sk, 1)]; Map.ofList [(wr_returning_customer_sk, 2); (wr_returned_date_sk, 1); (wr_return_amt, 30.0); (wr_returning_addr_sk, 2)]; Map.ofList [(wr_returning_customer_sk, 1); (wr_returned_date_sk, 1); (wr_return_amt, 50.0); (wr_returning_addr_sk, 1)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_state, "CA")]; Map.ofList [(ca_address_sk, 2); (ca_state, "CA")]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_customer_id, "C1"); (c_first_name, "John"); (c_last_name, "Doe"); (c_current_addr_sk, 1)]; Map.ofList [(c_customer_sk, 2); (c_customer_id, "C2"); (c_first_name, "Jane"); (c_last_name, "Smith"); (c_current_addr_sk, 2)]|]
+let customer_total_return = [| for g in _group_by [|
+    for wr in web_returns do
+        for d in date_dim do
+            if (wr.wr_returned_date_sk = d.d_date_sk) then
+                for ca in customer_address do
+                    if (wr.wr_returning_addr_sk = ca.ca_address_sk) then
+                        if ((d.d_year = 2000) && (ca.ca_state = "CA")) then
+                            yield (wr, d, ca)
+|] (fun (wr, d, ca) -> Map.ofList [(cust, wr.wr_returning_customer_sk); (state, ca.ca_state)]) do let g = g yield Map.ofList [(ctr_customer_sk, g.key.cust); (ctr_state, g.key.state); (ctr_total_return, sum 
+    [|
+    for x in g do
+        yield x.wr_return_amt
+    |])] |]
+let avg_by_state = _group_by customer_total_return (fun ctr -> ctr.ctr_state) |> List.map (fun g -> Map.ofList [(state, g.key); (avg_return, avg 
+    [|
+    for x in g do
+        yield x.ctr_total_return
+    |])])
+let result = 
+    [|
+    for ctr in customer_total_return do
+        for avg in avg_by_state do
+            if (ctr.ctr_state = avg.state) then
+                for c in customer do
+                    if (ctr.ctr_customer_sk = c.c_customer_sk) then
+                        if (ctr.ctr_total_return > (avg.avg_return * 1.2)) then
+                            yield Map.ofList [(c_customer_id, c.c_customer_id); (c_first_name, c.c_first_name); (c_last_name, c.c_last_name); (ctr_total_return, ctr.ctr_total_return)]
+    |]
+ignore (_json result)
+let test_TPCDS_Q30_simplified() =
+    if not ((result = [|Map.ofList [(c_customer_id, "C1"); (c_first_name, "John"); (c_last_name, "Doe"); (ctr_total_return, 150.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q30 simplified" test_TPCDS_Q30_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q31.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q31.fs.out
@@ -1,0 +1,109 @@
+open System
+
+let ca_county = "ca_county"
+let d_qoy = "d_qoy"
+let d_year = "d_year"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let ws_ext_sales_price = "ws_ext_sales_price"
+let web_q1_q2_increase = "web_q1_q2_increase"
+let store_q1_q2_increase = "store_q1_q2_increase"
+let web_q2_q3_increase = "web_q2_q3_increase"
+let store_q2_q3_increase = "store_q2_q3_increase"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(ca_county, "A"); (d_qoy, 1); (d_year, 2000); (ss_ext_sales_price, 100.0)]; Map.ofList [(ca_county, "A"); (d_qoy, 2); (d_year, 2000); (ss_ext_sales_price, 120.0)]; Map.ofList [(ca_county, "A"); (d_qoy, 3); (d_year, 2000); (ss_ext_sales_price, 160.0)]; Map.ofList [(ca_county, "B"); (d_qoy, 1); (d_year, 2000); (ss_ext_sales_price, 80.0)]; Map.ofList [(ca_county, "B"); (d_qoy, 2); (d_year, 2000); (ss_ext_sales_price, 90.0)]; Map.ofList [(ca_county, "B"); (d_qoy, 3); (d_year, 2000); (ss_ext_sales_price, 100.0)]|]
+let web_sales = [|Map.ofList [(ca_county, "A"); (d_qoy, 1); (d_year, 2000); (ws_ext_sales_price, 100.0)]; Map.ofList [(ca_county, "A"); (d_qoy, 2); (d_year, 2000); (ws_ext_sales_price, 150.0)]; Map.ofList [(ca_county, "A"); (d_qoy, 3); (d_year, 2000); (ws_ext_sales_price, 250.0)]; Map.ofList [(ca_county, "B"); (d_qoy, 1); (d_year, 2000); (ws_ext_sales_price, 80.0)]; Map.ofList [(ca_county, "B"); (d_qoy, 2); (d_year, 2000); (ws_ext_sales_price, 90.0)]; Map.ofList [(ca_county, "B"); (d_qoy, 3); (d_year, 2000); (ws_ext_sales_price, 95.0)]|]
+let counties = [|"A"; "B"|]
+let mutable result = [||]
+for county in counties do
+    let ss1 = sum 
+    [|
+    for s in store_sales do
+        if ((s.ca_county = county) && (s.d_qoy = 1)) then
+            yield s.ss_ext_sales_price
+    |]
+    let ss2 = sum 
+    [|
+    for s in store_sales do
+        if ((s.ca_county = county) && (s.d_qoy = 2)) then
+            yield s.ss_ext_sales_price
+    |]
+    let ss3 = sum 
+    [|
+    for s in store_sales do
+        if ((s.ca_county = county) && (s.d_qoy = 3)) then
+            yield s.ss_ext_sales_price
+    |]
+    let ws1 = sum 
+    [|
+    for w in web_sales do
+        if ((w.ca_county = county) && (w.d_qoy = 1)) then
+            yield w.ws_ext_sales_price
+    |]
+    let ws2 = sum 
+    [|
+    for w in web_sales do
+        if ((w.ca_county = county) && (w.d_qoy = 2)) then
+            yield w.ws_ext_sales_price
+    |]
+    let ws3 = sum 
+    [|
+    for w in web_sales do
+        if ((w.ca_county = county) && (w.d_qoy = 3)) then
+            yield w.ws_ext_sales_price
+    |]
+    let web_g1 = (ws2 / ws1)
+    let store_g1 = (ss2 / ss1)
+    let web_g2 = (ws3 / ws2)
+    let store_g2 = (ss3 / ss2)
+    if ((web_g1 > store_g1) && (web_g2 > store_g2)) then
+        result <- append result (Map.ofList [(ca_county, county); (d_year, 2000); (web_q1_q2_increase, web_g1); (store_q1_q2_increase, store_g1); (web_q2_q3_increase, web_g2); (store_q2_q3_increase, store_g2)])
+ignore (_json result)
+let test_TPCDS_Q31_simplified() =
+    if not ((result = [|Map.ofList [(ca_county, "A"); (d_year, 2000); (web_q1_q2_increase, 1.5); (store_q1_q2_increase, 1.2); (web_q2_q3_increase, 1.6666666666666667); (store_q2_q3_increase, 1.3333333333333333)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q31 simplified" test_TPCDS_Q31_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q32.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q32.fs.out
@@ -1,0 +1,80 @@
+open System
+
+let cs_item_sk = "cs_item_sk"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_ext_discount_amt = "cs_ext_discount_amt"
+let i_item_sk = "i_item_sk"
+let i_manufact_id = "i_manufact_id"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let catalog_sales = [|Map.ofList [(cs_item_sk, 1); (cs_sold_date_sk, 1); (cs_ext_discount_amt, 5.0)]; Map.ofList [(cs_item_sk, 1); (cs_sold_date_sk, 2); (cs_ext_discount_amt, 10.0)]; Map.ofList [(cs_item_sk, 1); (cs_sold_date_sk, 3); (cs_ext_discount_amt, 20.0)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_manufact_id, 1)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000)]; Map.ofList [(d_date_sk, 2); (d_year, 2000)]; Map.ofList [(d_date_sk, 3); (d_year, 2000)]|]
+let filtered = 
+    [|
+    for cs in catalog_sales do
+        for i in item do
+            if (cs.cs_item_sk = i.i_item_sk) then
+                for d in date_dim do
+                    if (cs.cs_sold_date_sk = d.d_date_sk) then
+                        if ((i.i_manufact_id = 1) && (d.d_year = 2000)) then
+                            yield cs.cs_ext_discount_amt
+    |]
+let avg_discount = avg filtered
+let result = sum 
+    [|
+    for x in filtered do
+        if (x > (avg_discount * 1.3)) then
+            yield x
+    |]
+ignore (_json result)
+let test_TPCDS_Q32_simplified() =
+    if not ((result = 20.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q32 simplified" test_TPCDS_Q32_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q33.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q33.fs.out
@@ -1,0 +1,150 @@
+open System
+
+let i_item_sk = "i_item_sk"
+let i_manufact_id = "i_manufact_id"
+let i_category = "i_category"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let ca_address_sk = "ca_address_sk"
+let ca_gmt_offset = "ca_gmt_offset"
+let ss_item_sk = "ss_item_sk"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_addr_sk = "ss_addr_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_ext_sales_price = "cs_ext_sales_price"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_bill_addr_sk = "cs_bill_addr_sk"
+let ws_item_sk = "ws_item_sk"
+let ws_ext_sales_price = "ws_ext_sales_price"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_bill_addr_sk = "ws_bill_addr_sk"
+let manu = "manu"
+let price = "price"
+let total_sales = "total_sales"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let item = [|Map.ofList [(i_item_sk, 1); (i_manufact_id, 1); (i_category, "Books")]; Map.ofList [(i_item_sk, 2); (i_manufact_id, 2); (i_category, "Books")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000); (d_moy, 1)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_gmt_offset, (-5))]; Map.ofList [(ca_address_sk, 2); (ca_gmt_offset, (-5))]|]
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_ext_sales_price, 100.0); (ss_sold_date_sk, 1); (ss_addr_sk, 1)]; Map.ofList [(ss_item_sk, 2); (ss_ext_sales_price, 50.0); (ss_sold_date_sk, 1); (ss_addr_sk, 2)]|]
+let catalog_sales = [|Map.ofList [(cs_item_sk, 1); (cs_ext_sales_price, 20.0); (cs_sold_date_sk, 1); (cs_bill_addr_sk, 1)]|]
+let web_sales = [|Map.ofList [(ws_item_sk, 1); (ws_ext_sales_price, 30.0); (ws_sold_date_sk, 1); (ws_bill_addr_sk, 1)]|]
+let month = 1
+let year = 2000
+let union_sales = _concat _concat 
+    [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                for ca in customer_address do
+                    if (ss.ss_addr_sk = ca.ca_address_sk) then
+                        for i in item do
+                            if (ss.ss_item_sk = i.i_item_sk) then
+                                if ((((i.i_category = "Books") && (d.d_year = year)) && (d.d_moy = month)) && (ca.ca_gmt_offset = ((-5)))) then
+                                    yield Map.ofList [(manu, i.i_manufact_id); (price, ss.ss_ext_sales_price)]
+    |] 
+    [|
+    for cs in catalog_sales do
+        for d in date_dim do
+            if (cs.cs_sold_date_sk = d.d_date_sk) then
+                for ca in customer_address do
+                    if (cs.cs_bill_addr_sk = ca.ca_address_sk) then
+                        for i in item do
+                            if (cs.cs_item_sk = i.i_item_sk) then
+                                if ((((i.i_category = "Books") && (d.d_year = year)) && (d.d_moy = month)) && (ca.ca_gmt_offset = ((-5)))) then
+                                    yield Map.ofList [(manu, i.i_manufact_id); (price, cs.cs_ext_sales_price)]
+    |] 
+    [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (ws.ws_sold_date_sk = d.d_date_sk) then
+                for ca in customer_address do
+                    if (ws.ws_bill_addr_sk = ca.ca_address_sk) then
+                        for i in item do
+                            if (ws.ws_item_sk = i.i_item_sk) then
+                                if ((((i.i_category = "Books") && (d.d_year = year)) && (d.d_moy = month)) && (ca.ca_gmt_offset = ((-5)))) then
+                                    yield Map.ofList [(manu, i.i_manufact_id); (price, ws.ws_ext_sales_price)]
+    |]
+let result = [| for g in _group_by [|
+    for s in union_sales do
+        yield s
+|] (fun s -> s.manu) do let g = g yield ((-sum 
+    [|
+    for x in g do
+        yield x.price
+    |]), Map.ofList [(i_manufact_id, g.key); (total_sales, sum 
+    [|
+    for x in g do
+        yield x.price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q33_simplified() =
+    if not ((result = [|Map.ofList [(i_manufact_id, 1); (total_sales, 150.0)]; Map.ofList [(i_manufact_id, 2); (total_sales, 50.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q33 simplified" test_TPCDS_Q33_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q34.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q34.fs.out
@@ -1,0 +1,119 @@
+open System
+
+let ss_ticket_number = "ss_ticket_number"
+let ss_customer_sk = "ss_customer_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_hdemo_sk = "ss_hdemo_sk"
+let d_date_sk = "d_date_sk"
+let d_dom = "d_dom"
+let d_year = "d_year"
+let s_store_sk = "s_store_sk"
+let s_county = "s_county"
+let hd_demo_sk = "hd_demo_sk"
+let hd_buy_potential = "hd_buy_potential"
+let hd_vehicle_count = "hd_vehicle_count"
+let hd_dep_count = "hd_dep_count"
+let c_customer_sk = "c_customer_sk"
+let c_last_name = "c_last_name"
+let c_first_name = "c_first_name"
+let c_salutation = "c_salutation"
+let c_preferred_cust_flag = "c_preferred_cust_flag"
+let cnt = "cnt"
+let ticket = "ticket"
+let cust = "cust"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]; Map.ofList [(ss_ticket_number, 2); (ss_customer_sk, 2); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 2)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_dom, 2); (d_year, 2000)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_county, "A")]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_buy_potential, ">10000"); (hd_vehicle_count, 2); (hd_dep_count, 3)]; Map.ofList [(hd_demo_sk, 2); (hd_buy_potential, ">10000"); (hd_vehicle_count, 2); (hd_dep_count, 1)]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_last_name, "Smith"); (c_first_name, "John"); (c_salutation, "Mr."); (c_preferred_cust_flag, "Y")]; Map.ofList [(c_customer_sk, 2); (c_last_name, "Jones"); (c_first_name, "Alice"); (c_salutation, "Ms."); (c_preferred_cust_flag, "N")]|]
+let dn = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                for s in store do
+                    if (ss.ss_store_sk = s.s_store_sk) then
+                        for hd in household_demographics do
+                            if (ss.ss_hdemo_sk = hd.hd_demo_sk) then
+                                if ((((((((d.d_dom >= 1) && (d.d_dom <= 3))) && (hd.hd_buy_potential = ">10000")) && (hd.hd_vehicle_count > 0)) && (((hd.hd_dep_count / hd.hd_vehicle_count)) > 1.2)) && (d.d_year = 2000)) && (s.s_county = "A")) then
+                                    yield (ss, d, s, hd)
+|] (fun (ss, d, s, hd) -> Map.ofList [(ticket, ss.ss_ticket_number); (cust, ss.ss_customer_sk)]) do let g = g yield Map.ofList [(ss_ticket_number, g.key.ticket); (ss_customer_sk, g.key.cust); (cnt, count g)] |]
+let result = 
+    [|
+    for dn1 in dn do
+        for c in customer do
+            if (dn1.ss_customer_sk = c.c_customer_sk) then
+                if ((dn1.cnt >= 15) && (dn1.cnt <= 20)) then
+                    yield (c.c_last_name, Map.ofList [(c_last_name, c.c_last_name); (c_first_name, c.c_first_name); (c_salutation, c.c_salutation); (c_preferred_cust_flag, c.c_preferred_cust_flag); (ss_ticket_number, dn1.ss_ticket_number); (cnt, dn1.cnt)])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q34_simplified() =
+    if not ((result = [|Map.ofList [(c_last_name, "Smith"); (c_first_name, "John"); (c_salutation, "Mr."); (c_preferred_cust_flag, "Y"); (ss_ticket_number, 1); (cnt, 16)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q34 simplified" test_TPCDS_Q34_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q35.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q35.fs.out
@@ -1,0 +1,116 @@
+open System
+
+let c_customer_sk = "c_customer_sk"
+let c_current_addr_sk = "c_current_addr_sk"
+let c_current_cdemo_sk = "c_current_cdemo_sk"
+let ca_address_sk = "ca_address_sk"
+let ca_state = "ca_state"
+let cd_demo_sk = "cd_demo_sk"
+let cd_gender = "cd_gender"
+let cd_marital_status = "cd_marital_status"
+let cd_dep_count = "cd_dep_count"
+let cd_dep_employed_count = "cd_dep_employed_count"
+let cd_dep_college_count = "cd_dep_college_count"
+let ss_customer_sk = "ss_customer_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_qoy = "d_qoy"
+let cnt = "cnt"
+let state = "state"
+let gender = "gender"
+let marital = "marital"
+let dep = "dep"
+let emp = "emp"
+let col = "col"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_current_addr_sk, 1); (c_current_cdemo_sk, 1)]; Map.ofList [(c_customer_sk, 2); (c_current_addr_sk, 2); (c_current_cdemo_sk, 2)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_state, "CA")]; Map.ofList [(ca_address_sk, 2); (ca_state, "NY")]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1); (cd_gender, "M"); (cd_marital_status, "S"); (cd_dep_count, 1); (cd_dep_employed_count, 1); (cd_dep_college_count, 0)]; Map.ofList [(cd_demo_sk, 2); (cd_gender, "F"); (cd_marital_status, "M"); (cd_dep_count, 2); (cd_dep_employed_count, 1); (cd_dep_college_count, 1)]|]
+let store_sales = [|Map.ofList [(ss_customer_sk, 1); (ss_sold_date_sk, 1)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000); (d_qoy, 1)]|]
+let purchased = 
+    [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                if ((d.d_year = 2000) && (d.d_qoy < 4)) then
+                    yield ss.ss_customer_sk
+    |]
+let groups = [| for g in _group_by [|
+    for c in customer do
+        for ca in customer_address do
+            if (c.c_current_addr_sk = ca.ca_address_sk) then
+                for cd in customer_demographics do
+                    if (c.c_current_cdemo_sk = cd.cd_demo_sk) then
+                        if Array.contains c.c_customer_sk purchased then
+                            yield (c, ca, cd)
+|] (fun (c, ca, cd) -> Map.ofList [(state, ca.ca_state); (gender, cd.cd_gender); (marital, cd.cd_marital_status); (dep, cd.cd_dep_count); (emp, cd.cd_dep_employed_count); (col, cd.cd_dep_college_count)]) do let g = g yield Map.ofList [(ca_state, g.key.state); (cd_gender, g.key.gender); (cd_marital_status, g.key.marital); (cd_dep_count, g.key.dep); (cd_dep_employed_count, g.key.emp); (cd_dep_college_count, g.key.col); (cnt, count g)] |]
+ignore (_json groups)
+let test_TPCDS_Q35_simplified() =
+    if not ((groups = [|Map.ofList [(ca_state, "CA"); (cd_gender, "M"); (cd_marital_status, "S"); (cd_dep_count, 1); (cd_dep_employed_count, 1); (cd_dep_college_count, 0); (cnt, 1)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q35 simplified" test_TPCDS_Q35_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q36.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q36.fs.out
@@ -1,0 +1,109 @@
+open System
+
+let ss_item_sk = "ss_item_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let ss_net_profit = "ss_net_profit"
+let i_item_sk = "i_item_sk"
+let i_category = "i_category"
+let i_class = "i_class"
+let s_store_sk = "s_store_sk"
+let s_state = "s_state"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let gross_margin = "gross_margin"
+let category = "category"
+let _class = "class"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_store_sk, 1); (ss_sold_date_sk, 1); (ss_ext_sales_price, 100.0); (ss_net_profit, 20.0)]; Map.ofList [(ss_item_sk, 2); (ss_store_sk, 1); (ss_sold_date_sk, 1); (ss_ext_sales_price, 200.0); (ss_net_profit, 50.0)]; Map.ofList [(ss_item_sk, 3); (ss_store_sk, 2); (ss_sold_date_sk, 1); (ss_ext_sales_price, 150.0); (ss_net_profit, 30.0)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_category, "Books"); (i_class, "C1")]; Map.ofList [(i_item_sk, 2); (i_category, "Books"); (i_class, "C2")]; Map.ofList [(i_item_sk, 3); (i_category, "Electronics"); (i_class, "C3")]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_state, "A")]; Map.ofList [(s_store_sk, 2); (s_state, "B")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000)]|]
+let result = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                for i in item do
+                    if (ss.ss_item_sk = i.i_item_sk) then
+                        for s in store do
+                            if (ss.ss_store_sk = s.s_store_sk) then
+                                if ((d.d_year = 2000) && (((s.s_state = "A") || (s.s_state = "B")))) then
+                                    yield (ss, d, i, s)
+|] (fun (ss, d, i, s) -> Map.ofList [(category, i.i_category); (_class, i.i_class)]) do let g = g yield ([|g.key.category; g.key._class|], Map.ofList [(i_category, g.key.category); (i_class, g.key._class); (gross_margin, (sum 
+    [|
+    for x in g do
+        yield x.ss_net_profit
+    |] / sum 
+    [|
+    for x in g do
+        yield x.ss_ext_sales_price
+    |]))]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q36_simplified() =
+    if not ((result = [|Map.ofList [(i_category, "Books"); (i_class, "C1"); (gross_margin, 0.2)]; Map.ofList [(i_category, "Books"); (i_class, "C2"); (gross_margin, 0.25)]; Map.ofList [(i_category, "Electronics"); (i_class, "C3"); (gross_margin, 0.2)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q36 simplified" test_TPCDS_Q36_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q37.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q37.fs.out
@@ -1,0 +1,92 @@
+open System
+
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let i_item_desc = "i_item_desc"
+let i_current_price = "i_current_price"
+let i_manufact_id = "i_manufact_id"
+let inv_item_sk = "inv_item_sk"
+let inv_warehouse_sk = "inv_warehouse_sk"
+let inv_date_sk = "inv_date_sk"
+let inv_quantity_on_hand = "inv_quantity_on_hand"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let cs_item_sk = "cs_item_sk"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let id = "id"
+let desc = "desc"
+let price = "price"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "I1"); (i_item_desc, "Item1"); (i_current_price, 30.0); (i_manufact_id, 800)]; Map.ofList [(i_item_sk, 2); (i_item_id, "I2"); (i_item_desc, "Item2"); (i_current_price, 60.0); (i_manufact_id, 801)]|]
+let inventory = [|Map.ofList [(inv_item_sk, 1); (inv_warehouse_sk, 1); (inv_date_sk, 1); (inv_quantity_on_hand, 200)]; Map.ofList [(inv_item_sk, 2); (inv_warehouse_sk, 1); (inv_date_sk, 1); (inv_quantity_on_hand, 300)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2000-01-15")]|]
+let catalog_sales = [|Map.ofList [(cs_item_sk, 1); (cs_sold_date_sk, 1)]|]
+let result = [| for g in _group_by [|
+    for i in item do
+        for inv in inventory do
+            if (i.i_item_sk = inv.inv_item_sk) then
+                for d in date_dim do
+                    if (inv.inv_date_sk = d.d_date_sk) then
+                        for cs in catalog_sales do
+                            if (cs.cs_item_sk = i.i_item_sk) then
+                                if ((((((i.i_current_price >= 20) && (i.i_current_price <= 50)) && (i.i_manufact_id >= 800)) && (i.i_manufact_id <= 803)) && (inv.inv_quantity_on_hand >= 100)) && (inv.inv_quantity_on_hand <= 500)) then
+                                    yield (i, inv, d, cs)
+|] (fun (i, inv, d, cs) -> Map.ofList [(id, i.i_item_id); (desc, i.i_item_desc); (price, i.i_current_price)]) do let g = g yield (g.key.id, Map.ofList [(i_item_id, g.key.id); (i_item_desc, g.key.desc); (i_current_price, g.key.price)]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q37_simplified() =
+    if not ((result = [|Map.ofList [(i_item_id, "I1"); (i_item_desc, "Item1"); (i_current_price, 30.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q37 simplified" test_TPCDS_Q37_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q38.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q38.fs.out
@@ -1,0 +1,89 @@
+open System
+
+let c_customer_sk = "c_customer_sk"
+let c_last_name = "c_last_name"
+let c_first_name = "c_first_name"
+let ss_customer_sk = "ss_customer_sk"
+let d_month_seq = "d_month_seq"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let ws_bill_customer_sk = "ws_bill_customer_sk"
+let _intersect (a: 'T[]) (b: 'T[]) : 'T[] =
+  let setB = Set.ofArray b
+  Array.filter (fun x -> Set.contains x setB) a |> Array.distinct
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+exception Return_distinct of any[]
+let rec distinct (xs: any[]) : any[] =
+    try
+        let mutable xs = xs
+        let mutable out = [||]
+        for x in xs do
+            if (not contains out x) then
+                out <- append out x
+        raise (Return_distinct (out))
+        failwith "unreachable"
+    with Return_distinct v -> v
+
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_last_name, "Smith"); (c_first_name, "John")]; Map.ofList [(c_customer_sk, 2); (c_last_name, "Jones"); (c_first_name, "Alice")]|]
+let store_sales = [|Map.ofList [(ss_customer_sk, 1); (d_month_seq, 1200)]; Map.ofList [(ss_customer_sk, 2); (d_month_seq, 1205)]|]
+let catalog_sales = [|Map.ofList [(cs_bill_customer_sk, 1); (d_month_seq, 1203)]|]
+let web_sales = [|Map.ofList [(ws_bill_customer_sk, 1); (d_month_seq, 1206)]|]
+let store_ids = distinct (
+    [|
+    for s in store_sales do
+        if ((s.d_month_seq >= 1200) && (s.d_month_seq <= 1211)) then
+            yield s.ss_customer_sk
+    |])
+let catalog_ids = distinct (
+    [|
+    for c in catalog_sales do
+        if ((c.d_month_seq >= 1200) && (c.d_month_seq <= 1211)) then
+            yield c.cs_bill_customer_sk
+    |])
+let web_ids = distinct (
+    [|
+    for w in web_sales do
+        if ((w.d_month_seq >= 1200) && (w.d_month_seq <= 1211)) then
+            yield w.ws_bill_customer_sk
+    |])
+let hot = _intersect _intersect store_ids catalog_ids web_ids
+let result = hot.Length
+ignore (_json result)
+let test_TPCDS_Q38_simplified() =
+    if not ((result = 1)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q38 simplified" test_TPCDS_Q38_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q39.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q39.fs.out
@@ -1,0 +1,125 @@
+open System
+
+let inv_item_sk = "inv_item_sk"
+let inv_warehouse_sk = "inv_warehouse_sk"
+let inv_date_sk = "inv_date_sk"
+let inv_quantity_on_hand = "inv_quantity_on_hand"
+let i_item_sk = "i_item_sk"
+let w_warehouse_sk = "w_warehouse_sk"
+let w_warehouse_name = "w_warehouse_name"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let w = "w"
+let i = "i"
+let qty = "qty"
+let month = "month"
+let qtys = "qtys"
+let cov = "cov"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let math_sqrt (x: float) : float = failwith "extern"
+let inventory = [|Map.ofList [(inv_item_sk, 1); (inv_warehouse_sk, 1); (inv_date_sk, 1); (inv_quantity_on_hand, 10)]; Map.ofList [(inv_item_sk, 1); (inv_warehouse_sk, 1); (inv_date_sk, 2); (inv_quantity_on_hand, 10)]; Map.ofList [(inv_item_sk, 1); (inv_warehouse_sk, 1); (inv_date_sk, 3); (inv_quantity_on_hand, 250)]|]
+let item = [|Map.ofList [(i_item_sk, 1)]|]
+let warehouse = [|Map.ofList [(w_warehouse_sk, 1); (w_warehouse_name, "W1")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000); (d_moy, 1)]; Map.ofList [(d_date_sk, 2); (d_year, 2000); (d_moy, 2)]; Map.ofList [(d_date_sk, 3); (d_year, 2000); (d_moy, 3)]|]
+let monthly = [| for g in _group_by [|
+    for inv in inventory do
+        for d in date_dim do
+            if (inv.inv_date_sk = d.d_date_sk) then
+                for i in item do
+                    if (inv.inv_item_sk = i.i_item_sk) then
+                        for w in warehouse do
+                            if (inv.inv_warehouse_sk = w.w_warehouse_sk) then
+                                if (d.d_year = 2000) then
+                                    yield (inv, d, i, w)
+|] (fun (inv, d, i, w) -> Map.ofList [(w, w.w_warehouse_sk); (i, i.i_item_sk); (month, d.d_moy)]) do let g = g yield Map.ofList [(w, g.key.w); (i, g.key.i); (qty, sum 
+    [|
+    for x in g do
+        yield x.inv_quantity_on_hand
+    |])] |]
+let mutable grouped: Map<string,Map<string,any>> = Map.empty
+for m in monthly do
+    let key = (string Map.ofList [(w, m.w); (i, m.i)])
+    if Map.containsKey key grouped then
+        let g = grouped.[key]
+        grouped <- Map.add key Map.ofList [(w, g.w); (i, g.i); (qtys, append (g.qtys) (m.qty))] grouped
+    else
+        grouped <- Map.add key Map.ofList [(w, m.w); (i, m.i); (qtys, [|m.qty|])] grouped
+let mutable summary = [||]
+for g in values grouped do
+    let mean = avg g.qtys
+    let mutable sumsq = 0.0
+    for q in g.qtys do
+        sumsq <- (sumsq + (((q - mean)) * ((q - mean))))
+    let variance = (sumsq / ((g.qtys.Length - 1)))
+    let cov = (math.sqrt variance / mean)
+    if (cov > 1.5) then
+        summary <- append summary (Map.ofList [(w_warehouse_sk, g.w); (i_item_sk, g.i); (cov, cov)])
+ignore (_json summary)
+let test_TPCDS_Q39_simplified() =
+    if not ((summary = [|Map.ofList [(w_warehouse_sk, 1); (i_item_sk, 1); (cov, 1.539600717839002)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q39 simplified" test_TPCDS_Q39_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q40.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q40.fs.out
@@ -1,0 +1,116 @@
+open System
+
+let order = "order"
+let item_sk = "item_sk"
+let warehouse_sk = "warehouse_sk"
+let date_sk = "date_sk"
+let price = "price"
+let refunded = "refunded"
+let item_id = "item_id"
+let current_price = "current_price"
+let state = "state"
+let date = "date"
+let w_state = "w_state"
+let i_item_id = "i_item_id"
+let sold_date = "sold_date"
+let net = "net"
+let sales_before = "sales_before"
+let sales_after = "sales_after"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let catalog_sales = [|Map.ofList [(order, 1); (item_sk, 1); (warehouse_sk, 1); (date_sk, 1); (price, 100.0)]; Map.ofList [(order, 2); (item_sk, 1); (warehouse_sk, 1); (date_sk, 2); (price, 150.0)]|]
+let catalog_returns = [|Map.ofList [(order, 2); (item_sk, 1); (refunded, 150.0)]|]
+let item = [|Map.ofList [(item_sk, 1); (item_id, "I1"); (current_price, 1.2)]|]
+let warehouse = [|Map.ofList [(warehouse_sk, 1); (state, "CA")]|]
+let date_dim = [|Map.ofList [(date_sk, 1); (date, "2020-01-10")]; Map.ofList [(date_sk, 2); (date, "2020-01-20")]|]
+let sales_date = "2020-01-15"
+let records = 
+    [|
+    for cs in catalog_sales do
+        for cr in catalog_returns do
+            if ((cs.order = cr.order) && (cs.item_sk = cr.item_sk)) then
+                for w in warehouse do
+                    if (cs.warehouse_sk = w.warehouse_sk) then
+                        for i in item do
+                            if (cs.item_sk = i.item_sk) then
+                                for d in date_dim do
+                                    if (cs.date_sk = d.date_sk) then
+                                        if ((i.current_price >= 0.99) && (i.current_price <= 1.49)) then
+                                            yield Map.ofList [(w_state, w.state); (i_item_id, i.item_id); (sold_date, d.date); (net, (cs.price - ((if (cr = null) then 0.0 else cr.refunded))))]
+    |]
+let result = _group_by records (fun r -> Map.ofList [(w_state, r.w_state); (i_item_id, r.i_item_id)]) |> List.map (fun g -> Map.ofList [(w_state, g.key.w_state); (i_item_id, g.key.i_item_id); (sales_before, sum 
+    [|
+    for x in g do
+        yield (if (x.sold_date < sales_date) then x.net else 0.0)
+    |]); (sales_after, sum 
+    [|
+    for x in g do
+        yield (if (x.sold_date >= sales_date) then x.net else 0.0)
+    |])])
+ignore (_json result)
+let test_TPCDS_Q40_simplified() =
+    if not ((result = [|Map.ofList [(w_state, "CA"); (i_item_id, "I1"); (sales_before, 100.0); (sales_after, 0.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q40 simplified" test_TPCDS_Q40_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q41.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q41.fs.out
@@ -1,0 +1,75 @@
+open System
+
+let product_name = "product_name"
+let manufact_id = "manufact_id"
+let manufact = "manufact"
+let category = "category"
+let color = "color"
+let units = "units"
+let size = "size"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let item = [|Map.ofList [(product_name, "Blue Shirt"); (manufact_id, 100); (manufact, 1); (category, "Women"); (color, "blue"); (units, "pack"); (size, "M")]; Map.ofList [(product_name, "Red Dress"); (manufact_id, 120); (manufact, 1); (category, "Women"); (color, "red"); (units, "pack"); (size, "M")]; Map.ofList [(product_name, "Pants"); (manufact_id, 200); (manufact, 2); (category, "Men"); (color, "black"); (units, "pair"); (size, "L")]|]
+let lower = 100
+let result = 
+    [|
+    for i1 in item do
+        if (((i1.manufact_id >= lower) && (i1.manufact_id <= (lower + 40))) && (count 
+    [|
+    for i2 in item do
+        if ((i2.manufact = i1.manufact) && (i2.category = i1.category)) then
+            yield i2
+    |] > 1)) then
+            yield (i1.product_name, i1.product_name)
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q41_simplified() =
+    if not ((result = [|"Blue Shirt"; "Red Dress"|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q41 simplified" test_TPCDS_Q41_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q42.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q42.fs.out
@@ -1,0 +1,111 @@
+open System
+
+let sold_date_sk = "sold_date_sk"
+let item_sk = "item_sk"
+let ext_sales_price = "ext_sales_price"
+let i_item_sk = "i_item_sk"
+let i_manager_id = "i_manager_id"
+let i_category_id = "i_category_id"
+let i_category = "i_category"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let price = "price"
+let sum_ss_ext_sales_price = "sum_ss_ext_sales_price"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(sold_date_sk, 1); (item_sk, 1); (ext_sales_price, 10.0)]; Map.ofList [(sold_date_sk, 1); (item_sk, 2); (ext_sales_price, 20.0)]; Map.ofList [(sold_date_sk, 2); (item_sk, 1); (ext_sales_price, 15.0)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_manager_id, 1); (i_category_id, 100); (i_category, "CatA")]; Map.ofList [(i_item_sk, 2); (i_manager_id, 2); (i_category_id, 200); (i_category, "CatB")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2020); (d_moy, 5)]; Map.ofList [(d_date_sk, 2); (d_year, 2021); (d_moy, 5)]|]
+let month = 5
+let year = 2020
+let records = 
+    [|
+    for dt in date_dim do
+        for ss in store_sales do
+            if (ss.sold_date_sk = dt.d_date_sk) then
+                for it in item do
+                    if (ss.item_sk = it.i_item_sk) then
+                        if (((it.i_manager_id = 1) && (dt.d_moy = month)) && (dt.d_year = year)) then
+                            yield Map.ofList [(d_year, dt.d_year); (i_category_id, it.i_category_id); (i_category, it.i_category); (price, ss.ext_sales_price)]
+    |]
+let _base = [| for g in _group_by [|
+    for r in records do
+        yield r
+|] (fun r -> Map.ofList [(d_year, r.d_year); (i_category_id, r.i_category_id); (i_category, r.i_category)]) do let g = g yield ([|(-sum 
+    [|
+    for x in g do
+        yield x.price
+    |]); g.key.d_year; g.key.i_category_id; g.key.i_category|], Map.ofList [(d_year, g.key.d_year); (i_category_id, g.key.i_category_id); (i_category, g.key.i_category); (sum_ss_ext_sales_price, sum 
+    [|
+    for x in g do
+        yield x.price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+let result = _base
+ignore (_json result)
+let test_TPCDS_Q42_simplified() =
+    if not ((result = [|Map.ofList [(d_year, 2020); (i_category_id, 200); (i_category, "CatB"); (sum_ss_ext_sales_price, 20.0)]; Map.ofList [(d_year, 2020); (i_category_id, 100); (i_category, "CatA"); (sum_ss_ext_sales_price, 10.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q42 simplified" test_TPCDS_Q42_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q43.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q43.fs.out
@@ -1,0 +1,137 @@
+open System
+
+let date_sk = "date_sk"
+let d_day_name = "d_day_name"
+let d_year = "d_year"
+let store_sk = "store_sk"
+let store_id = "store_id"
+let store_name = "store_name"
+let gmt_offset = "gmt_offset"
+let sold_date_sk = "sold_date_sk"
+let sales_price = "sales_price"
+let s_store_name = "s_store_name"
+let s_store_id = "s_store_id"
+let price = "price"
+let name = "name"
+let id = "id"
+let sun_sales = "sun_sales"
+let mon_sales = "mon_sales"
+let tue_sales = "tue_sales"
+let wed_sales = "wed_sales"
+let thu_sales = "thu_sales"
+let fri_sales = "fri_sales"
+let sat_sales = "sat_sales"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let date_dim = [|Map.ofList [(date_sk, 1); (d_day_name, "Sunday"); (d_year, 2020)]; Map.ofList [(date_sk, 2); (d_day_name, "Monday"); (d_year, 2020)]; Map.ofList [(date_sk, 3); (d_day_name, "Tuesday"); (d_year, 2020)]; Map.ofList [(date_sk, 4); (d_day_name, "Wednesday"); (d_year, 2020)]; Map.ofList [(date_sk, 5); (d_day_name, "Thursday"); (d_year, 2020)]; Map.ofList [(date_sk, 6); (d_day_name, "Friday"); (d_year, 2020)]; Map.ofList [(date_sk, 7); (d_day_name, "Saturday"); (d_year, 2020)]|]
+let store = [|Map.ofList [(store_sk, 1); (store_id, "S1"); (store_name, "Main"); (gmt_offset, 0)]|]
+let store_sales = [|Map.ofList [(sold_date_sk, 1); (store_sk, 1); (sales_price, 10.0)]; Map.ofList [(sold_date_sk, 2); (store_sk, 1); (sales_price, 20.0)]; Map.ofList [(sold_date_sk, 3); (store_sk, 1); (sales_price, 30.0)]; Map.ofList [(sold_date_sk, 4); (store_sk, 1); (sales_price, 40.0)]; Map.ofList [(sold_date_sk, 5); (store_sk, 1); (sales_price, 50.0)]; Map.ofList [(sold_date_sk, 6); (store_sk, 1); (sales_price, 60.0)]; Map.ofList [(sold_date_sk, 7); (store_sk, 1); (sales_price, 70.0)]|]
+let year = 2020
+let gmt = 0
+let records = 
+    [|
+    for d in date_dim do
+        for ss in store_sales do
+            if (ss.sold_date_sk = d.date_sk) then
+                for s in store do
+                    if (ss.store_sk = s.store_sk) then
+                        if ((s.gmt_offset = gmt) && (d.d_year = year)) then
+                            yield Map.ofList [(d_day_name, d.d_day_name); (s_store_name, s.store_name); (s_store_id, s.store_id); (price, ss.sales_price)]
+    |]
+let _base = _group_by records (fun r -> Map.ofList [(name, r.s_store_name); (id, r.s_store_id)]) |> List.map (fun g -> Map.ofList [(s_store_name, g.key.name); (s_store_id, g.key.id); (sun_sales, sum 
+    [|
+    for x in g do
+        yield (if (x.d_day_name = "Sunday") then x.price else 0.0)
+    |]); (mon_sales, sum 
+    [|
+    for x in g do
+        yield (if (x.d_day_name = "Monday") then x.price else 0.0)
+    |]); (tue_sales, sum 
+    [|
+    for x in g do
+        yield (if (x.d_day_name = "Tuesday") then x.price else 0.0)
+    |]); (wed_sales, sum 
+    [|
+    for x in g do
+        yield (if (x.d_day_name = "Wednesday") then x.price else 0.0)
+    |]); (thu_sales, sum 
+    [|
+    for x in g do
+        yield (if (x.d_day_name = "Thursday") then x.price else 0.0)
+    |]); (fri_sales, sum 
+    [|
+    for x in g do
+        yield (if (x.d_day_name = "Friday") then x.price else 0.0)
+    |]); (sat_sales, sum 
+    [|
+    for x in g do
+        yield (if (x.d_day_name = "Saturday") then x.price else 0.0)
+    |])])
+let result = _base
+ignore (_json result)
+let test_TPCDS_Q43_simplified() =
+    if not ((result = [|Map.ofList [(s_store_name, "Main"); (s_store_id, "S1"); (sun_sales, 10.0); (mon_sales, 20.0); (tue_sales, 30.0); (wed_sales, 40.0); (thu_sales, 50.0); (fri_sales, 60.0); (sat_sales, 70.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q43 simplified" test_TPCDS_Q43_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q44.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q44.fs.out
@@ -1,0 +1,115 @@
+open System
+
+let ss_item_sk = "ss_item_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_net_profit = "ss_net_profit"
+let i_item_sk = "i_item_sk"
+let i_product_name = "i_product_name"
+let item_sk = "item_sk"
+let avg_profit = "avg_profit"
+let best_performing = "best_performing"
+let worst_performing = "worst_performing"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_store_sk, 1); (ss_net_profit, 5.0)]; Map.ofList [(ss_item_sk, 1); (ss_store_sk, 1); (ss_net_profit, 5.0)]; Map.ofList [(ss_item_sk, 2); (ss_store_sk, 1); (ss_net_profit, (-1.0))]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_product_name, "ItemA")]; Map.ofList [(i_item_sk, 2); (i_product_name, "ItemB")]|]
+let grouped_base = (_group_by store_sales (fun ss -> ss.ss_item_sk) |> List.map (fun g -> Map.ofList [(item_sk, g.key); (avg_profit, avg 
+    [|
+    for x in g do
+        yield x.ss_net_profit
+    |])]))
+let grouped = grouped_base
+let best = first (
+    [|
+    for x in grouped do
+        yield ((-x.avg_profit), x)
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd)
+let worst = first (
+    [|
+    for x in grouped do
+        yield (x.avg_profit, x)
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd)
+let best_name = first (
+    [|
+    for i in item do
+        if (i.i_item_sk = best.item_sk) then
+            yield i.i_product_name
+    |])
+let worst_name = first (
+    [|
+    for i in item do
+        if (i.i_item_sk = worst.item_sk) then
+            yield i.i_product_name
+    |])
+let result = Map.ofList [(best_performing, best_name); (worst_performing, worst_name)]
+ignore (_json result)
+let test_TPCDS_Q44_simplified() =
+    if not ((result = Map.ofList [(best_performing, "ItemA"); (worst_performing, "ItemB")])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q44 simplified" test_TPCDS_Q44_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q45.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q45.fs.out
@@ -1,0 +1,122 @@
+open System
+
+let bill_customer_sk = "bill_customer_sk"
+let item_sk = "item_sk"
+let sold_date_sk = "sold_date_sk"
+let sales_price = "sales_price"
+let c_customer_sk = "c_customer_sk"
+let c_current_addr_sk = "c_current_addr_sk"
+let ca_address_sk = "ca_address_sk"
+let ca_zip = "ca_zip"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let d_date_sk = "d_date_sk"
+let d_qoy = "d_qoy"
+let d_year = "d_year"
+let sum_ws_sales_price = "sum_ws_sales_price"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _slice_string (s: string) (i: int) (j: int) : string =
+  let mutable start = i
+  let mutable stop = j
+  let n = s.Length
+  if start < 0 then start <- start + n
+  if stop < 0 then stop <- stop + n
+  if start < 0 then start <- 0
+  if stop > n then stop <- n
+  if stop < start then stop <- start
+  s.Substring(start, stop - start)
+
+let web_sales = [|Map.ofList [(bill_customer_sk, 1); (item_sk, 1); (sold_date_sk, 1); (sales_price, 50.0)]; Map.ofList [(bill_customer_sk, 2); (item_sk, 2); (sold_date_sk, 1); (sales_price, 30.0)]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_current_addr_sk, 1)]; Map.ofList [(c_customer_sk, 2); (c_current_addr_sk, 2)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_zip, "85669")]; Map.ofList [(ca_address_sk, 2); (ca_zip, "99999")]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "I1")]; Map.ofList [(i_item_sk, 2); (i_item_id, "I2")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_qoy, 1); (d_year, 2020)]|]
+let zip_list = [|"85669"; "86197"; "88274"; "83405"; "86475"; "85392"; "85460"; "80348"; "81792"|]
+let item_ids = [|"I2"|]
+let qoy = 1
+let year = 2020
+let _base = [| for g in _group_by [|
+    for ws in web_sales do
+        for c in customer do
+            if (ws.bill_customer_sk = c.c_customer_sk) then
+                for ca in customer_address do
+                    if (c.c_current_addr_sk = ca.ca_address_sk) then
+                        for i in item do
+                            if (ws.item_sk = i.i_item_sk) then
+                                for d in date_dim do
+                                    if (ws.sold_date_sk = d.d_date_sk) then
+                                        if ((((Array.contains _slice_string ca.ca_zip 0 5 zip_list || Array.contains i.i_item_id item_ids)) && (d.d_qoy = qoy)) && (d.d_year = year)) then
+                                            yield (ws, c, ca, i, d)
+|] (fun (ws, c, ca, i, d) -> ca.ca_zip) do let g = g yield Map.ofList [(ca_zip, g.key); (sum_ws_sales_price, sum 
+    [|
+    for x in g do
+        yield x.ws.sales_price
+    |])] |]
+let records = _base
+ignore (_json records)
+let test_TPCDS_Q45_simplified() =
+    if not ((records = [|Map.ofList [(ca_zip, "85669"); (sum_ws_sales_price, 50.0)]; Map.ofList [(ca_zip, "99999"); (sum_ws_sales_price, 30.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q45 simplified" test_TPCDS_Q45_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q46.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q46.fs.out
@@ -1,0 +1,140 @@
+open System
+
+let ss_ticket_number = "ss_ticket_number"
+let ss_customer_sk = "ss_customer_sk"
+let ss_addr_sk = "ss_addr_sk"
+let ss_hdemo_sk = "ss_hdemo_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_coupon_amt = "ss_coupon_amt"
+let ss_net_profit = "ss_net_profit"
+let d_date_sk = "d_date_sk"
+let d_dow = "d_dow"
+let d_year = "d_year"
+let s_store_sk = "s_store_sk"
+let s_city = "s_city"
+let hd_demo_sk = "hd_demo_sk"
+let hd_dep_count = "hd_dep_count"
+let hd_vehicle_count = "hd_vehicle_count"
+let ca_address_sk = "ca_address_sk"
+let ca_city = "ca_city"
+let c_customer_sk = "c_customer_sk"
+let c_last_name = "c_last_name"
+let c_first_name = "c_first_name"
+let c_current_addr_sk = "c_current_addr_sk"
+let bought_city = "bought_city"
+let amt = "amt"
+let profit = "profit"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_addr_sk, 1); (ss_hdemo_sk, 1); (ss_store_sk, 1); (ss_sold_date_sk, 1); (ss_coupon_amt, 5.0); (ss_net_profit, 20.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_dow, 6); (d_year, 2020)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_city, "CityA")]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_dep_count, 2); (hd_vehicle_count, 0)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_city, "Portland")]; Map.ofList [(ca_address_sk, 2); (ca_city, "Seattle")]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_last_name, "Doe"); (c_first_name, "John"); (c_current_addr_sk, 2)]|]
+let depcnt = 2
+let vehcnt = 0
+let year = 2020
+let cities = [|"CityA"|]
+let dn = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (ss.ss_sold_date_sk = d.d_date_sk) then
+                for s in store do
+                    if (ss.ss_store_sk = s.s_store_sk) then
+                        for hd in household_demographics do
+                            if (ss.ss_hdemo_sk = hd.hd_demo_sk) then
+                                for ca in customer_address do
+                                    if (ss.ss_addr_sk = ca.ca_address_sk) then
+                                        if ((((((hd.hd_dep_count = depcnt) || (hd.hd_vehicle_count = vehcnt))) && Array.contains d.d_dow [|6; 0|]) && (d.d_year = year)) && Array.contains s.s_city cities) then
+                                            yield (ss, d, s, hd, ca)
+|] (fun (ss, d, s, hd, ca) -> Map.ofList [(ss_ticket_number, ss.ss_ticket_number); (ss_customer_sk, ss.ss_customer_sk); (ca_city, ca.ca_city)]) do let g = g yield Map.ofList [(ss_ticket_number, g.key.ss_ticket_number); (ss_customer_sk, g.key.ss_customer_sk); (bought_city, g.key.ca_city); (amt, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_coupon_amt
+    |]); (profit, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_net_profit
+    |])] |]
+let _base = 
+    [|
+    for dnrec in dn do
+        for c in customer do
+            if (dnrec.ss_customer_sk = c.c_customer_sk) then
+                for current_addr in customer_address do
+                    if (c.c_current_addr_sk = current_addr.ca_address_sk) then
+                        if (current_addr.ca_city <> dnrec.bought_city) then
+                            yield ([|c.c_last_name; c.c_first_name; current_addr.ca_city; dnrec.bought_city; dnrec.ss_ticket_number|], Map.ofList [(c_last_name, c.c_last_name); (c_first_name, c.c_first_name); (ca_city, current_addr.ca_city); (bought_city, dnrec.bought_city); (ss_ticket_number, dnrec.ss_ticket_number); (amt, dnrec.amt); (profit, dnrec.profit)])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+let result = _base
+ignore (_json result)
+let test_TPCDS_Q46_simplified() =
+    if not ((result = [|Map.ofList [(c_last_name, "Doe"); (c_first_name, "John"); (ca_city, "Seattle"); (bought_city, "Portland"); (ss_ticket_number, 1); (amt, 5.0); (profit, 20.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q46 simplified" test_TPCDS_Q46_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q47.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q47.fs.out
@@ -1,0 +1,69 @@
+open System
+
+let d_year = "d_year"
+let item = "item"
+let avg_monthly_sales = "avg_monthly_sales"
+let sum_sales = "sum_sales"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+exception Return_abs of float
+let rec abs (x: float) : float =
+    try
+        let mutable x = x
+        if (x >= 0.0) then
+            ignore (x)
+        else
+            ignore ((-x))
+        failwith "unreachable"
+    with Return_abs v -> v
+
+let v2 = [|Map.ofList [(d_year, 2020); (item, "A"); (avg_monthly_sales, 100.0); (sum_sales, 120.0)]; Map.ofList [(d_year, 2020); (item, "B"); (avg_monthly_sales, 80.0); (sum_sales, 70.0)]; Map.ofList [(d_year, 2019); (item, "C"); (avg_monthly_sales, 50.0); (sum_sales, 60.0)]|]
+let year = 2020
+let orderby = "item"
+let result = 
+    [|
+    for v in v2 do
+        if (((v.d_year = year) && (v.avg_monthly_sales > 0)) && ((abs ((v.sum_sales - v.avg_monthly_sales)) / v.avg_monthly_sales) > 0.1)) then
+            yield ([|(v.sum_sales - v.avg_monthly_sales); v.item|], v)
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q47_simplified() =
+    if not ((result = [|Map.ofList [(d_year, 2019); (item, "C"); (avg_monthly_sales, 50.0); (sum_sales, 60.0)]; Map.ofList [(d_year, 2020); (item, "A"); (avg_monthly_sales, 100.0); (sum_sales, 120.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q47 simplified" test_TPCDS_Q47_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q48.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q48.fs.out
@@ -1,0 +1,91 @@
+open System
+
+let cdemo_sk = "cdemo_sk"
+let addr_sk = "addr_sk"
+let sold_date_sk = "sold_date_sk"
+let sales_price = "sales_price"
+let net_profit = "net_profit"
+let quantity = "quantity"
+let s_store_sk = "s_store_sk"
+let cd_demo_sk = "cd_demo_sk"
+let cd_marital_status = "cd_marital_status"
+let cd_education_status = "cd_education_status"
+let ca_address_sk = "ca_address_sk"
+let ca_country = "ca_country"
+let ca_state = "ca_state"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(cdemo_sk, 1); (addr_sk, 1); (sold_date_sk, 1); (sales_price, 120.0); (net_profit, 1000.0); (quantity, 5)]; Map.ofList [(cdemo_sk, 2); (addr_sk, 2); (sold_date_sk, 1); (sales_price, 60.0); (net_profit, 2000.0); (quantity, 10)]; Map.ofList [(cdemo_sk, 3); (addr_sk, 3); (sold_date_sk, 1); (sales_price, 170.0); (net_profit, 10000.0); (quantity, 20)]|]
+let store = [|Map.ofList [(s_store_sk, 1)]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1); (cd_marital_status, "S"); (cd_education_status, "E1")]; Map.ofList [(cd_demo_sk, 2); (cd_marital_status, "M"); (cd_education_status, "E2")]; Map.ofList [(cd_demo_sk, 3); (cd_marital_status, "W"); (cd_education_status, "E3")]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_country, "United States"); (ca_state, "TX")]; Map.ofList [(ca_address_sk, 2); (ca_country, "United States"); (ca_state, "CA")]; Map.ofList [(ca_address_sk, 3); (ca_country, "United States"); (ca_state, "NY")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000)]|]
+let year = 2000
+let states1 = [|"TX"|]
+let states2 = [|"CA"|]
+let states3 = [|"NY"|]
+let qty_base = 
+    [|
+    for ss in store_sales do
+        for cd in customer_demographics do
+            if (ss.cdemo_sk = cd.cd_demo_sk) then
+                for ca in customer_address do
+                    if (ss.addr_sk = ca.ca_address_sk) then
+                        for d in date_dim do
+                            if (ss.sold_date_sk = d.d_date_sk) then
+                                if (((d.d_year = year) && ((((((((cd.cd_marital_status = "S") && (cd.cd_education_status = "E1")) && (ss.sales_price >= 100.0)) && (ss.sales_price <= 150.0))) || (((((cd.cd_marital_status = "M") && (cd.cd_education_status = "E2")) && (ss.sales_price >= 50.0)) && (ss.sales_price <= 100.0)))) || (((((cd.cd_marital_status = "W") && (cd.cd_education_status = "E3")) && (ss.sales_price >= 150.0)) && (ss.sales_price <= 200.0)))))) && ((((((Array.contains ca.ca_state states1 && (ss.net_profit >= 0)) && (ss.net_profit <= 2000))) || (((Array.contains ca.ca_state states2 && (ss.net_profit >= 150)) && (ss.net_profit <= 3000)))) || (((Array.contains ca.ca_state states3 && (ss.net_profit >= 50)) && (ss.net_profit <= 25000)))))) then
+                                    yield ss.quantity
+    |]
+let qty = qty_base
+let result = sum qty
+ignore (_json result)
+let test_TPCDS_Q48_simplified() =
+    if not ((result = 35)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q48 simplified" test_TPCDS_Q48_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q49.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q49.fs.out
@@ -1,0 +1,77 @@
+open System
+
+let item = "item"
+let return_ratio = "return_ratio"
+let currency_ratio = "currency_ratio"
+let return_rank = "return_rank"
+let currency_rank = "currency_rank"
+let channel = "channel"
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let web = [|Map.ofList [(item, "A"); (return_ratio, 0.2); (currency_ratio, 0.3); (return_rank, 1); (currency_rank, 1)]; Map.ofList [(item, "B"); (return_ratio, 0.5); (currency_ratio, 0.6); (return_rank, 2); (currency_rank, 2)]|]
+let catalog = [|Map.ofList [(item, "A"); (return_ratio, 0.3); (currency_ratio, 0.4); (return_rank, 1); (currency_rank, 1)]|]
+let store = [|Map.ofList [(item, "A"); (return_ratio, 0.25); (currency_ratio, 0.35); (return_rank, 1); (currency_rank, 1)]|]
+let tmp = (_concat _concat 
+    [|
+    for w in web do
+        if ((w.return_rank <= 10) || (w.currency_rank <= 10)) then
+            yield Map.ofList [(channel, "web"); (item, w.item); (return_ratio, w.return_ratio); (return_rank, w.return_rank); (currency_rank, w.currency_rank)]
+    |] 
+    [|
+    for c in catalog do
+        if ((c.return_rank <= 10) || (c.currency_rank <= 10)) then
+            yield Map.ofList [(channel, "catalog"); (item, c.item); (return_ratio, c.return_ratio); (return_rank, c.return_rank); (currency_rank, c.currency_rank)]
+    |] 
+    [|
+    for s in store do
+        if ((s.return_rank <= 10) || (s.currency_rank <= 10)) then
+            yield Map.ofList [(channel, "store"); (item, s.item); (return_ratio, s.return_ratio); (return_rank, s.return_rank); (currency_rank, s.currency_rank)]
+    |])
+let result = 
+    [|
+    for r in tmp do
+        yield ([|r.channel; r.return_rank; r.currency_rank; r.item|], r)
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q49_simplified() =
+    if not ((result = [|Map.ofList [(channel, "catalog"); (item, "A"); (return_ratio, 0.3); (return_rank, 1); (currency_rank, 1)]; Map.ofList [(channel, "store"); (item, "A"); (return_ratio, 0.25); (return_rank, 1); (currency_rank, 1)]; Map.ofList [(channel, "web"); (item, "A"); (return_ratio, 0.2); (return_rank, 1); (currency_rank, 1)]; Map.ofList [(channel, "web"); (item, "B"); (return_ratio, 0.5); (return_rank, 2); (currency_rank, 2)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q49 simplified" test_TPCDS_Q49_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures


### PR DESCRIPTION
## Summary
- extend F# compiler test range to q30–q49
- add generated F# code for TPCDS queries q30–q49

## Testing
- `go test ./compile/x/fs -run TestFSCompiler_TPCDS/q30 -tags slow`
- `go test ./... -run TestNonexistent`


------
https://chatgpt.com/codex/tasks/task_e_68640f25e99c8320ac53f163859bf0fb