### PR TITLE
Update Smalltalk tpc-ds support

### DIFF
--- a/compile/x/st/TASKS.md
+++ b/compile/x/st/TASKS.md
@@ -8,8 +8,8 @@ golden tests cover `tpch_q1` and `tpch_q2` as well as simple `group_by` queries.
 Running the TPCH programs under `gst` still reports parse errors,
 so executing the compiled Smalltalk code remains TODO.
 
-The TPCDS suite has begun with query `q1`. The Smalltalk backend
-successfully compiles this program and golden output is stored under
+The TPCDS suite now covers queries `q1` through `q19`. The Smalltalk backend
+successfully compiles these programs and golden output is stored under
 `tests/dataset/tpc-ds/compiler/st`.
 
 ## Pending JOB Queries

--- a/compile/x/st/tpcds_golden_test.go
+++ b/compile/x/st/tpcds_golden_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSTCompiler_TPCDS_Golden(t *testing.T) {
 	root := testutil.FindRepoRoot(t)
-	for i := 1; i <= 9; i++ {
+	for i := 1; i <= 19; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")

--- a/tests/dataset/tpc-ds/compiler/st/q1.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q1.st.out
@@ -9,67 +9,67 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q1_result
-	((result = Array with: (Dictionary from: {'c_customer_id' -> 'C2'}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'c_customer_id' -> 'C2'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !_Group class methodsFor: 'instance creation'!
 key: k | g |
-	g := self new.
-	g key: k.
-	g initialize.
-	^ g
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
 !
 !_Group methodsFor: 'initialization'!
 initialize
-	items := OrderedCollection new.
-	^ self
+    items := OrderedCollection new.
+    ^ self
 !
 !_Group methodsFor: 'accessing'!
 key
-	^ key
+    ^ key
 !
 key: k
-	key := k
+    key := k
 !
 add: it
-	items add: it
+    items add: it
 !
 do: blk
-	items do: blk
+    items do: blk
 !
 size
-	^ items size
+    ^ items size
 !
 !Main class methodsFor: 'runtime'!
 __avg: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
-	v size = 0 ifTrue: [ ^ 0 ]
-	| sum |
-	sum := 0.
-	v do: [:it | sum := sum + it].
-	^ sum / v size
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
 !
 __sum: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
-	| s |
-	s := 0.
-	v do: [:it | s := s + it].
-	^ s
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
 !
 _group_by: src keyFn: blk
-	| groups order |
-	groups := Dictionary new.
-	order := OrderedCollection new.
-	src do: [:it |
-		| key ks g |
-		key := blk value: it.
-		ks := key printString.
-		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
-		g add: it.
-	]
-	^ order collect: [:k | groups at: k ]
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
 !
 !!
 store_returns := Array with: (Dictionary from: {'sr_returned_date_sk' -> 1. 'sr_customer_sk' -> 1. 'sr_store_sk' -> 10. 'sr_return_amt' -> 20.000000}) with: (Dictionary from: {'sr_returned_date_sk' -> 1. 'sr_customer_sk' -> 2. 'sr_store_sk' -> 10. 'sr_return_amt' -> 50.000000}).
@@ -79,15 +79,15 @@ customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_customer_id'
 customer_total_return := ((| rows groups |
 rows := OrderedCollection new.
 (store_returns) do: [:sr |
-	rows add: sr.
+    rows add: sr.
 ]
 groups := (Main _group_by: rows keyFn: [:sr | Dictionary from: {'customer_sk' -> sr at: 'sr_customer_sk'. 'store_sk' -> sr at: 'sr_store_sk'}]).
 rows := OrderedCollection new.
 (groups) do: [:g |
-	rows add: Dictionary from: {'ctr_customer_sk' -> g at: 'key' at: 'customer_sk'. 'ctr_store_sk' -> g at: 'key' at: 'store_sk'. 'ctr_total_return' -> (Main __sum: ((| res |
+    rows add: Dictionary from: {'ctr_customer_sk' -> g at: 'key' at: 'customer_sk'. 'ctr_store_sk' -> g at: 'key' at: 'store_sk'. 'ctr_total_return' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'sr_return_amt'.
+    res add: x at: 'sr_return_amt'.
 ]
 res := res asArray.
 res)))}.
@@ -99,15 +99,15 @@ res := OrderedCollection new.
 ((customer_total_return) select: [:ctr1 | ((((((ctr1 at: 'ctr_total_return' > (Main __avg: ((| res |
 res := OrderedCollection new.
 ((customer_total_return) select: [:ctr2 | (ctr1 at: 'ctr_store_sk' = ctr2 at: 'ctr_store_sk')]) do: [:ctr2 |
-	res add: ctr2 at: 'ctr_total_return'.
+    res add: ctr2 at: 'ctr_total_return'.
 ]
 res := res asArray.
 res)))) * 1.200000) and: [s at: 's_state']) = 'TN') and: [(ctr1 at: 'ctr_store_sk' = s at: 's_store_sk')]) and: [(ctr1 at: 'ctr_customer_sk' = c at: 'c_customer_sk')])]) do: [:ctr1 |
-	(store) do: [:s |
-		(customer) do: [:c |
-			res add: { c at: 'c_customer_id' . Dictionary from: {'c_customer_id' -> c at: 'c_customer_id'} }.
-		]
-	]
+    (store) do: [:s |
+        (customer) do: [:c |
+            res add: { c at: 'c_customer_id' . Dictionary from: {'c_customer_id' -> c at: 'c_customer_id'} }.
+        ]
+    ]
 ]
 res := res asArray.
 res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.

--- a/tests/dataset/tpc-ds/compiler/st/q10.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q10.st.out
@@ -1,0 +1,186 @@
+Smalltalk at: #active put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCustomer: c_customer_sk c_current_addr_sk: c_current_addr_sk c_current_cdemo_sk: c_current_cdemo_sk | dict |
+    dict := Dictionary new.
+    dict at: 'c_customer_sk' put: c_customer_sk.
+    dict at: 'c_current_addr_sk' put: c_current_addr_sk.
+    dict at: 'c_current_cdemo_sk' put: c_current_cdemo_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_county: ca_county | dict |
+    dict := Dictionary new.
+    dict at: 'ca_address_sk' put: ca_address_sk.
+    dict at: 'ca_county' put: ca_county.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerDemographics: cd_demo_sk cd_gender: cd_gender cd_marital_status: cd_marital_status cd_education_status: cd_education_status cd_purchase_estimate: cd_purchase_estimate cd_credit_rating: cd_credit_rating cd_dep_count: cd_dep_count cd_dep_employed_count: cd_dep_employed_count cd_dep_college_count: cd_dep_college_count | dict |
+    dict := Dictionary new.
+    dict at: 'cd_demo_sk' put: cd_demo_sk.
+    dict at: 'cd_gender' put: cd_gender.
+    dict at: 'cd_marital_status' put: cd_marital_status.
+    dict at: 'cd_education_status' put: cd_education_status.
+    dict at: 'cd_purchase_estimate' put: cd_purchase_estimate.
+    dict at: 'cd_credit_rating' put: cd_credit_rating.
+    dict at: 'cd_dep_count' put: cd_dep_count.
+    dict at: 'cd_dep_employed_count' put: cd_dep_employed_count.
+    dict at: 'cd_dep_college_count' put: cd_dep_college_count.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStoreSale: ss_customer_sk ss_sold_date_sk: ss_sold_date_sk | dict |
+    dict := Dictionary new.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year d_moy: d_moy | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    dict at: 'd_moy' put: d_moy.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q10_demographics_count
+    ((result = Array with: (Dictionary from: {'cd_gender' -> 'F'. 'cd_marital_status' -> 'M'. 'cd_education_status' -> 'College'. 'cnt1' -> 1. 'cd_purchase_estimate' -> 5000. 'cnt2' -> 1. 'cd_credit_rating' -> 'Good'. 'cnt3' -> 1. 'cd_dep_count' -> 1. 'cnt4' -> 1. 'cd_dep_employed_count' -> 1. 'cnt5' -> 1. 'cd_dep_college_count' -> 0. 'cnt6' -> 1}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_addr_sk' -> 1. 'c_current_cdemo_sk' -> 1}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_county' -> 'CountyA'}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_gender' -> 'F'. 'cd_marital_status' -> 'M'. 'cd_education_status' -> 'College'. 'cd_purchase_estimate' -> 5000. 'cd_credit_rating' -> 'Good'. 'cd_dep_count' -> 1. 'cd_dep_employed_count' -> 1. 'cd_dep_college_count' -> 0}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1}).
+web_sales := Array new.
+catalog_sales := Array new.
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000. 'd_moy' -> 2}).
+active := ((| res |
+res := OrderedCollection new.
+((customer) select: [:c | ((exists value: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((((((ss at: 'ss_customer_sk' = c at: 'c_customer_sk') and: [d at: 'd_year']) = 2000) and: [d at: 'd_moy']) >= 2) and: [d at: 'd_moy']) <= 5) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')])]) do: [:ss |
+    (date_dim) do: [:d |
+        res add: ss.
+    ]
+]
+res := res asArray.
+res)) and: [(((c at: 'c_current_addr_sk' = ca at: 'ca_address_sk') and: [ca at: 'ca_county']) = 'CountyA')]) and: [(c at: 'c_current_cdemo_sk' = cd at: 'cd_demo_sk')])]) do: [:c |
+    (customer_address) do: [:ca |
+        (customer_demographics) do: [:cd |
+            res add: cd.
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(active) do: [:a |
+    rows add: a.
+]
+groups := (Main _group_by: rows keyFn: [:a | Dictionary from: {'gender' -> a at: 'cd_gender'. 'marital' -> a at: 'cd_marital_status'. 'education' -> a at: 'cd_education_status'. 'purchase' -> a at: 'cd_purchase_estimate'. 'credit' -> a at: 'cd_credit_rating'. 'dep' -> a at: 'cd_dep_count'. 'depemp' -> a at: 'cd_dep_employed_count'. 'depcol' -> a at: 'cd_dep_college_count'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'cd_gender' -> g at: 'key' at: 'gender'. 'cd_marital_status' -> g at: 'key' at: 'marital'. 'cd_education_status' -> g at: 'key' at: 'education'. 'cnt1' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'cd_purchase_estimate' -> g at: 'key' at: 'purchase'. 'cnt2' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'cd_credit_rating' -> g at: 'key' at: 'credit'. 'cnt3' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'cd_dep_count' -> g at: 'key' at: 'dep'. 'cnt4' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'cd_dep_employed_count' -> g at: 'key' at: 'depemp'. 'cnt5' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'cd_dep_college_count' -> g at: 'key' at: 'depcol'. 'cnt6' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q10_demographics_count.

--- a/tests/dataset/tpc-ds/compiler/st/q11.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q11.st.out
@@ -1,0 +1,86 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #growth_ok put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #ss98 put: nil.
+Smalltalk at: #ss99 put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #ws98 put: nil.
+Smalltalk at: #ws99 put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCustomer: c_customer_sk c_customer_id: c_customer_id c_first_name: c_first_name c_last_name: c_last_name | dict |
+    dict := Dictionary new.
+    dict at: 'c_customer_sk' put: c_customer_sk.
+    dict at: 'c_customer_id' put: c_customer_id.
+    dict at: 'c_first_name' put: c_first_name.
+    dict at: 'c_last_name' put: c_last_name.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStoreSale: ss_customer_sk ss_sold_date_sk: ss_sold_date_sk ss_ext_list_price: ss_ext_list_price | dict |
+    dict := Dictionary new.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_ext_list_price' put: ss_ext_list_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newWebSale: ws_bill_customer_sk ws_sold_date_sk: ws_sold_date_sk ws_ext_list_price: ws_ext_list_price | dict |
+    dict := Dictionary new.
+    dict at: 'ws_bill_customer_sk' put: ws_bill_customer_sk.
+    dict at: 'ws_sold_date_sk' put: ws_sold_date_sk.
+    dict at: 'ws_ext_list_price' put: ws_ext_list_price.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q11_growth
+    ((result = Array with: (Dictionary from: {'customer_id' -> 'C1'. 'customer_first_name' -> 'John'. 'customer_last_name' -> 'Doe'}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_customer_id' -> 'C1'. 'c_first_name' -> 'John'. 'c_last_name' -> 'Doe'}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1998. 'ss_ext_list_price' -> 60.000000}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1999. 'ss_ext_list_price' -> 90.000000}).
+web_sales := Array with: (Dictionary from: {'ws_bill_customer_sk' -> 1. 'ws_sold_date_sk' -> 1998. 'ws_ext_list_price' -> 50.000000}) with: (Dictionary from: {'ws_bill_customer_sk' -> 1. 'ws_sold_date_sk' -> 1999. 'ws_ext_list_price' -> 150.000000}).
+ss98 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (ss at: 'ss_sold_date_sk' = 1998)]) do: [:ss |
+    res add: ss at: 'ss_ext_list_price'.
+]
+res := res asArray.
+res))).
+ss99 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (ss at: 'ss_sold_date_sk' = 1999)]) do: [:ss |
+    res add: ss at: 'ss_ext_list_price'.
+]
+res := res asArray.
+res))).
+ws98 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | (ws at: 'ws_sold_date_sk' = 1998)]) do: [:ws |
+    res add: ws at: 'ws_ext_list_price'.
+]
+res := res asArray.
+res))).
+ws99 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | (ws at: 'ws_sold_date_sk' = 1999)]) do: [:ws |
+    res add: ws at: 'ws_ext_list_price'.
+]
+res := res asArray.
+res))).
+growth_ok := (((((ws98 > 0) and: [ss98]) > 0) and: [((ws99 / ws98))]) > ((ss99 / ss98))).
+result := ((growth_ok) ifTrue: [Array with: (Dictionary from: {'customer_id' -> 'C1'. 'customer_first_name' -> 'John'. 'customer_last_name' -> 'Doe'})] ifFalse: [Array new]).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q11_growth.

