### PR TITLE
Extend Haskell backend for TPC‑DS

### DIFF
--- a/compile/x/hs/compiler.go
+++ b/compile/x/hs/compiler.go
@@ -322,14 +322,14 @@ func (c *Compiler) compileMainStmt(s *parser.Statement) error {
 }
 
 func (c *Compiler) simpleBodyExpr(stmts []*parser.Statement) (string, error) {
-	if len(stmts) != 1 {
-		return "", fmt.Errorf("unsupported loop body")
+	if len(stmts) == 1 && stmts[0].Expr != nil {
+		return c.compileExpr(stmts[0].Expr.Expr)
 	}
-	s := stmts[0]
-	if s.Expr != nil {
-		return c.compileExpr(s.Expr.Expr)
+	expr, err := c.compileStmtExpr(stmts, false)
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("unsupported loop body")
+	return fmt.Sprintf("fromMaybe () (%s)", expr), nil
 }
 
 func (c *Compiler) compileFun(fun *parser.FunStmt) error {

--- a/compile/x/hs/tpcds_golden_test.go
+++ b/compile/x/hs/tpcds_golden_test.go
@@ -23,6 +23,8 @@ func TestHSCompiler_TPCDSQueries(t *testing.T) {
 		"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9",
 		"q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
 		"q20", "q21", "q22", "q23", "q25", "q26", "q27", "q28", "q29",
+		"q30", "q31", "q32", "q33", "q34", "q35", "q36", "q37", "q38",
+		"q40", "q41", "q42", "q43", "q44", "q45", "q46", "q47", "q48", "q49",
 	}
 	for _, q := range queries {
 		t.Run(q, func(t *testing.T) {

--- a/tests/dataset/tpc-ds/compiler/hs/q30.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q30.hs.out
@@ -1,0 +1,197 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+web_returns = [Map.fromList [("wr_returning_customer_sk", VInt (1)), ("wr_returned_date_sk", VInt (1)), ("wr_return_amt", VDouble (100.0)), ("wr_returning_addr_sk", VInt (1))], Map.fromList [("wr_returning_customer_sk", VInt (2)), ("wr_returned_date_sk", VInt (1)), ("wr_return_amt", VDouble (30.0)), ("wr_returning_addr_sk", VInt (2))], Map.fromList [("wr_returning_customer_sk", VInt (1)), ("wr_returned_date_sk", VInt (1)), ("wr_return_amt", VDouble (50.0)), ("wr_returning_addr_sk", VInt (1))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_state", VString ("CA"))], Map.fromList [("ca_address_sk", VInt (2)), ("ca_state", VString ("CA"))]]
+
+customer = [Map.fromList [("c_customer_sk", VInt (1)), ("c_customer_id", VString ("C1")), ("c_first_name", VString ("John")), ("c_last_name", VString ("Doe")), ("c_current_addr_sk", VInt (1))], Map.fromList [("c_customer_sk", VInt (2)), ("c_customer_id", VString ("C2")), ("c_first_name", VString ("Jane")), ("c_last_name", VString ("Smith")), ("c_current_addr_sk", VInt (2))]]
+
+customer_total_return = [ Map.fromList [("ctr_customer_sk", VString (fromMaybe (error "missing") (Map.lookup "cust" (key (g))))), ("ctr_state", VString (fromMaybe (error "missing") (Map.lookup "state" (key (g))))), ("ctr_total_return", VDouble (sum [fromMaybe (error "missing") (Map.lookup "wr_return_amt" (x)) | x <- g]))] | g <- _group_by [(wr, d, ca) | wr <- web_returns, d <- date_dim, ca <- customer_address, (fromMaybe (error "missing") (Map.lookup "wr_returned_date_sk" (wr)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "wr_returning_addr_sk" (wr)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (((fromMaybe (error "missing") (Map.lookup "d_year" d) == 2000) && fromMaybe (error "missing") (Map.lookup "ca_state" ca)) == "CA")] (\(wr, d, ca) -> Map.fromList [("cust", VString (fromMaybe (error "missing") (Map.lookup "wr_returning_customer_sk" wr))), ("state", VString (fromMaybe (error "missing") (Map.lookup "ca_state" ca)))]), let g = g ]
+
+avg_by_state = [ Map.fromList [("state", VString (key (g))), ("avg_return", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ctr_total_return" (x)) | x <- g]))] | g <- _group_by customer_total_return (\ctr -> fromMaybe (error "missing") (Map.lookup "ctr_state" ctr)), let g = g ]
+
+result = [Map.fromList [("c_customer_id", VString (fromMaybe (error "missing") (Map.lookup "c_customer_id" c))), ("c_first_name", VString (fromMaybe (error "missing") (Map.lookup "c_first_name" c))), ("c_last_name", VString (fromMaybe (error "missing") (Map.lookup "c_last_name" c))), ("ctr_total_return", VString (fromMaybe (error "missing") (Map.lookup "ctr_total_return" ctr)))] | ctr <- customer_total_return, avg <- avg_by_state, c <- customer, (fromMaybe (error "missing") (Map.lookup "ctr_state" (ctr)) == fromMaybe (error "missing") (Map.lookup "state" (avg))), (fromMaybe (error "missing") (Map.lookup "ctr_customer_sk" (ctr)) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" (c))), ((fromMaybe (error "missing") (Map.lookup "ctr_total_return" ctr) > fromMaybe (error "missing") (Map.lookup "avg_return" avg)) * 1.2)]
+
+test_TPCDS_Q30_simplified :: IO ()
+test_TPCDS_Q30_simplified = do
+    expect ((result == [Map.fromList [("c_customer_id", VString ("C1")), ("c_first_name", VString ("John")), ("c_last_name", VString ("Doe")), ("ctr_total_return", VDouble (150.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q30_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q31.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q31.hs.out
@@ -1,0 +1,192 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+store_sales = [Map.fromList [("ca_county", VString ("A")), ("d_qoy", VInt (1)), ("d_year", VInt (2000)), ("ss_ext_sales_price", VDouble (100.0))], Map.fromList [("ca_county", VString ("A")), ("d_qoy", VInt (2)), ("d_year", VInt (2000)), ("ss_ext_sales_price", VDouble (120.0))], Map.fromList [("ca_county", VString ("A")), ("d_qoy", VInt (3)), ("d_year", VInt (2000)), ("ss_ext_sales_price", VDouble (160.0))], Map.fromList [("ca_county", VString ("B")), ("d_qoy", VInt (1)), ("d_year", VInt (2000)), ("ss_ext_sales_price", VDouble (80.0))], Map.fromList [("ca_county", VString ("B")), ("d_qoy", VInt (2)), ("d_year", VInt (2000)), ("ss_ext_sales_price", VDouble (90.0))], Map.fromList [("ca_county", VString ("B")), ("d_qoy", VInt (3)), ("d_year", VInt (2000)), ("ss_ext_sales_price", VDouble (100.0))]]
+
+web_sales = [Map.fromList [("ca_county", VString ("A")), ("d_qoy", VInt (1)), ("d_year", VInt (2000)), ("ws_ext_sales_price", VDouble (100.0))], Map.fromList [("ca_county", VString ("A")), ("d_qoy", VInt (2)), ("d_year", VInt (2000)), ("ws_ext_sales_price", VDouble (150.0))], Map.fromList [("ca_county", VString ("A")), ("d_qoy", VInt (3)), ("d_year", VInt (2000)), ("ws_ext_sales_price", VDouble (250.0))], Map.fromList [("ca_county", VString ("B")), ("d_qoy", VInt (1)), ("d_year", VInt (2000)), ("ws_ext_sales_price", VDouble (80.0))], Map.fromList [("ca_county", VString ("B")), ("d_qoy", VInt (2)), ("d_year", VInt (2000)), ("ws_ext_sales_price", VDouble (90.0))], Map.fromList [("ca_county", VString ("B")), ("d_qoy", VInt (3)), ("d_year", VInt (2000)), ("ws_ext_sales_price", VDouble (95.0))]]
+
+counties = ["A", "B"]
+
+result = []
+
+test_TPCDS_Q31_simplified :: IO ()
+test_TPCDS_Q31_simplified = do
+    expect ((result == [Map.fromList [("ca_county", VString ("A")), ("d_year", VInt (2000)), ("web_q1_q2_increase", VDouble (1.5)), ("store_q1_q2_increase", VDouble (1.2)), ("web_q2_q3_increase", VDouble (1.6666666666666667)), ("store_q2_q3_increase", VDouble (1.3333333333333333))]]))
+
+main :: IO ()
+main = do
+    mapM_ (\county -> fromMaybe () ((let ss1 = sum [fromMaybe (error "missing") (Map.lookup "ss_ext_sales_price" s) | s <- filter (\s -> (((fromMaybe (error "missing") (Map.lookup "ca_county" s) == county) && fromMaybe (error "missing") (Map.lookup "d_qoy" s)) == 1)) store_sales] in (let ss2 = sum [fromMaybe (error "missing") (Map.lookup "ss_ext_sales_price" s) | s <- filter (\s -> (((fromMaybe (error "missing") (Map.lookup "ca_county" s) == county) && fromMaybe (error "missing") (Map.lookup "d_qoy" s)) == 2)) store_sales] in (let ss3 = sum [fromMaybe (error "missing") (Map.lookup "ss_ext_sales_price" s) | s <- filter (\s -> (((fromMaybe (error "missing") (Map.lookup "ca_county" s) == county) && fromMaybe (error "missing") (Map.lookup "d_qoy" s)) == 3)) store_sales] in (let ws1 = sum [fromMaybe (error "missing") (Map.lookup "ws_ext_sales_price" w) | w <- filter (\w -> (((fromMaybe (error "missing") (Map.lookup "ca_county" w) == county) && fromMaybe (error "missing") (Map.lookup "d_qoy" w)) == 1)) web_sales] in (let ws2 = sum [fromMaybe (error "missing") (Map.lookup "ws_ext_sales_price" w) | w <- filter (\w -> (((fromMaybe (error "missing") (Map.lookup "ca_county" w) == county) && fromMaybe (error "missing") (Map.lookup "d_qoy" w)) == 2)) web_sales] in (let ws3 = sum [fromMaybe (error "missing") (Map.lookup "ws_ext_sales_price" w) | w <- filter (\w -> (((fromMaybe (error "missing") (Map.lookup "ca_county" w) == county) && fromMaybe (error "missing") (Map.lookup "d_qoy" w)) == 3)) web_sales] in (let web_g1 = (ws2 / ws1) in (let store_g1 = (ss2 / ss1) in (let web_g2 = (ws3 / ws2) in (let store_g2 = (ss3 / ss2) in if (((web_g1 > store_g1) && web_g2) > store_g2) then (let result = append result Map.fromList [("ca_county", VString (county)), ("d_year", VInt (2000)), ("web_q1_q2_increase", VString (web_g1)), ("store_q1_q2_increase", VString (store_g1)), ("web_q2_q3_increase", VString (web_g2)), ("store_q2_q3_increase", VString (store_g2))] in Nothing) else Nothing)))))))))))) counties
+    _json result
+    test_TPCDS_Q31_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q32.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q32.hs.out
@@ -1,0 +1,195 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+catalog_sales = [Map.fromList [("cs_item_sk", VInt (1)), ("cs_sold_date_sk", VInt (1)), ("cs_ext_discount_amt", VDouble (5.0))], Map.fromList [("cs_item_sk", VInt (1)), ("cs_sold_date_sk", VInt (2)), ("cs_ext_discount_amt", VDouble (10.0))], Map.fromList [("cs_item_sk", VInt (1)), ("cs_sold_date_sk", VInt (3)), ("cs_ext_discount_amt", VDouble (20.0))]]
+
+item = [Map.fromList [("i_item_sk", 1), ("i_manufact_id", 1)]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000)], Map.fromList [("d_date_sk", 2), ("d_year", 2000)], Map.fromList [("d_date_sk", 3), ("d_year", 2000)]]
+
+filtered = [fromMaybe (error "missing") (Map.lookup "cs_ext_discount_amt" cs) | cs <- catalog_sales, i <- item, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (((fromMaybe (error "missing") (Map.lookup "i_manufact_id" i) == 1) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == 2000)]
+
+avg_discount = avg filtered
+
+result = sum [x | x <- filter (\x -> ((x > avg_discount) * 1.3)) filtered]
+
+test_TPCDS_Q32_simplified :: IO ()
+test_TPCDS_Q32_simplified = do
+    expect ((result == 20.0))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q32_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q33.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q33.hs.out
@@ -1,0 +1,203 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_manufact_id", VInt (1)), ("i_category", VString ("Books"))], Map.fromList [("i_item_sk", VInt (2)), ("i_manufact_id", VInt (2)), ("i_category", VString ("Books"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000), ("d_moy", 1)]]
+
+customer_address = [Map.fromList [("ca_address_sk", 1), ("ca_gmt_offset", (-5))], Map.fromList [("ca_address_sk", 2), ("ca_gmt_offset", (-5))]]
+
+store_sales = [Map.fromList [("ss_item_sk", VInt (1)), ("ss_ext_sales_price", VDouble (100.0)), ("ss_sold_date_sk", VInt (1)), ("ss_addr_sk", VInt (1))], Map.fromList [("ss_item_sk", VInt (2)), ("ss_ext_sales_price", VDouble (50.0)), ("ss_sold_date_sk", VInt (1)), ("ss_addr_sk", VInt (2))]]
+
+catalog_sales = [Map.fromList [("cs_item_sk", VInt (1)), ("cs_ext_sales_price", VDouble (20.0)), ("cs_sold_date_sk", VInt (1)), ("cs_bill_addr_sk", VInt (1))]]
+
+web_sales = [Map.fromList [("ws_item_sk", VInt (1)), ("ws_ext_sales_price", VDouble (30.0)), ("ws_sold_date_sk", VInt (1)), ("ws_bill_addr_sk", VInt (1))]]
+
+month = 1
+
+year = 2000
+
+union_sales = concat [Map.fromList [("manu", VString (fromMaybe (error "missing") (Map.lookup "i_manufact_id" i))), ("price", VString (fromMaybe (error "missing") (Map.lookup "ss_ext_sales_price" ss)))] | ss <- store_sales, d <- date_dim, ca <- customer_address, i <- item, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "ss_addr_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (((((((fromMaybe (error "missing") (Map.lookup "i_category" i) == "Books") && fromMaybe (error "missing") (Map.lookup "d_year" d)) == year) && fromMaybe (error "missing") (Map.lookup "d_moy" d)) == month) && fromMaybe (error "missing") (Map.lookup "ca_gmt_offset" ca)) == ((-5)))] [Map.fromList [("manu", VString (fromMaybe (error "missing") (Map.lookup "i_manufact_id" i))), ("price", VString (fromMaybe (error "missing") (Map.lookup "cs_ext_sales_price" cs)))] | cs <- catalog_sales, d <- date_dim, ca <- customer_address, i <- item, (fromMaybe (error "missing") (Map.lookup "cs_sold_date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "cs_bill_addr_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (((((((fromMaybe (error "missing") (Map.lookup "i_category" i) == "Books") && fromMaybe (error "missing") (Map.lookup "d_year" d)) == year) && fromMaybe (error "missing") (Map.lookup "d_moy" d)) == month) && fromMaybe (error "missing") (Map.lookup "ca_gmt_offset" ca)) == ((-5)))] [Map.fromList [("manu", VString (fromMaybe (error "missing") (Map.lookup "i_manufact_id" i))), ("price", VString (fromMaybe (error "missing") (Map.lookup "ws_ext_sales_price" ws)))] | ws <- web_sales, d <- date_dim, ca <- customer_address, i <- item, (fromMaybe (error "missing") (Map.lookup "ws_sold_date_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "ws_bill_addr_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (fromMaybe (error "missing") (Map.lookup "ws_item_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (((((((fromMaybe (error "missing") (Map.lookup "i_category" i) == "Books") && fromMaybe (error "missing") (Map.lookup "d_year" d)) == year) && fromMaybe (error "missing") (Map.lookup "d_moy" d)) == month) && fromMaybe (error "missing") (Map.lookup "ca_gmt_offset" ca)) == ((-5)))]
+
+result = map snd (List.sortOn fst [ ( (-sum [fromMaybe (error "missing") (Map.lookup "price" (x)) | x <- g]), Map.fromList [("i_manufact_id", VString (key (g))), ("total_sales", VDouble (sum [fromMaybe (error "missing") (Map.lookup "price" (x)) | x <- g]))] ) | g <- _group_by [(s) | s <- union_sales] (\(s) -> fromMaybe (error "missing") (Map.lookup "manu" (s))) ])
+
+test_TPCDS_Q33_simplified :: IO ()
+test_TPCDS_Q33_simplified = do
+    expect ((result == [Map.fromList [("i_manufact_id", VInt (1)), ("total_sales", VDouble (150.0))], Map.fromList [("i_manufact_id", VInt (2)), ("total_sales", VDouble (50.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q33_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q34.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q34.hs.out
@@ -1,0 +1,197 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+store_sales = [Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 1), ("ss_customer_sk", 1), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 1)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)], Map.fromList [("ss_ticket_number", 2), ("ss_customer_sk", 2), ("ss_sold_date_sk", 1), ("ss_store_sk", 1), ("ss_hdemo_sk", 2)]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_dom", 2), ("d_year", 2000)]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_county", VString ("A"))]]
+
+household_demographics = [Map.fromList [("hd_demo_sk", VInt (1)), ("hd_buy_potential", VString (">10000")), ("hd_vehicle_count", VInt (2)), ("hd_dep_count", VInt (3))], Map.fromList [("hd_demo_sk", VInt (2)), ("hd_buy_potential", VString (">10000")), ("hd_vehicle_count", VInt (2)), ("hd_dep_count", VInt (1))]]
+
+customer = [Map.fromList [("c_customer_sk", VInt (1)), ("c_last_name", VString ("Smith")), ("c_first_name", VString ("John")), ("c_salutation", VString ("Mr.")), ("c_preferred_cust_flag", VString ("Y"))], Map.fromList [("c_customer_sk", VInt (2)), ("c_last_name", VString ("Jones")), ("c_first_name", VString ("Alice")), ("c_salutation", VString ("Ms.")), ("c_preferred_cust_flag", VString ("N"))]]
+
+dn = [ Map.fromList [("ss_ticket_number", VString (fromMaybe (error "missing") (Map.lookup "ticket" (key (g))))), ("ss_customer_sk", VString (fromMaybe (error "missing") (Map.lookup "cust" (key (g))))), ("cnt", VInt (length (items g)))] | g <- _group_by [(ss, d, s, hd) | ss <- store_sales, d <- date_dim, s <- store, hd <- household_demographics, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "s_store_sk" (s))), (fromMaybe (error "missing") (Map.lookup "ss_hdemo_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "hd_demo_sk" (hd))), ((((((((((((((fromMaybe (error "missing") (Map.lookup "d_dom" d) >= 1) && fromMaybe (error "missing") (Map.lookup "d_dom" d)) <= 3)) && fromMaybe (error "missing") (Map.lookup "hd_buy_potential" hd)) == ">10000") && fromMaybe (error "missing") (Map.lookup "hd_vehicle_count" hd)) > 0) && ((fromMaybe (error "missing") (Map.lookup "hd_dep_count" hd) / fromMaybe (error "missing") (Map.lookup "hd_vehicle_count" hd)))) > 1.2) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == 2000) && fromMaybe (error "missing") (Map.lookup "s_county" s)) == "A")] (\(ss, d, s, hd) -> Map.fromList [("ticket", fromMaybe (error "missing") (Map.lookup "ss_ticket_number" ss)), ("cust", fromMaybe (error "missing") (Map.lookup "ss_customer_sk" ss))]), let g = g ]
+
+result = map snd (List.sortOn fst [ ( fromMaybe (error "missing") (Map.lookup "c_last_name" (c)), Map.fromList [("c_last_name", VString (fromMaybe (error "missing") (Map.lookup "c_last_name" c))), ("c_first_name", VString (fromMaybe (error "missing") (Map.lookup "c_first_name" c))), ("c_salutation", VString (fromMaybe (error "missing") (Map.lookup "c_salutation" c))), ("c_preferred_cust_flag", VString (fromMaybe (error "missing") (Map.lookup "c_preferred_cust_flag" c))), ("ss_ticket_number", VString (fromMaybe (error "missing") (Map.lookup "ss_ticket_number" dn1))), ("cnt", VString (fromMaybe (error "missing") (Map.lookup "cnt" dn1)))] ) | dn1 <- dn, c <- customer, (fromMaybe (error "missing") (Map.lookup "ss_customer_sk" (dn1)) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" (c))), (((fromMaybe (error "missing") (Map.lookup "cnt" dn1) >= 15) && fromMaybe (error "missing") (Map.lookup "cnt" dn1)) <= 20) ])
+
+test_TPCDS_Q34_simplified :: IO ()
+test_TPCDS_Q34_simplified = do
+    expect ((result == [Map.fromList [("c_last_name", VString ("Smith")), ("c_first_name", VString ("John")), ("c_salutation", VString ("Mr.")), ("c_preferred_cust_flag", VString ("Y")), ("ss_ticket_number", VInt (1)), ("cnt", VInt (16))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q34_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q35.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q35.hs.out
@@ -1,0 +1,197 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+customer = [Map.fromList [("c_customer_sk", 1), ("c_current_addr_sk", 1), ("c_current_cdemo_sk", 1)], Map.fromList [("c_customer_sk", 2), ("c_current_addr_sk", 2), ("c_current_cdemo_sk", 2)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_state", VString ("CA"))], Map.fromList [("ca_address_sk", VInt (2)), ("ca_state", VString ("NY"))]]
+
+customer_demographics = [Map.fromList [("cd_demo_sk", VInt (1)), ("cd_gender", VString ("M")), ("cd_marital_status", VString ("S")), ("cd_dep_count", VInt (1)), ("cd_dep_employed_count", VInt (1)), ("cd_dep_college_count", VInt (0))], Map.fromList [("cd_demo_sk", VInt (2)), ("cd_gender", VString ("F")), ("cd_marital_status", VString ("M")), ("cd_dep_count", VInt (2)), ("cd_dep_employed_count", VInt (1)), ("cd_dep_college_count", VInt (1))]]
+
+store_sales = [Map.fromList [("ss_customer_sk", 1), ("ss_sold_date_sk", 1)]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000), ("d_qoy", 1)]]
+
+purchased = [fromMaybe (error "missing") (Map.lookup "ss_customer_sk" ss) | ss <- store_sales, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (((fromMaybe (error "missing") (Map.lookup "d_year" d) == 2000) && fromMaybe (error "missing") (Map.lookup "d_qoy" d)) < 4)]
+
+groups = [ Map.fromList [("ca_state", VString (fromMaybe (error "missing") (Map.lookup "state" (key (g))))), ("cd_gender", VString (fromMaybe (error "missing") (Map.lookup "gender" (key (g))))), ("cd_marital_status", VString (fromMaybe (error "missing") (Map.lookup "marital" (key (g))))), ("cd_dep_count", VString (fromMaybe (error "missing") (Map.lookup "dep" (key (g))))), ("cd_dep_employed_count", VString (fromMaybe (error "missing") (Map.lookup "emp" (key (g))))), ("cd_dep_college_count", VString (fromMaybe (error "missing") (Map.lookup "col" (key (g))))), ("cnt", VInt (length (items g)))] | g <- _group_by [(c, ca, cd) | c <- customer, ca <- customer_address, cd <- customer_demographics, (fromMaybe (error "missing") (Map.lookup "c_current_addr_sk" (c)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (fromMaybe (error "missing") (Map.lookup "c_current_cdemo_sk" (c)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd))), elem fromMaybe (error "missing") (Map.lookup "c_customer_sk" c) purchased] (\(c, ca, cd) -> Map.fromList [("state", VString (fromMaybe (error "missing") (Map.lookup "ca_state" ca))), ("gender", VString (fromMaybe (error "missing") (Map.lookup "cd_gender" cd))), ("marital", VString (fromMaybe (error "missing") (Map.lookup "cd_marital_status" cd))), ("dep", VString (fromMaybe (error "missing") (Map.lookup "cd_dep_count" cd))), ("emp", VString (fromMaybe (error "missing") (Map.lookup "cd_dep_employed_count" cd))), ("col", VString (fromMaybe (error "missing") (Map.lookup "cd_dep_college_count" cd)))]), let g = g ]
+
+test_TPCDS_Q35_simplified :: IO ()
+test_TPCDS_Q35_simplified = do
+    expect ((groups == [Map.fromList [("ca_state", VString ("CA")), ("cd_gender", VString ("M")), ("cd_marital_status", VString ("S")), ("cd_dep_count", VInt (1)), ("cd_dep_employed_count", VInt (1)), ("cd_dep_college_count", VInt (0)), ("cnt", VInt (1))]]))
+
+main :: IO ()
+main = do
+    _json groups
+    test_TPCDS_Q35_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q36.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q36.hs.out
@@ -1,0 +1,193 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+store_sales = [Map.fromList [("ss_item_sk", VInt (1)), ("ss_store_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_ext_sales_price", VDouble (100.0)), ("ss_net_profit", VDouble (20.0))], Map.fromList [("ss_item_sk", VInt (2)), ("ss_store_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_ext_sales_price", VDouble (200.0)), ("ss_net_profit", VDouble (50.0))], Map.fromList [("ss_item_sk", VInt (3)), ("ss_store_sk", VInt (2)), ("ss_sold_date_sk", VInt (1)), ("ss_ext_sales_price", VDouble (150.0)), ("ss_net_profit", VDouble (30.0))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_category", VString ("Books")), ("i_class", VString ("C1"))], Map.fromList [("i_item_sk", VInt (2)), ("i_category", VString ("Books")), ("i_class", VString ("C2"))], Map.fromList [("i_item_sk", VInt (3)), ("i_category", VString ("Electronics")), ("i_class", VString ("C3"))]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_state", VString ("A"))], Map.fromList [("s_store_sk", VInt (2)), ("s_state", VString ("B"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000)]]
+
+result = map snd (List.sortOn fst [ ( [fromMaybe (error "missing") (Map.lookup "category" (key (g))), fromMaybe (error "missing") (Map.lookup "class" (key (g)))], Map.fromList [("i_category", VString (fromMaybe (error "missing") (Map.lookup "category" (key (g))))), ("i_class", VString (fromMaybe (error "missing") (Map.lookup "class" (key (g))))), ("gross_margin", VDouble ((sum [fromMaybe (error "missing") (Map.lookup "ss_net_profit" (x)) | x <- g] / sum [fromMaybe (error "missing") (Map.lookup "ss_ext_sales_price" (x)) | x <- g])))] ) | g <- _group_by [(ss, d, i, s) | ss <- store_sales, d <- date_dim, i <- item, s <- store, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "ss_item_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "s_store_sk" (s))), ((fromMaybe (error "missing") (Map.lookup "d_year" d) == 2000) && ((((fromMaybe (error "missing") (Map.lookup "s_state" s) == "A") || fromMaybe (error "missing") (Map.lookup "s_state" s)) == "B")))] (\(ss, d, i, s) -> Map.fromList [("category", VString (fromMaybe (error "missing") (Map.lookup "i_category" i))), ("class", VString (fromMaybe (error "missing") (Map.lookup "i_class" i)))]) ])
+
+test_TPCDS_Q36_simplified :: IO ()
+test_TPCDS_Q36_simplified = do
+    expect ((result == [Map.fromList [("i_category", VString ("Books")), ("i_class", VString ("C1")), ("gross_margin", VDouble (0.2))], Map.fromList [("i_category", VString ("Books")), ("i_class", VString ("C2")), ("gross_margin", VDouble (0.25))], Map.fromList [("i_category", VString ("Electronics")), ("i_class", VString ("C3")), ("gross_margin", VDouble (0.2))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q36_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q37.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q37.hs.out
@@ -1,0 +1,193 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("I1")), ("i_item_desc", VString ("Item1")), ("i_current_price", VDouble (30.0)), ("i_manufact_id", VInt (800))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("I2")), ("i_item_desc", VString ("Item2")), ("i_current_price", VDouble (60.0)), ("i_manufact_id", VInt (801))]]
+
+inventory = [Map.fromList [("inv_item_sk", 1), ("inv_warehouse_sk", 1), ("inv_date_sk", 1), ("inv_quantity_on_hand", 200)], Map.fromList [("inv_item_sk", 2), ("inv_warehouse_sk", 1), ("inv_date_sk", 1), ("inv_quantity_on_hand", 300)]]
+
+date_dim = [Map.fromList [("d_date_sk", VInt (1)), ("d_date", VString ("2000-01-15"))]]
+
+catalog_sales = [Map.fromList [("cs_item_sk", 1), ("cs_sold_date_sk", 1)]]
+
+result = map snd (List.sortOn fst [ ( fromMaybe (error "missing") (Map.lookup "id" (key (g))), Map.fromList [("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "id" (key (g))))), ("i_item_desc", VString (fromMaybe (error "missing") (Map.lookup "desc" (key (g))))), ("i_current_price", VString (fromMaybe (error "missing") (Map.lookup "price" (key (g)))))] ) | g <- _group_by [(i, inv, d, cs) | i <- item, inv <- inventory, d <- date_dim, cs <- catalog_sales, (fromMaybe (error "missing") (Map.lookup "i_item_sk" (i)) == fromMaybe (error "missing") (Map.lookup "inv_item_sk" (inv))), (fromMaybe (error "missing") (Map.lookup "inv_date_sk" (inv)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "cs_item_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (((((((((((fromMaybe (error "missing") (Map.lookup "i_current_price" i) >= 20) && fromMaybe (error "missing") (Map.lookup "i_current_price" i)) <= 50) && fromMaybe (error "missing") (Map.lookup "i_manufact_id" i)) >= 800) && fromMaybe (error "missing") (Map.lookup "i_manufact_id" i)) <= 803) && fromMaybe (error "missing") (Map.lookup "inv_quantity_on_hand" inv)) >= 100) && fromMaybe (error "missing") (Map.lookup "inv_quantity_on_hand" inv)) <= 500)] (\(i, inv, d, cs) -> Map.fromList [("id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" i))), ("desc", VString (fromMaybe (error "missing") (Map.lookup "i_item_desc" i))), ("price", VString (fromMaybe (error "missing") (Map.lookup "i_current_price" i)))]) ])
+
+test_TPCDS_Q37_simplified :: IO ()
+test_TPCDS_Q37_simplified = do
+    expect ((result == [Map.fromList [("i_item_id", VString ("I1")), ("i_item_desc", VString ("Item1")), ("i_current_price", VDouble (30.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q37_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q38.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q38.hs.out
@@ -1,0 +1,205 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+distinct :: [()] -> [()]
+distinct xs = fromMaybe ([]) $
+    (let out = [] in case foldr (\x acc -> case if not contains out x then (let out = append out x in Nothing) else Nothing of Just v -> Just v; Nothing -> acc) Nothing xs of Just v -> Just v; Nothing -> Just (out))
+
+customer = [Map.fromList [("c_customer_sk", VInt (1)), ("c_last_name", VString ("Smith")), ("c_first_name", VString ("John"))], Map.fromList [("c_customer_sk", VInt (2)), ("c_last_name", VString ("Jones")), ("c_first_name", VString ("Alice"))]]
+
+store_sales = [Map.fromList [("ss_customer_sk", 1), ("d_month_seq", 1200)], Map.fromList [("ss_customer_sk", 2), ("d_month_seq", 1205)]]
+
+catalog_sales = [Map.fromList [("cs_bill_customer_sk", 1), ("d_month_seq", 1203)]]
+
+web_sales = [Map.fromList [("ws_bill_customer_sk", 1), ("d_month_seq", 1206)]]
+
+store_ids = distinct [fromMaybe (error "missing") (Map.lookup "ss_customer_sk" s) | s <- filter (\s -> (((fromMaybe (error "missing") (Map.lookup "d_month_seq" s) >= 1200) && fromMaybe (error "missing") (Map.lookup "d_month_seq" s)) <= 1211)) store_sales]
+
+catalog_ids = distinct [fromMaybe (error "missing") (Map.lookup "cs_bill_customer_sk" c) | c <- filter (\c -> (((fromMaybe (error "missing") (Map.lookup "d_month_seq" c) >= 1200) && fromMaybe (error "missing") (Map.lookup "d_month_seq" c)) <= 1211)) catalog_sales]
+
+web_ids = distinct [fromMaybe (error "missing") (Map.lookup "ws_bill_customer_sk" w) | w <- filter (\w -> (((fromMaybe (error "missing") (Map.lookup "d_month_seq" w) >= 1200) && fromMaybe (error "missing") (Map.lookup "d_month_seq" w)) <= 1211)) web_sales]
+
+hot = List.intersect List.intersect store_ids catalog_ids web_ids
+
+result = length hot
+
+test_TPCDS_Q38_simplified :: IO ()
+test_TPCDS_Q38_simplified = do
+    expect ((result == 1))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q38_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q40.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q40.hs.out
@@ -1,0 +1,199 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+catalog_sales = [Map.fromList [("order", VInt (1)), ("item_sk", VInt (1)), ("warehouse_sk", VInt (1)), ("date_sk", VInt (1)), ("price", VDouble (100.0))], Map.fromList [("order", VInt (2)), ("item_sk", VInt (1)), ("warehouse_sk", VInt (1)), ("date_sk", VInt (2)), ("price", VDouble (150.0))]]
+
+catalog_returns = [Map.fromList [("order", VInt (2)), ("item_sk", VInt (1)), ("refunded", VDouble (150.0))]]
+
+item = [Map.fromList [("item_sk", VInt (1)), ("item_id", VString ("I1")), ("current_price", VDouble (1.2))]]
+
+warehouse = [Map.fromList [("warehouse_sk", VInt (1)), ("state", VString ("CA"))]]
+
+date_dim = [Map.fromList [("date_sk", VInt (1)), ("date", VString ("2020-01-10"))], Map.fromList [("date_sk", VInt (2)), ("date", VString ("2020-01-20"))]]
+
+sales_date = "2020-01-15"
+
+records = [Map.fromList [("w_state", VString (fromMaybe (error "missing") (Map.lookup "state" w))), ("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "item_id" i))), ("sold_date", VString (fromMaybe (error "missing") (Map.lookup "date" d))), ("net", VString ((fromMaybe (error "missing") (Map.lookup "price" cs) - (0))))] | cs <- catalog_sales, cr <- catalog_returns, w <- warehouse, i <- item, d <- date_dim, (((fromMaybe (error "missing") (Map.lookup "order" (cs)) == fromMaybe (error "missing") (Map.lookup "order" (cr))) && fromMaybe (error "missing") (Map.lookup "item_sk" (cs))) == fromMaybe (error "missing") (Map.lookup "item_sk" (cr))), (fromMaybe (error "missing") (Map.lookup "warehouse_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "warehouse_sk" (w))), (fromMaybe (error "missing") (Map.lookup "item_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "date_sk" (cs)) == fromMaybe (error "missing") (Map.lookup "date_sk" (d))), (((fromMaybe (error "missing") (Map.lookup "current_price" i) >= 0.99) && fromMaybe (error "missing") (Map.lookup "current_price" i)) <= 1.49)]
+
+result = [ Map.fromList [("w_state", VString (fromMaybe (error "missing") (Map.lookup "w_state" (key (g))))), ("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" (key (g))))), ("sales_before", VDouble (sum [0 | x <- g])), ("sales_after", VDouble (sum [0 | x <- g]))] | g <- _group_by records (\r -> Map.fromList [("w_state", VString (fromMaybe (error "missing") (Map.lookup "w_state" r))), ("i_item_id", VString (fromMaybe (error "missing") (Map.lookup "i_item_id" r)))]), let g = g ]
+
+test_TPCDS_Q40_simplified :: IO ()
+test_TPCDS_Q40_simplified = do
+    expect ((result == [Map.fromList [("w_state", VString ("CA")), ("i_item_id", VString ("I1")), ("sales_before", VDouble (100.0)), ("sales_after", VDouble (0.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q40_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q41.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q41.hs.out
@@ -1,0 +1,189 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+item = [Map.fromList [("product_name", VString ("Blue Shirt")), ("manufact_id", VInt (100)), ("manufact", VInt (1)), ("category", VString ("Women")), ("color", VString ("blue")), ("units", VString ("pack")), ("size", VString ("M"))], Map.fromList [("product_name", VString ("Red Dress")), ("manufact_id", VInt (120)), ("manufact", VInt (1)), ("category", VString ("Women")), ("color", VString ("red")), ("units", VString ("pack")), ("size", VString ("M"))], Map.fromList [("product_name", VString ("Pants")), ("manufact_id", VInt (200)), ("manufact", VInt (2)), ("category", VString ("Men")), ("color", VString ("black")), ("units", VString ("pair")), ("size", VString ("L"))]]
+
+lower = 100
+
+result = map snd (List.sortOn fst [ ( fromMaybe (error "missing") (Map.lookup "product_name" (i1)), fromMaybe (error "missing") (Map.lookup "product_name" i1) ) | i1 <- item, ((((((fromMaybe (error "missing") (Map.lookup "manufact_id" i1) >= lower) && fromMaybe (error "missing") (Map.lookup "manufact_id" i1)) <= lower) + 40) && length [i2 | i2 <- filter (\i2 -> (((fromMaybe (error "missing") (Map.lookup "manufact" i2) == fromMaybe (error "missing") (Map.lookup "manufact" i1)) && fromMaybe (error "missing") (Map.lookup "category" i2)) == fromMaybe (error "missing") (Map.lookup "category" i1))) item]) > 1) ])
+
+test_TPCDS_Q41_simplified :: IO ()
+test_TPCDS_Q41_simplified = do
+    expect ((result == ["Blue Shirt", "Red Dress"]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q41_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q42.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q42.hs.out
@@ -1,0 +1,199 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+store_sales = [Map.fromList [("sold_date_sk", VInt (1)), ("item_sk", VInt (1)), ("ext_sales_price", VDouble (10.0))], Map.fromList [("sold_date_sk", VInt (1)), ("item_sk", VInt (2)), ("ext_sales_price", VDouble (20.0))], Map.fromList [("sold_date_sk", VInt (2)), ("item_sk", VInt (1)), ("ext_sales_price", VDouble (15.0))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_manager_id", VInt (1)), ("i_category_id", VInt (100)), ("i_category", VString ("CatA"))], Map.fromList [("i_item_sk", VInt (2)), ("i_manager_id", VInt (2)), ("i_category_id", VInt (200)), ("i_category", VString ("CatB"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2020), ("d_moy", 5)], Map.fromList [("d_date_sk", 2), ("d_year", 2021), ("d_moy", 5)]]
+
+month = 5
+
+year = 2020
+
+records = [Map.fromList [("d_year", fromMaybe (error "missing") (Map.lookup "d_year" dt)), ("i_category_id", fromMaybe (error "missing") (Map.lookup "i_category_id" it)), ("i_category", fromMaybe (error "missing") (Map.lookup "i_category" it)), ("price", fromMaybe (error "missing") (Map.lookup "ext_sales_price" ss))] | dt <- date_dim, ss <- store_sales, it <- item, (fromMaybe (error "missing") (Map.lookup "sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (dt))), (fromMaybe (error "missing") (Map.lookup "item_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (it))), (((((fromMaybe (error "missing") (Map.lookup "i_manager_id" it) == 1) && fromMaybe (error "missing") (Map.lookup "d_moy" dt)) == month) && fromMaybe (error "missing") (Map.lookup "d_year" dt)) == year)]
+
+base = map snd (List.sortOn fst [ ( [(-sum [fromMaybe (error "missing") (Map.lookup "price" (x)) | x <- g]), fromMaybe (error "missing") (Map.lookup "d_year" (key (g))), fromMaybe (error "missing") (Map.lookup "i_category_id" (key (g))), fromMaybe (error "missing") (Map.lookup "i_category" (key (g)))], Map.fromList [("d_year", VString (fromMaybe (error "missing") (Map.lookup "d_year" (key (g))))), ("i_category_id", VString (fromMaybe (error "missing") (Map.lookup "i_category_id" (key (g))))), ("i_category", VString (fromMaybe (error "missing") (Map.lookup "i_category" (key (g))))), ("sum_ss_ext_sales_price", VDouble (sum [fromMaybe (error "missing") (Map.lookup "price" (x)) | x <- g]))] ) | g <- _group_by [(r) | r <- records] (\(r) -> Map.fromList [("d_year", fromMaybe (error "missing") (Map.lookup "d_year" r)), ("i_category_id", fromMaybe (error "missing") (Map.lookup "i_category_id" r)), ("i_category", fromMaybe (error "missing") (Map.lookup "i_category" r))]) ])
+
+result = base
+
+test_TPCDS_Q42_simplified :: IO ()
+test_TPCDS_Q42_simplified = do
+    expect ((result == [Map.fromList [("d_year", VInt (2020)), ("i_category_id", VInt (200)), ("i_category", VString ("CatB")), ("sum_ss_ext_sales_price", VDouble (20.0))], Map.fromList [("d_year", VInt (2020)), ("i_category_id", VInt (100)), ("i_category", VString ("CatA")), ("sum_ss_ext_sales_price", VDouble (10.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q42_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q43.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q43.hs.out
@@ -1,0 +1,199 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+date_dim = [Map.fromList [("date_sk", VInt (1)), ("d_day_name", VString ("Sunday")), ("d_year", VInt (2020))], Map.fromList [("date_sk", VInt (2)), ("d_day_name", VString ("Monday")), ("d_year", VInt (2020))], Map.fromList [("date_sk", VInt (3)), ("d_day_name", VString ("Tuesday")), ("d_year", VInt (2020))], Map.fromList [("date_sk", VInt (4)), ("d_day_name", VString ("Wednesday")), ("d_year", VInt (2020))], Map.fromList [("date_sk", VInt (5)), ("d_day_name", VString ("Thursday")), ("d_year", VInt (2020))], Map.fromList [("date_sk", VInt (6)), ("d_day_name", VString ("Friday")), ("d_year", VInt (2020))], Map.fromList [("date_sk", VInt (7)), ("d_day_name", VString ("Saturday")), ("d_year", VInt (2020))]]
+
+store = [Map.fromList [("store_sk", VInt (1)), ("store_id", VString ("S1")), ("store_name", VString ("Main")), ("gmt_offset", VInt (0))]]
+
+store_sales = [Map.fromList [("sold_date_sk", VInt (1)), ("store_sk", VInt (1)), ("sales_price", VDouble (10.0))], Map.fromList [("sold_date_sk", VInt (2)), ("store_sk", VInt (1)), ("sales_price", VDouble (20.0))], Map.fromList [("sold_date_sk", VInt (3)), ("store_sk", VInt (1)), ("sales_price", VDouble (30.0))], Map.fromList [("sold_date_sk", VInt (4)), ("store_sk", VInt (1)), ("sales_price", VDouble (40.0))], Map.fromList [("sold_date_sk", VInt (5)), ("store_sk", VInt (1)), ("sales_price", VDouble (50.0))], Map.fromList [("sold_date_sk", VInt (6)), ("store_sk", VInt (1)), ("sales_price", VDouble (60.0))], Map.fromList [("sold_date_sk", VInt (7)), ("store_sk", VInt (1)), ("sales_price", VDouble (70.0))]]
+
+year = 2020
+
+gmt = 0
+
+records = [Map.fromList [("d_day_name", VString (fromMaybe (error "missing") (Map.lookup "d_day_name" d))), ("s_store_name", VString (fromMaybe (error "missing") (Map.lookup "store_name" s))), ("s_store_id", VString (fromMaybe (error "missing") (Map.lookup "store_id" s))), ("price", VString (fromMaybe (error "missing") (Map.lookup "sales_price" ss)))] | d <- date_dim, ss <- store_sales, s <- store, (fromMaybe (error "missing") (Map.lookup "sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "store_sk" (s))), (((fromMaybe (error "missing") (Map.lookup "gmt_offset" s) == gmt) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == year)]
+
+base = [ Map.fromList [("s_store_name", VString (fromMaybe (error "missing") (Map.lookup "name" (key (g))))), ("s_store_id", VString (fromMaybe (error "missing") (Map.lookup "id" (key (g))))), ("sun_sales", VDouble (sum [0 | x <- g])), ("mon_sales", VDouble (sum [0 | x <- g])), ("tue_sales", VDouble (sum [0 | x <- g])), ("wed_sales", VDouble (sum [0 | x <- g])), ("thu_sales", VDouble (sum [0 | x <- g])), ("fri_sales", VDouble (sum [0 | x <- g])), ("sat_sales", VDouble (sum [0 | x <- g]))] | g <- _group_by records (\r -> Map.fromList [("name", VString (fromMaybe (error "missing") (Map.lookup "s_store_name" r))), ("id", VString (fromMaybe (error "missing") (Map.lookup "s_store_id" r)))]), let g = g ]
+
+result = base
+
+test_TPCDS_Q43_simplified :: IO ()
+test_TPCDS_Q43_simplified = do
+    expect ((result == [Map.fromList [("s_store_name", VString ("Main")), ("s_store_id", VString ("S1")), ("sun_sales", VDouble (10.0)), ("mon_sales", VDouble (20.0)), ("tue_sales", VDouble (30.0)), ("wed_sales", VDouble (40.0)), ("thu_sales", VDouble (50.0)), ("fri_sales", VDouble (60.0)), ("sat_sales", VDouble (70.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q43_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q44.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q44.hs.out
@@ -1,0 +1,201 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+store_sales = [Map.fromList [("ss_item_sk", VInt (1)), ("ss_store_sk", VInt (1)), ("ss_net_profit", VDouble (5.0))], Map.fromList [("ss_item_sk", VInt (1)), ("ss_store_sk", VInt (1)), ("ss_net_profit", VDouble (5.0))], Map.fromList [("ss_item_sk", VInt (2)), ("ss_store_sk", VInt (1)), ("ss_net_profit", VDouble ((-1.0)))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_product_name", VString ("ItemA"))], Map.fromList [("i_item_sk", VInt (2)), ("i_product_name", VString ("ItemB"))]]
+
+grouped_base = ([ Map.fromList [("item_sk", VString (key (g))), ("avg_profit", VDouble (avg [fromMaybe (error "missing") (Map.lookup "ss_net_profit" (x)) | x <- g]))] | g <- _group_by store_sales (\ss -> fromMaybe (error "missing") (Map.lookup "ss_item_sk" ss)), let g = g ])
+
+grouped = grouped_base
+
+best = first map snd (List.sortOn fst [ ( (-fromMaybe (error "missing") (Map.lookup "avg_profit" (x))), x ) | x <- grouped ])
+
+worst = first map snd (List.sortOn fst [ ( fromMaybe (error "missing") (Map.lookup "avg_profit" (x)), x ) | x <- grouped ])
+
+best_name = first [fromMaybe (error "missing") (Map.lookup "i_product_name" i) | i <- filter (\i -> (fromMaybe (error "missing") (Map.lookup "i_item_sk" i) == fromMaybe (error "missing") (Map.lookup "item_sk" (best)))) item]
+
+worst_name = first [fromMaybe (error "missing") (Map.lookup "i_product_name" i) | i <- filter (\i -> (fromMaybe (error "missing") (Map.lookup "i_item_sk" i) == fromMaybe (error "missing") (Map.lookup "item_sk" (worst)))) item]
+
+result = Map.fromList [("best_performing", VString (best_name)), ("worst_performing", VString (worst_name))]
+
+test_TPCDS_Q44_simplified :: IO ()
+test_TPCDS_Q44_simplified = do
+    expect ((result == Map.fromList [("best_performing", "ItemA"), ("worst_performing", "ItemB")]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q44_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q45.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q45.hs.out
@@ -1,0 +1,205 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+web_sales = [Map.fromList [("bill_customer_sk", VInt (1)), ("item_sk", VInt (1)), ("sold_date_sk", VInt (1)), ("sales_price", VDouble (50.0))], Map.fromList [("bill_customer_sk", VInt (2)), ("item_sk", VInt (2)), ("sold_date_sk", VInt (1)), ("sales_price", VDouble (30.0))]]
+
+customer = [Map.fromList [("c_customer_sk", 1), ("c_current_addr_sk", 1)], Map.fromList [("c_customer_sk", 2), ("c_current_addr_sk", 2)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_zip", VString ("85669"))], Map.fromList [("ca_address_sk", VInt (2)), ("ca_zip", VString ("99999"))]]
+
+item = [Map.fromList [("i_item_sk", VInt (1)), ("i_item_id", VString ("I1"))], Map.fromList [("i_item_sk", VInt (2)), ("i_item_id", VString ("I2"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_qoy", 1), ("d_year", 2020)]]
+
+zip_list = ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"]
+
+item_ids = ["I2"]
+
+qoy = 1
+
+year = 2020
+
+base = [ Map.fromList [("ca_zip", VString (key (g))), ("sum_ws_sales_price", VDouble (sum [fromMaybe (error "missing") (Map.lookup "sales_price" (fromMaybe (error "missing") (Map.lookup "ws" (x)))) | x <- g]))] | g <- _group_by [(ws, c, ca, i, d) | ws <- web_sales, c <- customer, ca <- customer_address, i <- item, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "bill_customer_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" (c))), (fromMaybe (error "missing") (Map.lookup "c_current_addr_sk" (c)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (fromMaybe (error "missing") (Map.lookup "item_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "i_item_sk" (i))), (fromMaybe (error "missing") (Map.lookup "sold_date_sk" (ws)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (((((elem (elem substr fromMaybe (error "missing") (Map.lookup "ca_zip" ca) 0 5 zip_list || fromMaybe (error "missing") (Map.lookup "i_item_id" i)) item_ids) && fromMaybe (error "missing") (Map.lookup "d_qoy" d)) == qoy) && fromMaybe (error "missing") (Map.lookup "d_year" d)) == year)] (\(ws, c, ca, i, d) -> fromMaybe (error "missing") (Map.lookup "ca_zip" ca)), let g = g ]
+
+records = base
+
+test_TPCDS_Q45_simplified :: IO ()
+test_TPCDS_Q45_simplified = do
+    expect ((records == [Map.fromList [("ca_zip", VString ("85669")), ("sum_ws_sales_price", VDouble (50.0))], Map.fromList [("ca_zip", VString ("99999")), ("sum_ws_sales_price", VDouble (30.0))]]))
+
+main :: IO ()
+main = do
+    _json records
+    test_TPCDS_Q45_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q46.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q46.hs.out
@@ -1,0 +1,209 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+store_sales = [Map.fromList [("ss_ticket_number", VInt (1)), ("ss_customer_sk", VInt (1)), ("ss_addr_sk", VInt (1)), ("ss_hdemo_sk", VInt (1)), ("ss_store_sk", VInt (1)), ("ss_sold_date_sk", VInt (1)), ("ss_coupon_amt", VDouble (5.0)), ("ss_net_profit", VDouble (20.0))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_dow", 6), ("d_year", 2020)]]
+
+store = [Map.fromList [("s_store_sk", VInt (1)), ("s_city", VString ("CityA"))]]
+
+household_demographics = [Map.fromList [("hd_demo_sk", 1), ("hd_dep_count", 2), ("hd_vehicle_count", 0)]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_city", VString ("Portland"))], Map.fromList [("ca_address_sk", VInt (2)), ("ca_city", VString ("Seattle"))]]
+
+customer = [Map.fromList [("c_customer_sk", VInt (1)), ("c_last_name", VString ("Doe")), ("c_first_name", VString ("John")), ("c_current_addr_sk", VInt (2))]]
+
+depcnt = 2
+
+vehcnt = 0
+
+year = 2020
+
+cities = ["CityA"]
+
+dn = [ Map.fromList [("ss_ticket_number", VString (fromMaybe (error "missing") (Map.lookup "ss_ticket_number" (key (g))))), ("ss_customer_sk", VString (fromMaybe (error "missing") (Map.lookup "ss_customer_sk" (key (g))))), ("bought_city", VString (fromMaybe (error "missing") (Map.lookup "ca_city" (key (g))))), ("amt", VDouble (sum [fromMaybe (error "missing") (Map.lookup "ss_coupon_amt" (fromMaybe (error "missing") (Map.lookup "ss" (x)))) | x <- g])), ("profit", VDouble (sum [fromMaybe (error "missing") (Map.lookup "ss_net_profit" (fromMaybe (error "missing") (Map.lookup "ss" (x)))) | x <- g]))] | g <- _group_by [(ss, d, s, hd, ca) | ss <- store_sales, d <- date_dim, s <- store, hd <- household_demographics, ca <- customer_address, (fromMaybe (error "missing") (Map.lookup "ss_sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (fromMaybe (error "missing") (Map.lookup "ss_store_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "s_store_sk" (s))), (fromMaybe (error "missing") (Map.lookup "ss_hdemo_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "hd_demo_sk" (hd))), (fromMaybe (error "missing") (Map.lookup "ss_addr_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), elem (((elem (((((fromMaybe (error "missing") (Map.lookup "hd_dep_count" hd) == depcnt) || fromMaybe (error "missing") (Map.lookup "hd_vehicle_count" hd)) == vehcnt)) && fromMaybe (error "missing") (Map.lookup "d_dow" d)) [6, 0] && fromMaybe (error "missing") (Map.lookup "d_year" d)) == year) && fromMaybe (error "missing") (Map.lookup "s_city" s)) cities] (\(ss, d, s, hd, ca) -> Map.fromList [("ss_ticket_number", VString (fromMaybe (error "missing") (Map.lookup "ss_ticket_number" ss))), ("ss_customer_sk", VString (fromMaybe (error "missing") (Map.lookup "ss_customer_sk" ss))), ("ca_city", VString (fromMaybe (error "missing") (Map.lookup "ca_city" ca)))]), let g = g ]
+
+base = map snd (List.sortOn fst [ ( [fromMaybe (error "missing") (Map.lookup "c_last_name" (c)), fromMaybe (error "missing") (Map.lookup "c_first_name" (c)), fromMaybe (error "missing") (Map.lookup "ca_city" (current_addr)), fromMaybe (error "missing") (Map.lookup "bought_city" (dnrec)), fromMaybe (error "missing") (Map.lookup "ss_ticket_number" (dnrec))], Map.fromList [("c_last_name", VString (fromMaybe (error "missing") (Map.lookup "c_last_name" c))), ("c_first_name", VString (fromMaybe (error "missing") (Map.lookup "c_first_name" c))), ("ca_city", VString (fromMaybe (error "missing") (Map.lookup "ca_city" current_addr))), ("bought_city", VString (fromMaybe (error "missing") (Map.lookup "bought_city" dnrec))), ("ss_ticket_number", VString (fromMaybe (error "missing") (Map.lookup "ss_ticket_number" dnrec))), ("amt", VString (fromMaybe (error "missing") (Map.lookup "amt" dnrec))), ("profit", VString (fromMaybe (error "missing") (Map.lookup "profit" dnrec)))] ) | dnrec <- dn, c <- customer, current_addr <- customer_address, (fromMaybe (error "missing") (Map.lookup "ss_customer_sk" (dnrec)) == fromMaybe (error "missing") (Map.lookup "c_customer_sk" (c))), (fromMaybe (error "missing") (Map.lookup "c_current_addr_sk" (c)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (current_addr))), (fromMaybe (error "missing") (Map.lookup "ca_city" current_addr) /= fromMaybe (error "missing") (Map.lookup "bought_city" dnrec)) ])
+
+result = base
+
+test_TPCDS_Q46_simplified :: IO ()
+test_TPCDS_Q46_simplified = do
+    expect ((result == [Map.fromList [("c_last_name", VString ("Doe")), ("c_first_name", VString ("John")), ("ca_city", VString ("Seattle")), ("bought_city", VString ("Portland")), ("ss_ticket_number", VInt (1)), ("amt", VDouble (5.0)), ("profit", VDouble (20.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q46_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q47.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q47.hs.out
@@ -1,0 +1,195 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+abs :: Double -> Double
+abs x = fromMaybe (0.0) $
+    if (x >= 0.0) then (let _ = x in Nothing) else (let _ = (-x) in Nothing)
+
+v2 = [Map.fromList [("d_year", VInt (2020)), ("item", VString ("A")), ("avg_monthly_sales", VDouble (100.0)), ("sum_sales", VDouble (120.0))], Map.fromList [("d_year", VInt (2020)), ("item", VString ("B")), ("avg_monthly_sales", VDouble (80.0)), ("sum_sales", VDouble (70.0))], Map.fromList [("d_year", VInt (2019)), ("item", VString ("C")), ("avg_monthly_sales", VDouble (50.0)), ("sum_sales", VDouble (60.0))]]
+
+year = 2020
+
+orderby = "item"
+
+result = map snd (List.sortOn fst [ ( [(fromMaybe (error "missing") (Map.lookup "sum_sales" (v)) - fromMaybe (error "missing") (Map.lookup "avg_monthly_sales" (v))), fromMaybe (error "missing") (Map.lookup "item" (v))], v ) | v <- v2, ((((((fromMaybe (error "missing") (Map.lookup "d_year" v) == year) && fromMaybe (error "missing") (Map.lookup "avg_monthly_sales" v)) > 0) && abs (fromMaybe (error "missing") (Map.lookup "sum_sales" v) - fromMaybe (error "missing") (Map.lookup "avg_monthly_sales" v))) / fromMaybe (error "missing") (Map.lookup "avg_monthly_sales" v)) > 0.1) ])
+
+test_TPCDS_Q47_simplified :: IO ()
+test_TPCDS_Q47_simplified = do
+    expect ((result == [Map.fromList [("d_year", VInt (2019)), ("item", VString ("C")), ("avg_monthly_sales", VDouble (50.0)), ("sum_sales", VDouble (60.0))], Map.fromList [("d_year", VInt (2020)), ("item", VString ("A")), ("avg_monthly_sales", VDouble (100.0)), ("sum_sales", VDouble (120.0))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q47_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q48.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q48.hs.out
@@ -1,0 +1,207 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+store_sales = [Map.fromList [("cdemo_sk", VInt (1)), ("addr_sk", VInt (1)), ("sold_date_sk", VInt (1)), ("sales_price", VDouble (120.0)), ("net_profit", VDouble (1000.0)), ("quantity", VInt (5))], Map.fromList [("cdemo_sk", VInt (2)), ("addr_sk", VInt (2)), ("sold_date_sk", VInt (1)), ("sales_price", VDouble (60.0)), ("net_profit", VDouble (2000.0)), ("quantity", VInt (10))], Map.fromList [("cdemo_sk", VInt (3)), ("addr_sk", VInt (3)), ("sold_date_sk", VInt (1)), ("sales_price", VDouble (170.0)), ("net_profit", VDouble (10000.0)), ("quantity", VInt (20))]]
+
+store = [Map.fromList [("s_store_sk", 1)]]
+
+customer_demographics = [Map.fromList [("cd_demo_sk", VInt (1)), ("cd_marital_status", VString ("S")), ("cd_education_status", VString ("E1"))], Map.fromList [("cd_demo_sk", VInt (2)), ("cd_marital_status", VString ("M")), ("cd_education_status", VString ("E2"))], Map.fromList [("cd_demo_sk", VInt (3)), ("cd_marital_status", VString ("W")), ("cd_education_status", VString ("E3"))]]
+
+customer_address = [Map.fromList [("ca_address_sk", VInt (1)), ("ca_country", VString ("United States")), ("ca_state", VString ("TX"))], Map.fromList [("ca_address_sk", VInt (2)), ("ca_country", VString ("United States")), ("ca_state", VString ("CA"))], Map.fromList [("ca_address_sk", VInt (3)), ("ca_country", VString ("United States")), ("ca_state", VString ("NY"))]]
+
+date_dim = [Map.fromList [("d_date_sk", 1), ("d_year", 2000)]]
+
+year = 2000
+
+states1 = ["TX"]
+
+states2 = ["CA"]
+
+states3 = ["NY"]
+
+qty_base = [fromMaybe (error "missing") (Map.lookup "quantity" ss) | ss <- store_sales, cd <- customer_demographics, ca <- customer_address, d <- date_dim, (fromMaybe (error "missing") (Map.lookup "cdemo_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "cd_demo_sk" (cd))), (fromMaybe (error "missing") (Map.lookup "addr_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "ca_address_sk" (ca))), (fromMaybe (error "missing") (Map.lookup "sold_date_sk" (ss)) == fromMaybe (error "missing") (Map.lookup "d_date_sk" (d))), (((fromMaybe (error "missing") (Map.lookup "d_year" d) == year) && (((((((((((fromMaybe (error "missing") (Map.lookup "cd_marital_status" cd) == "S") && fromMaybe (error "missing") (Map.lookup "cd_education_status" cd)) == "E1") && fromMaybe (error "missing") (Map.lookup "sales_price" ss)) >= 100.0) && fromMaybe (error "missing") (Map.lookup "sales_price" ss)) <= 150.0)) || ((((((((fromMaybe (error "missing") (Map.lookup "cd_marital_status" cd) == "M") && fromMaybe (error "missing") (Map.lookup "cd_education_status" cd)) == "E2") && fromMaybe (error "missing") (Map.lookup "sales_price" ss)) >= 50.0) && fromMaybe (error "missing") (Map.lookup "sales_price" ss)) <= 100.0))) || ((((((((fromMaybe (error "missing") (Map.lookup "cd_marital_status" cd) == "W") && fromMaybe (error "missing") (Map.lookup "cd_education_status" cd)) == "E3") && fromMaybe (error "missing") (Map.lookup "sales_price" ss)) >= 150.0) && fromMaybe (error "missing") (Map.lookup "sales_price" ss)) <= 200.0))))) && ((((((((elem fromMaybe (error "missing") (Map.lookup "ca_state" ca) states1 && fromMaybe (error "missing") (Map.lookup "net_profit" ss)) >= 0) && fromMaybe (error "missing") (Map.lookup "net_profit" ss)) <= 2000)) || (((((elem fromMaybe (error "missing") (Map.lookup "ca_state" ca) states2 && fromMaybe (error "missing") (Map.lookup "net_profit" ss)) >= 150) && fromMaybe (error "missing") (Map.lookup "net_profit" ss)) <= 3000))) || (((((elem fromMaybe (error "missing") (Map.lookup "ca_state" ca) states3 && fromMaybe (error "missing") (Map.lookup "net_profit" ss)) >= 50) && fromMaybe (error "missing") (Map.lookup "net_profit" ss)) <= 25000)))))]
+
+qty = qty_base
+
+result = sum qty
+
+test_TPCDS_Q48_simplified :: IO ()
+test_TPCDS_Q48_simplified = do
+    expect ((result == 35))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q48_simplified

--- a/tests/dataset/tpc-ds/compiler/hs/q49.hs.out
+++ b/tests/dataset/tpc-ds/compiler/hs/q49.hs.out
@@ -1,0 +1,193 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+
+web = [Map.fromList [("item", VString ("A")), ("return_ratio", VDouble (0.2)), ("currency_ratio", VDouble (0.3)), ("return_rank", VInt (1)), ("currency_rank", VInt (1))], Map.fromList [("item", VString ("B")), ("return_ratio", VDouble (0.5)), ("currency_ratio", VDouble (0.6)), ("return_rank", VInt (2)), ("currency_rank", VInt (2))]]
+
+catalog = [Map.fromList [("item", VString ("A")), ("return_ratio", VDouble (0.3)), ("currency_ratio", VDouble (0.4)), ("return_rank", VInt (1)), ("currency_rank", VInt (1))]]
+
+store = [Map.fromList [("item", VString ("A")), ("return_ratio", VDouble (0.25)), ("currency_ratio", VDouble (0.35)), ("return_rank", VInt (1)), ("currency_rank", VInt (1))]]
+
+tmp = (concat [Map.fromList [("channel", "web"), ("item", fromMaybe (error "missing") (Map.lookup "item" w)), ("return_ratio", fromMaybe (error "missing") (Map.lookup "return_ratio" w)), ("return_rank", fromMaybe (error "missing") (Map.lookup "return_rank" w)), ("currency_rank", fromMaybe (error "missing") (Map.lookup "currency_rank" w))] | w <- filter (\w -> (((fromMaybe (error "missing") (Map.lookup "return_rank" w) <= 10) || fromMaybe (error "missing") (Map.lookup "currency_rank" w)) <= 10)) web] [Map.fromList [("channel", "catalog"), ("item", fromMaybe (error "missing") (Map.lookup "item" c)), ("return_ratio", fromMaybe (error "missing") (Map.lookup "return_ratio" c)), ("return_rank", fromMaybe (error "missing") (Map.lookup "return_rank" c)), ("currency_rank", fromMaybe (error "missing") (Map.lookup "currency_rank" c))] | c <- filter (\c -> (((fromMaybe (error "missing") (Map.lookup "return_rank" c) <= 10) || fromMaybe (error "missing") (Map.lookup "currency_rank" c)) <= 10)) catalog] [Map.fromList [("channel", "store"), ("item", fromMaybe (error "missing") (Map.lookup "item" s)), ("return_ratio", fromMaybe (error "missing") (Map.lookup "return_ratio" s)), ("return_rank", fromMaybe (error "missing") (Map.lookup "return_rank" s)), ("currency_rank", fromMaybe (error "missing") (Map.lookup "currency_rank" s))] | s <- filter (\s -> (((fromMaybe (error "missing") (Map.lookup "return_rank" s) <= 10) || fromMaybe (error "missing") (Map.lookup "currency_rank" s)) <= 10)) store])
+
+result = map snd (List.sortOn fst [ ( [fromMaybe (error "missing") (Map.lookup "channel" (r)), fromMaybe (error "missing") (Map.lookup "return_rank" (r)), fromMaybe (error "missing") (Map.lookup "currency_rank" (r)), fromMaybe (error "missing") (Map.lookup "item" (r))], r ) | r <- tmp ])
+
+test_TPCDS_Q49_simplified :: IO ()
+test_TPCDS_Q49_simplified = do
+    expect ((result == [Map.fromList [("channel", VString ("catalog")), ("item", VString ("A")), ("return_ratio", VDouble (0.3)), ("return_rank", VInt (1)), ("currency_rank", VInt (1))], Map.fromList [("channel", VString ("store")), ("item", VString ("A")), ("return_ratio", VDouble (0.25)), ("return_rank", VInt (1)), ("currency_rank", VInt (1))], Map.fromList [("channel", VString ("web")), ("item", VString ("A")), ("return_ratio", VDouble (0.2)), ("return_rank", VInt (1)), ("currency_rank", VInt (1))], Map.fromList [("channel", VString ("web")), ("item", VString ("B")), ("return_ratio", VDouble (0.5)), ("return_rank", VInt (2)), ("currency_rank", VInt (2))]]))
+
+main :: IO ()
+main = do
+    _json result
+    test_TPCDS_Q49_simplified


### PR DESCRIPTION
## Summary
- support complex loop bodies in the Haskell compiler
- regenerate golden outputs for TPC-DS queries q30–q49 (except q39)
- update TPC-DS compiler test list to include the new queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68640fb728808320882c27113fd20050