### PR TITLE
Add F# TPC‑DS queries q50–q99

### DIFF
--- a/compile/x/fs/tpcds_q1_test.go
+++ b/compile/x/fs/tpcds_q1_test.go
@@ -26,7 +26,7 @@ func TestFSCompiler_TPCDS(t *testing.T) {
 		t.Skipf("fantomas not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	for i := 1; i <= 49; i++ {
+	for i := 1; i <= 99; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")

--- a/tests/dataset/tpc-ds/compiler/fs/q50.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q50.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 50)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q50_placeholder() =
+    if not ((result = 50)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q50 placeholder" test_TPCDS_Q50_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q51.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q51.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 51)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q51_placeholder() =
+    if not ((result = 51)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q51 placeholder" test_TPCDS_Q51_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q52.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q52.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 52)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q52_placeholder() =
+    if not ((result = 52)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q52 placeholder" test_TPCDS_Q52_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q53.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q53.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 53)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q53_placeholder() =
+    if not ((result = 53)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q53 placeholder" test_TPCDS_Q53_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q54.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q54.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 54)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q54_placeholder() =
+    if not ((result = 54)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q54 placeholder" test_TPCDS_Q54_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q55.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q55.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 55)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q55_placeholder() =
+    if not ((result = 55)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q55 placeholder" test_TPCDS_Q55_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q56.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q56.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 56)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q56_placeholder() =
+    if not ((result = 56)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q56 placeholder" test_TPCDS_Q56_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q57.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q57.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 57)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q57_placeholder() =
+    if not ((result = 57)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q57 placeholder" test_TPCDS_Q57_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q58.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q58.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 58)]|]
+let tmp = lower ("ignore")
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q58_placeholder() =
+    if not ((result = 58)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q58 placeholder" test_TPCDS_Q58_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q59.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q59.fs.out
@@ -1,0 +1,53 @@
+open System
+
+let id = "id"
+let _val = "val"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let t = [|Map.ofList [(id, 1); (_val, 59)]|]
+let tmp = lower (59)
+let vals = 
+    [|
+    for r in t do
+        yield r._val
+    |]
+let result = first vals
+ignore (_json result)
+let test_TPCDS_Q59_placeholder() =
+    if not ((result = 59)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q59 placeholder" test_TPCDS_Q59_placeholder) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q60.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q60.fs.out
@@ -1,0 +1,66 @@
+open System
+
+let item = "item"
+let price = "price"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _union_all (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+
+let store_sales = [|Map.ofList [(item, 1); (price, 10)]; Map.ofList [(item, 1); (price, 20)]|]
+let catalog_sales = [|Map.ofList [(item, 1); (price, 15)]|]
+let web_sales = [|Map.ofList [(item, 1); (price, 15)]|]
+let all_sales = _union_all _union_all store_sales catalog_sales web_sales
+let result = sum 
+    [|
+    for s in all_sales do
+        yield s.price
+    |]
+ignore (_json result)
+let test_TPCDS_Q60_simplified() =
+    if not ((result = 60)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q60 simplified" test_TPCDS_Q60_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q61.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q61.fs.out
@@ -1,0 +1,68 @@
+open System
+
+let promo = "promo"
+let price = "price"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let sales = [|Map.ofList [(promo, true); (price, 20)]; Map.ofList [(promo, true); (price, 41)]; Map.ofList [(promo, false); (price, 39)]|]
+let promotions = sum 
+    [|
+    for s in sales do
+        if s.promo then
+            yield s.price
+    |]
+let total = sum 
+    [|
+    for s in sales do
+        yield s.price
+    |]
+let result = ((promotions * 100) / total)
+ignore (_json result)
+let test_TPCDS_Q61_simplified() =
+    if not ((result = 61)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q61 simplified" test_TPCDS_Q61_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q62.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q62.fs.out
@@ -1,0 +1,56 @@
+open System
+
+let days = "days"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let web_sales = [|Map.ofList [(days, 10)]; Map.ofList [(days, 40)]; Map.ofList [(days, 70)]; Map.ofList [(days, 100)]; Map.ofList [(days, 130)]|]
+let result = ((count web_sales * 12) + 2)
+ignore (_json result)
+let test_TPCDS_Q62_simplified() =
+    if not ((result = 62)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q62 simplified" test_TPCDS_Q62_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q63.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q63.fs.out
@@ -1,0 +1,85 @@
+open System
+
+let mgr = "mgr"
+let amount = "amount"
+let sum_sales = "sum_sales"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let sales = [|Map.ofList [(mgr, 1); (amount, 30)]; Map.ofList [(mgr, 2); (amount, 33)]|]
+let by_mgr = _group_by sales (fun s -> Map.ofList [(mgr, s.mgr)]) |> List.map (fun g -> Map.ofList [(mgr, g.key.mgr); (sum_sales, sum 
+    [|
+    for x in g do
+        yield x.amount
+    |])])
+let result = sum 
+    [|
+    for x in by_mgr do
+        yield x.sum_sales
+    |]
+ignore (_json result)
+let test_TPCDS_Q63_simplified() =
+    if not ((result = 63)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q63 simplified" test_TPCDS_Q63_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q64.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q64.fs.out
@@ -1,0 +1,51 @@
+open System
+
+let item = "item"
+let cost = "cost"
+let list = "list"
+let coupon = "coupon"
+let ticket = "ticket"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let store_sales = [|Map.ofList [(item, 1); (cost, 20); (list, 30); (coupon, 5)]|]
+let store_returns = [|Map.ofList [(item, 1); (ticket, 1)]|]
+let result = (((20 + 30) - 5) + 19)
+ignore (_json result)
+let test_TPCDS_Q64_simplified() =
+    if not ((result = 64)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q64 simplified" test_TPCDS_Q64_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q65.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q65.fs.out
@@ -1,0 +1,48 @@
+open System
+
+let store = "store"
+let item = "item"
+let price = "price"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let store_sales = [|Map.ofList [(store, 1); (item, 1); (price, 1)]; Map.ofList [(store, 1); (item, 1); (price, 1)]; Map.ofList [(store, 1); (item, 2); (price, 60)]|]
+let result = 65
+ignore (_json result)
+let test_TPCDS_Q65_simplified() =
+    if not ((result = 65)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q65 simplified" test_TPCDS_Q65_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q66.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q66.fs.out
@@ -1,0 +1,65 @@
+open System
+
+let net = "net"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let web_sales = [|Map.ofList [(net, 30)]|]
+let catalog_sales = [|Map.ofList [(net, 36)]|]
+let result = (sum 
+    [|
+    for w in web_sales do
+        yield w.net
+    |] + sum 
+    [|
+    for c in catalog_sales do
+        yield c.net
+    |])
+ignore (_json result)
+let test_TPCDS_Q66_simplified() =
+    if not ((result = 66)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q66 simplified" test_TPCDS_Q66_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q67.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q67.fs.out
@@ -1,0 +1,50 @@
+open System
+
+let reason = "reason"
+let price = "price"
+let id = "id"
+let name = "name"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let store_sales = [|Map.ofList [(reason, 1); (price, 40)]; Map.ofList [(reason, 2); (price, 27)]|]
+let reason = [|Map.ofList [(id, 1); (name, "PROMO")]; Map.ofList [(id, 2); (name, "RETURN")]|]
+let result = 67
+ignore (_json result)
+let test_TPCDS_Q67_simplified() =
+    if not ((result = 67)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q67 simplified" test_TPCDS_Q67_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q68.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q68.fs.out
@@ -1,0 +1,66 @@
+open System
+
+let item = "item"
+let profit = "profit"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let catalog_sales = [|Map.ofList [(item, 1); (profit, 30)]; Map.ofList [(item, 2); (profit, 38)]|]
+let store_sales = [|Map.ofList [(item, 1); (profit, 30)]|]
+let result = ((sum 
+    [|
+    for c in catalog_sales do
+        yield c.profit
+    |] - sum 
+    [|
+    for s in store_sales do
+        yield s.profit
+    |]) + 30)
+ignore (_json result)
+let test_TPCDS_Q68_simplified() =
+    if not ((result = 68)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q68 simplified" test_TPCDS_Q68_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q69.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q69.fs.out
@@ -1,0 +1,65 @@
+open System
+
+let amount = "amount"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let web_sales = [|Map.ofList [(amount, 34)]|]
+let store_sales = [|Map.ofList [(amount, 35)]|]
+let result = (sum 
+    [|
+    for w in web_sales do
+        yield w.amount
+    |] + sum 
+    [|
+    for s in store_sales do
+        yield s.amount
+    |])
+ignore (_json result)
+let test_TPCDS_Q69_simplified() =
+    if not ((result = 69)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q69 simplified" test_TPCDS_Q69_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q70.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q70.fs.out
@@ -1,0 +1,99 @@
+open System
+
+let s_store_sk = "s_store_sk"
+let s_state = "s_state"
+let s_county = "s_county"
+let d_date_sk = "d_date_sk"
+let d_month_seq = "d_month_seq"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_net_profit = "ss_net_profit"
+let total_sum = "total_sum"
+let state = "state"
+let county = "county"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store = [|Map.ofList [(s_store_sk, 1); (s_state, "CA"); (s_county, "Orange")]; Map.ofList [(s_store_sk, 2); (s_state, "CA"); (s_county, "Orange")]; Map.ofList [(s_store_sk, 3); (s_state, "TX"); (s_county, "Travis")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_month_seq, 1200)]; Map.ofList [(d_date_sk, 2); (d_month_seq, 1201)]|]
+let store_sales = [|Map.ofList [(ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_net_profit, 10.0)]; Map.ofList [(ss_sold_date_sk, 1); (ss_store_sk, 2); (ss_net_profit, 5.0)]; Map.ofList [(ss_sold_date_sk, 2); (ss_store_sk, 3); (ss_net_profit, 20.0)]|]
+let dms = 1200
+let result = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ss.ss_sold_date_sk) then
+                for s in store do
+                    if (s.s_store_sk = ss.ss_store_sk) then
+                        if ((d.d_month_seq >= dms) && (d.d_month_seq <= (dms + 11))) then
+                            yield (ss, d, s)
+|] (fun (ss, d, s) -> Map.ofList [(state, s.s_state); (county, s.s_county)]) do let g = g yield ([|g.key.state; g.key.county|], Map.ofList [(s_state, g.key.state); (s_county, g.key.county); (total_sum, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_net_profit
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q70_simplified() =
+    if not ((result = [|Map.ofList [(s_state, "CA"); (s_county, "Orange"); (total_sum, 15.0)]; Map.ofList [(s_state, "TX"); (s_county, "Travis"); (total_sum, 20.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q70 simplified" test_TPCDS_Q70_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q71.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q71.fs.out
@@ -1,0 +1,148 @@
+open System
+
+let i_item_sk = "i_item_sk"
+let i_brand_id = "i_brand_id"
+let i_brand = "i_brand"
+let i_manager_id = "i_manager_id"
+let t_time_sk = "t_time_sk"
+let t_hour = "t_hour"
+let t_minute = "t_minute"
+let t_meal_time = "t_meal_time"
+let d_date_sk = "d_date_sk"
+let d_moy = "d_moy"
+let d_year = "d_year"
+let ws_ext_sales_price = "ws_ext_sales_price"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_item_sk = "ws_item_sk"
+let ws_sold_time_sk = "ws_sold_time_sk"
+let cs_ext_sales_price = "cs_ext_sales_price"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_sold_time_sk = "cs_sold_time_sk"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_item_sk = "ss_item_sk"
+let ss_sold_time_sk = "ss_sold_time_sk"
+let ext_price = "ext_price"
+let item_sk = "item_sk"
+let time_sk = "time_sk"
+let brand_id = "brand_id"
+let brand = "brand"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let item = [|Map.ofList [(i_item_sk, 1); (i_brand_id, 10); (i_brand, "BrandA"); (i_manager_id, 1)]; Map.ofList [(i_item_sk, 2); (i_brand_id, 20); (i_brand, "BrandB"); (i_manager_id, 1)]|]
+let time_dim = [|Map.ofList [(t_time_sk, 1); (t_hour, 8); (t_minute, 30); (t_meal_time, "breakfast")]; Map.ofList [(t_time_sk, 2); (t_hour, 18); (t_minute, 0); (t_meal_time, "dinner")]; Map.ofList [(t_time_sk, 3); (t_hour, 12); (t_minute, 0); (t_meal_time, "lunch")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_moy, 12); (d_year, 1998)]|]
+let web_sales = [|Map.ofList [(ws_ext_sales_price, 100.0); (ws_sold_date_sk, 1); (ws_item_sk, 1); (ws_sold_time_sk, 1)]|]
+let catalog_sales = [|Map.ofList [(cs_ext_sales_price, 200.0); (cs_sold_date_sk, 1); (cs_item_sk, 1); (cs_sold_time_sk, 2)]|]
+let store_sales = [|Map.ofList [(ss_ext_sales_price, 150.0); (ss_sold_date_sk, 1); (ss_item_sk, 2); (ss_sold_time_sk, 1)]|]
+let month = 12
+let year = 1998
+let union_sales = _concat _concat 
+    [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ws.ws_sold_date_sk) then
+                if ((d.d_moy = month) && (d.d_year = year)) then
+                    yield Map.ofList [(ext_price, ws.ws_ext_sales_price); (item_sk, ws.ws_item_sk); (time_sk, ws.ws_sold_time_sk)]
+    |] 
+    [|
+    for cs in catalog_sales do
+        for d in date_dim do
+            if (d.d_date_sk = cs.cs_sold_date_sk) then
+                if ((d.d_moy = month) && (d.d_year = year)) then
+                    yield Map.ofList [(ext_price, cs.cs_ext_sales_price); (item_sk, cs.cs_item_sk); (time_sk, cs.cs_sold_time_sk)]
+    |] 
+    [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ss.ss_sold_date_sk) then
+                if ((d.d_moy = month) && (d.d_year = year)) then
+                    yield Map.ofList [(ext_price, ss.ss_ext_sales_price); (item_sk, ss.ss_item_sk); (time_sk, ss.ss_sold_time_sk)]
+    |]
+let result = [| for g in _group_by [|
+    for i in item do
+        for s in union_sales do
+            if (s.item_sk = i.i_item_sk) then
+                for t in time_dim do
+                    if (t.t_time_sk = s.time_sk) then
+                        if ((i.i_manager_id = 1) && (((t.t_meal_time = "breakfast") || (t.t_meal_time = "dinner")))) then
+                            yield (i, s, t)
+|] (fun (i, s, t) -> Map.ofList [(brand_id, i.i_brand_id); (brand, i.i_brand); (t_hour, t.t_hour); (t_minute, t.t_minute)]) do let g = g yield ([|(-sum 
+    [|
+    for x in g do
+        yield x.s.ext_price
+    |]); g.key.brand_id|], Map.ofList [(i_brand_id, g.key.brand_id); (i_brand, g.key.brand); (t_hour, g.key.t_hour); (t_minute, g.key.t_minute); (ext_price, sum 
+    [|
+    for x in g do
+        yield x.s.ext_price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q71_simplified() =
+    if not ((result = [|Map.ofList [(i_brand_id, 10); (i_brand, "BrandA"); (t_hour, 18); (t_minute, 0); (ext_price, 200.0)]; Map.ofList [(i_brand_id, 20); (i_brand, "BrandB"); (t_hour, 8); (t_minute, 30); (ext_price, 150.0)]; Map.ofList [(i_brand_id, 10); (i_brand, "BrandA"); (t_hour, 8); (t_minute, 30); (ext_price, 100.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q71 simplified" test_TPCDS_Q71_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q72.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q72.fs.out
@@ -1,0 +1,139 @@
+open System
+
+let cs_item_sk = "cs_item_sk"
+let cs_order_number = "cs_order_number"
+let cs_quantity = "cs_quantity"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_ship_date_sk = "cs_ship_date_sk"
+let cs_bill_cdemo_sk = "cs_bill_cdemo_sk"
+let cs_bill_hdemo_sk = "cs_bill_hdemo_sk"
+let cs_promo_sk = "cs_promo_sk"
+let inv_item_sk = "inv_item_sk"
+let inv_warehouse_sk = "inv_warehouse_sk"
+let inv_date_sk = "inv_date_sk"
+let inv_quantity_on_hand = "inv_quantity_on_hand"
+let w_warehouse_sk = "w_warehouse_sk"
+let w_warehouse_name = "w_warehouse_name"
+let i_item_sk = "i_item_sk"
+let i_item_desc = "i_item_desc"
+let cd_demo_sk = "cd_demo_sk"
+let cd_marital_status = "cd_marital_status"
+let hd_demo_sk = "hd_demo_sk"
+let hd_buy_potential = "hd_buy_potential"
+let d_date_sk = "d_date_sk"
+let d_week_seq = "d_week_seq"
+let d_date = "d_date"
+let d_year = "d_year"
+let no_promo = "no_promo"
+let promo = "promo"
+let total_cnt = "total_cnt"
+let item_desc = "item_desc"
+let warehouse = "warehouse"
+let week_seq = "week_seq"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let catalog_sales = [|Map.ofList [(cs_item_sk, 1); (cs_order_number, 1); (cs_quantity, 1); (cs_sold_date_sk, 1); (cs_ship_date_sk, 3); (cs_bill_cdemo_sk, 1); (cs_bill_hdemo_sk, 1); (cs_promo_sk, null)]|]
+let inventory = [|Map.ofList [(inv_item_sk, 1); (inv_warehouse_sk, 1); (inv_date_sk, 2); (inv_quantity_on_hand, 0)]|]
+let warehouse = [|Map.ofList [(w_warehouse_sk, 1); (w_warehouse_name, "Main")]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_desc, "ItemA")]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1); (cd_marital_status, "M")]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_buy_potential, "5001-10000")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_week_seq, 10); (d_date, 1); (d_year, 2000)]; Map.ofList [(d_date_sk, 2); (d_week_seq, 10); (d_date, 1); (d_year, 2000)]; Map.ofList [(d_date_sk, 3); (d_week_seq, 10); (d_date, 7); (d_year, 2000)]|]
+let result = [| for g in _group_by [|
+    for cs in catalog_sales do
+        for inv in inventory do
+            if (inv.inv_item_sk = cs.cs_item_sk) then
+                for w in warehouse do
+                    if (w.w_warehouse_sk = inv.inv_warehouse_sk) then
+                        for i in item do
+                            if (i.i_item_sk = cs.cs_item_sk) then
+                                for cd in customer_demographics do
+                                    if (cd.cd_demo_sk = cs.cs_bill_cdemo_sk) then
+                                        for hd in household_demographics do
+                                            if (hd.hd_demo_sk = cs.cs_bill_hdemo_sk) then
+                                                for d1 in date_dim do
+                                                    if (d1.d_date_sk = cs.cs_sold_date_sk) then
+                                                        for d2 in date_dim do
+                                                            if (d2.d_date_sk = inv.inv_date_sk) then
+                                                                for d3 in date_dim do
+                                                                    if (d3.d_date_sk = cs.cs_ship_date_sk) then
+                                                                        if ((((((d1.d_week_seq = d2.d_week_seq) && (inv.inv_quantity_on_hand < cs.cs_quantity)) && (d3.d_date > (d1.d_date + 5))) && (hd.hd_buy_potential = "5001-10000")) && (d1.d_year = 2000)) && (cd.cd_marital_status = "M")) then
+                                                                            yield (cs, inv, w, i, cd, hd, d1, d2, d3)
+|] (fun (cs, inv, w, i, cd, hd, d1, d2, d3) -> Map.ofList [(item_desc, i.i_item_desc); (warehouse, w.w_warehouse_name); (week_seq, d1.d_week_seq)]) do let g = g yield Map.ofList [(i_item_desc, g.key.item_desc); (w_warehouse_name, g.key.warehouse); (d_week_seq, g.key.week_seq); (no_promo, count 
+    [|
+    for x in g do
+        if (x.cs_promo_sk = null) then
+            yield x
+    |]); (promo, count 
+    [|
+    for x in g do
+        if (x.cs_promo_sk <> null) then
+            yield x
+    |]); (total_cnt, count g)] |]
+ignore (_json result)
+let test_TPCDS_Q72_simplified() =
+    if not ((result = [|Map.ofList [(i_item_desc, "ItemA"); (w_warehouse_name, "Main"); (d_week_seq, 10); (no_promo, 1); (promo, 0); (total_cnt, 1)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q72 simplified" test_TPCDS_Q72_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q73.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q73.fs.out
@@ -1,0 +1,120 @@
+open System
+
+let ss_ticket_number = "ss_ticket_number"
+let ss_customer_sk = "ss_customer_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_hdemo_sk = "ss_hdemo_sk"
+let d_date_sk = "d_date_sk"
+let d_dom = "d_dom"
+let d_year = "d_year"
+let s_store_sk = "s_store_sk"
+let s_county = "s_county"
+let hd_demo_sk = "hd_demo_sk"
+let hd_buy_potential = "hd_buy_potential"
+let hd_vehicle_count = "hd_vehicle_count"
+let hd_dep_count = "hd_dep_count"
+let c_customer_sk = "c_customer_sk"
+let c_last_name = "c_last_name"
+let c_first_name = "c_first_name"
+let c_salutation = "c_salutation"
+let c_preferred_cust_flag = "c_preferred_cust_flag"
+let key = "key"
+let cnt = "cnt"
+let ticket = "ticket"
+let cust = "cust"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(ss_ticket_number, 1); (ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_hdemo_sk, 1)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_dom, 1); (d_year, 1998)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_county, "A")]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_buy_potential, "1001-5000"); (hd_vehicle_count, 2); (hd_dep_count, 3)]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_last_name, "Smith"); (c_first_name, "Alice"); (c_salutation, "Ms."); (c_preferred_cust_flag, "Y")]|]
+let groups = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ss.ss_sold_date_sk) then
+                for s in store do
+                    if (s.s_store_sk = ss.ss_store_sk) then
+                        for hd in household_demographics do
+                            if (hd.hd_demo_sk = ss.ss_hdemo_sk) then
+                                if (((((((d.d_dom >= 1) && (d.d_dom <= 2)) && (((hd.hd_buy_potential = "1001-5000") || (hd.hd_buy_potential = "0-500")))) && (hd.hd_vehicle_count > 0)) && ((hd.hd_dep_count / hd.hd_vehicle_count) > 1)) && ((((d.d_year = 1998) || (d.d_year = 1999)) || (d.d_year = 2000)))) && (s.s_county = "A")) then
+                                    yield (ss, d, s, hd)
+|] (fun (ss, d, s, hd) -> Map.ofList [(ticket, ss.ss_ticket_number); (cust, ss.ss_customer_sk)]) do let g = g yield Map.ofList [(key, g.key); (cnt, count g)] |]
+let result = 
+    [|
+    for g in groups do
+        for c in customer do
+            if (c.c_customer_sk = g.key.cust) then
+                if ((g.cnt >= 1) && (g.cnt <= 5)) then
+                    yield ([|(-g.cnt); c.c_last_name|], Map.ofList [(c_last_name, c.c_last_name); (c_first_name, c.c_first_name); (c_salutation, c.c_salutation); (c_preferred_cust_flag, c.c_preferred_cust_flag); (ss_ticket_number, g.key.ticket); (cnt, g.cnt)])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q73_simplified() =
+    if not ((result = [|Map.ofList [(c_last_name, "Smith"); (c_first_name, "Alice"); (c_salutation, "Ms."); (c_preferred_cust_flag, "Y"); (ss_ticket_number, 1); (cnt, 1)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q73 simplified" test_TPCDS_Q73_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q74.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q74.fs.out
@@ -1,0 +1,148 @@
+open System
+
+let c_customer_sk = "c_customer_sk"
+let c_customer_id = "c_customer_id"
+let c_first_name = "c_first_name"
+let c_last_name = "c_last_name"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let ss_customer_sk = "ss_customer_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_net_paid = "ss_net_paid"
+let ws_bill_customer_sk = "ws_bill_customer_sk"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_net_paid = "ws_net_paid"
+let customer_id = "customer_id"
+let customer_first_name = "customer_first_name"
+let customer_last_name = "customer_last_name"
+let year = "year"
+let year_total = "year_total"
+let sale_type = "sale_type"
+let id = "id"
+let first = "first"
+let last = "last"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_customer_id, 1); (c_first_name, "Alice"); (c_last_name, "Smith")]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 1998)]; Map.ofList [(d_date_sk, 2); (d_year, 1999)]|]
+let store_sales = [|Map.ofList [(ss_customer_sk, 1); (ss_sold_date_sk, 1); (ss_net_paid, 100.0)]; Map.ofList [(ss_customer_sk, 1); (ss_sold_date_sk, 2); (ss_net_paid, 110.0)]|]
+let web_sales = [|Map.ofList [(ws_bill_customer_sk, 1); (ws_sold_date_sk, 1); (ws_net_paid, 40.0)]; Map.ofList [(ws_bill_customer_sk, 1); (ws_sold_date_sk, 2); (ws_net_paid, 80.0)]|]
+let year_total = _concat [| for g in _group_by [|
+    for c in customer do
+        for ss in store_sales do
+            if (c.c_customer_sk = ss.ss_customer_sk) then
+                for d in date_dim do
+                    if (d.d_date_sk = ss.ss_sold_date_sk) then
+                        if ((d.d_year = 1998) || (d.d_year = 1999)) then
+                            yield (c, ss, d)
+|] (fun (c, ss, d) -> Map.ofList [(id, c.c_customer_id); (first, c.c_first_name); (last, c.c_last_name); (year, d.d_year)]) do let g = g yield Map.ofList [(customer_id, g.key.id); (customer_first_name, g.key.first); (customer_last_name, g.key.last); (year, g.key.year); (year_total, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_net_paid
+    |]); (sale_type, "s")] |] [| for g in _group_by [|
+    for c in customer do
+        for ws in web_sales do
+            if (c.c_customer_sk = ws.ws_bill_customer_sk) then
+                for d in date_dim do
+                    if (d.d_date_sk = ws.ws_sold_date_sk) then
+                        if ((d.d_year = 1998) || (d.d_year = 1999)) then
+                            yield (c, ws, d)
+|] (fun (c, ws, d) -> Map.ofList [(id, c.c_customer_id); (first, c.c_first_name); (last, c.c_last_name); (year, d.d_year)]) do let g = g yield Map.ofList [(customer_id, g.key.id); (customer_first_name, g.key.first); (customer_last_name, g.key.last); (year, g.key.year); (year_total, sum 
+    [|
+    for x in g do
+        yield x.ws.ws_net_paid
+    |]); (sale_type, "w")] |]
+let s_firstyear = first (
+    [|
+    for y in year_total do
+        if ((y.sale_type = "s") && (y.year = 1998)) then
+            yield y
+    |])
+let s_secyear = first (
+    [|
+    for y in year_total do
+        if ((y.sale_type = "s") && (y.year = 1999)) then
+            yield y
+    |])
+let w_firstyear = first (
+    [|
+    for y in year_total do
+        if ((y.sale_type = "w") && (y.year = 1998)) then
+            yield y
+    |])
+let w_secyear = first (
+    [|
+    for y in year_total do
+        if ((y.sale_type = "w") && (y.year = 1999)) then
+            yield y
+    |])
+let result = (if (((s_firstyear.year_total > 0) && (w_firstyear.year_total > 0)) && (((w_secyear.year_total / w_firstyear.year_total)) > ((s_secyear.year_total / s_firstyear.year_total)))) then [|Map.ofList [(customer_id, s_secyear.customer_id); (customer_first_name, s_secyear.customer_first_name); (customer_last_name, s_secyear.customer_last_name)]|] else [||])
+ignore (_json result)
+let test_TPCDS_Q74_simplified() =
+    if not ((result = [|Map.ofList [(customer_id, 1); (customer_first_name, "Alice"); (customer_last_name, "Smith")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q74 simplified" test_TPCDS_Q74_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q75.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q75.fs.out
@@ -1,0 +1,159 @@
+open System
+
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let ss_item_sk = "ss_item_sk"
+let ss_quantity = "ss_quantity"
+let ss_sales_price = "ss_sales_price"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ws_item_sk = "ws_item_sk"
+let ws_quantity = "ws_quantity"
+let ws_sales_price = "ws_sales_price"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_quantity = "cs_quantity"
+let cs_sales_price = "cs_sales_price"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let i_item_sk = "i_item_sk"
+let i_brand_id = "i_brand_id"
+let i_class_id = "i_class_id"
+let i_category_id = "i_category_id"
+let i_manufact_id = "i_manufact_id"
+let i_category = "i_category"
+let quantity = "quantity"
+let amount = "amount"
+let sales_cnt = "sales_cnt"
+let sales_amt = "sales_amt"
+let year = "year"
+let brand_id = "brand_id"
+let class_id = "class_id"
+let category_id = "category_id"
+let manuf_id = "manuf_id"
+let prev_year = "prev_year"
+let prev_yr_cnt = "prev_yr_cnt"
+let curr_yr_cnt = "curr_yr_cnt"
+let sales_cnt_diff = "sales_cnt_diff"
+let sales_amt_diff = "sales_amt_diff"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2000)]; Map.ofList [(d_date_sk, 2); (d_year, 2001)]|]
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_quantity, 50); (ss_sales_price, 500.0); (ss_sold_date_sk, 1)]; Map.ofList [(ss_item_sk, 1); (ss_quantity, 40); (ss_sales_price, 400.0); (ss_sold_date_sk, 2)]|]
+let web_sales = [|Map.ofList [(ws_item_sk, 1); (ws_quantity, 30); (ws_sales_price, 300.0); (ws_sold_date_sk, 1)]; Map.ofList [(ws_item_sk, 1); (ws_quantity, 25); (ws_sales_price, 250.0); (ws_sold_date_sk, 2)]|]
+let catalog_sales = [|Map.ofList [(cs_item_sk, 1); (cs_quantity, 20); (cs_sales_price, 200.0); (cs_sold_date_sk, 1)]; Map.ofList [(cs_item_sk, 1); (cs_quantity, 15); (cs_sales_price, 150.0); (cs_sold_date_sk, 2)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_brand_id, 1); (i_class_id, 2); (i_category_id, 3); (i_manufact_id, 4); (i_category, "Electronics")]|]
+let sales_detail = _concat _concat 
+    [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ss.ss_sold_date_sk) then
+                yield Map.ofList [(d_year, d.d_year); (i_item_sk, ss.ss_item_sk); (quantity, ss.ss_quantity); (amount, ss.ss_sales_price)]
+    |] 
+    [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ws.ws_sold_date_sk) then
+                yield Map.ofList [(d_year, d.d_year); (i_item_sk, ws.ws_item_sk); (quantity, ws.ws_quantity); (amount, ws.ws_sales_price)]
+    |] 
+    [|
+    for cs in catalog_sales do
+        for d in date_dim do
+            if (d.d_date_sk = cs.cs_sold_date_sk) then
+                yield Map.ofList [(d_year, d.d_year); (i_item_sk, cs.cs_item_sk); (quantity, cs.cs_quantity); (amount, cs.cs_sales_price)]
+    |]
+let all_sales = [| for g in _group_by [|
+    for sd in sales_detail do
+        for i in item do
+            if (i.i_item_sk = sd.i_item_sk) then
+                if (i.i_category = "Electronics") then
+                    yield (sd, i)
+|] (fun (sd, i) -> Map.ofList [(year, sd.d_year); (brand_id, i.i_brand_id); (class_id, i.i_class_id); (category_id, i.i_category_id); (manuf_id, i.i_manufact_id)]) do let g = g yield Map.ofList [(d_year, g.key.year); (i_brand_id, g.key.brand_id); (i_class_id, g.key.class_id); (i_category_id, g.key.category_id); (i_manufact_id, g.key.manuf_id); (sales_cnt, sum 
+    [|
+    for x in g do
+        yield x.sd.quantity
+    |]); (sales_amt, sum 
+    [|
+    for x in g do
+        yield x.sd.amount
+    |])] |]
+let prev_yr = first (
+    [|
+    for a in all_sales do
+        if (a.d_year = 2000) then
+            yield a
+    |])
+let curr_yr = first (
+    [|
+    for a in all_sales do
+        if (a.d_year = 2001) then
+            yield a
+    |])
+let result = (if (((curr_yr.sales_cnt / prev_yr.sales_cnt)) < 0.9) then [|Map.ofList [(prev_year, prev_yr.d_year); (year, curr_yr.d_year); (i_brand_id, curr_yr.i_brand_id); (i_class_id, curr_yr.i_class_id); (i_category_id, curr_yr.i_category_id); (i_manufact_id, curr_yr.i_manufact_id); (prev_yr_cnt, prev_yr.sales_cnt); (curr_yr_cnt, curr_yr.sales_cnt); (sales_cnt_diff, (curr_yr.sales_cnt - prev_yr.sales_cnt)); (sales_amt_diff, (curr_yr.sales_amt - prev_yr.sales_amt))]|] else [||])
+ignore (_json result)
+let test_TPCDS_Q75_simplified() =
+    if not ((result = [|Map.ofList [(prev_year, 2000); (year, 2001); (i_brand_id, 1); (i_class_id, 2); (i_category_id, 3); (i_manufact_id, 4); (prev_yr_cnt, 100); (curr_yr_cnt, 80); (sales_cnt_diff, (-20)); (sales_amt_diff, (-200.0))]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q75 simplified" test_TPCDS_Q75_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q76.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q76.fs.out
@@ -1,0 +1,139 @@
+open System
+
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_qoy = "d_qoy"
+let i_item_sk = "i_item_sk"
+let i_category = "i_category"
+let ss_customer_sk = "ss_customer_sk"
+let ss_item_sk = "ss_item_sk"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ws_bill_customer_sk = "ws_bill_customer_sk"
+let ws_item_sk = "ws_item_sk"
+let ws_ext_sales_price = "ws_ext_sales_price"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_item_sk = "cs_item_sk"
+let cs_ext_sales_price = "cs_ext_sales_price"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let channel = "channel"
+let col_name = "col_name"
+let ext_sales_price = "ext_sales_price"
+let sales_cnt = "sales_cnt"
+let sales_amt = "sales_amt"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 1998); (d_qoy, 1)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_category, "CatA")]; Map.ofList [(i_item_sk, 2); (i_category, "CatB")]; Map.ofList [(i_item_sk, 3); (i_category, "CatC")]|]
+let store_sales = [|Map.ofList [(ss_customer_sk, null); (ss_item_sk, 1); (ss_ext_sales_price, 10.0); (ss_sold_date_sk, 1)]|]
+let web_sales = [|Map.ofList [(ws_bill_customer_sk, null); (ws_item_sk, 2); (ws_ext_sales_price, 15.0); (ws_sold_date_sk, 1)]|]
+let catalog_sales = [|Map.ofList [(cs_bill_customer_sk, null); (cs_item_sk, 3); (cs_ext_sales_price, 20.0); (cs_sold_date_sk, 1)]|]
+let store_part = 
+    [|
+    for ss in store_sales do
+        for i in item do
+            if (i.i_item_sk = ss.ss_item_sk) then
+                for d in date_dim do
+                    if (d.d_date_sk = ss.ss_sold_date_sk) then
+                        if (ss.ss_customer_sk = null) then
+                            yield Map.ofList [(channel, "store"); (col_name, ss.ss_customer_sk); (d_year, d.d_year); (d_qoy, d.d_qoy); (i_category, i.i_category); (ext_sales_price, ss.ss_ext_sales_price)]
+    |]
+let web_part = 
+    [|
+    for ws in web_sales do
+        for i in item do
+            if (i.i_item_sk = ws.ws_item_sk) then
+                for d in date_dim do
+                    if (d.d_date_sk = ws.ws_sold_date_sk) then
+                        if (ws.ws_bill_customer_sk = null) then
+                            yield Map.ofList [(channel, "web"); (col_name, ws.ws_bill_customer_sk); (d_year, d.d_year); (d_qoy, d.d_qoy); (i_category, i.i_category); (ext_sales_price, ws.ws_ext_sales_price)]
+    |]
+let catalog_part = 
+    [|
+    for cs in catalog_sales do
+        for i in item do
+            if (i.i_item_sk = cs.cs_item_sk) then
+                for d in date_dim do
+                    if (d.d_date_sk = cs.cs_sold_date_sk) then
+                        if (cs.cs_bill_customer_sk = null) then
+                            yield Map.ofList [(channel, "catalog"); (col_name, cs.cs_bill_customer_sk); (d_year, d.d_year); (d_qoy, d.d_qoy); (i_category, i.i_category); (ext_sales_price, cs.cs_ext_sales_price)]
+    |]
+let all_rows = _concat _concat store_part web_part catalog_part
+let result = [| for g in _group_by [|
+    for r in all_rows do
+        yield r
+|] (fun r -> Map.ofList [(channel, r.channel); (col_name, r.col_name); (d_year, r.d_year); (d_qoy, r.d_qoy); (i_category, r.i_category)]) do let g = g yield (g.key.channel, Map.ofList [(channel, g.key.channel); (col_name, g.key.col_name); (d_year, g.key.d_year); (d_qoy, g.key.d_qoy); (i_category, g.key.i_category); (sales_cnt, count g); (sales_amt, sum 
+    [|
+    for x in g do
+        yield x.r.ext_sales_price
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q76_simplified() =
+    if not ((result = [|Map.ofList [(channel, "store"); (col_name, null); (d_year, 1998); (d_qoy, 1); (i_category, "CatA"); (sales_cnt, 1); (sales_amt, 10.0)]; Map.ofList [(channel, "web"); (col_name, null); (d_year, 1998); (d_qoy, 1); (i_category, "CatB"); (sales_cnt, 1); (sales_amt, 15.0)]; Map.ofList [(channel, "catalog"); (col_name, null); (d_year, 1998); (d_qoy, 1); (i_category, "CatC"); (sales_cnt, 1); (sales_amt, 20.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q76 simplified" test_TPCDS_Q76_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q77.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q77.fs.out
@@ -1,0 +1,231 @@
+open System
+
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let s_store_sk = "s_store_sk"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let ss_net_profit = "ss_net_profit"
+let sr_returned_date_sk = "sr_returned_date_sk"
+let sr_return_amt = "sr_return_amt"
+let sr_net_loss = "sr_net_loss"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_call_center_sk = "cs_call_center_sk"
+let cs_ext_sales_price = "cs_ext_sales_price"
+let cs_net_profit = "cs_net_profit"
+let cr_returned_date_sk = "cr_returned_date_sk"
+let cr_call_center_sk = "cr_call_center_sk"
+let cr_return_amount = "cr_return_amount"
+let cr_net_loss = "cr_net_loss"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_web_page_sk = "ws_web_page_sk"
+let ws_ext_sales_price = "ws_ext_sales_price"
+let ws_net_profit = "ws_net_profit"
+let wr_returned_date_sk = "wr_returned_date_sk"
+let wr_web_page_sk = "wr_web_page_sk"
+let wr_return_amt = "wr_return_amt"
+let wr_net_loss = "wr_net_loss"
+let sales = "sales"
+let profit = "profit"
+let returns = "returns"
+let profit_loss = "profit_loss"
+let wp_web_page_sk = "wp_web_page_sk"
+let channel = "channel"
+let id = "id"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+  Array.append a b
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, 1)]|]
+let store_sales = [|Map.ofList [(ss_sold_date_sk, 1); (s_store_sk, 1); (ss_ext_sales_price, 100.0); (ss_net_profit, 10.0)]|]
+let store_returns = [|Map.ofList [(sr_returned_date_sk, 1); (s_store_sk, 1); (sr_return_amt, 5.0); (sr_net_loss, 1.0)]|]
+let catalog_sales = [|Map.ofList [(cs_sold_date_sk, 1); (cs_call_center_sk, 1); (cs_ext_sales_price, 150.0); (cs_net_profit, 15.0)]|]
+let catalog_returns = [|Map.ofList [(cr_returned_date_sk, 1); (cr_call_center_sk, 1); (cr_return_amount, 7.0); (cr_net_loss, 3.0)]|]
+let web_sales = [|Map.ofList [(ws_sold_date_sk, 1); (ws_web_page_sk, 1); (ws_ext_sales_price, 200.0); (ws_net_profit, 20.0)]|]
+let web_returns = [|Map.ofList [(wr_returned_date_sk, 1); (wr_web_page_sk, 1); (wr_return_amt, 10.0); (wr_net_loss, 2.0)]|]
+let ss = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ss.ss_sold_date_sk) then
+                yield (ss, d)
+|] (fun (ss, d) -> ss.s_store_sk) do let g = g yield Map.ofList [(s_store_sk, g.key); (sales, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_ext_sales_price
+    |]); (profit, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_net_profit
+    |])] |]
+let sr = [| for g in _group_by [|
+    for sr in store_returns do
+        for d in date_dim do
+            if (d.d_date_sk = sr.sr_returned_date_sk) then
+                yield (sr, d)
+|] (fun (sr, d) -> sr.s_store_sk) do let g = g yield Map.ofList [(s_store_sk, g.key); (returns, sum 
+    [|
+    for x in g do
+        yield x.sr.sr_return_amt
+    |]); (profit_loss, sum 
+    [|
+    for x in g do
+        yield x.sr.sr_net_loss
+    |])] |]
+let cs = [| for g in _group_by [|
+    for cs in catalog_sales do
+        for d in date_dim do
+            if (d.d_date_sk = cs.cs_sold_date_sk) then
+                yield (cs, d)
+|] (fun (cs, d) -> cs.cs_call_center_sk) do let g = g yield Map.ofList [(cs_call_center_sk, g.key); (sales, sum 
+    [|
+    for x in g do
+        yield x.cs.cs_ext_sales_price
+    |]); (profit, sum 
+    [|
+    for x in g do
+        yield x.cs.cs_net_profit
+    |])] |]
+let cr = [| for g in _group_by [|
+    for cr in catalog_returns do
+        for d in date_dim do
+            if (d.d_date_sk = cr.cr_returned_date_sk) then
+                yield (cr, d)
+|] (fun (cr, d) -> cr.cr_call_center_sk) do let g = g yield Map.ofList [(cr_call_center_sk, g.key); (returns, sum 
+    [|
+    for x in g do
+        yield x.cr.cr_return_amount
+    |]); (profit_loss, sum 
+    [|
+    for x in g do
+        yield x.cr.cr_net_loss
+    |])] |]
+let ws = [| for g in _group_by [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ws.ws_sold_date_sk) then
+                yield (ws, d)
+|] (fun (ws, d) -> ws.ws_web_page_sk) do let g = g yield Map.ofList [(wp_web_page_sk, g.key); (sales, sum 
+    [|
+    for x in g do
+        yield x.ws.ws_ext_sales_price
+    |]); (profit, sum 
+    [|
+    for x in g do
+        yield x.ws.ws_net_profit
+    |])] |]
+let wr = [| for g in _group_by [|
+    for wr in web_returns do
+        for d in date_dim do
+            if (d.d_date_sk = wr.wr_returned_date_sk) then
+                yield (wr, d)
+|] (fun (wr, d) -> wr.wr_web_page_sk) do let g = g yield Map.ofList [(wp_web_page_sk, g.key); (returns, sum 
+    [|
+    for x in g do
+        yield x.wr.wr_return_amt
+    |]); (profit_loss, sum 
+    [|
+    for x in g do
+        yield x.wr.wr_net_loss
+    |])] |]
+let per_channel = _concat _concat 
+    [|
+    for s in ss do
+        for r in sr do
+            if (s.s_store_sk = r.s_store_sk) then
+                yield Map.ofList [(channel, "store channel"); (id, s.s_store_sk); (sales, s.sales); (returns, (if (r = null) then 0.0 else r.returns)); (profit, (s.profit - ((if (r = null) then 0.0 else r.profit_loss))))]
+    |] 
+    [|
+    for c in cs do
+        for r in cr do
+            if (c.cs_call_center_sk = r.cr_call_center_sk) then
+                yield Map.ofList [(channel, "catalog channel"); (id, c.cs_call_center_sk); (sales, c.sales); (returns, r.returns); (profit, (c.profit - r.profit_loss))]
+    |] 
+    [|
+    for w in ws do
+        for r in wr do
+            if (w.wp_web_page_sk = r.wp_web_page_sk) then
+                yield Map.ofList [(channel, "web channel"); (id, w.wp_web_page_sk); (sales, w.sales); (returns, (if (r = null) then 0.0 else r.returns)); (profit, (w.profit - ((if (r = null) then 0.0 else r.profit_loss))))]
+    |]
+let result = [| for g in _group_by [|
+    for p in per_channel do
+        yield p
+|] (fun p -> Map.ofList [(channel, p.channel); (id, p.id)]) do let g = g yield (g.key.channel, Map.ofList [(channel, g.key.channel); (id, g.key.id); (sales, sum 
+    [|
+    for x in g do
+        yield x.p.sales
+    |]); (returns, sum 
+    [|
+    for x in g do
+        yield x.p.returns
+    |]); (profit, sum 
+    [|
+    for x in g do
+        yield x.p.profit
+    |])]) |] |> Array.sortBy fst |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q77_simplified() =
+    if not ((result = [|Map.ofList [(channel, "catalog channel"); (id, 1); (sales, 150.0); (returns, 7.0); (profit, 12.0)]; Map.ofList [(channel, "store channel"); (id, 1); (sales, 100.0); (returns, 5.0); (profit, 9.0)]; Map.ofList [(channel, "web channel"); (id, 1); (sales, 200.0); (returns, 10.0); (profit, 18.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q77 simplified" test_TPCDS_Q77_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q78.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q78.fs.out
@@ -1,0 +1,81 @@
+open System
+
+let ss_sold_year = "ss_sold_year"
+let ss_item_sk = "ss_item_sk"
+let ss_customer_sk = "ss_customer_sk"
+let ss_qty = "ss_qty"
+let ss_wc = "ss_wc"
+let ss_sp = "ss_sp"
+let ws_sold_year = "ws_sold_year"
+let ws_item_sk = "ws_item_sk"
+let ws_customer_sk = "ws_customer_sk"
+let ws_qty = "ws_qty"
+let ws_wc = "ws_wc"
+let ws_sp = "ws_sp"
+let cs_sold_year = "cs_sold_year"
+let cs_item_sk = "cs_item_sk"
+let cs_customer_sk = "cs_customer_sk"
+let cs_qty = "cs_qty"
+let cs_wc = "cs_wc"
+let cs_sp = "cs_sp"
+let ratio = "ratio"
+let store_qty = "store_qty"
+let store_wholesale_cost = "store_wholesale_cost"
+let store_sales_price = "store_sales_price"
+let other_chan_qty = "other_chan_qty"
+let other_chan_wholesale_cost = "other_chan_wholesale_cost"
+let other_chan_sales_price = "other_chan_sales_price"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let ss = [|Map.ofList [(ss_sold_year, 1998); (ss_item_sk, 1); (ss_customer_sk, 1); (ss_qty, 10); (ss_wc, 50.0); (ss_sp, 100.0)]|]
+let ws = [|Map.ofList [(ws_sold_year, 1998); (ws_item_sk, 1); (ws_customer_sk, 1); (ws_qty, 5); (ws_wc, 25.0); (ws_sp, 50.0)]|]
+let cs = [|Map.ofList [(cs_sold_year, 1998); (cs_item_sk, 1); (cs_customer_sk, 1); (cs_qty, 3); (cs_wc, 15.0); (cs_sp, 30.0)]|]
+let result = 
+    [|
+    for s in ss do
+        for w in ws do
+            if (((w.ws_sold_year = s.ss_sold_year) && (w.ws_item_sk = s.ss_item_sk)) && (w.ws_customer_sk = s.ss_customer_sk)) then
+                for c in cs do
+                    if (((c.cs_sold_year = s.ss_sold_year) && (c.cs_item_sk = s.ss_item_sk)) && (c.cs_customer_sk = s.ss_customer_sk)) then
+                        if ((((((if (w = null) then 0 else w.ws_qty)) > 0) || (((if (c = null) then 0 else c.cs_qty)) > 0))) && (s.ss_sold_year = 1998)) then
+                            yield Map.ofList [(ss_sold_year, s.ss_sold_year); (ss_item_sk, s.ss_item_sk); (ss_customer_sk, s.ss_customer_sk); (ratio, (s.ss_qty / ((((if (w = null) then 0 else w.ws_qty)) + ((if (c = null) then 0 else c.cs_qty)))))); (store_qty, s.ss_qty); (store_wholesale_cost, s.ss_wc); (store_sales_price, s.ss_sp); (other_chan_qty, (((if (w = null) then 0 else w.ws_qty)) + ((if (c = null) then 0 else c.cs_qty)))); (other_chan_wholesale_cost, (((if (w = null) then 0.0 else w.ws_wc)) + ((if (c = null) then 0.0 else c.cs_wc)))); (other_chan_sales_price, (((if (w = null) then 0.0 else w.ws_sp)) + ((if (c = null) then 0.0 else c.cs_sp))))]
+    |]
+ignore (_json result)
+let test_TPCDS_Q78_simplified() =
+    if not ((result = [|Map.ofList [(ss_sold_year, 1998); (ss_item_sk, 1); (ss_customer_sk, 1); (ratio, 1.25); (store_qty, 10); (store_wholesale_cost, 50.0); (store_sales_price, 100.0); (other_chan_qty, 8); (other_chan_wholesale_cost, 40.0); (other_chan_sales_price, 80.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q78 simplified" test_TPCDS_Q78_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q79.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q79.fs.out
@@ -1,0 +1,129 @@
+open System
+
+let d_date_sk = "d_date_sk"
+let d_dow = "d_dow"
+let d_year = "d_year"
+let s_store_sk = "s_store_sk"
+let s_city = "s_city"
+let s_number_employees = "s_number_employees"
+let hd_demo_sk = "hd_demo_sk"
+let hd_dep_count = "hd_dep_count"
+let hd_vehicle_count = "hd_vehicle_count"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_store_sk = "ss_store_sk"
+let ss_ticket_number = "ss_ticket_number"
+let ss_customer_sk = "ss_customer_sk"
+let ss_hdemo_sk = "ss_hdemo_sk"
+let ss_coupon_amt = "ss_coupon_amt"
+let ss_net_profit = "ss_net_profit"
+let c_customer_sk = "c_customer_sk"
+let c_last_name = "c_last_name"
+let c_first_name = "c_first_name"
+let key = "key"
+let amt = "amt"
+let profit = "profit"
+let ticket = "ticket"
+let customer_sk = "customer_sk"
+let city = "city"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_dow, 1); (d_year, 1999)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_city, "CityA"); (s_number_employees, 250)]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_dep_count, 2); (hd_vehicle_count, 1)]|]
+let store_sales = [|Map.ofList [(ss_sold_date_sk, 1); (ss_store_sk, 1); (ss_ticket_number, 1); (ss_customer_sk, 1); (ss_hdemo_sk, 1); (ss_coupon_amt, 5.0); (ss_net_profit, 10.0)]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_last_name, "Smith"); (c_first_name, "Alice")]|]
+let agg = [| for g in _group_by [|
+    for ss in store_sales do
+        for d in date_dim do
+            if (d.d_date_sk = ss.ss_sold_date_sk) then
+                for s in store do
+                    if (s.s_store_sk = ss.ss_store_sk) then
+                        for hd in household_demographics do
+                            if (hd.hd_demo_sk = ss.ss_hdemo_sk) then
+                                if (((((((hd.hd_dep_count = 2) || (hd.hd_vehicle_count > 1))) && (d.d_dow = 1)) && ((((d.d_year = 1998) || (d.d_year = 1999)) || (d.d_year = 2000)))) && (s.s_number_employees >= 200)) && (s.s_number_employees <= 295)) then
+                                    yield (ss, d, s, hd)
+|] (fun (ss, d, s, hd) -> Map.ofList [(ticket, ss.ss_ticket_number); (customer_sk, ss.ss_customer_sk); (city, s.s_city)]) do let g = g yield Map.ofList [(key, g.key); (amt, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_coupon_amt
+    |]); (profit, sum 
+    [|
+    for x in g do
+        yield x.ss.ss_net_profit
+    |])] |]
+let result = 
+    [|
+    for a in agg do
+        for c in customer do
+            if (c.c_customer_sk = a.key.customer_sk) then
+                yield ([|c.c_last_name; c.c_first_name; a.key.city; a.profit|], Map.ofList [(c_last_name, c.c_last_name); (c_first_name, c.c_first_name); (s_city, a.key.city); (ss_ticket_number, a.key.ticket); (amt, a.amt); (profit, a.profit)])
+    |]
+    |> Array.sortBy fst
+    |> Array.map snd
+ignore (_json result)
+let test_TPCDS_Q79_simplified() =
+    if not ((result = [|Map.ofList [(c_last_name, "Smith"); (c_first_name, "Alice"); (s_city, "CityA"); (ss_ticket_number, 1); (amt, 5.0); (profit, 10.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q79 simplified" test_TPCDS_Q79_simplified) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q80.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q80.fs.out
@@ -1,0 +1,71 @@
+open System
+
+let price = "price"
+let ret = "ret"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(price, 20.0); (ret, 5.0)]; Map.ofList [(price, 10.0); (ret, 2.0)]; Map.ofList [(price, 5.0); (ret, 0.0)]|]
+let catalog_sales = [|Map.ofList [(price, 15.0); (ret, 3.0)]; Map.ofList [(price, 8.0); (ret, 1.0)]|]
+let web_sales = [|Map.ofList [(price, 25.0); (ret, 5.0)]; Map.ofList [(price, 15.0); (ret, 8.0)]; Map.ofList [(price, 8.0); (ret, 2.0)]|]
+let total_profit = ((sum 
+    [|
+    for s in store_sales do
+        yield (s.price - s.ret)
+    |] + sum 
+    [|
+    for c in catalog_sales do
+        yield (c.price - c.ret)
+    |]) + sum 
+    [|
+    for w in web_sales do
+        yield (w.price - w.ret)
+    |])
+ignore (_json total_profit)
+let test_TPCDS_Q80_sample() =
+    if not ((total_profit = 80.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q80 sample" test_TPCDS_Q80_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q81.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q81.fs.out
@@ -1,0 +1,94 @@
+open System
+
+let cust = "cust"
+let state = "state"
+let amt = "amt"
+let avg_amt = "avg_amt"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let catalog_returns = [|Map.ofList [(cust, 1); (state, "CA"); (amt, 40.0)]; Map.ofList [(cust, 2); (state, "CA"); (amt, 50.0)]; Map.ofList [(cust, 3); (state, "CA"); (amt, 81.0)]; Map.ofList [(cust, 4); (state, "TX"); (amt, 30.0)]; Map.ofList [(cust, 5); (state, "TX"); (amt, 20.0)]|]
+let avg_list = _group_by catalog_returns (fun r -> r.state) |> List.map (fun g -> Map.ofList [(state, g.key); (avg_amt, avg 
+    [|
+    for x in g do
+        yield x.amt
+    |])])
+let avg_state = first (
+    [|
+    for a in avg_list do
+        if (a.state = "CA") then
+            yield a
+    |])
+let result_list = 
+    [|
+    for r in catalog_returns do
+        if ((r.state = "CA") && (r.amt > (avg_state.avg_amt * 1.2))) then
+            yield r.amt
+    |]
+let result = first result_list
+ignore (_json result)
+let test_TPCDS_Q81_sample() =
+    if not ((result = 81.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q81 sample" test_TPCDS_Q81_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q82.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q82.fs.out
@@ -1,0 +1,54 @@
+open System
+
+let id = "id"
+let item = "item"
+let qty = "qty"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let item = [|Map.ofList [(id, 1)]; Map.ofList [(id, 2)]; Map.ofList [(id, 3)]|]
+let inventory = [|Map.ofList [(item, 1); (qty, 20)]; Map.ofList [(item, 1); (qty, 22)]; Map.ofList [(item, 1); (qty, 5)]; Map.ofList [(item, 2); (qty, 30)]; Map.ofList [(item, 2); (qty, 5)]; Map.ofList [(item, 3); (qty, 10)]|]
+let store_sales = [|Map.ofList [(item, 1)]; Map.ofList [(item, 2)]|]
+let result = 0
+for inv in inventory do
+    for s in store_sales do
+        if (inv.item = s.item) then
+            result <- (result + inv.qty)
+ignore (_json result)
+let test_TPCDS_Q82_sample() =
+    if not ((result = 82)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q82 sample" test_TPCDS_Q82_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q83.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q83.fs.out
@@ -1,0 +1,70 @@
+open System
+
+let qty = "qty"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let sr_items = [|Map.ofList [(qty, 10)]; Map.ofList [(qty, 5)]|]
+let cr_items = [|Map.ofList [(qty, 25)]; Map.ofList [(qty, 20)]|]
+let wr_items = [|Map.ofList [(qty, 10)]; Map.ofList [(qty, 13)]|]
+let result = ((sum 
+    [|
+    for x in sr_items do
+        yield x.qty
+    |] + sum 
+    [|
+    for x in cr_items do
+        yield x.qty
+    |]) + sum 
+    [|
+    for x in wr_items do
+        yield x.qty
+    |])
+ignore (_json result)
+let test_TPCDS_Q83_sample() =
+    if not ((result = 83)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q83 sample" test_TPCDS_Q83_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q84.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q84.fs.out
@@ -1,0 +1,62 @@
+open System
+
+let id = "id"
+let city = "city"
+let cdemo = "cdemo"
+let cd_demo_sk = "cd_demo_sk"
+let hd_demo_sk = "hd_demo_sk"
+let income_band_sk = "income_band_sk"
+let ib_income_band_sk = "ib_income_band_sk"
+let ib_lower_bound = "ib_lower_bound"
+let ib_upper_bound = "ib_upper_bound"
+let ca_address_sk = "ca_address_sk"
+let ca_city = "ca_city"
+let sr_cdemo_sk = "sr_cdemo_sk"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let customers = [|Map.ofList [(id, 1); (city, "A"); (cdemo, 1)]; Map.ofList [(id, 2); (city, "A"); (cdemo, 2)]; Map.ofList [(id, 3); (city, "B"); (cdemo, 1)]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1)]; Map.ofList [(cd_demo_sk, 2)]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (income_band_sk, 1)]; Map.ofList [(hd_demo_sk, 2); (income_band_sk, 2)]|]
+let income_band = [|Map.ofList [(ib_income_band_sk, 1); (ib_lower_bound, 0); (ib_upper_bound, 50000)]; Map.ofList [(ib_income_band_sk, 2); (ib_lower_bound, 50001); (ib_upper_bound, 100000)]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_city, "A")]; Map.ofList [(ca_address_sk, 2); (ca_city, "B")]|]
+let store_returns = [|Map.ofList [(sr_cdemo_sk, 1)]; Map.ofList [(sr_cdemo_sk, 1)]; Map.ofList [(sr_cdemo_sk, 2)]; Map.ofList [(sr_cdemo_sk, 1)]|]
+let result = (80 + store_returns.Length)
+ignore (_json result)
+let test_TPCDS_Q84_sample() =
+    if not ((result = 84)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q84 sample" test_TPCDS_Q84_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q85.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q85.fs.out
@@ -1,0 +1,62 @@
+open System
+
+let qty = "qty"
+let cash = "cash"
+let fee = "fee"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let web_returns = [|Map.ofList [(qty, 60); (cash, 20.0); (fee, 1.0)]; Map.ofList [(qty, 100); (cash, 30.0); (fee, 2.0)]; Map.ofList [(qty, 95); (cash, 25.0); (fee, 3.0)]|]
+let result = avg 
+    [|
+    for r in web_returns do
+        yield r.qty
+    |]
+ignore (_json result)
+let test_TPCDS_Q85_sample() =
+    if not ((result = 85.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q85 sample" test_TPCDS_Q85_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q86.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q86.fs.out
@@ -1,0 +1,63 @@
+open System
+
+let cat = "cat"
+let _class = "class"
+let net = "net"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let web_sales = [|Map.ofList [(cat, "A"); (_class, "B"); (net, 40.0)]; Map.ofList [(cat, "A"); (_class, "B"); (net, 46.0)]; Map.ofList [(cat, "A"); (_class, "C"); (net, 10.0)]; Map.ofList [(cat, "B"); (_class, "B"); (net, 20.0)]|]
+let result = sum 
+    [|
+    for ws in web_sales do
+        if ((ws.cat = "A") && (ws._class = "B")) then
+            yield ws.net
+    |]
+ignore (_json result)
+let test_TPCDS_Q86_sample() =
+    if not ((result = 86.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q86 sample" test_TPCDS_Q86_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q87.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q87.fs.out
@@ -1,0 +1,80 @@
+open System
+
+let cust = "cust"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+exception Return_distinct of any[]
+let rec distinct (xs: any[]) : any[] =
+    try
+        let mutable xs = xs
+        let mutable out = [||]
+        for x in xs do
+            if (not contains out x) then
+                out <- append out x
+        raise (Return_distinct (out))
+        failwith "unreachable"
+    with Return_distinct v -> v
+
+exception Return_concat of any[]
+let rec concat (a: any[]) (b: any[]) : any[] =
+    try
+        let mutable a = a
+        let mutable b = b
+        let mutable out = a
+        for x in b do
+            out <- append out x
+        raise (Return_concat (out))
+        failwith "unreachable"
+    with Return_concat v -> v
+
+exception Return_to_list of any[]
+let rec to_list (xs: any[]) : any[] =
+    try
+        let mutable xs = xs
+        raise (Return_to_list (xs))
+        failwith "unreachable"
+    with Return_to_list v -> v
+
+let store_sales = [|Map.ofList [(cust, "A")]; Map.ofList [(cust, "B")]; Map.ofList [(cust, "B")]; Map.ofList [(cust, "C")]|]
+let catalog_sales = [|Map.ofList [(cust, "A")]; Map.ofList [(cust, "C")]; Map.ofList [(cust, "D")]|]
+let web_sales = [|Map.ofList [(cust, "A")]; Map.ofList [(cust, "D")]|]
+let result = 87
+ignore (_json result)
+let test_TPCDS_Q87_sample() =
+    if not ((result = 87)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q87 sample" test_TPCDS_Q87_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q88.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q88.fs.out
@@ -1,0 +1,50 @@
+open System
+
+let time_sk = "time_sk"
+let hour = "hour"
+let minute = "minute"
+let sold_time_sk = "sold_time_sk"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let time_dim = [|Map.ofList [(time_sk, 1); (hour, 8); (minute, 30)]; Map.ofList [(time_sk, 2); (hour, 9); (minute, 0)]; Map.ofList [(time_sk, 3); (hour, 11); (minute, 15)]|]
+let store_sales = [|Map.ofList [(sold_time_sk, 1)]; Map.ofList [(sold_time_sk, 2)]; Map.ofList [(sold_time_sk, 3)]|]
+let result = 88
+ignore (_json result)
+let test_TPCDS_Q88_sample() =
+    if not ((result = 88)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q88 sample" test_TPCDS_Q88_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q89.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q89.fs.out
@@ -1,0 +1,60 @@
+open System
+
+let price = "price"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let store_sales = [|Map.ofList [(price, 40.0)]; Map.ofList [(price, 30.0)]; Map.ofList [(price, 19.0)]|]
+let result = sum 
+    [|
+    for s in store_sales do
+        yield s.price
+    |]
+ignore (_json result)
+let test_TPCDS_Q89_sample() =
+    if not ((result = 89.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q89 sample" test_TPCDS_Q89_sample) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q90.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q90.fs.out
@@ -1,0 +1,104 @@
+open System
+
+let ws_sold_time_sk = "ws_sold_time_sk"
+let ws_ship_hdemo_sk = "ws_ship_hdemo_sk"
+let ws_web_page_sk = "ws_web_page_sk"
+let hd_demo_sk = "hd_demo_sk"
+let hd_dep_count = "hd_dep_count"
+let t_time_sk = "t_time_sk"
+let t_hour = "t_hour"
+let wp_web_page_sk = "wp_web_page_sk"
+let wp_char_count = "wp_char_count"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type WebSale =
+    {
+        ws_sold_time_sk: int;
+        ws_ship_hdemo_sk: int;
+        ws_web_page_sk: int
+    }
+
+type WebSale =
+    {
+        ws_sold_time_sk: int;
+        ws_ship_hdemo_sk: int;
+        ws_web_page_sk: int
+    }
+let web_sales = [|Map.ofList [(ws_sold_time_sk, 1); (ws_ship_hdemo_sk, 1); (ws_web_page_sk, 10)]; Map.ofList [(ws_sold_time_sk, 1); (ws_ship_hdemo_sk, 1); (ws_web_page_sk, 10)]; Map.ofList [(ws_sold_time_sk, 2); (ws_ship_hdemo_sk, 1); (ws_web_page_sk, 10)]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_dep_count, 2)]|]
+let time_dim = [|Map.ofList [(t_time_sk, 1); (t_hour, 7)]; Map.ofList [(t_time_sk, 2); (t_hour, 14)]|]
+let web_page = [|Map.ofList [(wp_web_page_sk, 10); (wp_char_count, 5100)]|]
+let amc = count 
+    [|
+    for ws in web_sales do
+        for hd in household_demographics do
+            if (ws.ws_ship_hdemo_sk = hd.hd_demo_sk) then
+                for t in time_dim do
+                    if (ws.ws_sold_time_sk = t.t_time_sk) then
+                        for wp in web_page do
+                            if (ws.ws_web_page_sk = wp.wp_web_page_sk) then
+                                if (((((t.t_hour >= 7) && (t.t_hour <= 8)) && (hd.hd_dep_count = 2)) && (wp.wp_char_count >= 5000)) && (wp.wp_char_count <= 5200)) then
+                                    yield ws
+    |]
+let pmc = count 
+    [|
+    for ws in web_sales do
+        for hd in household_demographics do
+            if (ws.ws_ship_hdemo_sk = hd.hd_demo_sk) then
+                for t in time_dim do
+                    if (ws.ws_sold_time_sk = t.t_time_sk) then
+                        for wp in web_page do
+                            if (ws.ws_web_page_sk = wp.wp_web_page_sk) then
+                                if (((((t.t_hour >= 14) && (t.t_hour <= 15)) && (hd.hd_dep_count = 2)) && (wp.wp_char_count >= 5000)) && (wp.wp_char_count <= 5200)) then
+                                    yield ws
+    |]
+let result = (((float amc)) / ((float pmc)))
+ignore (_json result)
+let test_TPCDS_Q90_ratio() =
+    if not ((result = 2.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q90 ratio" test_TPCDS_Q90_ratio) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q91.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q91.fs.out
@@ -1,0 +1,221 @@
+open System
+
+let cc_call_center_sk = "cc_call_center_sk"
+let cc_call_center_id = "cc_call_center_id"
+let cc_name = "cc_name"
+let cc_manager = "cc_manager"
+let cr_call_center_sk = "cr_call_center_sk"
+let cr_returned_date_sk = "cr_returned_date_sk"
+let cr_returning_customer_sk = "cr_returning_customer_sk"
+let cr_net_loss = "cr_net_loss"
+let d_date_sk = "d_date_sk"
+let d_year = "d_year"
+let d_moy = "d_moy"
+let c_customer_sk = "c_customer_sk"
+let c_current_cdemo_sk = "c_current_cdemo_sk"
+let c_current_hdemo_sk = "c_current_hdemo_sk"
+let c_current_addr_sk = "c_current_addr_sk"
+let cd_demo_sk = "cd_demo_sk"
+let cd_marital_status = "cd_marital_status"
+let cd_education_status = "cd_education_status"
+let hd_demo_sk = "hd_demo_sk"
+let hd_buy_potential = "hd_buy_potential"
+let ca_address_sk = "ca_address_sk"
+let ca_gmt_offset = "ca_gmt_offset"
+let Call_Center = "Call_Center"
+let Call_Center_Name = "Call_Center_Name"
+let Manager = "Manager"
+let Returns_Loss = "Returns_Loss"
+let id = "id"
+let name = "name"
+let mgr = "mgr"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type CallCenter =
+    {
+        cc_call_center_sk: int;
+        cc_call_center_id: string;
+        cc_name: string;
+        cc_manager: string
+    }
+
+type CatalogReturn =
+    {
+        cr_call_center_sk: int;
+        cr_returned_date_sk: int;
+        cr_returning_customer_sk: int;
+        cr_net_loss: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_cdemo_sk: int;
+        c_current_hdemo_sk: int;
+        c_current_addr_sk: int
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_gmt_offset: int
+    }
+
+type CustomerDemographics =
+    {
+        cd_demo_sk: int;
+        cd_marital_status: string;
+        cd_education_status: string
+    }
+
+type HouseholdDemographics =
+    {
+        hd_demo_sk: int;
+        hd_buy_potential: string
+    }
+
+type CallCenter =
+    {
+        cc_call_center_sk: int;
+        cc_call_center_id: string;
+        cc_name: string;
+        cc_manager: string
+    }
+type CatalogReturn =
+    {
+        cr_call_center_sk: int;
+        cr_returned_date_sk: int;
+        cr_returning_customer_sk: int;
+        cr_net_loss: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_year: int;
+        d_moy: int
+    }
+type Customer =
+    {
+        c_customer_sk: int;
+        c_current_cdemo_sk: int;
+        c_current_hdemo_sk: int;
+        c_current_addr_sk: int
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_gmt_offset: int
+    }
+type CustomerDemographics =
+    {
+        cd_demo_sk: int;
+        cd_marital_status: string;
+        cd_education_status: string
+    }
+type HouseholdDemographics =
+    {
+        hd_demo_sk: int;
+        hd_buy_potential: string
+    }
+let call_center = [|Map.ofList [(cc_call_center_sk, 1); (cc_call_center_id, "CC1"); (cc_name, "Main"); (cc_manager, "Alice")]|]
+let catalog_returns = [|Map.ofList [(cr_call_center_sk, 1); (cr_returned_date_sk, 1); (cr_returning_customer_sk, 1); (cr_net_loss, 10.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_year, 2001); (d_moy, 5)]|]
+let customer = [|Map.ofList [(c_customer_sk, 1); (c_current_cdemo_sk, 1); (c_current_hdemo_sk, 1); (c_current_addr_sk, 1)]|]
+let customer_demographics = [|Map.ofList [(cd_demo_sk, 1); (cd_marital_status, "M"); (cd_education_status, "Unknown")]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_buy_potential, "1001-5000")]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_gmt_offset, (-6))]|]
+let result = first ([| for g in _group_by [|
+    for cc in call_center do
+        for cr in catalog_returns do
+            if (cc.cc_call_center_sk = cr.cr_call_center_sk) then
+                for d in date_dim do
+                    if (cr.cr_returned_date_sk = d.d_date_sk) then
+                        for c in customer do
+                            if (cr.cr_returning_customer_sk = c.c_customer_sk) then
+                                for cd in customer_demographics do
+                                    if (c.c_current_cdemo_sk = cd.cd_demo_sk) then
+                                        for hd in household_demographics do
+                                            if (c.c_current_hdemo_sk = hd.hd_demo_sk) then
+                                                for ca in customer_address do
+                                                    if (c.c_current_addr_sk = ca.ca_address_sk) then
+                                                        if ((((((d.d_year = 2001) && (d.d_moy = 5)) && (cd.cd_marital_status = "M")) && (cd.cd_education_status = "Unknown")) && (hd.hd_buy_potential = "1001-5000")) && (ca.ca_gmt_offset = ((-6)))) then
+                                                            yield (cc, cr, d, c, cd, hd, ca)
+|] (fun (cc, cr, d, c, cd, hd, ca) -> Map.ofList [(id, cc.cc_call_center_id); (name, cc.cc_name); (mgr, cc.cc_manager)]) do let g = g yield Map.ofList [(Call_Center, g.key.id); (Call_Center_Name, g.key.name); (Manager, g.key.mgr); (Returns_Loss, sum 
+    [|
+    for x in g do
+        yield x.cr_net_loss
+    |])] |])
+ignore (_json result)
+let test_TPCDS_Q91_returns() =
+    if not ((result = Map.ofList [(Call_Center, "CC1"); (Call_Center_Name, "Main"); (Manager, "Alice"); (Returns_Loss, 10.0)])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q91 returns" test_TPCDS_Q91_returns) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q92.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q92.fs.out
@@ -1,0 +1,87 @@
+open System
+
+let ws_item_sk = "ws_item_sk"
+let ws_sold_date_sk = "ws_sold_date_sk"
+let ws_ext_discount_amt = "ws_ext_discount_amt"
+let i_item_sk = "i_item_sk"
+let i_manufact_id = "i_manufact_id"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type WebSale =
+    {
+        ws_item_sk: int;
+        ws_sold_date_sk: int;
+        ws_ext_discount_amt: float
+    }
+
+type WebSale =
+    {
+        ws_item_sk: int;
+        ws_sold_date_sk: int;
+        ws_ext_discount_amt: float
+    }
+let web_sales = [|Map.ofList [(ws_item_sk, 1); (ws_sold_date_sk, 1); (ws_ext_discount_amt, 1.0)]; Map.ofList [(ws_item_sk, 1); (ws_sold_date_sk, 1); (ws_ext_discount_amt, 1.0)]; Map.ofList [(ws_item_sk, 1); (ws_sold_date_sk, 1); (ws_ext_discount_amt, 2.0)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_manufact_id, 1)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2000-01-02")]|]
+let sum_amt = sum 
+    [|
+    for ws in web_sales do
+        yield ws.ws_ext_discount_amt
+    |]
+let avg_amt = avg 
+    [|
+    for ws in web_sales do
+        yield ws.ws_ext_discount_amt
+    |]
+let result = (if (sum_amt > (avg_amt * 1.3)) then sum_amt else 0.0)
+ignore (_json result)
+let test_TPCDS_Q92_threshold() =
+    if not ((result = 4.0)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q92 threshold" test_TPCDS_Q92_threshold) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q93.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q93.fs.out
@@ -1,0 +1,145 @@
+open System
+
+let ss_item_sk = "ss_item_sk"
+let ss_ticket_number = "ss_ticket_number"
+let ss_customer_sk = "ss_customer_sk"
+let ss_quantity = "ss_quantity"
+let ss_sales_price = "ss_sales_price"
+let sr_item_sk = "sr_item_sk"
+let sr_ticket_number = "sr_ticket_number"
+let sr_reason_sk = "sr_reason_sk"
+let sr_return_quantity = "sr_return_quantity"
+let r_reason_sk = "r_reason_sk"
+let r_reason_desc = "r_reason_desc"
+let act_sales = "act_sales"
+let sumsales = "sumsales"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_ticket_number: int;
+        ss_customer_sk: int;
+        ss_quantity: int;
+        ss_sales_price: float
+    }
+
+type StoreReturn =
+    {
+        sr_item_sk: int;
+        sr_ticket_number: int;
+        sr_reason_sk: int;
+        sr_return_quantity: int
+    }
+
+type Reason =
+    {
+        r_reason_sk: int;
+        r_reason_desc: string
+    }
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_ticket_number: int;
+        ss_customer_sk: int;
+        ss_quantity: int;
+        ss_sales_price: float
+    }
+type StoreReturn =
+    {
+        sr_item_sk: int;
+        sr_ticket_number: int;
+        sr_reason_sk: int;
+        sr_return_quantity: int
+    }
+type Reason =
+    {
+        r_reason_sk: int;
+        r_reason_desc: string
+    }
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_ticket_number, 1); (ss_customer_sk, 1); (ss_quantity, 5); (ss_sales_price, 10.0)]; Map.ofList [(ss_item_sk, 1); (ss_ticket_number, 2); (ss_customer_sk, 2); (ss_quantity, 3); (ss_sales_price, 20.0)]|]
+let store_returns = [|Map.ofList [(sr_item_sk, 1); (sr_ticket_number, 1); (sr_reason_sk, 1); (sr_return_quantity, 1)]|]
+let reason = [|Map.ofList [(r_reason_sk, 1); (r_reason_desc, "ReasonA")]|]
+let t = 
+    [|
+    for ss in store_sales do
+        for sr in store_returns do
+            if ((ss.ss_item_sk = sr.sr_item_sk) && (ss.ss_ticket_number = sr.sr_ticket_number)) then
+                for r in reason do
+                    if (sr.sr_reason_sk = r.r_reason_sk) then
+                        if (r.r_reason_desc = "ReasonA") then
+                            yield Map.ofList [(ss_customer_sk, ss.ss_customer_sk); (act_sales, (if (sr <> null) then (((ss.ss_quantity - sr.sr_return_quantity)) * ss.ss_sales_price) else (ss.ss_quantity * ss.ss_sales_price)))]
+    |]
+let result = _group_by t (fun x -> x.ss_customer_sk) |> List.map (fun g -> Map.ofList [(ss_customer_sk, g.key); (sumsales, sum 
+    [|
+    for y in g do
+        yield y.act_sales
+    |])])
+ignore (_json result)
+let test_TPCDS_Q93_active_sales() =
+    if not ((result = [|Map.ofList [(ss_customer_sk, 1); (sumsales, 40.0)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q93 active sales" test_TPCDS_Q93_active_sales) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q94.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q94.fs.out
@@ -1,0 +1,180 @@
+open System
+
+let ws_order_number = "ws_order_number"
+let ws_ship_date_sk = "ws_ship_date_sk"
+let ws_warehouse_sk = "ws_warehouse_sk"
+let ws_ship_addr_sk = "ws_ship_addr_sk"
+let ws_web_site_sk = "ws_web_site_sk"
+let ws_net_profit = "ws_net_profit"
+let ws_ext_ship_cost = "ws_ext_ship_cost"
+let wr_order_number = "wr_order_number"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let ca_address_sk = "ca_address_sk"
+let ca_state = "ca_state"
+let web_site_sk = "web_site_sk"
+let web_company_name = "web_company_name"
+let order_count = "order_count"
+let total_shipping_cost = "total_shipping_cost"
+let total_net_profit = "total_net_profit"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type WebSale =
+    {
+        ws_order_number: int;
+        ws_ship_date_sk: int;
+        ws_warehouse_sk: int;
+        ws_ship_addr_sk: int;
+        ws_web_site_sk: int;
+        ws_net_profit: float;
+        ws_ext_ship_cost: float
+    }
+
+type WebReturn =
+    {
+        wr_order_number: int
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string
+    }
+
+type WebSite =
+    {
+        web_site_sk: int;
+        web_company_name: string
+    }
+
+exception Return_distinct of any[]
+let rec distinct (xs: any[]) : any[] =
+    try
+        let mutable xs = xs
+        let mutable out = [||]
+        for x in xs do
+            if (not contains out x) then
+                out <- append out x
+        raise (Return_distinct (out))
+        failwith "unreachable"
+    with Return_distinct v -> v
+
+type WebSale =
+    {
+        ws_order_number: int;
+        ws_ship_date_sk: int;
+        ws_warehouse_sk: int;
+        ws_ship_addr_sk: int;
+        ws_web_site_sk: int;
+        ws_net_profit: float;
+        ws_ext_ship_cost: float
+    }
+type WebReturn =
+    {
+        wr_order_number: int
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string
+    }
+type WebSite =
+    {
+        web_site_sk: int;
+        web_company_name: string
+    }
+let web_sales = [|Map.ofList [(ws_order_number, 1); (ws_ship_date_sk, 1); (ws_warehouse_sk, 1); (ws_ship_addr_sk, 1); (ws_web_site_sk, 1); (ws_net_profit, 5.0); (ws_ext_ship_cost, 2.0)]; Map.ofList [(ws_order_number, 2); (ws_ship_date_sk, 1); (ws_warehouse_sk, 2); (ws_ship_addr_sk, 1); (ws_web_site_sk, 1); (ws_net_profit, 3.0); (ws_ext_ship_cost, 1.0)]|]
+let web_returns = [|Map.ofList [(wr_order_number, 2)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2001-02-01")]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_state, "CA")]|]
+let web_site = [|Map.ofList [(web_site_sk, 1); (web_company_name, "pri")]|]
+let filtered = 
+    [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (ws.ws_ship_date_sk = d.d_date_sk) then
+                for ca in customer_address do
+                    if (ws.ws_ship_addr_sk = ca.ca_address_sk) then
+                        for w in web_site do
+                            if (ws.ws_web_site_sk = w.web_site_sk) then
+                                if (((ca.ca_state = "CA") && (w.web_company_name = "pri")) && (exists (
+    [|
+    for wr in web_returns do
+        if (wr.wr_order_number = ws.ws_order_number) then
+            yield wr
+    |]) = false)) then
+                                    yield ws
+    |]
+let result = Map.ofList [(order_count, distinct (
+    [|
+    for x in filtered do
+        yield x.ws_order_number
+    |]).Length); (total_shipping_cost, sum 
+    [|
+    for x in filtered do
+        yield x.ws_ext_ship_cost
+    |]); (total_net_profit, sum 
+    [|
+    for x in filtered do
+        yield x.ws_net_profit
+    |])]
+ignore (_json result)
+let test_TPCDS_Q94_shipping() =
+    if not ((result = Map.ofList [(order_count, 1); (total_shipping_cost, 2.0); (total_net_profit, 5.0)])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q94 shipping" test_TPCDS_Q94_shipping) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q95.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q95.fs.out
@@ -1,0 +1,190 @@
+open System
+
+let ws_order_number = "ws_order_number"
+let ws_warehouse_sk = "ws_warehouse_sk"
+let ws_ship_date_sk = "ws_ship_date_sk"
+let ws_ship_addr_sk = "ws_ship_addr_sk"
+let ws_web_site_sk = "ws_web_site_sk"
+let ws_ext_ship_cost = "ws_ext_ship_cost"
+let ws_net_profit = "ws_net_profit"
+let wr_order_number = "wr_order_number"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let ca_address_sk = "ca_address_sk"
+let ca_state = "ca_state"
+let web_site_sk = "web_site_sk"
+let web_company_name = "web_company_name"
+let order_count = "order_count"
+let total_shipping_cost = "total_shipping_cost"
+let total_net_profit = "total_net_profit"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type WebSale =
+    {
+        ws_order_number: int;
+        ws_warehouse_sk: int;
+        ws_ship_date_sk: int;
+        ws_ship_addr_sk: int;
+        ws_web_site_sk: int;
+        ws_ext_ship_cost: float;
+        ws_net_profit: float
+    }
+
+type WebReturn =
+    {
+        wr_order_number: int
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string
+    }
+
+type WebSite =
+    {
+        web_site_sk: int;
+        web_company_name: string
+    }
+
+exception Return_distinct of any[]
+let rec distinct (xs: any[]) : any[] =
+    try
+        let mutable xs = xs
+        let mutable out = [||]
+        for x in xs do
+            if (not contains out x) then
+                out <- append out x
+        raise (Return_distinct (out))
+        failwith "unreachable"
+    with Return_distinct v -> v
+
+type WebSale =
+    {
+        ws_order_number: int;
+        ws_warehouse_sk: int;
+        ws_ship_date_sk: int;
+        ws_ship_addr_sk: int;
+        ws_web_site_sk: int;
+        ws_ext_ship_cost: float;
+        ws_net_profit: float
+    }
+type WebReturn =
+    {
+        wr_order_number: int
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+type CustomerAddress =
+    {
+        ca_address_sk: int;
+        ca_state: string
+    }
+type WebSite =
+    {
+        web_site_sk: int;
+        web_company_name: string
+    }
+let web_sales = [|Map.ofList [(ws_order_number, 1); (ws_warehouse_sk, 1); (ws_ship_date_sk, 1); (ws_ship_addr_sk, 1); (ws_web_site_sk, 1); (ws_ext_ship_cost, 2.0); (ws_net_profit, 5.0)]; Map.ofList [(ws_order_number, 1); (ws_warehouse_sk, 2); (ws_ship_date_sk, 1); (ws_ship_addr_sk, 1); (ws_web_site_sk, 1); (ws_ext_ship_cost, 0.0); (ws_net_profit, 0.0)]|]
+let web_returns = [|Map.ofList [(wr_order_number, 1)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2001-02-01")]|]
+let customer_address = [|Map.ofList [(ca_address_sk, 1); (ca_state, "CA")]|]
+let web_site = [|Map.ofList [(web_site_sk, 1); (web_company_name, "pri")]|]
+let ws_wh = 
+    [|
+    for ws1 in web_sales do
+        for ws2 in web_sales do
+            if ((ws1.ws_order_number = ws2.ws_order_number) && (ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk)) then
+                yield Map.ofList [(ws_order_number, ws1.ws_order_number)]
+    |]
+let filtered = 
+    [|
+    for ws in web_sales do
+        for d in date_dim do
+            if (ws.ws_ship_date_sk = d.d_date_sk) then
+                for ca in customer_address do
+                    if (ws.ws_ship_addr_sk = ca.ca_address_sk) then
+                        for w in web_site do
+                            if (ws.ws_web_site_sk = w.web_site_sk) then
+                                if ((((ca.ca_state = "CA") && (w.web_company_name = "pri")) && Array.contains ws.ws_order_number (
+    [|
+    for x in ws_wh do
+        yield x.ws_order_number
+    |])) && Array.contains ws.ws_order_number (
+    [|
+    for wr in web_returns do
+        yield wr.wr_order_number
+    |])) then
+                                    yield ws
+    |]
+let result = Map.ofList [(order_count, distinct (
+    [|
+    for x in filtered do
+        yield x.ws_order_number
+    |]).Length); (total_shipping_cost, sum 
+    [|
+    for x in filtered do
+        yield x.ws_ext_ship_cost
+    |]); (total_net_profit, sum 
+    [|
+    for x in filtered do
+        yield x.ws_net_profit
+    |])]
+ignore (_json result)
+let test_TPCDS_Q95_shipping_returns() =
+    if not ((result = Map.ofList [(order_count, 1); (total_shipping_cost, 2.0); (total_net_profit, 5.0)])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q95 shipping returns" test_TPCDS_Q95_shipping_returns) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q96.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q96.fs.out
@@ -1,0 +1,127 @@
+open System
+
+let ss_sold_time_sk = "ss_sold_time_sk"
+let ss_hdemo_sk = "ss_hdemo_sk"
+let ss_store_sk = "ss_store_sk"
+let hd_demo_sk = "hd_demo_sk"
+let hd_dep_count = "hd_dep_count"
+let t_time_sk = "t_time_sk"
+let t_hour = "t_hour"
+let t_minute = "t_minute"
+let s_store_sk = "s_store_sk"
+let s_store_name = "s_store_name"
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_sold_time_sk: int;
+        ss_hdemo_sk: int;
+        ss_store_sk: int
+    }
+
+type HouseholdDemographics =
+    {
+        hd_demo_sk: int;
+        hd_dep_count: int
+    }
+
+type TimeDim =
+    {
+        t_time_sk: int;
+        t_hour: int;
+        t_minute: int
+    }
+
+type Store =
+    {
+        s_store_sk: int;
+        s_store_name: string
+    }
+
+type StoreSale =
+    {
+        ss_sold_time_sk: int;
+        ss_hdemo_sk: int;
+        ss_store_sk: int
+    }
+type HouseholdDemographics =
+    {
+        hd_demo_sk: int;
+        hd_dep_count: int
+    }
+type TimeDim =
+    {
+        t_time_sk: int;
+        t_hour: int;
+        t_minute: int
+    }
+type Store =
+    {
+        s_store_sk: int;
+        s_store_name: string
+    }
+let store_sales = [|Map.ofList [(ss_sold_time_sk, 1); (ss_hdemo_sk, 1); (ss_store_sk, 1)]; Map.ofList [(ss_sold_time_sk, 1); (ss_hdemo_sk, 1); (ss_store_sk, 1)]; Map.ofList [(ss_sold_time_sk, 2); (ss_hdemo_sk, 1); (ss_store_sk, 1)]|]
+let household_demographics = [|Map.ofList [(hd_demo_sk, 1); (hd_dep_count, 3)]|]
+let time_dim = [|Map.ofList [(t_time_sk, 1); (t_hour, 20); (t_minute, 35)]; Map.ofList [(t_time_sk, 2); (t_hour, 20); (t_minute, 45)]|]
+let store = [|Map.ofList [(s_store_sk, 1); (s_store_name, "ese")]|]
+let result = count 
+    [|
+    for ss in store_sales do
+        for hd in household_demographics do
+            if (ss.ss_hdemo_sk = hd.hd_demo_sk) then
+                for t in time_dim do
+                    if (ss.ss_sold_time_sk = t.t_time_sk) then
+                        for s in store do
+                            if (ss.ss_store_sk = s.s_store_sk) then
+                                if ((((t.t_hour = 20) && (t.t_minute >= 30)) && (hd.hd_dep_count = 3)) && (s.s_store_name = "ese")) then
+                                    yield ss
+    |]
+ignore (_json result)
+let test_TPCDS_Q96_count() =
+    if not ((result = 3)) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q96 count" test_TPCDS_Q96_count) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q97.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q97.fs.out
@@ -1,0 +1,127 @@
+open System
+
+let ss_customer_sk = "ss_customer_sk"
+let ss_item_sk = "ss_item_sk"
+let cs_bill_customer_sk = "cs_bill_customer_sk"
+let cs_item_sk = "cs_item_sk"
+let customer_sk = "customer_sk"
+let item_sk = "item_sk"
+let store_only = "store_only"
+let catalog_only = "catalog_only"
+let both = "both"
+let store_and_catalog = "store_and_catalog"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_customer_sk: int;
+        ss_item_sk: int
+    }
+
+type CatalogSale =
+    {
+        cs_bill_customer_sk: int;
+        cs_item_sk: int
+    }
+
+type StoreSale =
+    {
+        ss_customer_sk: int;
+        ss_item_sk: int
+    }
+type CatalogSale =
+    {
+        cs_bill_customer_sk: int;
+        cs_item_sk: int
+    }
+let store_sales = [|Map.ofList [(ss_customer_sk, 1); (ss_item_sk, 1)]; Map.ofList [(ss_customer_sk, 2); (ss_item_sk, 1)]|]
+let catalog_sales = [|Map.ofList [(cs_bill_customer_sk, 1); (cs_item_sk, 1)]; Map.ofList [(cs_bill_customer_sk, 3); (cs_item_sk, 2)]|]
+let ssci = _group_by store_sales (fun ss -> Map.ofList [(customer_sk, ss.ss_customer_sk); (item_sk, ss.ss_item_sk)]) |> List.map (fun g -> Map.ofList [(customer_sk, g.key.customer_sk); (item_sk, g.key.item_sk)])
+let csci = _group_by catalog_sales (fun cs -> Map.ofList [(customer_sk, cs.cs_bill_customer_sk); (item_sk, cs.cs_item_sk)]) |> List.map (fun g -> Map.ofList [(customer_sk, g.key.customer_sk); (item_sk, g.key.item_sk)])
+let joined = 
+    [|
+    for s in ssci do
+        for c in csci do
+            if ((s.customer_sk = c.customer_sk) && (s.item_sk = c.item_sk)) then
+                yield Map.ofList [(store_only, (if ((s.customer_sk <> null) && (c.customer_sk = null)) then 1 else 0)); (catalog_only, (if ((s.customer_sk = null) && (c.customer_sk <> null)) then 1 else 0)); (both, (if ((s.customer_sk <> null) && (c.customer_sk <> null)) then 1 else 0))]
+    |]
+let result = Map.ofList [(store_only, sum 
+    [|
+    for x in joined do
+        yield x.store_only
+    |]); (catalog_only, sum 
+    [|
+    for x in joined do
+        yield x.catalog_only
+    |]); (store_and_catalog, sum 
+    [|
+    for x in joined do
+        yield x.both
+    |])]
+ignore (_json result)
+let test_TPCDS_Q97_overlap() =
+    if not ((((result.store_only = 1) && (result.catalog_only = 1)) && (result.store_and_catalog = 1))) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q97 overlap" test_TPCDS_Q97_overlap) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q98.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q98.fs.out
@@ -1,0 +1,160 @@
+open System
+
+let ss_item_sk = "ss_item_sk"
+let ss_sold_date_sk = "ss_sold_date_sk"
+let ss_ext_sales_price = "ss_ext_sales_price"
+let i_item_sk = "i_item_sk"
+let i_item_id = "i_item_id"
+let i_item_desc = "i_item_desc"
+let i_category = "i_category"
+let i_class = "i_class"
+let i_current_price = "i_current_price"
+let d_date_sk = "d_date_sk"
+let d_date = "d_date"
+let itemrevenue = "itemrevenue"
+let item_id = "item_id"
+let item_desc = "item_desc"
+let category = "category"
+let _class = "class"
+let price = "price"
+let total = "total"
+let revenueratio = "revenueratio"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_sold_date_sk: int;
+        ss_ext_sales_price: float
+    }
+
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string;
+        i_category: string;
+        i_class: string;
+        i_current_price: float
+    }
+
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+
+type StoreSale =
+    {
+        ss_item_sk: int;
+        ss_sold_date_sk: int;
+        ss_ext_sales_price: float
+    }
+type Item =
+    {
+        i_item_sk: int;
+        i_item_id: string;
+        i_item_desc: string;
+        i_category: string;
+        i_class: string;
+        i_current_price: float
+    }
+type DateDim =
+    {
+        d_date_sk: int;
+        d_date: string
+    }
+let store_sales = [|Map.ofList [(ss_item_sk, 1); (ss_sold_date_sk, 1); (ss_ext_sales_price, 50.0)]; Map.ofList [(ss_item_sk, 2); (ss_sold_date_sk, 1); (ss_ext_sales_price, 100.0)]|]
+let item = [|Map.ofList [(i_item_sk, 1); (i_item_id, "I1"); (i_item_desc, "desc1"); (i_category, "CatA"); (i_class, "Class1"); (i_current_price, 100.0)]; Map.ofList [(i_item_sk, 2); (i_item_id, "I2"); (i_item_desc, "desc2"); (i_category, "CatB"); (i_class, "Class1"); (i_current_price, 200.0)]|]
+let date_dim = [|Map.ofList [(d_date_sk, 1); (d_date, "2000-02-01")]|]
+let grouped = [| for g in _group_by [|
+    for ss in store_sales do
+        for i in item do
+            if (ss.ss_item_sk = i.i_item_sk) then
+                for d in date_dim do
+                    if (ss.ss_sold_date_sk = d.d_date_sk) then
+                        yield (ss, i, d)
+|] (fun (ss, i, d) -> Map.ofList [(item_id, i.i_item_id); (item_desc, i.i_item_desc); (category, i.i_category); (_class, i.i_class); (price, i.i_current_price)]) do let g = g yield Map.ofList [(i_item_id, g.key.item_id); (i_item_desc, g.key.item_desc); (i_category, g.key.category); (i_class, g.key._class); (i_current_price, g.key.price); (itemrevenue, sum 
+    [|
+    for x in g do
+        yield x.ss_ext_sales_price
+    |])] |]
+let totals = _group_by grouped (fun g -> g.i_class) |> List.map (fun cg -> Map.ofList [(_class, cg.key); (total, sum 
+    [|
+    for x in cg do
+        yield x.itemrevenue
+    |])])
+let result = 
+    [|
+    for g in grouped do
+        for t in totals do
+            if (g.i_class = t._class) then
+                yield Map.ofList [(i_item_id, g.i_item_id); (i_item_desc, g.i_item_desc); (i_category, g.i_category); (i_class, g.i_class); (i_current_price, g.i_current_price); (itemrevenue, g.itemrevenue); (revenueratio, ((g.itemrevenue * 100) / t.total))]
+    |]
+ignore (_json result)
+let test_TPCDS_Q98_revenue() =
+    if not ((result = [|Map.ofList [(i_item_id, "I1"); (i_item_desc, "desc1"); (i_category, "CatA"); (i_class, "Class1"); (i_current_price, 100.0); (itemrevenue, 50.0); (revenueratio, 33.333333333333336)]; Map.ofList [(i_item_id, "I2"); (i_item_desc, "desc2"); (i_category, "CatB"); (i_class, "Class1"); (i_current_price, 200.0); (itemrevenue, 100.0); (revenueratio, 66.66666666666667)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q98 revenue" test_TPCDS_Q98_revenue) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/tpc-ds/compiler/fs/q99.fs.out
+++ b/tests/dataset/tpc-ds/compiler/fs/q99.fs.out
@@ -1,0 +1,187 @@
+open System
+
+let cs_ship_date_sk = "cs_ship_date_sk"
+let cs_sold_date_sk = "cs_sold_date_sk"
+let cs_warehouse_sk = "cs_warehouse_sk"
+let cs_ship_mode_sk = "cs_ship_mode_sk"
+let cs_call_center_sk = "cs_call_center_sk"
+let w_warehouse_sk = "w_warehouse_sk"
+let w_warehouse_name = "w_warehouse_name"
+let sm_ship_mode_sk = "sm_ship_mode_sk"
+let sm_type = "sm_type"
+let cc_call_center_sk = "cc_call_center_sk"
+let cc_name = "cc_name"
+let warehouse = "warehouse"
+let d30 = "d30"
+let d60 = "d60"
+let d90 = "d90"
+let d120 = "d120"
+let dmore = "dmore"
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+let _slice_string (s: string) (i: int) (j: int) : string =
+  let mutable start = i
+  let mutable stop = j
+  let n = s.Length
+  if start < 0 then start <- start + n
+  if stop < 0 then stop <- stop + n
+  if start < 0 then start <- 0
+  if stop > n then stop <- n
+  if stop < start then stop <- start
+  s.Substring(start, stop - start)
+
+type CatalogSale =
+    {
+        cs_ship_date_sk: int;
+        cs_sold_date_sk: int;
+        cs_warehouse_sk: int;
+        cs_ship_mode_sk: int;
+        cs_call_center_sk: int
+    }
+
+type Warehouse =
+    {
+        w_warehouse_sk: int;
+        w_warehouse_name: string
+    }
+
+type ShipMode =
+    {
+        sm_ship_mode_sk: int;
+        sm_type: string
+    }
+
+type CallCenter =
+    {
+        cc_call_center_sk: int;
+        cc_name: string
+    }
+
+type CatalogSale =
+    {
+        cs_ship_date_sk: int;
+        cs_sold_date_sk: int;
+        cs_warehouse_sk: int;
+        cs_ship_mode_sk: int;
+        cs_call_center_sk: int
+    }
+type Warehouse =
+    {
+        w_warehouse_sk: int;
+        w_warehouse_name: string
+    }
+type ShipMode =
+    {
+        sm_ship_mode_sk: int;
+        sm_type: string
+    }
+type CallCenter =
+    {
+        cc_call_center_sk: int;
+        cc_name: string
+    }
+let catalog_sales = [|Map.ofList [(cs_ship_date_sk, 31); (cs_sold_date_sk, 1); (cs_warehouse_sk, 1); (cs_ship_mode_sk, 1); (cs_call_center_sk, 1)]; Map.ofList [(cs_ship_date_sk, 51); (cs_sold_date_sk, 1); (cs_warehouse_sk, 1); (cs_ship_mode_sk, 1); (cs_call_center_sk, 1)]; Map.ofList [(cs_ship_date_sk, 71); (cs_sold_date_sk, 1); (cs_warehouse_sk, 1); (cs_ship_mode_sk, 1); (cs_call_center_sk, 1)]; Map.ofList [(cs_ship_date_sk, 101); (cs_sold_date_sk, 1); (cs_warehouse_sk, 1); (cs_ship_mode_sk, 1); (cs_call_center_sk, 1)]; Map.ofList [(cs_ship_date_sk, 131); (cs_sold_date_sk, 1); (cs_warehouse_sk, 1); (cs_ship_mode_sk, 1); (cs_call_center_sk, 1)]|]
+let warehouse = [|Map.ofList [(w_warehouse_sk, 1); (w_warehouse_name, "Warehouse1")]|]
+let ship_mode = [|Map.ofList [(sm_ship_mode_sk, 1); (sm_type, "EXP")]|]
+let call_center = [|Map.ofList [(cc_call_center_sk, 1); (cc_name, "CC1")]|]
+let grouped = [| for g in _group_by [|
+    for cs in catalog_sales do
+        for w in warehouse do
+            if (cs.cs_warehouse_sk = w.w_warehouse_sk) then
+                for sm in ship_mode do
+                    if (cs.cs_ship_mode_sk = sm.sm_ship_mode_sk) then
+                        for cc in call_center do
+                            if (cs.cs_call_center_sk = cc.cc_call_center_sk) then
+                                yield (cs, w, sm, cc)
+|] (fun (cs, w, sm, cc) -> Map.ofList [(warehouse, _slice_string w.w_warehouse_name 0 20); (sm_type, sm.sm_type); (cc_name, cc.cc_name)]) do let g = g yield Map.ofList [(warehouse, g.key.warehouse); (sm_type, g.key.sm_type); (cc_name, g.key.cc_name); (d30, count 
+    [|
+    for x in g do
+        if ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 30) then
+            yield x
+    |]); (d60, count 
+    [|
+    for x in g do
+        if (((x.cs_ship_date_sk - x.cs_sold_date_sk) > 30) && ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 60)) then
+            yield x
+    |]); (d90, count 
+    [|
+    for x in g do
+        if (((x.cs_ship_date_sk - x.cs_sold_date_sk) > 60) && ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 90)) then
+            yield x
+    |]); (d120, count 
+    [|
+    for x in g do
+        if (((x.cs_ship_date_sk - x.cs_sold_date_sk) > 90) && ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 120)) then
+            yield x
+    |]); (dmore, count 
+    [|
+    for x in g do
+        if ((x.cs_ship_date_sk - x.cs_sold_date_sk) > 120) then
+            yield x
+    |])] |]
+ignore (_json grouped)
+let test_TPCDS_Q99_buckets() =
+    if not ((grouped = [|Map.ofList [(warehouse, "Warehouse1"); (sm_type, "EXP"); (cc_name, "CC1"); (d30, 1); (d60, 1); (d90, 1); (d120, 1); (dmore, 1)]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "TPCDS Q99 buckets" test_TPCDS_Q99_buckets) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures


### PR DESCRIPTION
## Summary
- compile F# code for the remaining TPC‑DS queries (q50‑q99)
- run the F# TPC‑DS compiler test across all 99 queries

## Testing
- `go test ./... -tags slow` *(fails: missing dependencies)*
- `go test ./compile/x/fs -run TestFSCompiler_TPCDS -tags slow -count=1 -timeout=60s` *(fails: missing `dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_686411b1d9188320aa54b585c1c2837d