--- a/tests/dataset/tpc-ds/compiler/st/q12.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q12.st.out
@@ -1,0 +1,144 @@
+Smalltalk at: #class_totals put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newWebSale: ws_item_sk ws_sold_date_sk: ws_sold_date_sk ws_ext_sales_price: ws_ext_sales_price | dict |
+    dict := Dictionary new.
+    dict at: 'ws_item_sk' put: ws_item_sk.
+    dict at: 'ws_sold_date_sk' put: ws_sold_date_sk.
+    dict at: 'ws_ext_sales_price' put: ws_ext_sales_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id i_item_desc: i_item_desc i_category: i_category i_class: i_class i_current_price: i_current_price | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    dict at: 'i_item_desc' put: i_item_desc.
+    dict at: 'i_category' put: i_category.
+    dict at: 'i_class' put: i_class.
+    dict at: 'i_current_price' put: i_current_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_date: d_date | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_date' put: d_date.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q12_revenue_ratio
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Item One'. 'i_category' -> 'A'. 'i_class' -> 'C1'. 'i_current_price' -> 10.000000. 'itemrevenue' -> 200.000000. 'revenueratio' -> 50.000000}) with: (Dictionary from: {'i_item_id' -> 'ITEM2'. 'i_item_desc' -> 'Item Two'. 'i_category' -> 'A'. 'i_class' -> 'C1'. 'i_current_price' -> 20.000000. 'itemrevenue' -> 200.000000. 'revenueratio' -> 50.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+web_sales := Array with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_sold_date_sk' -> 1. 'ws_ext_sales_price' -> 100.000000}) with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_sold_date_sk' -> 2. 'ws_ext_sales_price' -> 100.000000}) with: (Dictionary from: {'ws_item_sk' -> 2. 'ws_sold_date_sk' -> 2. 'ws_ext_sales_price' -> 200.000000}) with: (Dictionary from: {'ws_item_sk' -> 3. 'ws_sold_date_sk' -> 3. 'ws_ext_sales_price' -> 50.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Item One'. 'i_category' -> 'A'. 'i_class' -> 'C1'. 'i_current_price' -> 10.000000}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'ITEM2'. 'i_item_desc' -> 'Item Two'. 'i_category' -> 'A'. 'i_class' -> 'C1'. 'i_current_price' -> 20.000000}) with: (Dictionary from: {'i_item_sk' -> 3. 'i_item_id' -> 'ITEM3'. 'i_item_desc' -> 'Item Three'. 'i_category' -> 'B'. 'i_class' -> 'C2'. 'i_current_price' -> 30.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2001-01-20'}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_date' -> '2001-02-05'}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_date' -> '2001-03-05'}).
+filtered := ((| rows groups |
+rows := OrderedCollection new.
+(web_sales) do: [:ws |
+    ((((((Array with: 'A' with: 'B' with: 'C' includes: i at: 'i_category') and: [d at: 'd_date']) >= '2001-01-15') and: [d at: 'd_date']) <= '2001-02-14')) ifTrue: [ rows add: ws ].
+]
+groups := (Main _group_by: rows keyFn: [:ws | Dictionary from: {'id' -> i at: 'i_item_id'. 'desc' -> i at: 'i_item_desc'. 'cat' -> i at: 'i_category'. 'class' -> i at: 'i_class'. 'price' -> i at: 'i_current_price'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_item_id' -> g at: 'key' at: 'id'. 'i_item_desc' -> g at: 'key' at: 'desc'. 'i_category' -> g at: 'key' at: 'cat'. 'i_class' -> g at: 'key' at: 'class'. 'i_current_price' -> g at: 'key' at: 'price'. 'itemrevenue' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ws_ext_sales_price'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+class_totals := ((| rows groups |
+rows := OrderedCollection new.
+(filtered) do: [:f |
+    rows add: f.
+]
+groups := (Main _group_by: rows keyFn: [:f | f at: 'i_class']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'class' -> g at: 'key'. 'total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'itemrevenue'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((filtered) select: [:f | (f at: 'i_class' = t at: 'class')]) do: [:f |
+    (class_totals) do: [:t |
+        res add: { Array with: (f at: 'i_category') with: (f at: 'i_class') with: (f at: 'i_item_id') with: (f at: 'i_item_desc') . Dictionary from: {'i_item_id' -> f at: 'i_item_id'. 'i_item_desc' -> f at: 'i_item_desc'. 'i_category' -> f at: 'i_category'. 'i_class' -> f at: 'i_class'. 'i_current_price' -> f at: 'i_current_price'. 'itemrevenue' -> f at: 'itemrevenue'. 'revenueratio' -> (((f at: 'itemrevenue' * 100.000000)) / t at: 'total')} }.
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q12_revenue_ratio.

--- a/tests/dataset/tpc-ds/compiler/st/q13.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q13.st.out
@@ -1,0 +1,189 @@
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_store_sk ss_sold_date_sk: ss_sold_date_sk ss_hdemo_sk: ss_hdemo_sk ss_cdemo_sk: ss_cdemo_sk ss_addr_sk: ss_addr_sk ss_sales_price: ss_sales_price ss_net_profit: ss_net_profit ss_quantity: ss_quantity ss_ext_sales_price: ss_ext_sales_price ss_ext_wholesale_cost: ss_ext_wholesale_cost | dict |
+    dict := Dictionary new.
+    dict at: 'ss_store_sk' put: ss_store_sk.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_hdemo_sk' put: ss_hdemo_sk.
+    dict at: 'ss_cdemo_sk' put: ss_cdemo_sk.
+    dict at: 'ss_addr_sk' put: ss_addr_sk.
+    dict at: 'ss_sales_price' put: ss_sales_price.
+    dict at: 'ss_net_profit' put: ss_net_profit.
+    dict at: 'ss_quantity' put: ss_quantity.
+    dict at: 'ss_ext_sales_price' put: ss_ext_sales_price.
+    dict at: 'ss_ext_wholesale_cost' put: ss_ext_wholesale_cost.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_state: s_state | dict |
+    dict := Dictionary new.
+    dict at: 's_store_sk' put: s_store_sk.
+    dict at: 's_state' put: s_state.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerDemographics: cd_demo_sk cd_marital_status: cd_marital_status cd_education_status: cd_education_status | dict |
+    dict := Dictionary new.
+    dict at: 'cd_demo_sk' put: cd_demo_sk.
+    dict at: 'cd_marital_status' put: cd_marital_status.
+    dict at: 'cd_education_status' put: cd_education_status.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newHouseholdDemographics: hd_demo_sk hd_dep_count: hd_dep_count | dict |
+    dict := Dictionary new.
+    dict at: 'hd_demo_sk' put: hd_demo_sk.
+    dict at: 'hd_dep_count' put: hd_dep_count.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_country: ca_country ca_state: ca_state | dict |
+    dict := Dictionary new.
+    dict at: 'ca_address_sk' put: ca_address_sk.
+    dict at: 'ca_country' put: ca_country.
+    dict at: 'ca_state' put: ca_state.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q13_averages
+    ((result = Array with: (Dictionary from: {'avg_ss_quantity' -> 10.000000. 'avg_ss_ext_sales_price' -> 100.000000. 'avg_ss_ext_wholesale_cost' -> 50.000000. 'sum_ss_ext_wholesale_cost' -> 50.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_store_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_hdemo_sk' -> 1. 'ss_cdemo_sk' -> 1. 'ss_addr_sk' -> 1. 'ss_sales_price' -> 120.000000. 'ss_net_profit' -> 150.000000. 'ss_quantity' -> 10. 'ss_ext_sales_price' -> 100.000000. 'ss_ext_wholesale_cost' -> 50.000000}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_state' -> 'CA'}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_marital_status' -> 'M1'. 'cd_education_status' -> 'ES1'}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_dep_count' -> 3}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_country' -> 'United States'. 'ca_state' -> 'CA'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2001}).
+filtered := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (((((ss at: 'ss_store_sk' = s at: 's_store_sk') and: [(((((ss at: 'ss_cdemo_sk' = cd at: 'cd_demo_sk') and: [cd at: 'cd_marital_status']) = 'M1') and: [cd at: 'cd_education_status']) = 'ES1')]) and: [(((ss at: 'ss_hdemo_sk' = hd at: 'hd_demo_sk') and: [hd at: 'hd_dep_count']) = 3)]) and: [(((((ss at: 'ss_addr_sk' = ca at: 'ca_address_sk') and: [ca at: 'ca_country']) = 'United States') and: [ca at: 'ca_state']) = 'CA')]) and: [(((ss at: 'ss_sold_date_sk' = d at: 'd_date_sk') and: [d at: 'd_year']) = 2001)])]) do: [:ss |
+    (store) do: [:s |
+        (customer_demographics) do: [:cd |
+            (household_demographics) do: [:hd |
+                (customer_address) do: [:ca |
+                    (date_dim) do: [:d |
+                        res add: ss.
+                    ]
+                ]
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(filtered) do: [:r |
+    rows add: r.
+]
+groups := (Main _group_by: rows keyFn: [:r | Dictionary new]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'avg_ss_quantity' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_quantity'.
+]
+res := res asArray.
+res))). 'avg_ss_ext_sales_price' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res))). 'avg_ss_ext_wholesale_cost' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_ext_wholesale_cost'.
+]
+res := res asArray.
+res))). 'sum_ss_ext_wholesale_cost' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_ext_wholesale_cost'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q13_averages.

--- a/tests/dataset/tpc-ds/compiler/st/q14.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q14.st.out
@@ -1,0 +1,171 @@
+Smalltalk at: #avg_sales put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #cross_items put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_filtered put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_item_sk ss_list_price: ss_list_price ss_quantity: ss_quantity ss_sold_date_sk: ss_sold_date_sk | dict |
+    dict := Dictionary new.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_list_price' put: ss_list_price.
+    dict at: 'ss_quantity' put: ss_quantity.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_item_sk cs_list_price: cs_list_price cs_quantity: cs_quantity cs_sold_date_sk: cs_sold_date_sk | dict |
+    dict := Dictionary new.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    dict at: 'cs_list_price' put: cs_list_price.
+    dict at: 'cs_quantity' put: cs_quantity.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newWebSale: ws_item_sk ws_list_price: ws_list_price ws_quantity: ws_quantity ws_sold_date_sk: ws_sold_date_sk | dict |
+    dict := Dictionary new.
+    dict at: 'ws_item_sk' put: ws_item_sk.
+    dict at: 'ws_list_price' put: ws_list_price.
+    dict at: 'ws_quantity' put: ws_quantity.
+    dict at: 'ws_sold_date_sk' put: ws_sold_date_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_brand_id: i_brand_id i_class_id: i_class_id i_category_id: i_category_id | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_brand_id' put: i_brand_id.
+    dict at: 'i_class_id' put: i_class_id.
+    dict at: 'i_category_id' put: i_category_id.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year d_moy: d_moy | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    dict at: 'd_moy' put: d_moy.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q14_cross_channel
+    ((result = Array with: (Dictionary from: {'channel' -> 'store'. 'i_brand_id' -> 1. 'i_class_id' -> 1. 'i_category_id' -> 1. 'sales' -> 60.000000. 'number_sales' -> 1}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_list_price' -> 10.000000. 'ss_quantity' -> 2. 'ss_sold_date_sk' -> 1}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_list_price' -> 20.000000. 'ss_quantity' -> 3. 'ss_sold_date_sk' -> 2}).
+catalog_sales := Array with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_list_price' -> 10.000000. 'cs_quantity' -> 2. 'cs_sold_date_sk' -> 1}).
+web_sales := Array with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_list_price' -> 30.000000. 'ws_quantity' -> 1. 'ws_sold_date_sk' -> 1}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_brand_id' -> 1. 'i_class_id' -> 1. 'i_category_id' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000. 'd_moy' -> 12}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_year' -> 2002. 'd_moy' -> 11}).
+cross_items := Array with: (Dictionary from: {'ss_item_sk' -> 1}).
+avg_sales := (Main __avg: Array with: 20.000000 with: 20.000000 with: 30.000000).
+store_filtered := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    (((((| res |
+res := OrderedCollection new.
+(cross_items) do: [:ci |
+    res add: ci at: 'ss_item_sk'.
+]
+res := res asArray.
+res))) includes: ss at: 'ss_item_sk')) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'brand_id' -> 1. 'class_id' -> 1. 'category_id' -> 1}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'channel' -> 'store'. 'sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (x at: 'ss_quantity' * x at: 'ss_list_price').
+]
+res := res asArray.
+res))). 'number_sales' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((store_filtered) select: [:r | (r at: 'sales' > avg_sales)]) do: [:r |
+    res add: Dictionary from: {'channel' -> r at: 'channel'. 'i_brand_id' -> 1. 'i_class_id' -> 1. 'i_category_id' -> 1. 'sales' -> r at: 'sales'. 'number_sales' -> r at: 'number_sales'}.
+]
+res := res asArray.
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q14_cross_channel.

