### PR TITLE
Add F# join helpers

### DIFF
--- a/compile/x/fs/README.md
+++ b/compile/x/fs/README.md
@@ -81,7 +81,7 @@ The F# tests are tagged `slow` because they invoke the .NET toolchain. Run them 
 go test ./compile/fs -tags slow
 ```
 
-This command compiles the subset programs in `tests/compiler/fs` and also runs the example solutions for LeetCode problems 1–30 to ensure the generated F# code behaves correctly.
+This command compiles the subset programs in `tests/compiler/fs` and also runs the example solutions for LeetCode problems 1–30 to ensure the generated F# code behaves correctly.  The dataset now includes TPC-DS queries `q1.mochi` through `q99.mochi` which can also be compiled to F#.
 
 
 The tests compile Mochi sources from `tests/compiler/fs` and execute them with `dotnet fsi`:


### PR DESCRIPTION
## Summary
- add `_left_join`, `_right_join` and `_outer_join` helpers for the F# backend
- register the new helpers
- mention TPC‑DS query set in the README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68641449876883209d9d0eb0f6b411b0