--- a/tests/dataset/tpc-ds/compiler/st/q15.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q15.st.out
@@ -1,0 +1,92 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_bill_customer_sk cs_sales_price: cs_sales_price cs_sold_date_sk: cs_sold_date_sk | dict |
+    dict := Dictionary new.
+    dict at: 'cs_bill_customer_sk' put: cs_bill_customer_sk.
+    dict at: 'cs_sales_price' put: cs_sales_price.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomer: c_customer_sk c_current_addr_sk: c_current_addr_sk | dict |
+    dict := Dictionary new.
+    dict at: 'c_customer_sk' put: c_customer_sk.
+    dict at: 'c_current_addr_sk' put: c_current_addr_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_zip: ca_zip ca_state: ca_state | dict |
+    dict := Dictionary new.
+    dict at: 'ca_address_sk' put: ca_address_sk.
+    dict at: 'ca_zip' put: ca_zip.
+    dict at: 'ca_state' put: ca_state.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_qoy: d_qoy d_year: d_year | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_qoy' put: d_qoy.
+    dict at: 'd_year' put: d_year.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q15_zip
+    ((filtered = Array with: (Dictionary from: {'ca_zip' -> '85669'. 'sum_sales' -> 600.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__slice_string: s start: i end: j
+    | start end n |
+    start := i.
+    end := j.
+    n := s size.
+    start < 0 ifTrue: [ start := start + n ].
+    end < 0 ifTrue: [ end := end + n ].
+    start < 0 ifTrue: [ start := 0 ].
+    end > n ifTrue: [ end := n ].
+    end < start ifTrue: [ end := start ].
+    ^ (s copyFrom: start + 1 to: end)
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_bill_customer_sk' -> 1. 'cs_sales_price' -> 600.000000. 'cs_sold_date_sk' -> 1}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_addr_sk' -> 1}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_zip' -> '85669'. 'ca_state' -> 'CA'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_qoy' -> 1. 'd_year' -> 2000}).
+filtered := ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | (((((((((((Array with: 'CA' with: 'WA' with: 'GA' includes: (Main __slice_string: ca at: 'ca_zip' start: 0 end: 0 + 5)) or: [cs at: 'cs_sales_price']) > 500)) and: [d at: 'd_qoy']) = 1) and: [d at: 'd_year']) = 2000) and: [(cs at: 'cs_bill_customer_sk' = c at: 'c_customer_sk')]) and: [(c at: 'c_current_addr_sk' = ca at: 'ca_address_sk')]) and: [(cs at: 'cs_sold_date_sk' = d at: 'd_date_sk')])]) do: [:cs |
+    (customer) do: [:c |
+        (customer_address) do: [:ca |
+            (date_dim) do: [:d |
+                res add: { g at: 'key' at: 'zip' . Dictionary from: {'ca_zip' -> g at: 'key' at: 'zip'. 'sum_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_sales_price'.
+]
+res := res asArray.
+res)))} }.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(filtered toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q15_zip.

--- a/tests/dataset/tpc-ds/compiler/st/q16.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q16.st.out
@@ -1,0 +1,167 @@
+Smalltalk at: #call_center put: nil.
+Smalltalk at: #catalog_returns put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_order_number cs_ship_date_sk: cs_ship_date_sk cs_ship_addr_sk: cs_ship_addr_sk cs_call_center_sk: cs_call_center_sk cs_warehouse_sk: cs_warehouse_sk cs_ext_ship_cost: cs_ext_ship_cost cs_net_profit: cs_net_profit | dict |
+    dict := Dictionary new.
+    dict at: 'cs_order_number' put: cs_order_number.
+    dict at: 'cs_ship_date_sk' put: cs_ship_date_sk.
+    dict at: 'cs_ship_addr_sk' put: cs_ship_addr_sk.
+    dict at: 'cs_call_center_sk' put: cs_call_center_sk.
+    dict at: 'cs_warehouse_sk' put: cs_warehouse_sk.
+    dict at: 'cs_ext_ship_cost' put: cs_ext_ship_cost.
+    dict at: 'cs_net_profit' put: cs_net_profit.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_date: d_date | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_date' put: d_date.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_state: ca_state | dict |
+    dict := Dictionary new.
+    dict at: 'ca_address_sk' put: ca_address_sk.
+    dict at: 'ca_state' put: ca_state.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCallCenter: cc_call_center_sk cc_county: cc_county | dict |
+    dict := Dictionary new.
+    dict at: 'cc_call_center_sk' put: cc_call_center_sk.
+    dict at: 'cc_county' put: cc_county.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogReturn: cr_order_number | dict |
+    dict := Dictionary new.
+    dict at: 'cr_order_number' put: cr_order_number.
+    ^ dict
+!
+!Main class methodsFor: 'mochi'!
+distinct: xs | out x |
+    out := Array new.
+    (xs) do: [:x |
+        ((contains value: out value: x) not) ifTrue: [
+            out := (out copyWith: x).
+        ]
+        .
+    ]
+    .
+    ^ out
+!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q16_shipping
+    ((filtered = Array with: (Dictionary from: {'order_count' -> 1. 'total_shipping_cost' -> 5.000000. 'total_net_profit' -> 20.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_order_number' -> 1. 'cs_ship_date_sk' -> 1. 'cs_ship_addr_sk' -> 1. 'cs_call_center_sk' -> 1. 'cs_warehouse_sk' -> 1. 'cs_ext_ship_cost' -> 5.000000. 'cs_net_profit' -> 20.000000}) with: (Dictionary from: {'cs_order_number' -> 1. 'cs_ship_date_sk' -> 1. 'cs_ship_addr_sk' -> 1. 'cs_call_center_sk' -> 1. 'cs_warehouse_sk' -> 2. 'cs_ext_ship_cost' -> 0.000000. 'cs_net_profit' -> 0.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2000-03-01'}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'}).
+call_center := Array with: (Dictionary from: {'cc_call_center_sk' -> 1. 'cc_county' -> 'CountyA'}).
+catalog_returns := Array new.
+filtered := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_sales) do: [:cs1 |
+    (((exists value: ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs2 | (((cs1 at: 'cs_order_number' = cs2 at: 'cs_order_number') and: [cs1 at: 'cs_warehouse_sk']) ~= cs2 at: 'cs_warehouse_sk')]) do: [:cs2 |
+    res add: cs2.
+]
+res := res asArray.
+res)) and: [exists value: ((| res |
+res := OrderedCollection new.
+((catalog_returns) select: [:cr | (cs1 at: 'cs_order_number' = cr at: 'cr_order_number')]) do: [:cr |
+    res add: cr.
+]
+res := res asArray.
+res))]) = false)) ifTrue: [ rows add: cs1 ].
+]
+groups := (Main _group_by: rows keyFn: [:cs1 | Dictionary new]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'order_count' -> ((Main distinct: (((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_order_number'.
+]
+res := res asArray.
+res))))) size. 'total_shipping_cost' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_ext_ship_cost'.
+]
+res := res asArray.
+res))). 'total_net_profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(filtered toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q16_shipping.

--- a/tests/dataset/tpc-ds/compiler/st/q17.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q17.st.out
@@ -1,0 +1,202 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #joined put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_returns put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_sold_date_sk ss_item_sk: ss_item_sk ss_customer_sk: ss_customer_sk ss_ticket_number: ss_ticket_number ss_quantity: ss_quantity ss_store_sk: ss_store_sk | dict |
+    dict := Dictionary new.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_ticket_number' put: ss_ticket_number.
+    dict at: 'ss_quantity' put: ss_quantity.
+    dict at: 'ss_store_sk' put: ss_store_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStoreReturn: sr_returned_date_sk sr_customer_sk: sr_customer_sk sr_item_sk: sr_item_sk sr_ticket_number: sr_ticket_number sr_return_quantity: sr_return_quantity | dict |
+    dict := Dictionary new.
+    dict at: 'sr_returned_date_sk' put: sr_returned_date_sk.
+    dict at: 'sr_customer_sk' put: sr_customer_sk.
+    dict at: 'sr_item_sk' put: sr_item_sk.
+    dict at: 'sr_ticket_number' put: sr_ticket_number.
+    dict at: 'sr_return_quantity' put: sr_return_quantity.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_sold_date_sk cs_item_sk: cs_item_sk cs_bill_customer_sk: cs_bill_customer_sk cs_quantity: cs_quantity | dict |
+    dict := Dictionary new.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    dict at: 'cs_bill_customer_sk' put: cs_bill_customer_sk.
+    dict at: 'cs_quantity' put: cs_quantity.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_quarter_name: d_quarter_name | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_quarter_name' put: d_quarter_name.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_state: s_state | dict |
+    dict := Dictionary new.
+    dict at: 's_store_sk' put: s_store_sk.
+    dict at: 's_state' put: s_state.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id i_item_desc: i_item_desc | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    dict at: 'i_item_desc' put: i_item_desc.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q17_stats
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'I1'. 'i_item_desc' -> 'Item 1'. 's_state' -> 'CA'. 'store_sales_quantitycount' -> 1. 'store_sales_quantityave' -> 10.000000. 'store_sales_quantitystdev' -> 0.000000. 'store_sales_quantitycov' -> 0.000000. 'store_returns_quantitycount' -> 1. 'store_returns_quantityave' -> 2.000000. 'store_returns_quantitystdev' -> 0.000000. 'store_returns_quantitycov' -> 0.000000. 'catalog_sales_quantitycount' -> 1. 'catalog_sales_quantityave' -> 5.000000. 'catalog_sales_quantitystdev' -> 0.000000. 'catalog_sales_quantitycov' -> 0.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_ticket_number' -> 1. 'ss_quantity' -> 10. 'ss_store_sk' -> 1}).
+store_returns := Array with: (Dictionary from: {'sr_returned_date_sk' -> 2. 'sr_customer_sk' -> 1. 'sr_item_sk' -> 1. 'sr_ticket_number' -> 1. 'sr_return_quantity' -> 2}).
+catalog_sales := Array with: (Dictionary from: {'cs_sold_date_sk' -> 3. 'cs_item_sk' -> 1. 'cs_bill_customer_sk' -> 1. 'cs_quantity' -> 5}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_quarter_name' -> '1998Q1'}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_quarter_name' -> '1998Q2'}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_quarter_name' -> '1998Q3'}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_state' -> 'CA'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'I1'. 'i_item_desc' -> 'Item 1'}).
+joined := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (((((((((((ss at: 'ss_customer_sk' = sr at: 'sr_customer_sk') and: [ss at: 'ss_item_sk']) = sr at: 'sr_item_sk') and: [ss at: 'ss_ticket_number']) = sr at: 'sr_ticket_number') and: [(((sr at: 'sr_customer_sk' = cs at: 'cs_bill_customer_sk') and: [sr at: 'sr_item_sk']) = cs at: 'cs_item_sk')]) and: [(((ss at: 'ss_sold_date_sk' = d1 at: 'd_date_sk') and: [d1 at: 'd_quarter_name']) = '1998Q1')]) and: [(Array with: '1998Q1' with: '1998Q2' with: '1998Q3' includes: sr at: 'sr_returned_date_sk')]) and: [(Array with: '1998Q1' with: '1998Q2' with: '1998Q3' includes: cs at: 'cs_sold_date_sk')]) and: [(ss at: 'ss_store_sk' = s at: 's_store_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')])]) do: [:ss |
+    (store_returns) do: [:sr |
+        (catalog_sales) do: [:cs |
+            (date_dim) do: [:d1 |
+                (date_dim) do: [:d2 |
+                    (date_dim) do: [:d3 |
+                        (store) do: [:s |
+                            (item) do: [:i |
+                                res add: Dictionary from: {'qty' -> ss at: 'ss_quantity'. 'ret' -> sr at: 'sr_return_quantity'. 'csq' -> cs at: 'cs_quantity'. 'i_item_id' -> i at: 'i_item_id'. 'i_item_desc' -> i at: 'i_item_desc'. 's_state' -> s at: 's_state'}.
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(joined) do: [:j |
+    rows add: j.
+]
+groups := (Main _group_by: rows keyFn: [:j | Dictionary from: {'i_item_id' -> j at: 'i_item_id'. 'i_item_desc' -> j at: 'i_item_desc'. 's_state' -> j at: 's_state'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_item_id' -> g at: 'key' at: 'i_item_id'. 'i_item_desc' -> g at: 'key' at: 'i_item_desc'. 's_state' -> g at: 'key' at: 's_state'. 'store_sales_quantitycount' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'store_sales_quantityave' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'qty'.
+]
+res := res asArray.
+res))). 'store_sales_quantitystdev' -> 0.000000. 'store_sales_quantitycov' -> 0.000000. 'store_returns_quantitycount' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'store_returns_quantityave' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ret'.
+]
+res := res asArray.
+res))). 'store_returns_quantitystdev' -> 0.000000. 'store_returns_quantitycov' -> 0.000000. 'catalog_sales_quantitycount' -> (Main __count: ((| res |
+res := OrderedCollection new.
+(g) do: [:_ |
+    res add: _.
+]
+res := res asArray.
+res))). 'catalog_sales_quantityave' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'csq'.
+]
+res := res asArray.
+res))). 'catalog_sales_quantitystdev' -> 0.000000. 'catalog_sales_quantitycov' -> 0.000000}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q17_stats.

--- a/tests/dataset/tpc-ds/compiler/st/q18.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q18.st.out
@@ -1,0 +1,206 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #joined put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_quantity cs_list_price: cs_list_price cs_coupon_amt: cs_coupon_amt cs_sales_price: cs_sales_price cs_net_profit: cs_net_profit cs_bill_cdemo_sk: cs_bill_cdemo_sk cs_bill_customer_sk: cs_bill_customer_sk cs_sold_date_sk: cs_sold_date_sk cs_item_sk: cs_item_sk | dict |
+    dict := Dictionary new.
+    dict at: 'cs_quantity' put: cs_quantity.
+    dict at: 'cs_list_price' put: cs_list_price.
+    dict at: 'cs_coupon_amt' put: cs_coupon_amt.
+    dict at: 'cs_sales_price' put: cs_sales_price.
+    dict at: 'cs_net_profit' put: cs_net_profit.
+    dict at: 'cs_bill_cdemo_sk' put: cs_bill_cdemo_sk.
+    dict at: 'cs_bill_customer_sk' put: cs_bill_customer_sk.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerDemographics: cd_demo_sk cd_gender: cd_gender cd_education_status: cd_education_status cd_dep_count: cd_dep_count | dict |
+    dict := Dictionary new.
+    dict at: 'cd_demo_sk' put: cd_demo_sk.
+    dict at: 'cd_gender' put: cd_gender.
+    dict at: 'cd_education_status' put: cd_education_status.
+    dict at: 'cd_dep_count' put: cd_dep_count.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomer: c_customer_sk c_current_cdemo_sk: c_current_cdemo_sk c_current_addr_sk: c_current_addr_sk c_birth_year: c_birth_year c_birth_month: c_birth_month | dict |
+    dict := Dictionary new.
+    dict at: 'c_customer_sk' put: c_customer_sk.
+    dict at: 'c_current_cdemo_sk' put: c_current_cdemo_sk.
+    dict at: 'c_current_addr_sk' put: c_current_addr_sk.
+    dict at: 'c_birth_year' put: c_birth_year.
+    dict at: 'c_birth_month' put: c_birth_month.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_country: ca_country ca_state: ca_state ca_county: ca_county | dict |
+    dict := Dictionary new.
+    dict at: 'ca_address_sk' put: ca_address_sk.
+    dict at: 'ca_country' put: ca_country.
+    dict at: 'ca_state' put: ca_state.
+    dict at: 'ca_county' put: ca_county.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q18_averages
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'I1'. 'ca_country' -> 'US'. 'ca_state' -> 'CA'. 'ca_county' -> 'County1'. 'agg1' -> 1.000000. 'agg2' -> 10.000000. 'agg3' -> 1.000000. 'agg4' -> 9.000000. 'agg5' -> 2.000000. 'agg6' -> 1980.000000. 'agg7' -> 2.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_quantity' -> 1. 'cs_list_price' -> 10.000000. 'cs_coupon_amt' -> 1.000000. 'cs_sales_price' -> 9.000000. 'cs_net_profit' -> 2.000000. 'cs_bill_cdemo_sk' -> 1. 'cs_bill_customer_sk' -> 1. 'cs_sold_date_sk' -> 1. 'cs_item_sk' -> 1}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_gender' -> 'M'. 'cd_education_status' -> 'College'. 'cd_dep_count' -> 2}) with: (Dictionary from: {'cd_demo_sk' -> 2. 'cd_gender' -> 'F'. 'cd_education_status' -> 'College'. 'cd_dep_count' -> 2}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_cdemo_sk' -> 2. 'c_current_addr_sk' -> 1. 'c_birth_year' -> 1980. 'c_birth_month' -> 1}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_country' -> 'US'. 'ca_state' -> 'CA'. 'ca_county' -> 'County1'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1999}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'I1'}).
+joined := ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | ((((((((((cs at: 'cs_bill_cdemo_sk' = cd1 at: 'cd_demo_sk') and: [cd1 at: 'cd_gender']) = 'M') and: [cd1 at: 'cd_education_status']) = 'College') and: [(cs at: 'cs_bill_customer_sk' = c at: 'c_customer_sk')]) and: [(c at: 'c_current_cdemo_sk' = cd2 at: 'cd_demo_sk')]) and: [(c at: 'c_current_addr_sk' = ca at: 'ca_address_sk')]) and: [(((cs at: 'cs_sold_date_sk' = d at: 'd_date_sk') and: [d at: 'd_year']) = 1999)]) and: [(cs at: 'cs_item_sk' = i at: 'i_item_sk')])]) do: [:cs |
+    (customer_demographics) do: [:cd1 |
+        (customer) do: [:c |
+            (customer_demographics) do: [:cd2 |
+                (customer_address) do: [:ca |
+                    (date_dim) do: [:d |
+                        (item) do: [:i |
+                            res add: Dictionary from: {'i_item_id' -> i at: 'i_item_id'. 'ca_country' -> ca at: 'ca_country'. 'ca_state' -> ca at: 'ca_state'. 'ca_county' -> ca at: 'ca_county'. 'q' -> cs at: 'cs_quantity'. 'lp' -> cs at: 'cs_list_price'. 'cp' -> cs at: 'cs_coupon_amt'. 'sp' -> cs at: 'cs_sales_price'. 'np' -> cs at: 'cs_net_profit'. 'by' -> c at: 'c_birth_year'. 'dep' -> cd1 at: 'cd_dep_count'}.
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(joined) do: [:j |
+    rows add: j.
+]
+groups := (Main _group_by: rows keyFn: [:j | Dictionary from: {'i_item_id' -> j at: 'i_item_id'. 'ca_country' -> j at: 'ca_country'. 'ca_state' -> j at: 'ca_state'. 'ca_county' -> j at: 'ca_county'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_item_id' -> g at: 'key' at: 'i_item_id'. 'ca_country' -> g at: 'key' at: 'ca_country'. 'ca_state' -> g at: 'key' at: 'ca_state'. 'ca_county' -> g at: 'key' at: 'ca_county'. 'agg1' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'q'.
+]
+res := res asArray.
+res))). 'agg2' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'lp'.
+]
+res := res asArray.
+res))). 'agg3' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cp'.
+]
+res := res asArray.
+res))). 'agg4' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'sp'.
+]
+res := res asArray.
+res))). 'agg5' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'np'.
+]
+res := res asArray.
+res))). 'agg6' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'by'.
+]
+res := res asArray.
+res))). 'agg7' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'dep'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q18_averages.

--- a/tests/dataset/tpc-ds/compiler/st/q19.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q19.st.out
@@ -1,0 +1,119 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_sold_date_sk ss_item_sk: ss_item_sk ss_customer_sk: ss_customer_sk ss_store_sk: ss_store_sk ss_ext_sales_price: ss_ext_sales_price | dict |
+    dict := Dictionary new.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_store_sk' put: ss_store_sk.
+    dict at: 'ss_ext_sales_price' put: ss_ext_sales_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year d_moy: d_moy | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    dict at: 'd_moy' put: d_moy.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_brand_id: i_brand_id i_brand: i_brand i_manufact_id: i_manufact_id i_manufact: i_manufact i_manager_id: i_manager_id | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_brand_id' put: i_brand_id.
+    dict at: 'i_brand' put: i_brand.
+    dict at: 'i_manufact_id' put: i_manufact_id.
+    dict at: 'i_manufact' put: i_manufact.
+    dict at: 'i_manager_id' put: i_manager_id.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomer: c_customer_sk c_current_addr_sk: c_current_addr_sk | dict |
+    dict := Dictionary new.
+    dict at: 'c_customer_sk' put: c_customer_sk.
+    dict at: 'c_current_addr_sk' put: c_current_addr_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_zip: ca_zip | dict |
+    dict := Dictionary new.
+    dict at: 'ca_address_sk' put: ca_address_sk.
+    dict at: 'ca_zip' put: ca_zip.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_zip: s_zip | dict |
+    dict := Dictionary new.
+    dict at: 's_store_sk' put: s_store_sk.
+    dict at: 's_zip' put: s_zip.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q19_brand
+    ((result = Array with: (Dictionary from: {'i_brand' -> 'B1'. 'i_brand_id' -> 1. 'i_manufact_id' -> 1. 'i_manufact' -> 'M1'. 'ext_price' -> 100.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__slice_string: s start: i end: j
+    | start end n |
+    start := i.
+    end := j.
+    n := s size.
+    start < 0 ifTrue: [ start := start + n ].
+    end < 0 ifTrue: [ end := end + n ].
+    start < 0 ifTrue: [ start := 0 ].
+    end > n ifTrue: [ end := n ].
+    end < start ifTrue: [ end := start ].
+    ^ (s copyFrom: start + 1 to: end)
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_store_sk' -> 1. 'ss_ext_sales_price' -> 100.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1999. 'd_moy' -> 11}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_brand_id' -> 1. 'i_brand' -> 'B1'. 'i_manufact_id' -> 1. 'i_manufact' -> 'M1'. 'i_manager_id' -> 10}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_addr_sk' -> 1}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_zip' -> '11111'}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_zip' -> '99999'}).
+result := ((| res |
+res := OrderedCollection new.
+((date_dim) select: [:d | ((((((((d at: 'd_moy' = 11) and: [d at: 'd_year']) = 1999) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(((ss at: 'ss_item_sk' = i at: 'i_item_sk') and: [i at: 'i_manager_id']) = 10)]) and: [(ss at: 'ss_customer_sk' = c at: 'c_customer_sk')]) and: [(c at: 'c_current_addr_sk' = ca at: 'ca_address_sk')]) and: [(((ss at: 'ss_store_sk' = s at: 's_store_sk') and: [(Main __slice_string: ca at: 'ca_zip' start: 0 end: 0 + 5)]) ~= (Main __slice_string: s at: 's_zip' start: 0 end: 0 + 5))])]) do: [:d |
+    (store_sales) do: [:ss |
+        (item) do: [:i |
+            (customer) do: [:c |
+                (customer_address) do: [:ca |
+                    (store) do: [:s |
+                        res add: { Array with: (g at: 'key' at: 'brand') . Dictionary from: {'i_brand' -> g at: 'key' at: 'brand'. 'i_brand_id' -> g at: 'key' at: 'brand_id'. 'i_manufact_id' -> g at: 'key' at: 'man_id'. 'i_manufact' -> g at: 'key' at: 'man'. 'ext_price' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res)))} }.
+                    ]
+                ]
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q19_brand.

--- a/tests/dataset/tpc-ds/compiler/st/q2.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q2.st.out
@@ -11,66 +11,66 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q2_result
-	((result = Array with: (Dictionary from: {'d_week_seq1' -> 1. 'sun_ratio' -> 0.500000. 'mon_ratio' -> 0.500000}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'d_week_seq1' -> 1. 'sun_ratio' -> 0.500000. 'mon_ratio' -> 0.500000}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !_Group class methodsFor: 'instance creation'!
 key: k | g |
-	g := self new.
-	g key: k.
-	g initialize.
-	^ g
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
 !
 !_Group methodsFor: 'initialization'!
 initialize
-	items := OrderedCollection new.
-	^ self
+    items := OrderedCollection new.
+    ^ self
 !
 !_Group methodsFor: 'accessing'!
 key
-	^ key
+    ^ key
 !
 key: k
-	key := k
+    key := k
 !
 add: it
-	items add: it
+    items add: it
 !
 do: blk
-	items do: blk
+    items do: blk
 !
 size
-	^ items size
+    ^ items size
 !
 !Main class methodsFor: 'runtime'!
 __union_all: a with: b
-	| out |
-	out := OrderedCollection new.
-	a ifNotNil: [ a do: [:v | out add: v ] ].
-	b ifNotNil: [ b do: [:v | out add: v ] ].
-	^ out asArray
+    | out |
+    out := OrderedCollection new.
+    a ifNotNil: [ a do: [:v | out add: v ] ].
+    b ifNotNil: [ b do: [:v | out add: v ] ].
+    ^ out asArray
 !
 __sum: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
-	| s |
-	s := 0.
-	v do: [:it | s := s + it].
-	^ s
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
 !
 _group_by: src keyFn: blk
-	| groups order |
-	groups := Dictionary new.
-	order := OrderedCollection new.
-	src do: [:it |
-		| key ks g |
-		key := blk value: it.
-		ks := key printString.
-		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
-		g add: it.
-	]
-	^ order collect: [:k | groups at: k ]
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
 !
 !!
 web_sales := Array with: (Dictionary from: {'ws_sold_date_sk' -> 1. 'ws_ext_sales_price' -> 5.000000. 'ws_sold_date_name' -> 'Sunday'}) with: (Dictionary from: {'ws_sold_date_sk' -> 2. 'ws_ext_sales_price' -> 5.000000. 'ws_sold_date_name' -> 'Monday'}) with: (Dictionary from: {'ws_sold_date_sk' -> 8. 'ws_ext_sales_price' -> 10.000000. 'ws_sold_date_name' -> 'Sunday'}) with: (Dictionary from: {'ws_sold_date_sk' -> 9. 'ws_ext_sales_price' -> 10.000000. 'ws_sold_date_name' -> 'Monday'}).
@@ -79,64 +79,64 @@ date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_week_seq' -> 1. 
 wscs := (Main __union_all: ((((| res |
 res := OrderedCollection new.
 (web_sales) do: [:ws |
-	res add: Dictionary from: {'sold_date_sk' -> ws at: 'ws_sold_date_sk'. 'sales_price' -> ws at: 'ws_ext_sales_price'. 'day' -> ws at: 'ws_sold_date_name'}.
+    res add: Dictionary from: {'sold_date_sk' -> ws at: 'ws_sold_date_sk'. 'sales_price' -> ws at: 'ws_ext_sales_price'. 'day' -> ws at: 'ws_sold_date_name'}.
 ]
 res := res asArray.
 res)))) with: ((((| res |
 res := OrderedCollection new.
 (catalog_sales) do: [:cs |
-	res add: Dictionary from: {'sold_date_sk' -> cs at: 'cs_sold_date_sk'. 'sales_price' -> cs at: 'cs_ext_sales_price'. 'day' -> cs at: 'cs_sold_date_name'}.
+    res add: Dictionary from: {'sold_date_sk' -> cs at: 'cs_sold_date_sk'. 'sales_price' -> cs at: 'cs_ext_sales_price'. 'day' -> cs at: 'cs_sold_date_name'}.
 ]
 res := res asArray.
 res))))).
 wswscs := ((| rows groups |
 rows := OrderedCollection new.
 (wscs) do: [:w |
-	rows add: w.
+    rows add: w.
 ]
 groups := (Main _group_by: rows keyFn: [:w | Dictionary from: {'week_seq' -> d at: 'd_week_seq'}]).
 rows := OrderedCollection new.
 (groups) do: [:g |
-	rows add: Dictionary from: {'d_week_seq' -> g at: 'key' at: 'week_seq'. 'sun_sales' -> (Main __sum: ((| res |
+    rows add: Dictionary from: {'d_week_seq' -> g at: 'key' at: 'week_seq'. 'sun_sales' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 ((g) select: [:x | (x at: 'day' = 'Sunday')]) do: [:x |
-	res add: x at: 'sales_price'.
+    res add: x at: 'sales_price'.
 ]
 res := res asArray.
 res))). 'mon_sales' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 ((g) select: [:x | (x at: 'day' = 'Monday')]) do: [:x |
-	res add: x at: 'sales_price'.
+    res add: x at: 'sales_price'.
 ]
 res := res asArray.
 res))). 'tue_sales' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 ((g) select: [:x | (x at: 'day' = 'Tuesday')]) do: [:x |
-	res add: x at: 'sales_price'.
+    res add: x at: 'sales_price'.
 ]
 res := res asArray.
 res))). 'wed_sales' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 ((g) select: [:x | (x at: 'day' = 'Wednesday')]) do: [:x |
-	res add: x at: 'sales_price'.
+    res add: x at: 'sales_price'.
 ]
 res := res asArray.
 res))). 'thu_sales' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 ((g) select: [:x | (x at: 'day' = 'Thursday')]) do: [:x |
-	res add: x at: 'sales_price'.
+    res add: x at: 'sales_price'.
 ]
 res := res asArray.
 res))). 'fri_sales' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 ((g) select: [:x | (x at: 'day' = 'Friday')]) do: [:x |
-	res add: x at: 'sales_price'.
+    res add: x at: 'sales_price'.
 ]
 res := res asArray.
 res))). 'sat_sales' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 ((g) select: [:x | (x at: 'day' = 'Saturday')]) do: [:x |
-	res add: x at: 'sales_price'.
+    res add: x at: 'sales_price'.
 ]
 res := res asArray.
 res)))}.
@@ -146,23 +146,23 @@ rows)).
 year1 := ((| res |
 res := OrderedCollection new.
 ((wswscs) select: [:w | (w at: 'd_week_seq' = 1)]) do: [:w |
-	res add: w.
+    res add: w.
 ]
 res := res asArray.
 res)).
 year2 := ((| res |
 res := OrderedCollection new.
 ((wswscs) select: [:w | (w at: 'd_week_seq' = 54)]) do: [:w |
-	res add: w.
+    res add: w.
 ]
 res := res asArray.
 res)).
 result := ((| res |
 res := OrderedCollection new.
 ((year1) select: [:y | ((y at: 'd_week_seq' = z at: 'd_week_seq') - 53)]) do: [:y |
-	(year2) do: [:z |
-		res add: Dictionary from: {'d_week_seq1' -> y at: 'd_week_seq'. 'sun_ratio' -> (y at: 'sun_sales' / z at: 'sun_sales'). 'mon_ratio' -> (y at: 'mon_sales' / z at: 'mon_sales')}.
-	]
+    (year2) do: [:z |
+        res add: Dictionary from: {'d_week_seq1' -> y at: 'd_week_seq'. 'sun_ratio' -> (y at: 'sun_sales' / z at: 'sun_sales'). 'mon_ratio' -> (y at: 'mon_sales' / z at: 'mon_sales')}.
+    ]
 ]
 res := res asArray.
 res)).

--- a/tests/dataset/tpc-ds/compiler/st/q3.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q3.st.out
@@ -7,16 +7,16 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q3_result
-	((result = Array with: (Dictionary from: {'d_year' -> 1998. 'brand_id' -> 1. 'brand' -> 'Brand1'. 'sum_agg' -> 10.000000}) with: (Dictionary from: {'d_year' -> 1998. 'brand_id' -> 2. 'brand' -> 'Brand2'. 'sum_agg' -> 20.000000}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'d_year' -> 1998. 'brand_id' -> 1. 'brand' -> 'Brand1'. 'sum_agg' -> 10.000000}) with: (Dictionary from: {'d_year' -> 1998. 'brand_id' -> 2. 'brand' -> 'Brand2'. 'sum_agg' -> 20.000000}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
 __sum: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
-	| s |
-	s := 0.
-	v do: [:it | s := s + it].
-	^ s
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
 !
 !!
 date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1998. 'd_moy' -> 12}).
@@ -25,23 +25,23 @@ item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_manufact_id' -> 100.
 result := ((| res |
 res := OrderedCollection new.
 ((date_dim) select: [:dt | (((((i at: 'i_manufact_id' = 100) and: [dt at: 'd_moy']) = 12) and: [(dt at: 'd_date_sk' = ss at: 'ss_sold_date_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')])]) do: [:dt |
-	(store_sales) do: [:ss |
-		(item) do: [:i |
-			res add: { Array with: (g at: 'key' at: 'd_year') with: (((Main __sum: ((| res |
+    (store_sales) do: [:ss |
+        (item) do: [:i |
+            res add: { Array with: (g at: 'key' at: 'd_year') with: (((Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'ss_ext_sales_price'.
+    res add: x at: 'ss_ext_sales_price'.
 ]
 res := res asArray.
 res))) negated)) with: (g at: 'key' at: 'brand_id') . Dictionary from: {'d_year' -> g at: 'key' at: 'd_year'. 'brand_id' -> g at: 'key' at: 'brand_id'. 'brand' -> g at: 'key' at: 'brand'. 'sum_agg' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'ss_ext_sales_price'.
+    res add: x at: 'ss_ext_sales_price'.
 ]
 res := res asArray.
 res)))} }.
-		]
-	]
+        ]
+    ]
 ]
 res := res asArray.
 res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.

--- a/tests/dataset/tpc-ds/compiler/st/q4.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q4.st.out
@@ -10,66 +10,66 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q4_result
-	((result = Array with: (Dictionary from: {'customer_id' -> 'C1'. 'customer_first_name' -> 'Alice'. 'customer_last_name' -> 'A'. 'customer_login' -> 'alice'}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'customer_id' -> 'C1'. 'customer_first_name' -> 'Alice'. 'customer_last_name' -> 'A'. 'customer_login' -> 'alice'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !_Group class methodsFor: 'instance creation'!
 key: k | g |
-	g := self new.
-	g key: k.
-	g initialize.
-	^ g
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
 !
 !_Group methodsFor: 'initialization'!
 initialize
-	items := OrderedCollection new.
-	^ self
+    items := OrderedCollection new.
+    ^ self
 !
 !_Group methodsFor: 'accessing'!
 key
-	^ key
+    ^ key
 !
 key: k
-	key := k
+    key := k
 !
 add: it
-	items add: it
+    items add: it
 !
 do: blk
-	items do: blk
+    items do: blk
 !
 size
-	^ items size
+    ^ items size
 !
 !Main class methodsFor: 'runtime'!
 __union_all: a with: b
-	| out |
-	out := OrderedCollection new.
-	a ifNotNil: [ a do: [:v | out add: v ] ].
-	b ifNotNil: [ b do: [:v | out add: v ] ].
-	^ out asArray
+    | out |
+    out := OrderedCollection new.
+    a ifNotNil: [ a do: [:v | out add: v ] ].
+    b ifNotNil: [ b do: [:v | out add: v ] ].
+    ^ out asArray
 !
 __sum: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
-	| s |
-	s := 0.
-	v do: [:it | s := s + it].
-	^ s
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
 !
 _group_by: src keyFn: blk
-	| groups order |
-	groups := Dictionary new.
-	order := OrderedCollection new.
-	src do: [:it |
-		| key ks g |
-		key := blk value: it.
-		ks := key printString.
-		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
-		g add: it.
-	]
-	^ order collect: [:k | groups at: k ]
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
 !
 !!
 customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_customer_id' -> 'C1'. 'c_first_name' -> 'Alice'. 'c_last_name' -> 'A'. 'c_login' -> 'alice'}).
@@ -80,15 +80,15 @@ date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2001}) 
 year_total := (Main __union_all: ((Main __union_all: ((((| rows groups |
 rows := OrderedCollection new.
 (customer) do: [:c |
-	rows add: c.
+    rows add: c.
 ]
 groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'login' -> c at: 'c_login'. 'year' -> d at: 'd_year'}]).
 rows := OrderedCollection new.
 (groups) do: [:g |
-	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+    rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: ((((((x at: 'ss_ext_list_price' - x at: 'ss_ext_wholesale_cost') - x at: 'ss_ext_discount_amt')) + x at: 'ss_ext_sales_price')) / 2).
+    res add: ((((((x at: 'ss_ext_list_price' - x at: 'ss_ext_wholesale_cost') - x at: 'ss_ext_discount_amt')) + x at: 'ss_ext_sales_price')) / 2).
 ]
 res := res asArray.
 res))). 'sale_type' -> 's'}.
@@ -97,15 +97,15 @@ rows := rows asArray.
 rows)))) with: ((((| rows groups |
 rows := OrderedCollection new.
 (customer) do: [:c |
-	rows add: c.
+    rows add: c.
 ]
 groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'login' -> c at: 'c_login'. 'year' -> d at: 'd_year'}]).
 rows := OrderedCollection new.
 (groups) do: [:g |
-	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+    rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: ((((((x at: 'cs_ext_list_price' - x at: 'cs_ext_wholesale_cost') - x at: 'cs_ext_discount_amt')) + x at: 'cs_ext_sales_price')) / 2).
+    res add: ((((((x at: 'cs_ext_list_price' - x at: 'cs_ext_wholesale_cost') - x at: 'cs_ext_discount_amt')) + x at: 'cs_ext_sales_price')) / 2).
 ]
 res := res asArray.
 res))). 'sale_type' -> 'c'}.
@@ -114,15 +114,15 @@ rows := rows asArray.
 rows)))))) with: ((((| rows groups |
 rows := OrderedCollection new.
 (customer) do: [:c |
-	rows add: c.
+    rows add: c.
 ]
 groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'login' -> c at: 'c_login'. 'year' -> d at: 'd_year'}]).
 rows := OrderedCollection new.
 (groups) do: [:g |
-	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+    rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'customer_login' -> g at: 'key' at: 'login'. 'dyear' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: ((((((x at: 'ws_ext_list_price' - x at: 'ws_ext_wholesale_cost') - x at: 'ws_ext_discount_amt')) + x at: 'ws_ext_sales_price')) / 2).
+    res add: ((((((x at: 'ws_ext_list_price' - x at: 'ws_ext_wholesale_cost') - x at: 'ws_ext_discount_amt')) + x at: 'ws_ext_sales_price')) / 2).
 ]
 res := res asArray.
 res))). 'sale_type' -> 'w'}.
@@ -132,17 +132,17 @@ rows))))).
 result := ((| res |
 res := OrderedCollection new.
 ((year_total) select: [:s1 | ((((((((((((((((((((((((((((((((((((((s1 at: 'sale_type' = 's') and: [c1 at: 'sale_type']) = 'c') and: [w1 at: 'sale_type']) = 'w') and: [s2 at: 'sale_type']) = 's') and: [c2 at: 'sale_type']) = 'c') and: [w2 at: 'sale_type']) = 'w') and: [s1 at: 'dyear']) = 2001) and: [s2 at: 'dyear']) = 2002) and: [c1 at: 'dyear']) = 2001) and: [c2 at: 'dyear']) = 2002) and: [w1 at: 'dyear']) = 2001) and: [w2 at: 'dyear']) = 2002) and: [s1 at: 'year_total']) > 0) and: [c1 at: 'year_total']) > 0) and: [w1 at: 'year_total']) > 0) and: [((((c1 at: 'year_total' > 0)) ifTrue: [(c2 at: 'year_total' / c1 at: 'year_total')] ifFalse: [nil]))]) > ((((s1 at: 'year_total' > 0)) ifTrue: [(s2 at: 'year_total' / s1 at: 'year_total')] ifFalse: [nil]))) and: [((((c1 at: 'year_total' > 0)) ifTrue: [(c2 at: 'year_total' / c1 at: 'year_total')] ifFalse: [nil]))]) > ((((w1 at: 'year_total' > 0)) ifTrue: [(w2 at: 'year_total' / w1 at: 'year_total')] ifFalse: [nil]))) and: [(s2 at: 'customer_id' = s1 at: 'customer_id')]) and: [(c1 at: 'customer_id' = s1 at: 'customer_id')]) and: [(c2 at: 'customer_id' = s1 at: 'customer_id')]) and: [(w1 at: 'customer_id' = s1 at: 'customer_id')]) and: [(w2 at: 'customer_id' = s1 at: 'customer_id')])]) do: [:s1 |
-	(year_total) do: [:s2 |
-		(year_total) do: [:c1 |
-			(year_total) do: [:c2 |
-				(year_total) do: [:w1 |
-					(year_total) do: [:w2 |
-						res add: { Array with: (s2 at: 'customer_id') with: (s2 at: 'customer_first_name') with: (s2 at: 'customer_last_name') with: (s2 at: 'customer_login') . Dictionary from: {'customer_id' -> s2 at: 'customer_id'. 'customer_first_name' -> s2 at: 'customer_first_name'. 'customer_last_name' -> s2 at: 'customer_last_name'. 'customer_login' -> s2 at: 'customer_login'} }.
-					]
-				]
-			]
-		]
-	]
+    (year_total) do: [:s2 |
+        (year_total) do: [:c1 |
+            (year_total) do: [:c2 |
+                (year_total) do: [:w1 |
+                    (year_total) do: [:w2 |
+                        res add: { Array with: (s2 at: 'customer_id') with: (s2 at: 'customer_first_name') with: (s2 at: 'customer_last_name') with: (s2 at: 'customer_login') . Dictionary from: {'customer_id' -> s2 at: 'customer_id'. 'customer_first_name' -> s2 at: 'customer_first_name'. 'customer_last_name' -> s2 at: 'customer_last_name'. 'customer_login' -> s2 at: 'customer_login'} }.
+                    ]
+                ]
+            ]
+        ]
+    ]
 ]
 res := res asArray.
 res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.

--- a/tests/dataset/tpc-ds/compiler/st/q5.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q5.st.out
@@ -4,7 +4,7 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q5_result
-	(((result) size = 3)) ifFalse: [ self error: 'expect failed' ]
+    (((result) size = 3)) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!

--- a/tests/dataset/tpc-ds/compiler/st/q6.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q6.st.out
@@ -10,36 +10,36 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q6_result
-	((result = Array with: (Dictionary from: {'state' -> 'CA'. 'cnt' -> 10}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'state' -> 'CA'. 'cnt' -> 10}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
 __count: v
-	(v respondsTo: #size) ifTrue: [ ^ v size ]
-	^ self error: 'count() expects collection'
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
 !
 __avg: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
-	v size = 0 ifTrue: [ ^ 0 ]
-	| sum |
-	sum := 0.
-	v do: [:it | sum := sum + it].
-	^ sum / v size
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
 !
 __max: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'max() expects collection' ]
-	| m first |
-	first := true.
-	v do: [:it | first ifTrue: [ m := it. first := false ] ifFalse: [ (it > m) ifTrue: [ m := it ] ] ].
-	^ first ifTrue: [ 0 ] ifFalse: [ m ]
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'max() expects collection' ]
+    | m first |
+    first := true.
+    v do: [:it | first ifTrue: [ m := it. first := false ] ifFalse: [ (it > m) ifTrue: [ m := it ] ] ].
+    ^ first ifTrue: [ 0 ] ifFalse: [ m ]
 !
 _paginate: items skip: s take: t
-	| out start |
-	out := items asArray.
-	start := s ifNil: [ 0 ] ifNotNil: [ s ].
-	start > 0 ifTrue: [ out := out copyFrom: start + 1 to: out size ].
-	t notNil ifTrue: [ out := out copyFrom: 1 to: (t min: out size) ].
-	^ out
+    | out start |
+    out := items asArray.
+    start := s ifNil: [ 0 ] ifNotNil: [ s ].
+    start > 0 ifTrue: [ out := out copyFrom: start + 1 to: out size ].
+    t notNil ifTrue: [ out := out copyFrom: 1 to: (t min: out size) ].
+    ^ out
 !
 !!
 customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'. 'ca_zip' -> '12345'}).
@@ -50,7 +50,7 @@ item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_category' -> 'A'. 'i
 target_month_seq := (Main __max: ((| res |
 res := OrderedCollection new.
 ((date_dim) select: [:d | (((d at: 'd_year' = 1999) and: [d at: 'd_moy']) = 5)]) do: [:d |
-	res add: d at: 'd_month_seq'.
+    res add: d at: 'd_month_seq'.
 ]
 res := res asArray.
 res))).
@@ -59,19 +59,19 @@ res := OrderedCollection new.
 ((customer_address) select: [:a | ((((((((d at: 'd_month_seq' = target_month_seq) and: [i at: 'i_current_price']) > 1.200000) * (Main __avg: ((| res |
 res := OrderedCollection new.
 ((item) select: [:j | (j at: 'i_category' = i at: 'i_category')]) do: [:j |
-	res add: j at: 'i_current_price'.
+    res add: j at: 'i_current_price'.
 ]
 res := res asArray.
 res)))) and: [(a at: 'ca_address_sk' = c at: 'c_current_addr_sk')]) and: [(c at: 'c_customer_sk' = s at: 'ss_customer_sk')]) and: [(s at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(s at: 'ss_item_sk' = i at: 'i_item_sk')])]) do: [:a |
-	(customer) do: [:c |
-		(store_sales) do: [:s |
-			(date_dim) do: [:d |
-				(item) do: [:i |
-					res add: { Array with: ((Main __count: g)) with: (g at: 'key') . Dictionary from: {'state' -> g at: 'key'. 'cnt' -> (Main __count: g)} }.
-				]
-			]
-		]
-	]
+    (customer) do: [:c |
+        (store_sales) do: [:s |
+            (date_dim) do: [:d |
+                (item) do: [:i |
+                    res add: { Array with: ((Main __count: g)) with: (g at: 'key') . Dictionary from: {'state' -> g at: 'key'. 'cnt' -> (Main __count: g)} }.
+                ]
+            ]
+        ]
+    ]
 ]
 res := res asArray.
 res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.

--- a/tests/dataset/tpc-ds/compiler/st/q7.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q7.st.out
@@ -9,17 +9,17 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q7_result
-	((result = Array with: (Dictionary from: {'i_item_id' -> 'I1'. 'agg1' -> 5.000000. 'agg2' -> 10.000000. 'agg3' -> 2.000000. 'agg4' -> 8.000000}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'I1'. 'agg1' -> 5.000000. 'agg2' -> 10.000000. 'agg3' -> 2.000000. 'agg4' -> 8.000000}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
 __avg: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
-	v size = 0 ifTrue: [ ^ 0 ]
-	| sum |
-	sum := 0.
-	v do: [:it | sum := sum + it].
-	^ sum / v size
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
 !
 !!
 store_sales := Array with: (Dictionary from: {'ss_cdemo_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1. 'ss_promo_sk' -> 1. 'ss_quantity' -> 5. 'ss_list_price' -> 10.000000. 'ss_coupon_amt' -> 2.000000. 'ss_sales_price' -> 8.000000}).
@@ -30,39 +30,39 @@ promotion := Array with: (Dictionary from: {'p_promo_sk' -> 1. 'p_channel_email'
 result := ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:ss | ((((((((((((cd at: 'cd_gender' = 'M') and: [cd at: 'cd_marital_status']) = 'S') and: [cd at: 'cd_education_status']) = 'College') and: [((((p at: 'p_channel_email' = 'N') or: [p at: 'p_channel_event']) = 'N'))]) and: [d at: 'd_year']) = 1998) and: [(ss at: 'ss_cdemo_sk' = cd at: 'cd_demo_sk')]) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')]) and: [(ss at: 'ss_promo_sk' = p at: 'p_promo_sk')])]) do: [:ss |
-	(customer_demographics) do: [:cd |
-		(date_dim) do: [:d |
-			(item) do: [:i |
-				(promotion) do: [:p |
-					res add: { g at: 'key' at: 'i_item_id' . Dictionary from: {'i_item_id' -> g at: 'key' at: 'i_item_id'. 'agg1' -> (Main __avg: ((| res |
+    (customer_demographics) do: [:cd |
+        (date_dim) do: [:d |
+            (item) do: [:i |
+                (promotion) do: [:p |
+                    res add: { g at: 'key' at: 'i_item_id' . Dictionary from: {'i_item_id' -> g at: 'key' at: 'i_item_id'. 'agg1' -> (Main __avg: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'ss' at: 'ss_quantity'.
+    res add: x at: 'ss' at: 'ss_quantity'.
 ]
 res := res asArray.
 res))). 'agg2' -> (Main __avg: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'ss' at: 'ss_list_price'.
+    res add: x at: 'ss' at: 'ss_list_price'.
 ]
 res := res asArray.
 res))). 'agg3' -> (Main __avg: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'ss' at: 'ss_coupon_amt'.
+    res add: x at: 'ss' at: 'ss_coupon_amt'.
 ]
 res := res asArray.
 res))). 'agg4' -> (Main __avg: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'ss' at: 'ss_sales_price'.
+    res add: x at: 'ss' at: 'ss_sales_price'.
 ]
 res := res asArray.
 res)))} }.
-				]
-			]
-		]
-	]
+                ]
+            ]
+        ]
+    ]
 ]
 res := res asArray.
 res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.

--- a/tests/dataset/tpc-ds/compiler/st/q8.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q8.st.out
@@ -10,33 +10,33 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q8_result
-	((result = Array with: (Dictionary from: {'s_store_name' -> 'Store1'. 'net_profit' -> 10.000000}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'s_store_name' -> 'Store1'. 'net_profit' -> 10.000000}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
 __slice_string: s start: i end: j
-	| start end n |
-	start := i.
-	end := j.
-	n := s size.
-	start < 0 ifTrue: [ start := start + n ].
-	end < 0 ifTrue: [ end := end + n ].
-	start < 0 ifTrue: [ start := 0 ].
-	end > n ifTrue: [ end := n ].
-	end < start ifTrue: [ end := start ].
-	^ (s copyFrom: start + 1 to: end)
+    | start end n |
+    start := i.
+    end := j.
+    n := s size.
+    start < 0 ifTrue: [ start := start + n ].
+    end < 0 ifTrue: [ end := end + n ].
+    start < 0 ifTrue: [ start := 0 ].
+    end > n ifTrue: [ end := n ].
+    end < start ifTrue: [ end := start ].
+    ^ (s copyFrom: start + 1 to: end)
 !
 __reverse: obj
-	(obj isKindOf: Array) ifTrue: [ ^ obj reverse ]
-	(obj isString) ifTrue: [ ^ obj reverse ]
-	^ self error: 'reverse expects list or string'
+    (obj isKindOf: Array) ifTrue: [ ^ obj reverse ]
+    (obj isString) ifTrue: [ ^ obj reverse ]
+    ^ self error: 'reverse expects list or string'
 !
 __sum: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
-	| s |
-	s := 0.
-	v do: [:it | s := s + it].
-	^ s
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
 !
 !!
 store_sales := Array with: (Dictionary from: {'ss_store_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_net_profit' -> 10.000000}).
@@ -49,21 +49,21 @@ zip_list := Array with: '12345'.
 result := ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:ss | (((((zip_list includes: (Main __slice_string: ca at: 'ca_zip' start: 0 end: 0 + 5)) and: [(((((ss at: 'ss_sold_date_sk' = d at: 'd_date_sk') and: [d at: 'd_qoy']) = 1) and: [d at: 'd_year']) = 1998)]) and: [(ss at: 'ss_store_sk' = s at: 's_store_sk')]) and: [((Main __slice_string: s at: 's_zip' start: 0 end: 0 + 2) = (Main __slice_string: ca at: 'ca_zip' start: 0 end: 0 + 2))]) and: [(((ca at: 'ca_address_sk' = c at: 'c_current_addr_sk') and: [c at: 'c_preferred_cust_flag']) = 'Y')])]) do: [:ss |
-	(date_dim) do: [:d |
-		(store) do: [:s |
-			(customer_address) do: [:ca |
-				(customer) do: [:c |
-					res add: { g at: 'key' . Dictionary from: {'s_store_name' -> g at: 'key'. 'net_profit' -> (Main __sum: ((| res |
+    (date_dim) do: [:d |
+        (store) do: [:s |
+            (customer_address) do: [:ca |
+                (customer) do: [:c |
+                    res add: { g at: 'key' . Dictionary from: {'s_store_name' -> g at: 'key'. 'net_profit' -> (Main __sum: ((| res |
 res := OrderedCollection new.
 (g) do: [:x |
-	res add: x at: 'ss' at: 'ss_net_profit'.
+    res add: x at: 'ss' at: 'ss_net_profit'.
 ]
 res := res asArray.
 res)))} }.
-				]
-			]
-		]
-	]
+                ]
+            ]
+        ]
+    ]
 ]
 res := res asArray.
 res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.

--- a/tests/dataset/tpc-ds/compiler/st/q9.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q9.st.out
@@ -11,21 +11,21 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'tests'!
 test_TPCDS_Q9_result
-	((result = Array with: (Dictionary from: {'bucket1' -> 7.000000. 'bucket2' -> 15.000000. 'bucket3' -> 30.000000. 'bucket4' -> 35.000000. 'bucket5' -> 50.000000}))) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'bucket1' -> 7.000000. 'bucket2' -> 15.000000. 'bucket3' -> 30.000000. 'bucket4' -> 35.000000. 'bucket5' -> 50.000000}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
 __count: v
-	(v respondsTo: #size) ifTrue: [ ^ v size ]
-	^ self error: 'count() expects collection'
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
 !
 __avg: v
-	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
-	v size = 0 ifTrue: [ ^ 0 ]
-	| sum |
-	sum := 0.
-	v do: [:it | sum := sum + it].
-	^ sum / v size
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
 !
 !!
 store_sales := Array with: (Dictionary from: {'ss_quantity' -> 5. 'ss_ext_discount_amt' -> 5.000000. 'ss_net_paid' -> 7.000000}) with: (Dictionary from: {'ss_quantity' -> 30. 'ss_ext_discount_amt' -> 10.000000. 'ss_net_paid' -> 15.000000}) with: (Dictionary from: {'ss_quantity' -> 50. 'ss_ext_discount_amt' -> 20.000000. 'ss_net_paid' -> 30.000000}) with: (Dictionary from: {'ss_quantity' -> 70. 'ss_ext_discount_amt' -> 25.000000. 'ss_net_paid' -> 35.000000}) with: (Dictionary from: {'ss_quantity' -> 90. 'ss_ext_discount_amt' -> 40.000000. 'ss_net_paid' -> 50.000000}).
@@ -33,102 +33,102 @@ reason := Array with: (Dictionary from: {'r_reason_sk' -> 1}).
 bucket1 := ((((Main __count: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 1) and: [s at: 'ss_quantity']) <= 20)]) do: [:s |
-	res add: s.
+    res add: s.
 ]
 res := res asArray.
 res))) > 10)) ifTrue: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 1) and: [s at: 'ss_quantity']) <= 20)]) do: [:s |
-	res add: s at: 'ss_ext_discount_amt'.
+    res add: s at: 'ss_ext_discount_amt'.
 ]
 res := res asArray.
 res)))] ifFalse: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 1) and: [s at: 'ss_quantity']) <= 20)]) do: [:s |
-	res add: s at: 'ss_net_paid'.
+    res add: s at: 'ss_net_paid'.
 ]
 res := res asArray.
 res)))]).
 bucket2 := ((((Main __count: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 21) and: [s at: 'ss_quantity']) <= 40)]) do: [:s |
-	res add: s.
+    res add: s.
 ]
 res := res asArray.
 res))) > 20)) ifTrue: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 21) and: [s at: 'ss_quantity']) <= 40)]) do: [:s |
-	res add: s at: 'ss_ext_discount_amt'.
+    res add: s at: 'ss_ext_discount_amt'.
 ]
 res := res asArray.
 res)))] ifFalse: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 21) and: [s at: 'ss_quantity']) <= 40)]) do: [:s |
-	res add: s at: 'ss_net_paid'.
+    res add: s at: 'ss_net_paid'.
 ]
 res := res asArray.
 res)))]).
 bucket3 := ((((Main __count: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 41) and: [s at: 'ss_quantity']) <= 60)]) do: [:s |
-	res add: s.
+    res add: s.
 ]
 res := res asArray.
 res))) > 30)) ifTrue: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 41) and: [s at: 'ss_quantity']) <= 60)]) do: [:s |
-	res add: s at: 'ss_ext_discount_amt'.
+    res add: s at: 'ss_ext_discount_amt'.
 ]
 res := res asArray.
 res)))] ifFalse: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 41) and: [s at: 'ss_quantity']) <= 60)]) do: [:s |
-	res add: s at: 'ss_net_paid'.
+    res add: s at: 'ss_net_paid'.
 ]
 res := res asArray.
 res)))]).
 bucket4 := ((((Main __count: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 61) and: [s at: 'ss_quantity']) <= 80)]) do: [:s |
-	res add: s.
+    res add: s.
 ]
 res := res asArray.
 res))) > 40)) ifTrue: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 61) and: [s at: 'ss_quantity']) <= 80)]) do: [:s |
-	res add: s at: 'ss_ext_discount_amt'.
+    res add: s at: 'ss_ext_discount_amt'.
 ]
 res := res asArray.
 res)))] ifFalse: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 61) and: [s at: 'ss_quantity']) <= 80)]) do: [:s |
-	res add: s at: 'ss_net_paid'.
+    res add: s at: 'ss_net_paid'.
 ]
 res := res asArray.
 res)))]).
 bucket5 := ((((Main __count: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 81) and: [s at: 'ss_quantity']) <= 100)]) do: [:s |
-	res add: s.
+    res add: s.
 ]
 res := res asArray.
 res))) > 50)) ifTrue: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 81) and: [s at: 'ss_quantity']) <= 100)]) do: [:s |
-	res add: s at: 'ss_ext_discount_amt'.
+    res add: s at: 'ss_ext_discount_amt'.
 ]
 res := res asArray.
 res)))] ifFalse: [(Main __avg: ((| res |
 res := OrderedCollection new.
 ((store_sales) select: [:s | (((s at: 'ss_quantity' >= 81) and: [s at: 'ss_quantity']) <= 100)]) do: [:s |
-	res add: s at: 'ss_net_paid'.
+    res add: s at: 'ss_net_paid'.
 ]
 res := res asArray.
 res)))]).
 result := ((| res |
 res := OrderedCollection new.
 ((reason) select: [:r | (r at: 'r_reason_sk' = 1)]) do: [:r |
-	res add: Dictionary from: {'bucket1' -> bucket1. 'bucket2' -> bucket2. 'bucket3' -> bucket3. 'bucket4' -> bucket4. 'bucket5' -> bucket5}.
+    res add: Dictionary from: {'bucket1' -> bucket1. 'bucket2' -> bucket2. 'bucket3' -> bucket3. 'bucket4' -> bucket4. 'bucket5' -> bucket5}.
 ]
 res := res asArray.
 res)).

--- a/tools/update_tpcds_st/main.go
+++ b/tools/update_tpcds_st/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	stcode "mochi/compile/x/st"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("go.mod not found")
+}
+
+func main() {
+	root, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	queries := []string{}
+	for i := 1; i <= 19; i++ {
+		queries = append(queries, fmt.Sprintf("q%d", i))
+	}
+	dir := filepath.Join(root, "tests", "dataset", "tpc-ds")
+	outDir := filepath.Join(dir, "compiler", "st")
+	os.MkdirAll(outDir, 0755)
+	for _, q := range queries {
+		src := filepath.Join(dir, q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: parse error: %v\n", src, err)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "%s: type error: %v\n", src, errs[0])
+			continue
+		}
+		code, err := stcode.New(env).Compile(prog)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: compile error: %v\n", src, err)
+			continue
+		}
+		codePath := filepath.Join(outDir, q+".st.out")
+		if err := os.WriteFile(codePath, code, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: write code: %v\n", q, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expand TPC-DS Smalltalk golden tests to q1–q19
- regenerate Smalltalk code for all queries
- add helper `update_tpcds_st` to refresh golden files
- update Smalltalk backend tasks

## Testing
- `go test ./compile/x/st -tags slow -run TestSTCompiler_TPCDS_Golden -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686410e22540832086ee4eeb48aac25f