### PR TITLE
Add TPC-DS q20–q49 smalltalk output

### DIFF
--- a/compile/x/st/TASKS.md
+++ b/compile/x/st/TASKS.md
@@ -8,7 +8,7 @@ golden tests cover `tpch_q1` and `tpch_q2` as well as simple `group_by` queries.
 Running the TPCH programs under `gst` still reports parse errors,
 so executing the compiled Smalltalk code remains TODO.
 
-The TPCDS suite now covers queries `q1` through `q19`. The Smalltalk backend
+The TPCDS suite now covers queries `q1` through `q49`. The Smalltalk backend
 successfully compiles these programs and golden output is stored under
 `tests/dataset/tpc-ds/compiler/st`.
 

--- a/compile/x/st/tpcds_golden_test.go
+++ b/compile/x/st/tpcds_golden_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSTCompiler_TPCDS_Golden(t *testing.T) {
 	root := testutil.FindRepoRoot(t)
-	for i := 1; i <= 19; i++ {
+	for i := 1; i <= 49; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")

--- a/tests/dataset/tpc-ds/compiler/st/q20.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q20.st.out
@@ -1,0 +1,144 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #class_totals put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_item_sk cs_sold_date_sk: cs_sold_date_sk cs_ext_sales_price: cs_ext_sales_price | dict |
+    dict := Dictionary new.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    dict at: 'cs_ext_sales_price' put: cs_ext_sales_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id i_item_desc: i_item_desc i_category: i_category i_class: i_class i_current_price: i_current_price | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    dict at: 'i_item_desc' put: i_item_desc.
+    dict at: 'i_category' put: i_category.
+    dict at: 'i_class' put: i_class.
+    dict at: 'i_current_price' put: i_current_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_date: d_date | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_date' put: d_date.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q20_revenue_ratio
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Item One'. 'i_category' -> 'A'. 'i_class' -> 'X'. 'i_current_price' -> 10.000000. 'itemrevenue' -> 600.000000. 'revenueratio' -> 66.666667}) with: (Dictionary from: {'i_item_id' -> 'ITEM2'. 'i_item_desc' -> 'Item Two'. 'i_category' -> 'A'. 'i_class' -> 'X'. 'i_current_price' -> 20.000000. 'itemrevenue' -> 300.000000. 'revenueratio' -> 33.333333}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_sold_date_sk' -> 1. 'cs_ext_sales_price' -> 100.000000}) with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_sold_date_sk' -> 1. 'cs_ext_sales_price' -> 200.000000}) with: (Dictionary from: {'cs_item_sk' -> 2. 'cs_sold_date_sk' -> 1. 'cs_ext_sales_price' -> 150.000000}) with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_sold_date_sk' -> 2. 'cs_ext_sales_price' -> 300.000000}) with: (Dictionary from: {'cs_item_sk' -> 2. 'cs_sold_date_sk' -> 2. 'cs_ext_sales_price' -> 150.000000}) with: (Dictionary from: {'cs_item_sk' -> 3. 'cs_sold_date_sk' -> 1. 'cs_ext_sales_price' -> 50.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Item One'. 'i_category' -> 'A'. 'i_class' -> 'X'. 'i_current_price' -> 10.000000}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'ITEM2'. 'i_item_desc' -> 'Item Two'. 'i_category' -> 'A'. 'i_class' -> 'X'. 'i_current_price' -> 20.000000}) with: (Dictionary from: {'i_item_sk' -> 3. 'i_item_id' -> 'ITEM3'. 'i_item_desc' -> 'Item Three'. 'i_category' -> 'D'. 'i_class' -> 'Y'. 'i_current_price' -> 15.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2000-02-10'}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_date' -> '2000-02-20'}).
+filtered := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_sales) do: [:cs |
+    ((((((Array with: 'A' with: 'B' with: 'C' includes: i at: 'i_category') and: [d at: 'd_date']) >= '2000-02-01') and: [d at: 'd_date']) <= '2000-03-02')) ifTrue: [ rows add: cs ].
+]
+groups := (Main _group_by: rows keyFn: [:cs | Dictionary from: {'id' -> i at: 'i_item_id'. 'desc' -> i at: 'i_item_desc'. 'cat' -> i at: 'i_category'. 'class' -> i at: 'i_class'. 'price' -> i at: 'i_current_price'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_item_id' -> g at: 'key' at: 'id'. 'i_item_desc' -> g at: 'key' at: 'desc'. 'i_category' -> g at: 'key' at: 'cat'. 'i_class' -> g at: 'key' at: 'class'. 'i_current_price' -> g at: 'key' at: 'price'. 'itemrevenue' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_ext_sales_price'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+class_totals := ((| rows groups |
+rows := OrderedCollection new.
+(filtered) do: [:f |
+    rows add: f.
+]
+groups := (Main _group_by: rows keyFn: [:f | f at: 'i_class']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'class' -> g at: 'key'. 'total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'itemrevenue'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((filtered) select: [:f | (f at: 'i_class' = t at: 'class')]) do: [:f |
+    (class_totals) do: [:t |
+        res add: { Array with: (f at: 'i_category') with: (f at: 'i_class') with: (f at: 'i_item_id') with: (f at: 'i_item_desc') . Dictionary from: {'i_item_id' -> f at: 'i_item_id'. 'i_item_desc' -> f at: 'i_item_desc'. 'i_category' -> f at: 'i_category'. 'i_class' -> f at: 'i_class'. 'i_current_price' -> f at: 'i_current_price'. 'itemrevenue' -> f at: 'itemrevenue'. 'revenueratio' -> (((f at: 'itemrevenue' * 100.000000)) / t at: 'total')} }.
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q20_revenue_ratio.

--- a/tests/dataset/tpc-ds/compiler/st/q21.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q21.st.out
@@ -1,0 +1,162 @@
+Smalltalk at: #after put: nil.
+Smalltalk at: #before put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #inventory put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #joined put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #warehouse put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newInventory: inv_item_sk inv_warehouse_sk: inv_warehouse_sk inv_date_sk: inv_date_sk inv_quantity_on_hand: inv_quantity_on_hand | dict |
+    dict := Dictionary new.
+    dict at: 'inv_item_sk' put: inv_item_sk.
+    dict at: 'inv_warehouse_sk' put: inv_warehouse_sk.
+    dict at: 'inv_date_sk' put: inv_date_sk.
+    dict at: 'inv_quantity_on_hand' put: inv_quantity_on_hand.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newWarehouse: w_warehouse_sk w_warehouse_name: w_warehouse_name | dict |
+    dict := Dictionary new.
+    dict at: 'w_warehouse_sk' put: w_warehouse_sk.
+    dict at: 'w_warehouse_name' put: w_warehouse_name.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_date: d_date | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_date' put: d_date.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q21_inventory_ratio
+    ((result = Array with: (Dictionary from: {'w_warehouse_name' -> 'Main'. 'i_item_id' -> 'ITEM1'. 'inv_before' -> 30. 'inv_after' -> 40}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+inventory := Array with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 1. 'inv_quantity_on_hand' -> 30}) with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 2. 'inv_quantity_on_hand' -> 40}) with: (Dictionary from: {'inv_item_sk' -> 2. 'inv_warehouse_sk' -> 2. 'inv_date_sk' -> 1. 'inv_quantity_on_hand' -> 20}) with: (Dictionary from: {'inv_item_sk' -> 2. 'inv_warehouse_sk' -> 2. 'inv_date_sk' -> 2. 'inv_quantity_on_hand' -> 20}).
+warehouse := Array with: (Dictionary from: {'w_warehouse_sk' -> 1. 'w_warehouse_name' -> 'Main'}) with: (Dictionary from: {'w_warehouse_sk' -> 2. 'w_warehouse_name' -> 'Backup'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'ITEM1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'ITEM2'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2000-03-01'}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_date' -> '2000-03-20'}).
+before := ((| rows groups |
+rows := OrderedCollection new.
+(inventory) do: [:inv |
+    ((d at: 'd_date' < '2000-03-15')) ifTrue: [ rows add: inv ].
+]
+groups := (Main _group_by: rows keyFn: [:inv | Dictionary from: {'w' -> inv at: 'inv_warehouse_sk'. 'i' -> inv at: 'inv_item_sk'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'w' -> g at: 'key' at: 'w'. 'i' -> g at: 'key' at: 'i'. 'qty' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'inv_quantity_on_hand'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+after := ((| rows groups |
+rows := OrderedCollection new.
+(inventory) do: [:inv |
+    ((d at: 'd_date' >= '2000-03-15')) ifTrue: [ rows add: inv ].
+]
+groups := (Main _group_by: rows keyFn: [:inv | Dictionary from: {'w' -> inv at: 'inv_warehouse_sk'. 'i' -> inv at: 'inv_item_sk'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'w' -> g at: 'key' at: 'w'. 'i' -> g at: 'key' at: 'i'. 'qty' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'inv_quantity_on_hand'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+joined := ((| res |
+res := OrderedCollection new.
+((before) select: [:b | (((((b at: 'w' = a at: 'w') and: [b at: 'i']) = a at: 'i') and: [(w at: 'w_warehouse_sk' = b at: 'w')]) and: [(it at: 'i_item_sk' = b at: 'i')])]) do: [:b |
+    (after) do: [:a |
+        (warehouse) do: [:w |
+            (item) do: [:it |
+                res add: Dictionary from: {'w_name' -> w at: 'w_warehouse_name'. 'i_id' -> it at: 'i_item_id'. 'before_qty' -> b at: 'qty'. 'after_qty' -> a at: 'qty'. 'ratio' -> (a at: 'qty' / b at: 'qty')}.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| res |
+res := OrderedCollection new.
+((joined) select: [:r | (((r at: 'ratio' >= ((2.000000 / 3.000000))) and: [r at: 'ratio']) <= ((3.000000 / 2.000000)))]) do: [:r |
+    res add: { Array with: (r at: 'w_name') with: (r at: 'i_id') . Dictionary from: {'w_warehouse_name' -> r at: 'w_name'. 'i_item_id' -> r at: 'i_id'. 'inv_before' -> r at: 'before_qty'. 'inv_after' -> r at: 'after_qty'} }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q21_inventory_ratio.

--- a/tests/dataset/tpc-ds/compiler/st/q22.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q22.st.out
@@ -1,0 +1,113 @@
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #inventory put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #qoh put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newInventory: inv_item_sk inv_date_sk: inv_date_sk inv_quantity_on_hand: inv_quantity_on_hand | dict |
+    dict := Dictionary new.
+    dict at: 'inv_item_sk' put: inv_item_sk.
+    dict at: 'inv_date_sk' put: inv_date_sk.
+    dict at: 'inv_quantity_on_hand' put: inv_quantity_on_hand.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_month_seq: d_month_seq | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_month_seq' put: d_month_seq.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_product_name: i_product_name i_brand: i_brand i_class: i_class i_category: i_category | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_product_name' put: i_product_name.
+    dict at: 'i_brand' put: i_brand.
+    dict at: 'i_class' put: i_class.
+    dict at: 'i_category' put: i_category.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q22_average_inventory
+    ((qoh = Array with: (Dictionary from: {'i_product_name' -> 'Prod1'. 'i_brand' -> 'Brand1'. 'i_class' -> 'Class1'. 'i_category' -> 'Cat1'. 'qoh' -> 15.000000}) with: (Dictionary from: {'i_product_name' -> 'Prod2'. 'i_brand' -> 'Brand2'. 'i_class' -> 'Class2'. 'i_category' -> 'Cat2'. 'qoh' -> 50.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+inventory := Array with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_date_sk' -> 1. 'inv_quantity_on_hand' -> 10}) with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_date_sk' -> 2. 'inv_quantity_on_hand' -> 20}) with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_date_sk' -> 3. 'inv_quantity_on_hand' -> 10}) with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_date_sk' -> 4. 'inv_quantity_on_hand' -> 20}) with: (Dictionary from: {'inv_item_sk' -> 2. 'inv_date_sk' -> 1. 'inv_quantity_on_hand' -> 50}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_month_seq' -> 0}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_month_seq' -> 1}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_month_seq' -> 2}) with: (Dictionary from: {'d_date_sk' -> 4. 'd_month_seq' -> 3}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_product_name' -> 'Prod1'. 'i_brand' -> 'Brand1'. 'i_class' -> 'Class1'. 'i_category' -> 'Cat1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_product_name' -> 'Prod2'. 'i_brand' -> 'Brand2'. 'i_class' -> 'Class2'. 'i_category' -> 'Cat2'}).
+qoh := ((| rows groups |
+rows := OrderedCollection new.
+(inventory) do: [:inv |
+    ((((d at: 'd_month_seq' >= 0) and: [d at: 'd_month_seq']) <= 11)) ifTrue: [ rows add: inv ].
+]
+groups := (Main _group_by: rows keyFn: [:inv | Dictionary from: {'product_name' -> i at: 'i_product_name'. 'brand' -> i at: 'i_brand'. 'class' -> i at: 'i_class'. 'category' -> i at: 'i_category'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_product_name' -> g at: 'key' at: 'product_name'. 'i_brand' -> g at: 'key' at: 'brand'. 'i_class' -> g at: 'key' at: 'class'. 'i_category' -> g at: 'key' at: 'category'. 'qoh' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'inv_quantity_on_hand'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(qoh toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q22_average_inventory.

--- a/tests/dataset/tpc-ds/compiler/st/q23.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q23.st.out
@@ -1,0 +1,197 @@
+Smalltalk at: #best_ss_customer put: nil.
+Smalltalk at: #catalog put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer_totals put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #frequent_ss_items put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #max_sales put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_item_sk ss_sold_date_sk: ss_sold_date_sk ss_customer_sk: ss_customer_sk ss_quantity: ss_quantity ss_sales_price: ss_sales_price | dict |
+    dict := Dictionary new.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_quantity' put: ss_quantity.
+    dict at: 'ss_sales_price' put: ss_sales_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year d_moy: d_moy | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    dict at: 'd_moy' put: d_moy.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_sold_date_sk cs_item_sk: cs_item_sk cs_bill_customer_sk: cs_bill_customer_sk cs_quantity: cs_quantity cs_list_price: cs_list_price | dict |
+    dict := Dictionary new.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    dict at: 'cs_bill_customer_sk' put: cs_bill_customer_sk.
+    dict at: 'cs_quantity' put: cs_quantity.
+    dict at: 'cs_list_price' put: cs_list_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newWebSale: ws_sold_date_sk ws_item_sk: ws_item_sk ws_bill_customer_sk: ws_bill_customer_sk ws_quantity: ws_quantity ws_list_price: ws_list_price | dict |
+    dict := Dictionary new.
+    dict at: 'ws_sold_date_sk' put: ws_sold_date_sk.
+    dict at: 'ws_item_sk' put: ws_item_sk.
+    dict at: 'ws_bill_customer_sk' put: ws_bill_customer_sk.
+    dict at: 'ws_quantity' put: ws_quantity.
+    dict at: 'ws_list_price' put: ws_list_price.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q23_cross_channel_sales
+    ((result = 50.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+__max: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'max() expects collection' ]
+    | m first |
+    first := true.
+    v do: [:it | first ifTrue: [ m := it. first := false ] ifFalse: [ (it > m) ifTrue: [ m := it ] ] ].
+    ^ first ifTrue: [ 0 ] ifFalse: [ m ]
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 2. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 2. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_customer_sk' -> 2. 'ss_quantity' -> 1. 'ss_sales_price' -> 10.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000. 'd_moy' -> 1}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1}) with: (Dictionary from: {'i_item_sk' -> 2}).
+catalog_sales := Array with: (Dictionary from: {'cs_sold_date_sk' -> 1. 'cs_item_sk' -> 1. 'cs_bill_customer_sk' -> 1. 'cs_quantity' -> 2. 'cs_list_price' -> 10.000000}) with: (Dictionary from: {'cs_sold_date_sk' -> 1. 'cs_item_sk' -> 2. 'cs_bill_customer_sk' -> 2. 'cs_quantity' -> 2. 'cs_list_price' -> 10.000000}).
+web_sales := Array with: (Dictionary from: {'ws_sold_date_sk' -> 1. 'ws_item_sk' -> 1. 'ws_bill_customer_sk' -> 1. 'ws_quantity' -> 3. 'ws_list_price' -> 10.000000}) with: (Dictionary from: {'ws_sold_date_sk' -> 1. 'ws_item_sk' -> 2. 'ws_bill_customer_sk' -> 2. 'ws_quantity' -> 1. 'ws_list_price' -> 10.000000}).
+frequent_ss_items := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    ((d at: 'd_year' = 2000)) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'item_sk' -> i at: 'i_item_sk'. 'date_sk' -> d at: 'd_date_sk'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    (((Main __count: g) > 4)) ifTrue: [ rows add: g at: 'key' at: 'item_sk' ].
+]
+rows := rows asArray.
+rows)).
+customer_totals := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    rows add: ss.
+]
+groups := (Main _group_by: rows keyFn: [:ss | ss at: 'ss_customer_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'cust' -> g at: 'key'. 'sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (x at: 'ss_quantity' * x at: 'ss_sales_price').
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+max_sales := (Main __max: ((| res |
+res := OrderedCollection new.
+(customer_totals) do: [:c |
+    res add: c at: 'sales'.
+]
+res := res asArray.
+res))).
+best_ss_customer := ((| res |
+res := OrderedCollection new.
+((customer_totals) select: [:c | ((c at: 'sales' > 0.950000) * max_sales)]) do: [:c |
+    res add: c at: 'cust'.
+]
+res := res asArray.
+res)).
+catalog := ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | ((frequent_ss_items includes: d at: 'd_year') and: [(cs at: 'cs_sold_date_sk' = d at: 'd_date_sk')])]) do: [:cs |
+    (date_dim) do: [:d |
+        res add: (cs at: 'cs_quantity' * cs at: 'cs_list_price').
+    ]
+]
+res := res asArray.
+res)).
+web := ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | ((frequent_ss_items includes: d at: 'd_year') and: [(ws at: 'ws_sold_date_sk' = d at: 'd_date_sk')])]) do: [:ws |
+    (date_dim) do: [:d |
+        res add: (ws at: 'ws_quantity' * ws at: 'ws_list_price').
+    ]
+]
+res := res asArray.
+res)).
+result := ((Main __sum: catalog) + (Main __sum: web)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q23_cross_channel_sales.

--- a/tests/dataset/tpc-ds/compiler/st/q24.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q24.st.out
@@ -1,0 +1,176 @@
+Smalltalk at: #avg_paid put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #ssales put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_returns put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_ticket_number ss_item_sk: ss_item_sk ss_customer_sk: ss_customer_sk ss_store_sk: ss_store_sk ss_net_paid: ss_net_paid | dict |
+    dict := Dictionary new.
+    dict at: 'ss_ticket_number' put: ss_ticket_number.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_store_sk' put: ss_store_sk.
+    dict at: 'ss_net_paid' put: ss_net_paid.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStoreReturn: sr_ticket_number sr_item_sk: sr_item_sk | dict |
+    dict := Dictionary new.
+    dict at: 'sr_ticket_number' put: sr_ticket_number.
+    dict at: 'sr_item_sk' put: sr_item_sk.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_store_name: s_store_name s_market_id: s_market_id s_state: s_state s_zip: s_zip | dict |
+    dict := Dictionary new.
+    dict at: 's_store_sk' put: s_store_sk.
+    dict at: 's_store_name' put: s_store_name.
+    dict at: 's_market_id' put: s_market_id.
+    dict at: 's_state' put: s_state.
+    dict at: 's_zip' put: s_zip.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_color: i_color i_current_price: i_current_price i_manager_id: i_manager_id i_units: i_units i_size: i_size | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_color' put: i_color.
+    dict at: 'i_current_price' put: i_current_price.
+    dict at: 'i_manager_id' put: i_manager_id.
+    dict at: 'i_units' put: i_units.
+    dict at: 'i_size' put: i_size.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomer: c_customer_sk c_first_name: c_first_name c_last_name: c_last_name c_current_addr_sk: c_current_addr_sk c_birth_country: c_birth_country | dict |
+    dict := Dictionary new.
+    dict at: 'c_customer_sk' put: c_customer_sk.
+    dict at: 'c_first_name' put: c_first_name.
+    dict at: 'c_last_name' put: c_last_name.
+    dict at: 'c_current_addr_sk' put: c_current_addr_sk.
+    dict at: 'c_birth_country' put: c_birth_country.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_state: ca_state ca_country: ca_country ca_zip: ca_zip | dict |
+    dict := Dictionary new.
+    dict at: 'ca_address_sk' put: ca_address_sk.
+    dict at: 'ca_state' put: ca_state.
+    dict at: 'ca_country' put: ca_country.
+    dict at: 'ca_zip' put: ca_zip.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q24_customer_net_paid
+    ((result = Array with: (Dictionary from: {'c_last_name' -> 'Smith'. 'c_first_name' -> 'Ann'. 's_store_name' -> 'Store1'. 'paid' -> 100.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_item_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_store_sk' -> 1. 'ss_net_paid' -> 100.000000}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_item_sk' -> 2. 'ss_customer_sk' -> 2. 'ss_store_sk' -> 1. 'ss_net_paid' -> 50.000000}).
+store_returns := Array with: (Dictionary from: {'sr_ticket_number' -> 1. 'sr_item_sk' -> 1}) with: (Dictionary from: {'sr_ticket_number' -> 2. 'sr_item_sk' -> 2}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_store_name' -> 'Store1'. 's_market_id' -> 5. 's_state' -> 'CA'. 's_zip' -> '12345'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_color' -> 'RED'. 'i_current_price' -> 10.000000. 'i_manager_id' -> 1. 'i_units' -> 'EA'. 'i_size' -> 'M'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_color' -> 'BLUE'. 'i_current_price' -> 20.000000. 'i_manager_id' -> 2. 'i_units' -> 'EA'. 'i_size' -> 'L'}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_first_name' -> 'Ann'. 'c_last_name' -> 'Smith'. 'c_current_addr_sk' -> 1. 'c_birth_country' -> 'Canada'}) with: (Dictionary from: {'c_customer_sk' -> 2. 'c_first_name' -> 'Bob'. 'c_last_name' -> 'Jones'. 'c_current_addr_sk' -> 2. 'c_birth_country' -> 'USA'}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'. 'ca_country' -> 'USA'. 'ca_zip' -> '12345'}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_state' -> 'CA'. 'ca_country' -> 'USA'. 'ca_zip' -> '54321'}).
+ssales := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    ((((((c at: 'c_birth_country' ~= (strings at: 'ToUpper' value: ca at: 'ca_country')) and: [s at: 's_zip']) = ca at: 'ca_zip') and: [s at: 's_market_id']) = 5)) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'last' -> c at: 'c_last_name'. 'first' -> c at: 'c_first_name'. 'store_name' -> s at: 's_store_name'. 'color' -> i at: 'i_color'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'c_last_name' -> g at: 'key' at: 'last'. 'c_first_name' -> g at: 'key' at: 'first'. 's_store_name' -> g at: 'key' at: 'store_name'. 'color' -> g at: 'key' at: 'color'. 'netpaid' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_net_paid'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+avg_paid := (Main __avg: ((| res |
+res := OrderedCollection new.
+(ssales) do: [:x |
+    res add: x at: 'netpaid'.
+]
+res := res asArray.
+res))).
+result := ((| res |
+res := OrderedCollection new.
+((ssales) select: [:x | ((((x at: 'color' = 'RED') and: [x at: 'netpaid']) > 0.050000) * avg_paid)]) do: [:x |
+    res add: { Array with: (x at: 'c_last_name') with: (x at: 'c_first_name') with: (x at: 's_store_name') . Dictionary from: {'c_last_name' -> x at: 'c_last_name'. 'c_first_name' -> x at: 'c_first_name'. 's_store_name' -> x at: 's_store_name'. 'paid' -> x at: 'netpaid'} }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q24_customer_net_paid.

--- a/tests/dataset/tpc-ds/compiler/st/q25.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q25.st.out
@@ -1,0 +1,159 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_returns put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_sold_date_sk ss_item_sk: ss_item_sk ss_store_sk: ss_store_sk ss_customer_sk: ss_customer_sk ss_net_profit: ss_net_profit ss_ticket_number: ss_ticket_number | dict |
+    dict := Dictionary new.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_store_sk' put: ss_store_sk.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_net_profit' put: ss_net_profit.
+    dict at: 'ss_ticket_number' put: ss_ticket_number.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStoreReturn: sr_returned_date_sk sr_item_sk: sr_item_sk sr_customer_sk: sr_customer_sk sr_ticket_number: sr_ticket_number sr_net_loss: sr_net_loss | dict |
+    dict := Dictionary new.
+    dict at: 'sr_returned_date_sk' put: sr_returned_date_sk.
+    dict at: 'sr_item_sk' put: sr_item_sk.
+    dict at: 'sr_customer_sk' put: sr_customer_sk.
+    dict at: 'sr_ticket_number' put: sr_ticket_number.
+    dict at: 'sr_net_loss' put: sr_net_loss.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_sold_date_sk cs_item_sk: cs_item_sk cs_bill_customer_sk: cs_bill_customer_sk cs_net_profit: cs_net_profit | dict |
+    dict := Dictionary new.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    dict at: 'cs_bill_customer_sk' put: cs_bill_customer_sk.
+    dict at: 'cs_net_profit' put: cs_net_profit.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_moy: d_moy d_year: d_year | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_moy' put: d_moy.
+    dict at: 'd_year' put: d_year.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_store_id: s_store_id s_store_name: s_store_name | dict |
+    dict := Dictionary new.
+    dict at: 's_store_sk' put: s_store_sk.
+    dict at: 's_store_id' put: s_store_id.
+    dict at: 's_store_name' put: s_store_name.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id i_item_desc: i_item_desc | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    dict at: 'i_item_desc' put: i_item_desc.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q25_aggregated_profit
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Desc1'. 's_store_id' -> 'S1'. 's_store_name' -> 'Store1'. 'store_sales_profit' -> 50.000000. 'store_returns_loss' -> 10.000000. 'catalog_sales_profit' -> 30.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1. 'ss_store_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_net_profit' -> 50.000000. 'ss_ticket_number' -> 1}) with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 2. 'ss_store_sk' -> 1. 'ss_customer_sk' -> 2. 'ss_net_profit' -> 20.000000. 'ss_ticket_number' -> 2}).
+store_returns := Array with: (Dictionary from: {'sr_returned_date_sk' -> 2. 'sr_item_sk' -> 1. 'sr_customer_sk' -> 1. 'sr_ticket_number' -> 1. 'sr_net_loss' -> 10.000000}) with: (Dictionary from: {'sr_returned_date_sk' -> 2. 'sr_item_sk' -> 2. 'sr_customer_sk' -> 2. 'sr_ticket_number' -> 2. 'sr_net_loss' -> 5.000000}).
+catalog_sales := Array with: (Dictionary from: {'cs_sold_date_sk' -> 3. 'cs_item_sk' -> 1. 'cs_bill_customer_sk' -> 1. 'cs_net_profit' -> 30.000000}) with: (Dictionary from: {'cs_sold_date_sk' -> 3. 'cs_item_sk' -> 2. 'cs_bill_customer_sk' -> 2. 'cs_net_profit' -> 15.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_moy' -> 4. 'd_year' -> 2000}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_moy' -> 5. 'd_year' -> 2000}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_moy' -> 6. 'd_year' -> 2000}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_store_id' -> 'S1'. 's_store_name' -> 'Store1'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Desc1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'ITEM2'. 'i_item_desc' -> 'Desc2'}).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    ((((((((((((d1 at: 'd_moy' = 4) and: [d1 at: 'd_year']) = 2000) and: [d2 at: 'd_moy']) >= 4) and: [d2 at: 'd_moy']) <= 10) and: [d3 at: 'd_moy']) >= 4) and: [d3 at: 'd_moy']) <= 10)) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'item_id' -> i at: 'i_item_id'. 'item_desc' -> i at: 'i_item_desc'. 's_store_id' -> s at: 's_store_id'. 's_store_name' -> s at: 's_store_name'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_item_id' -> g at: 'key' at: 'item_id'. 'i_item_desc' -> g at: 'key' at: 'item_desc'. 's_store_id' -> g at: 'key' at: 's_store_id'. 's_store_name' -> g at: 'key' at: 's_store_name'. 'store_sales_profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_net_profit'.
+]
+res := res asArray.
+res))). 'store_returns_loss' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'sr_net_loss'.
+]
+res := res asArray.
+res))). 'catalog_sales_profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q25_aggregated_profit.

--- a/tests/dataset/tpc-ds/compiler/st/q26.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q26.st.out
@@ -1,0 +1,154 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #promotion put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_sold_date_sk cs_item_sk: cs_item_sk cs_bill_cdemo_sk: cs_bill_cdemo_sk cs_promo_sk: cs_promo_sk cs_quantity: cs_quantity cs_list_price: cs_list_price cs_coupon_amt: cs_coupon_amt cs_sales_price: cs_sales_price | dict |
+    dict := Dictionary new.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    dict at: 'cs_bill_cdemo_sk' put: cs_bill_cdemo_sk.
+    dict at: 'cs_promo_sk' put: cs_promo_sk.
+    dict at: 'cs_quantity' put: cs_quantity.
+    dict at: 'cs_list_price' put: cs_list_price.
+    dict at: 'cs_coupon_amt' put: cs_coupon_amt.
+    dict at: 'cs_sales_price' put: cs_sales_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerDemo: cd_demo_sk cd_gender: cd_gender cd_marital_status: cd_marital_status cd_education_status: cd_education_status | dict |
+    dict := Dictionary new.
+    dict at: 'cd_demo_sk' put: cd_demo_sk.
+    dict at: 'cd_gender' put: cd_gender.
+    dict at: 'cd_marital_status' put: cd_marital_status.
+    dict at: 'cd_education_status' put: cd_education_status.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newPromotion: p_promo_sk p_channel_email: p_channel_email p_channel_event: p_channel_event | dict |
+    dict := Dictionary new.
+    dict at: 'p_promo_sk' put: p_promo_sk.
+    dict at: 'p_channel_email' put: p_channel_email.
+    dict at: 'p_channel_event' put: p_channel_event.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q26_demographic_averages
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'ITEM1'. 'agg1' -> 10.000000. 'agg2' -> 100.000000. 'agg3' -> 5.000000. 'agg4' -> 95.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_sold_date_sk' -> 1. 'cs_item_sk' -> 1. 'cs_bill_cdemo_sk' -> 1. 'cs_promo_sk' -> 1. 'cs_quantity' -> 10. 'cs_list_price' -> 100.000000. 'cs_coupon_amt' -> 5.000000. 'cs_sales_price' -> 95.000000}) with: (Dictionary from: {'cs_sold_date_sk' -> 1. 'cs_item_sk' -> 2. 'cs_bill_cdemo_sk' -> 2. 'cs_promo_sk' -> 2. 'cs_quantity' -> 5. 'cs_list_price' -> 50.000000. 'cs_coupon_amt' -> 2.000000. 'cs_sales_price' -> 48.000000}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_gender' -> 'M'. 'cd_marital_status' -> 'S'. 'cd_education_status' -> 'College'}) with: (Dictionary from: {'cd_demo_sk' -> 2. 'cd_gender' -> 'F'. 'cd_marital_status' -> 'M'. 'cd_education_status' -> 'High School'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'ITEM1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'ITEM2'}).
+promotion := Array with: (Dictionary from: {'p_promo_sk' -> 1. 'p_channel_email' -> 'N'. 'p_channel_event' -> 'Y'}) with: (Dictionary from: {'p_promo_sk' -> 2. 'p_channel_email' -> 'Y'. 'p_channel_event' -> 'N'}).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_sales) do: [:cs |
+    (((((((((cd at: 'cd_gender' = 'M') and: [cd at: 'cd_marital_status']) = 'S') and: [cd at: 'cd_education_status']) = 'College') and: [((((p at: 'p_channel_email' = 'N') or: [p at: 'p_channel_event']) = 'N'))]) and: [d at: 'd_year']) = 2000)) ifTrue: [ rows add: cs ].
+]
+groups := (Main _group_by: rows keyFn: [:cs | i at: 'i_item_id']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_item_id' -> g at: 'key'. 'agg1' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_quantity'.
+]
+res := res asArray.
+res))). 'agg2' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_list_price'.
+]
+res := res asArray.
+res))). 'agg3' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_coupon_amt'.
+]
+res := res asArray.
+res))). 'agg4' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_sales_price'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q26_demographic_averages.

--- a/tests/dataset/tpc-ds/compiler/st/q27.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q27.st.out
@@ -1,0 +1,115 @@
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_item_sk ss_store_sk: ss_store_sk ss_cdemo_sk: ss_cdemo_sk ss_sold_date_sk: ss_sold_date_sk ss_quantity: ss_quantity ss_list_price: ss_list_price ss_coupon_amt: ss_coupon_amt ss_sales_price: ss_sales_price | dict |
+    dict := Dictionary new.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_store_sk' put: ss_store_sk.
+    dict at: 'ss_cdemo_sk' put: ss_cdemo_sk.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_quantity' put: ss_quantity.
+    dict at: 'ss_list_price' put: ss_list_price.
+    dict at: 'ss_coupon_amt' put: ss_coupon_amt.
+    dict at: 'ss_sales_price' put: ss_sales_price.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerDemo: cd_demo_sk cd_gender: cd_gender cd_marital_status: cd_marital_status cd_education_status: cd_education_status | dict |
+    dict := Dictionary new.
+    dict at: 'cd_demo_sk' put: cd_demo_sk.
+    dict at: 'cd_gender' put: cd_gender.
+    dict at: 'cd_marital_status' put: cd_marital_status.
+    dict at: 'cd_education_status' put: cd_education_status.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_year' put: d_year.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_state: s_state | dict |
+    dict := Dictionary new.
+    dict at: 's_store_sk' put: s_store_sk.
+    dict at: 's_state' put: s_state.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q27_averages_by_state
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'ITEM1'. 's_state' -> 'CA'. 'agg1' -> 5.000000. 'agg2' -> 100.000000. 'agg3' -> 10.000000. 'agg4' -> 90.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_store_sk' -> 1. 'ss_cdemo_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_quantity' -> 5. 'ss_list_price' -> 100.000000. 'ss_coupon_amt' -> 10.000000. 'ss_sales_price' -> 90.000000}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_store_sk' -> 2. 'ss_cdemo_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_quantity' -> 2. 'ss_list_price' -> 50.000000. 'ss_coupon_amt' -> 5.000000. 'ss_sales_price' -> 45.000000}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_gender' -> 'F'. 'cd_marital_status' -> 'M'. 'cd_education_status' -> 'College'}) with: (Dictionary from: {'cd_demo_sk' -> 2. 'cd_gender' -> 'M'. 'cd_marital_status' -> 'S'. 'cd_education_status' -> 'College'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_state' -> 'CA'}) with: (Dictionary from: {'s_store_sk' -> 2. 's_state' -> 'TX'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'ITEM1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'ITEM2'}).
+result := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (((((Array with: 'CA' includes: cd at: 'cd_gender') and: [(ss at: 'ss_cdemo_sk' = cd at: 'cd_demo_sk')]) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(ss at: 'ss_store_sk' = s at: 's_store_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')])]) do: [:ss |
+    (customer_demographics) do: [:cd |
+        (date_dim) do: [:d |
+            (store) do: [:s |
+                (item) do: [:i |
+                    res add: { Array with: (g at: 'key' at: 'item_id') with: (g at: 'key' at: 'state') . Dictionary from: {'i_item_id' -> g at: 'key' at: 'item_id'. 's_state' -> g at: 'key' at: 'state'. 'agg1' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_quantity'.
+]
+res := res asArray.
+res))). 'agg2' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_list_price'.
+]
+res := res asArray.
+res))). 'agg3' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_coupon_amt'.
+]
+res := res asArray.
+res))). 'agg4' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_sales_price'.
+]
+res := res asArray.
+res)))} }.
+                ]
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q27_averages_by_state.

--- a/tests/dataset/tpc-ds/compiler/st/q28.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q28.st.out
@@ -1,0 +1,130 @@
+Smalltalk at: #bucket1 put: nil.
+Smalltalk at: #bucket2 put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_quantity ss_list_price: ss_list_price ss_coupon_amt: ss_coupon_amt ss_wholesale_cost: ss_wholesale_cost | dict |
+    dict := Dictionary new.
+    dict at: 'ss_quantity' put: ss_quantity.
+    dict at: 'ss_list_price' put: ss_list_price.
+    dict at: 'ss_coupon_amt' put: ss_coupon_amt.
+    dict at: 'ss_wholesale_cost' put: ss_wholesale_cost.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q28_buckets
+    ((result = Dictionary from: {'B1_LP' -> 100.000000. 'B1_CNT' -> 1. 'B1_CNTD' -> 1. 'B2_LP' -> 80.000000. 'B2_CNT' -> 1. 'B2_CNTD' -> 1})) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_quantity' -> 3. 'ss_list_price' -> 100.000000. 'ss_coupon_amt' -> 50.000000. 'ss_wholesale_cost' -> 30.000000}) with: (Dictionary from: {'ss_quantity' -> 8. 'ss_list_price' -> 80.000000. 'ss_coupon_amt' -> 10.000000. 'ss_wholesale_cost' -> 20.000000}) with: (Dictionary from: {'ss_quantity' -> 12. 'ss_list_price' -> 60.000000. 'ss_coupon_amt' -> 5.000000. 'ss_wholesale_cost' -> 15.000000}).
+bucket1 := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((ss at: 'ss_quantity' >= 0) and: [ss at: 'ss_quantity']) <= 5) and: [(((((((ss at: 'ss_list_price' >= 0) and: [ss at: 'ss_list_price']) <= 110)) or: [((((ss at: 'ss_coupon_amt' >= 0) and: [ss at: 'ss_coupon_amt']) <= 1000))]) or: [((((ss at: 'ss_wholesale_cost' >= 0) and: [ss at: 'ss_wholesale_cost']) <= 50))]))])]) do: [:ss |
+    res add: ss.
+]
+res := res asArray.
+res)).
+bucket2 := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((ss at: 'ss_quantity' >= 6) and: [ss at: 'ss_quantity']) <= 10) and: [(((((((ss at: 'ss_list_price' >= 0) and: [ss at: 'ss_list_price']) <= 110)) or: [((((ss at: 'ss_coupon_amt' >= 0) and: [ss at: 'ss_coupon_amt']) <= 1000))]) or: [((((ss at: 'ss_wholesale_cost' >= 0) and: [ss at: 'ss_wholesale_cost']) <= 50))]))])]) do: [:ss |
+    res add: ss.
+]
+res := res asArray.
+res)).
+result := Dictionary from: {'B1_LP' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(bucket1) do: [:x |
+    res add: x at: 'ss_list_price'.
+]
+res := res asArray.
+res))). 'B1_CNT' -> (Main __count: bucket1). 'B1_CNTD' -> (Main __count: ((| rows groups |
+rows := OrderedCollection new.
+(bucket1) do: [:x |
+    rows add: x.
+]
+groups := (Main _group_by: rows keyFn: [:x | x at: 'ss_list_price']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: g at: 'key'.
+]
+rows := rows asArray.
+rows))). 'B2_LP' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(bucket2) do: [:x |
+    res add: x at: 'ss_list_price'.
+]
+res := res asArray.
+res))). 'B2_CNT' -> (Main __count: bucket2). 'B2_CNTD' -> (Main __count: ((| rows groups |
+rows := OrderedCollection new.
+(bucket2) do: [:x |
+    rows add: x.
+]
+groups := (Main _group_by: rows keyFn: [:x | x at: 'ss_list_price']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: g at: 'key'.
+]
+rows := rows asArray.
+rows)))}.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q28_buckets.

--- a/tests/dataset/tpc-ds/compiler/st/q29.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q29.st.out
@@ -1,0 +1,181 @@
+Smalltalk at: #base put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_returns put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_sold_date_sk ss_item_sk: ss_item_sk ss_store_sk: ss_store_sk ss_customer_sk: ss_customer_sk ss_quantity: ss_quantity ss_ticket_number: ss_ticket_number | dict |
+    dict := Dictionary new.
+    dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+    dict at: 'ss_item_sk' put: ss_item_sk.
+    dict at: 'ss_store_sk' put: ss_store_sk.
+    dict at: 'ss_customer_sk' put: ss_customer_sk.
+    dict at: 'ss_quantity' put: ss_quantity.
+    dict at: 'ss_ticket_number' put: ss_ticket_number.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStoreReturn: sr_returned_date_sk sr_item_sk: sr_item_sk sr_customer_sk: sr_customer_sk sr_ticket_number: sr_ticket_number sr_return_quantity: sr_return_quantity | dict |
+    dict := Dictionary new.
+    dict at: 'sr_returned_date_sk' put: sr_returned_date_sk.
+    dict at: 'sr_item_sk' put: sr_item_sk.
+    dict at: 'sr_customer_sk' put: sr_customer_sk.
+    dict at: 'sr_ticket_number' put: sr_ticket_number.
+    dict at: 'sr_return_quantity' put: sr_return_quantity.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_sold_date_sk cs_item_sk: cs_item_sk cs_bill_customer_sk: cs_bill_customer_sk cs_quantity: cs_quantity | dict |
+    dict := Dictionary new.
+    dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+    dict at: 'cs_item_sk' put: cs_item_sk.
+    dict at: 'cs_bill_customer_sk' put: cs_bill_customer_sk.
+    dict at: 'cs_quantity' put: cs_quantity.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_moy: d_moy d_year: d_year | dict |
+    dict := Dictionary new.
+    dict at: 'd_date_sk' put: d_date_sk.
+    dict at: 'd_moy' put: d_moy.
+    dict at: 'd_year' put: d_year.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_store_id: s_store_id s_store_name: s_store_name | dict |
+    dict := Dictionary new.
+    dict at: 's_store_sk' put: s_store_sk.
+    dict at: 's_store_id' put: s_store_id.
+    dict at: 's_store_name' put: s_store_name.
+    ^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id i_item_desc: i_item_desc | dict |
+    dict := Dictionary new.
+    dict at: 'i_item_sk' put: i_item_sk.
+    dict at: 'i_item_id' put: i_item_id.
+    dict at: 'i_item_desc' put: i_item_desc.
+    ^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q29_quantity_summary
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Desc1'. 's_store_id' -> 'S1'. 's_store_name' -> 'Store1'. 'store_sales_quantity' -> 10. 'store_returns_quantity' -> 2. 'catalog_sales_quantity' -> 5}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 1. 'ss_store_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_quantity' -> 10. 'ss_ticket_number' -> 1}).
+store_returns := Array with: (Dictionary from: {'sr_returned_date_sk' -> 2. 'sr_item_sk' -> 1. 'sr_customer_sk' -> 1. 'sr_ticket_number' -> 1. 'sr_return_quantity' -> 2}).
+catalog_sales := Array with: (Dictionary from: {'cs_sold_date_sk' -> 3. 'cs_item_sk' -> 1. 'cs_bill_customer_sk' -> 1. 'cs_quantity' -> 5}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_moy' -> 4. 'd_year' -> 1999}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_moy' -> 5. 'd_year' -> 1999}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_moy' -> 5. 'd_year' -> 2000}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_store_id' -> 'S1'. 's_store_name' -> 'Store1'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'ITEM1'. 'i_item_desc' -> 'Desc1'}).
+base := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((((((Array with: 1999 with: 2000 with: 2001 includes: d1 at: 'd_moy') and: [(((ss at: 'ss_ticket_number' = sr at: 'sr_ticket_number') and: [ss at: 'ss_item_sk']) = sr at: 'sr_item_sk')]) and: [(((sr at: 'sr_customer_sk' = cs at: 'cs_bill_customer_sk') and: [sr at: 'sr_item_sk']) = cs at: 'cs_item_sk')]) and: [(d1 at: 'd_date_sk' = ss at: 'ss_sold_date_sk')]) and: [(d2 at: 'd_date_sk' = sr at: 'sr_returned_date_sk')]) and: [(d3 at: 'd_date_sk' = cs at: 'cs_sold_date_sk')]) and: [(s at: 's_store_sk' = ss at: 'ss_store_sk')]) and: [(i at: 'i_item_sk' = ss at: 'ss_item_sk')])]) do: [:ss |
+    (store_returns) do: [:sr |
+        (catalog_sales) do: [:cs |
+            (date_dim) do: [:d1 |
+                (date_dim) do: [:d2 |
+                    (date_dim) do: [:d3 |
+                        (store) do: [:s |
+                            (item) do: [:i |
+                                res add: Dictionary from: {'ss_quantity' -> ss at: 'ss_quantity'. 'sr_return_quantity' -> sr at: 'sr_return_quantity'. 'cs_quantity' -> cs at: 'cs_quantity'. 'i_item_id' -> i at: 'i_item_id'. 'i_item_desc' -> i at: 'i_item_desc'. 's_store_id' -> s at: 's_store_id'. 's_store_name' -> s at: 's_store_name'}.
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(base) do: [:b |
+    rows add: b.
+]
+groups := (Main _group_by: rows keyFn: [:b | Dictionary from: {'item_id' -> b at: 'i_item_id'. 'item_desc' -> b at: 'i_item_desc'. 's_store_id' -> b at: 's_store_id'. 's_store_name' -> b at: 's_store_name'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'i_item_id' -> g at: 'key' at: 'item_id'. 'i_item_desc' -> g at: 'key' at: 'item_desc'. 's_store_id' -> g at: 'key' at: 's_store_id'. 's_store_name' -> g at: 'key' at: 's_store_name'. 'store_sales_quantity' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_quantity'.
+]
+res := res asArray.
+res))). 'store_returns_quantity' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'sr_return_quantity'.
+]
+res := res asArray.
+res))). 'catalog_sales_quantity' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'cs_quantity'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q29_quantity_summary.

--- a/tests/dataset/tpc-ds/compiler/st/q30.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q30.st.out
@@ -1,0 +1,128 @@
+Smalltalk at: #avg_by_state put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_total_return put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_returns put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q30_simplified
+    ((result = Array with: (Dictionary from: {'c_customer_id' -> 'C1'. 'c_first_name' -> 'John'. 'c_last_name' -> 'Doe'. 'ctr_total_return' -> 150.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+web_returns := Array with: (Dictionary from: {'wr_returning_customer_sk' -> 1. 'wr_returned_date_sk' -> 1. 'wr_return_amt' -> 100.000000. 'wr_returning_addr_sk' -> 1}) with: (Dictionary from: {'wr_returning_customer_sk' -> 2. 'wr_returned_date_sk' -> 1. 'wr_return_amt' -> 30.000000. 'wr_returning_addr_sk' -> 2}) with: (Dictionary from: {'wr_returning_customer_sk' -> 1. 'wr_returned_date_sk' -> 1. 'wr_return_amt' -> 50.000000. 'wr_returning_addr_sk' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_state' -> 'CA'}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_customer_id' -> 'C1'. 'c_first_name' -> 'John'. 'c_last_name' -> 'Doe'. 'c_current_addr_sk' -> 1}) with: (Dictionary from: {'c_customer_sk' -> 2. 'c_customer_id' -> 'C2'. 'c_first_name' -> 'Jane'. 'c_last_name' -> 'Smith'. 'c_current_addr_sk' -> 2}).
+customer_total_return := ((| rows groups |
+rows := OrderedCollection new.
+(web_returns) do: [:wr |
+    ((((d at: 'd_year' = 2000) and: [ca at: 'ca_state']) = 'CA')) ifTrue: [ rows add: wr ].
+]
+groups := (Main _group_by: rows keyFn: [:wr | Dictionary from: {'cust' -> wr at: 'wr_returning_customer_sk'. 'state' -> ca at: 'ca_state'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'ctr_customer_sk' -> g at: 'key' at: 'cust'. 'ctr_state' -> g at: 'key' at: 'state'. 'ctr_total_return' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'wr_return_amt'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+avg_by_state := ((| rows groups |
+rows := OrderedCollection new.
+(customer_total_return) do: [:ctr |
+    rows add: ctr.
+]
+groups := (Main _group_by: rows keyFn: [:ctr | ctr at: 'ctr_state']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'state' -> g at: 'key'. 'avg_return' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ctr_total_return'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((customer_total_return) select: [:ctr | ((((ctr at: 'ctr_total_return' > avg at: 'avg_return') * 1.200000) and: [(ctr at: 'ctr_state' = avg at: 'state')]) and: [(ctr at: 'ctr_customer_sk' = c at: 'c_customer_sk')])]) do: [:ctr |
+    (avg_by_state) do: [:avg |
+        (customer) do: [:c |
+            res add: Dictionary from: {'c_customer_id' -> c at: 'c_customer_id'. 'c_first_name' -> c at: 'c_first_name'. 'c_last_name' -> c at: 'c_last_name'. 'ctr_total_return' -> ctr at: 'ctr_total_return'}.
+        ]
+    ]
+]
+res := res asArray.
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q30_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q31.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q31.st.out
@@ -1,0 +1,80 @@
+Smalltalk at: #counties put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q31_simplified
+    ((result = Array with: (Dictionary from: {'ca_county' -> 'A'. 'd_year' -> 2000. 'web_q1_q2_increase' -> 1.500000. 'store_q1_q2_increase' -> 1.200000. 'web_q2_q3_increase' -> 1.666667. 'store_q2_q3_increase' -> 1.333333}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'ca_county' -> 'A'. 'd_qoy' -> 1. 'd_year' -> 2000. 'ss_ext_sales_price' -> 100.000000}) with: (Dictionary from: {'ca_county' -> 'A'. 'd_qoy' -> 2. 'd_year' -> 2000. 'ss_ext_sales_price' -> 120.000000}) with: (Dictionary from: {'ca_county' -> 'A'. 'd_qoy' -> 3. 'd_year' -> 2000. 'ss_ext_sales_price' -> 160.000000}) with: (Dictionary from: {'ca_county' -> 'B'. 'd_qoy' -> 1. 'd_year' -> 2000. 'ss_ext_sales_price' -> 80.000000}) with: (Dictionary from: {'ca_county' -> 'B'. 'd_qoy' -> 2. 'd_year' -> 2000. 'ss_ext_sales_price' -> 90.000000}) with: (Dictionary from: {'ca_county' -> 'B'. 'd_qoy' -> 3. 'd_year' -> 2000. 'ss_ext_sales_price' -> 100.000000}).
+web_sales := Array with: (Dictionary from: {'ca_county' -> 'A'. 'd_qoy' -> 1. 'd_year' -> 2000. 'ws_ext_sales_price' -> 100.000000}) with: (Dictionary from: {'ca_county' -> 'A'. 'd_qoy' -> 2. 'd_year' -> 2000. 'ws_ext_sales_price' -> 150.000000}) with: (Dictionary from: {'ca_county' -> 'A'. 'd_qoy' -> 3. 'd_year' -> 2000. 'ws_ext_sales_price' -> 250.000000}) with: (Dictionary from: {'ca_county' -> 'B'. 'd_qoy' -> 1. 'd_year' -> 2000. 'ws_ext_sales_price' -> 80.000000}) with: (Dictionary from: {'ca_county' -> 'B'. 'd_qoy' -> 2. 'd_year' -> 2000. 'ws_ext_sales_price' -> 90.000000}) with: (Dictionary from: {'ca_county' -> 'B'. 'd_qoy' -> 3. 'd_year' -> 2000. 'ws_ext_sales_price' -> 95.000000}).
+counties := Array with: 'A' with: 'B'.
+result := Array new.
+(counties) do: [:county |
+    ss1 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ca_county' = county) and: [s at: 'd_qoy']) = 1)]) do: [:s |
+    res add: s at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res))).
+    ss2 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ca_county' = county) and: [s at: 'd_qoy']) = 2)]) do: [:s |
+    res add: s at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res))).
+    ss3 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'ca_county' = county) and: [s at: 'd_qoy']) = 3)]) do: [:s |
+    res add: s at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res))).
+    ws1 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:w | (((w at: 'ca_county' = county) and: [w at: 'd_qoy']) = 1)]) do: [:w |
+    res add: w at: 'ws_ext_sales_price'.
+]
+res := res asArray.
+res))).
+    ws2 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:w | (((w at: 'ca_county' = county) and: [w at: 'd_qoy']) = 2)]) do: [:w |
+    res add: w at: 'ws_ext_sales_price'.
+]
+res := res asArray.
+res))).
+    ws3 := (Main __sum: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:w | (((w at: 'ca_county' = county) and: [w at: 'd_qoy']) = 3)]) do: [:w |
+    res add: w at: 'ws_ext_sales_price'.
+]
+res := res asArray.
+res))).
+    web_g1 := (ws2 / ws1).
+    store_g1 := (ss2 / ss1).
+    web_g2 := (ws3 / ws2).
+    store_g2 := (ss3 / ss2).
+    ((((web_g1 > store_g1) and: [web_g2]) > store_g2)) ifTrue: [
+        result := (result copyWith: Dictionary from: {'ca_county' -> county. 'd_year' -> 2000. 'web_q1_q2_increase' -> web_g1. 'store_q1_q2_increase' -> store_g1. 'web_q2_q3_increase' -> web_g2. 'store_q2_q3_increase' -> store_g2}).
+    ]
+    .
+]
+.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q31_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q32.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q32.st.out
@@ -1,0 +1,55 @@
+Smalltalk at: #avg_discount put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q32_simplified
+    ((result = 20.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_sold_date_sk' -> 1. 'cs_ext_discount_amt' -> 5.000000}) with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_sold_date_sk' -> 2. 'cs_ext_discount_amt' -> 10.000000}) with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_sold_date_sk' -> 3. 'cs_ext_discount_amt' -> 20.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_manufact_id' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_year' -> 2000}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_year' -> 2000}).
+filtered := ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | (((((i at: 'i_manufact_id' = 1) and: [d at: 'd_year']) = 2000) and: [(cs at: 'cs_item_sk' = i at: 'i_item_sk')]) and: [(cs at: 'cs_sold_date_sk' = d at: 'd_date_sk')])]) do: [:cs |
+    (item) do: [:i |
+        (date_dim) do: [:d |
+            res add: cs at: 'cs_ext_discount_amt'.
+        ]
+    ]
+]
+res := res asArray.
+res)).
+avg_discount := (Main __avg: filtered).
+result := (Main __sum: ((| res |
+res := OrderedCollection new.
+((filtered) select: [:x | ((x > avg_discount) * 1.300000)]) do: [:x |
+    res add: x.
+]
+res := res asArray.
+res))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q32_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q33.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q33.st.out
@@ -1,0 +1,95 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #month put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #union_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #year put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q33_simplified
+    ((result = Array with: (Dictionary from: {'i_manufact_id' -> 1. 'total_sales' -> 150.000000}) with: (Dictionary from: {'i_manufact_id' -> 2. 'total_sales' -> 50.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_manufact_id' -> 1. 'i_category' -> 'Books'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_manufact_id' -> 2. 'i_category' -> 'Books'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000. 'd_moy' -> 1}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_gmt_offset' -> (5 negated)}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_gmt_offset' -> (5 negated)}).
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_ext_sales_price' -> 100.000000. 'ss_sold_date_sk' -> 1. 'ss_addr_sk' -> 1}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_ext_sales_price' -> 50.000000. 'ss_sold_date_sk' -> 1. 'ss_addr_sk' -> 2}).
+catalog_sales := Array with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_ext_sales_price' -> 20.000000. 'cs_sold_date_sk' -> 1. 'cs_bill_addr_sk' -> 1}).
+web_sales := Array with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_ext_sales_price' -> 30.000000. 'ws_sold_date_sk' -> 1. 'ws_bill_addr_sk' -> 1}).
+month := 1.
+year := 2000.
+union_sales := concat value: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((((((((i at: 'i_category' = 'Books') and: [d at: 'd_year']) = year) and: [d at: 'd_moy']) = month) and: [ca at: 'ca_gmt_offset']) = ((5 negated))) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(ss at: 'ss_addr_sk' = ca at: 'ca_address_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')])]) do: [:ss |
+    (date_dim) do: [:d |
+        (customer_address) do: [:ca |
+            (item) do: [:i |
+                res add: Dictionary from: {'manu' -> i at: 'i_manufact_id'. 'price' -> ss at: 'ss_ext_sales_price'}.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | ((((((((((i at: 'i_category' = 'Books') and: [d at: 'd_year']) = year) and: [d at: 'd_moy']) = month) and: [ca at: 'ca_gmt_offset']) = ((5 negated))) and: [(cs at: 'cs_sold_date_sk' = d at: 'd_date_sk')]) and: [(cs at: 'cs_bill_addr_sk' = ca at: 'ca_address_sk')]) and: [(cs at: 'cs_item_sk' = i at: 'i_item_sk')])]) do: [:cs |
+    (date_dim) do: [:d |
+        (customer_address) do: [:ca |
+            (item) do: [:i |
+                res add: Dictionary from: {'manu' -> i at: 'i_manufact_id'. 'price' -> cs at: 'cs_ext_sales_price'}.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | ((((((((((i at: 'i_category' = 'Books') and: [d at: 'd_year']) = year) and: [d at: 'd_moy']) = month) and: [ca at: 'ca_gmt_offset']) = ((5 negated))) and: [(ws at: 'ws_sold_date_sk' = d at: 'd_date_sk')]) and: [(ws at: 'ws_bill_addr_sk' = ca at: 'ca_address_sk')]) and: [(ws at: 'ws_item_sk' = i at: 'i_item_sk')])]) do: [:ws |
+    (date_dim) do: [:d |
+        (customer_address) do: [:ca |
+            (item) do: [:i |
+                res add: Dictionary from: {'manu' -> i at: 'i_manufact_id'. 'price' -> ws at: 'ws_ext_sales_price'}.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| res |
+res := OrderedCollection new.
+(union_sales) do: [:s |
+    res add: { ((Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'price'.
+]
+res := res asArray.
+res))) negated) . Dictionary from: {'i_manufact_id' -> g at: 'key'. 'total_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'price'.
+]
+res := res asArray.
+res)))} }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q33_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q34.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q34.st.out
@@ -1,0 +1,94 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #dn put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q34_simplified
+    ((result = Array with: (Dictionary from: {'c_last_name' -> 'Smith'. 'c_first_name' -> 'John'. 'c_salutation' -> 'Mr.'. 'c_preferred_cust_flag' -> 'Y'. 'ss_ticket_number' -> 1. 'cnt' -> 16}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}) with: (Dictionary from: {'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 2}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_dom' -> 2. 'd_year' -> 2000}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_county' -> 'A'}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_buy_potential' -> '>10000'. 'hd_vehicle_count' -> 2. 'hd_dep_count' -> 3}) with: (Dictionary from: {'hd_demo_sk' -> 2. 'hd_buy_potential' -> '>10000'. 'hd_vehicle_count' -> 2. 'hd_dep_count' -> 1}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_last_name' -> 'Smith'. 'c_first_name' -> 'John'. 'c_salutation' -> 'Mr.'. 'c_preferred_cust_flag' -> 'Y'}) with: (Dictionary from: {'c_customer_sk' -> 2. 'c_last_name' -> 'Jones'. 'c_first_name' -> 'Alice'. 'c_salutation' -> 'Ms.'. 'c_preferred_cust_flag' -> 'N'}).
+dn := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    (((((((((((((((d at: 'd_dom' >= 1) and: [d at: 'd_dom']) <= 3)) and: [hd at: 'hd_buy_potential']) = '>10000') and: [hd at: 'hd_vehicle_count']) > 0) and: [((hd at: 'hd_dep_count' / hd at: 'hd_vehicle_count'))]) > 1.200000) and: [d at: 'd_year']) = 2000) and: [s at: 's_county']) = 'A')) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'ticket' -> ss at: 'ss_ticket_number'. 'cust' -> ss at: 'ss_customer_sk'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'ss_ticket_number' -> g at: 'key' at: 'ticket'. 'ss_customer_sk' -> g at: 'key' at: 'cust'. 'cnt' -> (Main __count: g)}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((dn) select: [:dn1 | ((((dn1 at: 'cnt' >= 15) and: [dn1 at: 'cnt']) <= 20) and: [(dn1 at: 'ss_customer_sk' = c at: 'c_customer_sk')])]) do: [:dn1 |
+    (customer) do: [:c |
+        res add: { c at: 'c_last_name' . Dictionary from: {'c_last_name' -> c at: 'c_last_name'. 'c_first_name' -> c at: 'c_first_name'. 'c_salutation' -> c at: 'c_salutation'. 'c_preferred_cust_flag' -> c at: 'c_preferred_cust_flag'. 'ss_ticket_number' -> dn1 at: 'ss_ticket_number'. 'cnt' -> dn1 at: 'cnt'} }.
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q34_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q35.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q35.st.out
@@ -1,0 +1,92 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #groups put: nil.
+Smalltalk at: #purchased put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q35_simplified
+    ((groups = Array with: (Dictionary from: {'ca_state' -> 'CA'. 'cd_gender' -> 'M'. 'cd_marital_status' -> 'S'. 'cd_dep_count' -> 1. 'cd_dep_employed_count' -> 1. 'cd_dep_college_count' -> 0. 'cnt' -> 1}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_addr_sk' -> 1. 'c_current_cdemo_sk' -> 1}) with: (Dictionary from: {'c_customer_sk' -> 2. 'c_current_addr_sk' -> 2. 'c_current_cdemo_sk' -> 2}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_state' -> 'NY'}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_gender' -> 'M'. 'cd_marital_status' -> 'S'. 'cd_dep_count' -> 1. 'cd_dep_employed_count' -> 1. 'cd_dep_college_count' -> 0}) with: (Dictionary from: {'cd_demo_sk' -> 2. 'cd_gender' -> 'F'. 'cd_marital_status' -> 'M'. 'cd_dep_count' -> 2. 'cd_dep_employed_count' -> 1. 'cd_dep_college_count' -> 1}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000. 'd_qoy' -> 1}).
+purchased := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((d at: 'd_year' = 2000) and: [d at: 'd_qoy']) < 4) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')])]) do: [:ss |
+    (date_dim) do: [:d |
+        res add: ss at: 'ss_customer_sk'.
+    ]
+]
+res := res asArray.
+res)).
+groups := ((| rows groups |
+rows := OrderedCollection new.
+(customer) do: [:c |
+    ((purchased includes: c at: 'c_customer_sk')) ifTrue: [ rows add: c ].
+]
+groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'state' -> ca at: 'ca_state'. 'gender' -> cd at: 'cd_gender'. 'marital' -> cd at: 'cd_marital_status'. 'dep' -> cd at: 'cd_dep_count'. 'emp' -> cd at: 'cd_dep_employed_count'. 'col' -> cd at: 'cd_dep_college_count'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'ca_state' -> g at: 'key' at: 'state'. 'cd_gender' -> g at: 'key' at: 'gender'. 'cd_marital_status' -> g at: 'key' at: 'marital'. 'cd_dep_count' -> g at: 'key' at: 'dep'. 'cd_dep_employed_count' -> g at: 'key' at: 'emp'. 'cd_dep_college_count' -> g at: 'key' at: 'col'. 'cnt' -> (Main __count: g)}.
+]
+rows := rows asArray.
+rows)).
+(groups toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q35_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q36.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q36.st.out
@@ -1,0 +1,55 @@
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q36_simplified
+    ((result = Array with: (Dictionary from: {'i_category' -> 'Books'. 'i_class' -> 'C1'. 'gross_margin' -> 0.200000}) with: (Dictionary from: {'i_category' -> 'Books'. 'i_class' -> 'C2'. 'gross_margin' -> 0.250000}) with: (Dictionary from: {'i_category' -> 'Electronics'. 'i_class' -> 'C3'. 'gross_margin' -> 0.200000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_store_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_ext_sales_price' -> 100.000000. 'ss_net_profit' -> 20.000000}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_store_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_ext_sales_price' -> 200.000000. 'ss_net_profit' -> 50.000000}) with: (Dictionary from: {'ss_item_sk' -> 3. 'ss_store_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_ext_sales_price' -> 150.000000. 'ss_net_profit' -> 30.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_category' -> 'Books'. 'i_class' -> 'C1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_category' -> 'Books'. 'i_class' -> 'C2'}) with: (Dictionary from: {'i_item_sk' -> 3. 'i_category' -> 'Electronics'. 'i_class' -> 'C3'}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_state' -> 'A'}) with: (Dictionary from: {'s_store_sk' -> 2. 's_state' -> 'B'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000}).
+result := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (((((d at: 'd_year' = 2000) and: [((((s at: 's_state' = 'A') or: [s at: 's_state']) = 'B'))]) and: [(ss at: 'ss_sold_date_sk' = d at: 'd_date_sk')]) and: [(ss at: 'ss_item_sk' = i at: 'i_item_sk')]) and: [(ss at: 'ss_store_sk' = s at: 's_store_sk')])]) do: [:ss |
+    (date_dim) do: [:d |
+        (item) do: [:i |
+            (store) do: [:s |
+                res add: { Array with: (g at: 'key' at: 'category') with: (g at: 'key' at: 'class') . Dictionary from: {'i_category' -> g at: 'key' at: 'category'. 'i_class' -> g at: 'key' at: 'class'. 'gross_margin' -> ((Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_net_profit'.
+]
+res := res asArray.
+res))) / (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res))))} }.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q36_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q37.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q37.st.out
@@ -1,0 +1,35 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #inventory put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q37_simplified
+    ((result = Array with: (Dictionary from: {'i_item_id' -> 'I1'. 'i_item_desc' -> 'Item1'. 'i_current_price' -> 30.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'I1'. 'i_item_desc' -> 'Item1'. 'i_current_price' -> 30.000000. 'i_manufact_id' -> 800}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'I2'. 'i_item_desc' -> 'Item2'. 'i_current_price' -> 60.000000. 'i_manufact_id' -> 801}).
+inventory := Array with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 1. 'inv_quantity_on_hand' -> 200}) with: (Dictionary from: {'inv_item_sk' -> 2. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 1. 'inv_quantity_on_hand' -> 300}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2000-01-15'}).
+catalog_sales := Array with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_sold_date_sk' -> 1}).
+result := ((| res |
+res := OrderedCollection new.
+((item) select: [:i | ((((((((((((((i at: 'i_current_price' >= 20) and: [i at: 'i_current_price']) <= 50) and: [i at: 'i_manufact_id']) >= 800) and: [i at: 'i_manufact_id']) <= 803) and: [inv at: 'inv_quantity_on_hand']) >= 100) and: [inv at: 'inv_quantity_on_hand']) <= 500) and: [(i at: 'i_item_sk' = inv at: 'inv_item_sk')]) and: [(inv at: 'inv_date_sk' = d at: 'd_date_sk')]) and: [(cs at: 'cs_item_sk' = i at: 'i_item_sk')])]) do: [:i |
+    (inventory) do: [:inv |
+        (date_dim) do: [:d |
+            (catalog_sales) do: [:cs |
+                res add: { g at: 'key' at: 'id' . Dictionary from: {'i_item_id' -> g at: 'key' at: 'id'. 'i_item_desc' -> g at: 'key' at: 'desc'. 'i_current_price' -> g at: 'key' at: 'price'} }.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q37_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q38.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q38.st.out
@@ -1,0 +1,69 @@
+Smalltalk at: #catalog_ids put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #hot put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_ids put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_ids put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+distinct: xs | out x |
+    out := Array new.
+    (xs) do: [:x |
+        ((contains value: out value: x) not) ifTrue: [
+            out := (out copyWith: x).
+        ]
+        .
+    ]
+    .
+    ^ out
+!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q38_simplified
+    ((result = 1)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__intersect: a with: b
+    | out |
+    out := OrderedCollection new.
+    (a notNil and: [ b notNil ]) ifTrue: [
+        a do: [:v | (b includes: v) ifTrue: [ (out includes: v) ifFalse: [ out add: v ] ] ].
+    ]
+    ^ out asArray
+!
+!!
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_last_name' -> 'Smith'. 'c_first_name' -> 'John'}) with: (Dictionary from: {'c_customer_sk' -> 2. 'c_last_name' -> 'Jones'. 'c_first_name' -> 'Alice'}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'd_month_seq' -> 1200}) with: (Dictionary from: {'ss_customer_sk' -> 2. 'd_month_seq' -> 1205}).
+catalog_sales := Array with: (Dictionary from: {'cs_bill_customer_sk' -> 1. 'd_month_seq' -> 1203}).
+web_sales := Array with: (Dictionary from: {'ws_bill_customer_sk' -> 1. 'd_month_seq' -> 1206}).
+store_ids := (Main distinct: (((| res |
+res := OrderedCollection new.
+((store_sales) select: [:s | (((s at: 'd_month_seq' >= 1200) and: [s at: 'd_month_seq']) <= 1211)]) do: [:s |
+    res add: s at: 'ss_customer_sk'.
+]
+res := res asArray.
+res)))).
+catalog_ids := (Main distinct: (((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:c | (((c at: 'd_month_seq' >= 1200) and: [c at: 'd_month_seq']) <= 1211)]) do: [:c |
+    res add: c at: 'cs_bill_customer_sk'.
+]
+res := res asArray.
+res)))).
+web_ids := (Main distinct: (((| res |
+res := OrderedCollection new.
+((web_sales) select: [:w | (((w at: 'd_month_seq' >= 1200) and: [w at: 'd_month_seq']) <= 1211)]) do: [:w |
+    res add: w at: 'ws_bill_customer_sk'.
+]
+res := res asArray.
+res)))).
+hot := (Main __intersect: ((Main __intersect: (store_ids) with: (catalog_ids))) with: (web_ids)).
+result := (hot) size.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q38_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q39.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q39.st.out
@@ -1,0 +1,127 @@
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #grouped put: nil.
+Smalltalk at: #inventory put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #monthly put: nil.
+Smalltalk at: #summary put: nil.
+Smalltalk at: #warehouse put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q39_simplified
+    ((summary = Array with: (Dictionary from: {'w_warehouse_sk' -> 1. 'i_item_sk' -> 1. 'cov' -> 1.539601}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+inventory := Array with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 1. 'inv_quantity_on_hand' -> 10}) with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 2. 'inv_quantity_on_hand' -> 10}) with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 3. 'inv_quantity_on_hand' -> 250}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1}).
+warehouse := Array with: (Dictionary from: {'w_warehouse_sk' -> 1. 'w_warehouse_name' -> 'W1'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000. 'd_moy' -> 1}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_year' -> 2000. 'd_moy' -> 2}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_year' -> 2000. 'd_moy' -> 3}).
+monthly := ((| rows groups |
+rows := OrderedCollection new.
+(inventory) do: [:inv |
+    ((d at: 'd_year' = 2000)) ifTrue: [ rows add: inv ].
+]
+groups := (Main _group_by: rows keyFn: [:inv | Dictionary from: {'w' -> w at: 'w_warehouse_sk'. 'i' -> i at: 'i_item_sk'. 'month' -> d at: 'd_moy'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'w' -> g at: 'key' at: 'w'. 'i' -> g at: 'key' at: 'i'. 'qty' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'inv_quantity_on_hand'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+grouped := Dictionary new.
+(monthly) do: [:m |
+    key := (Dictionary from: {'w' -> m at: 'w'. 'i' -> m at: 'i'} printString).
+    ((grouped includesKey: key)) ifTrue: [
+        g := (grouped at: key).
+        grouped at: key put: Dictionary from: {'w' -> g at: 'w'. 'i' -> g at: 'i'. 'qtys' -> (g at: 'qtys' copyWith: m at: 'qty')}.
+    ] ifFalse: [
+        grouped at: key put: Dictionary from: {'w' -> m at: 'w'. 'i' -> m at: 'i'. 'qtys' -> Array with: (m at: 'qty')}.
+    ]
+    .
+]
+.
+summary := Array new.
+(values value: grouped) do: [:g |
+    mean := (Main __avg: g at: 'qtys').
+    sumsq := 0.000000.
+    (g at: 'qtys') do: [:q |
+        sumsq := ((sumsq + ((q - mean))) * ((q - mean))).
+    ]
+    .
+    variance := (sumsq / (((g at: 'qtys') size - 1))).
+    cov := ((math at: 'sqrt' value: variance) / mean).
+    ((cov > 1.500000)) ifTrue: [
+        summary := (summary copyWith: Dictionary from: {'w_warehouse_sk' -> g at: 'w'. 'i_item_sk' -> g at: 'i'. 'cov' -> cov}).
+    ]
+    .
+]
+.
+(summary toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q39_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q40.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q40.st.out
@@ -1,0 +1,115 @@
+Smalltalk at: #catalog_returns put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #records put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #sales_date put: nil.
+Smalltalk at: #warehouse put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q40_simplified
+    ((result = Array with: (Dictionary from: {'w_state' -> 'CA'. 'i_item_id' -> 'I1'. 'sales_before' -> 100.000000. 'sales_after' -> 0.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'order' -> 1. 'item_sk' -> 1. 'warehouse_sk' -> 1. 'date_sk' -> 1. 'price' -> 100.000000}) with: (Dictionary from: {'order' -> 2. 'item_sk' -> 1. 'warehouse_sk' -> 1. 'date_sk' -> 2. 'price' -> 150.000000}).
+catalog_returns := Array with: (Dictionary from: {'order' -> 2. 'item_sk' -> 1. 'refunded' -> 150.000000}).
+item := Array with: (Dictionary from: {'item_sk' -> 1. 'item_id' -> 'I1'. 'current_price' -> 1.200000}).
+warehouse := Array with: (Dictionary from: {'warehouse_sk' -> 1. 'state' -> 'CA'}).
+date_dim := Array with: (Dictionary from: {'date_sk' -> 1. 'date' -> '2020-01-10'}) with: (Dictionary from: {'date_sk' -> 2. 'date' -> '2020-01-20'}).
+sales_date := '2020-01-15'.
+records := ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | (((((((i at: 'current_price' >= 0.990000) and: [i at: 'current_price']) <= 1.490000) and: [(((cs at: 'order' = cr at: 'order') and: [cs at: 'item_sk']) = cr at: 'item_sk')]) and: [(cs at: 'warehouse_sk' = w at: 'warehouse_sk')]) and: [(cs at: 'item_sk' = i at: 'item_sk')]) and: [(cs at: 'date_sk' = d at: 'date_sk')])]) do: [:cs |
+    (catalog_returns) do: [:cr |
+        (warehouse) do: [:w |
+            (item) do: [:i |
+                (date_dim) do: [:d |
+                    res add: Dictionary from: {'w_state' -> w at: 'state'. 'i_item_id' -> i at: 'item_id'. 'sold_date' -> d at: 'date'. 'net' -> (cs at: 'price' - ((((cr = nil)) ifTrue: [0.000000] ifFalse: [cr at: 'refunded'])))}.
+                ]
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(records) do: [:r |
+    rows add: r.
+]
+groups := (Main _group_by: rows keyFn: [:r | Dictionary from: {'w_state' -> r at: 'w_state'. 'i_item_id' -> r at: 'i_item_id'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'w_state' -> g at: 'key' at: 'w_state'. 'i_item_id' -> g at: 'key' at: 'i_item_id'. 'sales_before' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'sold_date' < sales_date)) ifTrue: [x at: 'net'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res))). 'sales_after' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'sold_date' >= sales_date)) ifTrue: [x at: 'net'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q40_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q41.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q41.st.out
@@ -1,0 +1,36 @@
+Smalltalk at: #item put: nil.
+Smalltalk at: #lower put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q41_simplified
+    ((result = Array with: ('Blue Shirt') with: ('Red Dress'))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+!!
+item := Array with: (Dictionary from: {'product_name' -> 'Blue Shirt'. 'manufact_id' -> 100. 'manufact' -> 1. 'category' -> 'Women'. 'color' -> 'blue'. 'units' -> 'pack'. 'size' -> 'M'}) with: (Dictionary from: {'product_name' -> 'Red Dress'. 'manufact_id' -> 120. 'manufact' -> 1. 'category' -> 'Women'. 'color' -> 'red'. 'units' -> 'pack'. 'size' -> 'M'}) with: (Dictionary from: {'product_name' -> 'Pants'. 'manufact_id' -> 200. 'manufact' -> 2. 'category' -> 'Men'. 'color' -> 'black'. 'units' -> 'pair'. 'size' -> 'L'}).
+lower := 100.
+result := ((| res |
+res := OrderedCollection new.
+((item) select: [:i1 | ((((((i1 at: 'manufact_id' >= lower) and: [i1 at: 'manufact_id']) <= lower) + 40) and: [(Main __count: ((| res |
+res := OrderedCollection new.
+((item) select: [:i2 | (((i2 at: 'manufact' = i1 at: 'manufact') and: [i2 at: 'category']) = i1 at: 'category')]) do: [:i2 |
+    res add: i2.
+]
+res := res asArray.
+res)))]) > 1)]) do: [:i1 |
+    res add: { i1 at: 'product_name' . i1 at: 'product_name' }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q41_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q42.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q42.st.out
@@ -1,0 +1,65 @@
+Smalltalk at: #base put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #month put: nil.
+Smalltalk at: #records put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #year put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q42_simplified
+    ((result = Array with: (Dictionary from: {'d_year' -> 2020. 'i_category_id' -> 200. 'i_category' -> 'CatB'. 'sum_ss_ext_sales_price' -> 20.000000}) with: (Dictionary from: {'d_year' -> 2020. 'i_category_id' -> 100. 'i_category' -> 'CatA'. 'sum_ss_ext_sales_price' -> 10.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'sold_date_sk' -> 1. 'item_sk' -> 1. 'ext_sales_price' -> 10.000000}) with: (Dictionary from: {'sold_date_sk' -> 1. 'item_sk' -> 2. 'ext_sales_price' -> 20.000000}) with: (Dictionary from: {'sold_date_sk' -> 2. 'item_sk' -> 1. 'ext_sales_price' -> 15.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_manager_id' -> 1. 'i_category_id' -> 100. 'i_category' -> 'CatA'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_manager_id' -> 2. 'i_category_id' -> 200. 'i_category' -> 'CatB'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2020. 'd_moy' -> 5}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_year' -> 2021. 'd_moy' -> 5}).
+month := 5.
+year := 2020.
+records := ((| res |
+res := OrderedCollection new.
+((date_dim) select: [:dt | (((((((it at: 'i_manager_id' = 1) and: [dt at: 'd_moy']) = month) and: [dt at: 'd_year']) = year) and: [(ss at: 'sold_date_sk' = dt at: 'd_date_sk')]) and: [(ss at: 'item_sk' = it at: 'i_item_sk')])]) do: [:dt |
+    (store_sales) do: [:ss |
+        (item) do: [:it |
+            res add: Dictionary from: {'d_year' -> dt at: 'd_year'. 'i_category_id' -> it at: 'i_category_id'. 'i_category' -> it at: 'i_category'. 'price' -> ss at: 'ext_sales_price'}.
+        ]
+    ]
+]
+res := res asArray.
+res)).
+base := ((| res |
+res := OrderedCollection new.
+(records) do: [:r |
+    res add: { Array with: (((Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'price'.
+]
+res := res asArray.
+res))) negated)) with: (g at: 'key' at: 'd_year') with: (g at: 'key' at: 'i_category_id') with: (g at: 'key' at: 'i_category') . Dictionary from: {'d_year' -> g at: 'key' at: 'd_year'. 'i_category_id' -> g at: 'key' at: 'i_category_id'. 'i_category' -> g at: 'key' at: 'i_category'. 'sum_ss_ext_sales_price' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'price'.
+]
+res := res asArray.
+res)))} }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+result := base.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q42_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q43.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q43.st.out
@@ -1,0 +1,141 @@
+Smalltalk at: #base put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #gmt put: nil.
+Smalltalk at: #records put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #year put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q43_simplified
+    ((result = Array with: (Dictionary from: {'s_store_name' -> 'Main'. 's_store_id' -> 'S1'. 'sun_sales' -> 10.000000. 'mon_sales' -> 20.000000. 'tue_sales' -> 30.000000. 'wed_sales' -> 40.000000. 'thu_sales' -> 50.000000. 'fri_sales' -> 60.000000. 'sat_sales' -> 70.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+date_dim := Array with: (Dictionary from: {'date_sk' -> 1. 'd_day_name' -> 'Sunday'. 'd_year' -> 2020}) with: (Dictionary from: {'date_sk' -> 2. 'd_day_name' -> 'Monday'. 'd_year' -> 2020}) with: (Dictionary from: {'date_sk' -> 3. 'd_day_name' -> 'Tuesday'. 'd_year' -> 2020}) with: (Dictionary from: {'date_sk' -> 4. 'd_day_name' -> 'Wednesday'. 'd_year' -> 2020}) with: (Dictionary from: {'date_sk' -> 5. 'd_day_name' -> 'Thursday'. 'd_year' -> 2020}) with: (Dictionary from: {'date_sk' -> 6. 'd_day_name' -> 'Friday'. 'd_year' -> 2020}) with: (Dictionary from: {'date_sk' -> 7. 'd_day_name' -> 'Saturday'. 'd_year' -> 2020}).
+store := Array with: (Dictionary from: {'store_sk' -> 1. 'store_id' -> 'S1'. 'store_name' -> 'Main'. 'gmt_offset' -> 0}).
+store_sales := Array with: (Dictionary from: {'sold_date_sk' -> 1. 'store_sk' -> 1. 'sales_price' -> 10.000000}) with: (Dictionary from: {'sold_date_sk' -> 2. 'store_sk' -> 1. 'sales_price' -> 20.000000}) with: (Dictionary from: {'sold_date_sk' -> 3. 'store_sk' -> 1. 'sales_price' -> 30.000000}) with: (Dictionary from: {'sold_date_sk' -> 4. 'store_sk' -> 1. 'sales_price' -> 40.000000}) with: (Dictionary from: {'sold_date_sk' -> 5. 'store_sk' -> 1. 'sales_price' -> 50.000000}) with: (Dictionary from: {'sold_date_sk' -> 6. 'store_sk' -> 1. 'sales_price' -> 60.000000}) with: (Dictionary from: {'sold_date_sk' -> 7. 'store_sk' -> 1. 'sales_price' -> 70.000000}).
+year := 2020.
+gmt := 0.
+records := ((| res |
+res := OrderedCollection new.
+((date_dim) select: [:d | (((((s at: 'gmt_offset' = gmt) and: [d at: 'd_year']) = year) and: [(ss at: 'sold_date_sk' = d at: 'date_sk')]) and: [(ss at: 'store_sk' = s at: 'store_sk')])]) do: [:d |
+    (store_sales) do: [:ss |
+        (store) do: [:s |
+            res add: Dictionary from: {'d_day_name' -> d at: 'd_day_name'. 's_store_name' -> s at: 'store_name'. 's_store_id' -> s at: 'store_id'. 'price' -> ss at: 'sales_price'}.
+        ]
+    ]
+]
+res := res asArray.
+res)).
+base := ((| rows groups |
+rows := OrderedCollection new.
+(records) do: [:r |
+    rows add: r.
+]
+groups := (Main _group_by: rows keyFn: [:r | Dictionary from: {'name' -> r at: 's_store_name'. 'id' -> r at: 's_store_id'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'s_store_name' -> g at: 'key' at: 'name'. 's_store_id' -> g at: 'key' at: 'id'. 'sun_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'd_day_name' = 'Sunday')) ifTrue: [x at: 'price'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res))). 'mon_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'd_day_name' = 'Monday')) ifTrue: [x at: 'price'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res))). 'tue_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'd_day_name' = 'Tuesday')) ifTrue: [x at: 'price'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res))). 'wed_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'd_day_name' = 'Wednesday')) ifTrue: [x at: 'price'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res))). 'thu_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'd_day_name' = 'Thursday')) ifTrue: [x at: 'price'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res))). 'fri_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'd_day_name' = 'Friday')) ifTrue: [x at: 'price'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res))). 'sat_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (((x at: 'd_day_name' = 'Saturday')) ifTrue: [x at: 'price'] ifFalse: [0.000000]).
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := base.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q43_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q44.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q44.st.out
@@ -1,0 +1,126 @@
+Smalltalk at: #best put: nil.
+Smalltalk at: #best_name put: nil.
+Smalltalk at: #grouped put: nil.
+Smalltalk at: #grouped_base put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #worst put: nil.
+Smalltalk at: #worst_name put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q44_simplified
+    ((result = Dictionary from: {'best_performing' -> 'ItemA'. 'worst_performing' -> 'ItemB'})) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_store_sk' -> 1. 'ss_net_profit' -> 5.000000}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_store_sk' -> 1. 'ss_net_profit' -> 5.000000}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_store_sk' -> 1. 'ss_net_profit' -> (1.000000 negated)}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_product_name' -> 'ItemA'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_product_name' -> 'ItemB'}).
+grouped_base := (((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    rows add: ss.
+]
+groups := (Main _group_by: rows keyFn: [:ss | ss at: 'ss_item_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'item_sk' -> g at: 'key'. 'avg_profit' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows))).
+grouped := grouped_base.
+best := first value: ((| res |
+res := OrderedCollection new.
+(grouped) do: [:x |
+    res add: { (x at: 'avg_profit' negated) . x }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+worst := first value: ((| res |
+res := OrderedCollection new.
+(grouped) do: [:x |
+    res add: { x at: 'avg_profit' . x }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+best_name := first value: ((| res |
+res := OrderedCollection new.
+((item) select: [:i | (i at: 'i_item_sk' = best at: 'item_sk')]) do: [:i |
+    res add: i at: 'i_product_name'.
+]
+res := res asArray.
+res)).
+worst_name := first value: ((| res |
+res := OrderedCollection new.
+((item) select: [:i | (i at: 'i_item_sk' = worst at: 'item_sk')]) do: [:i |
+    res add: i at: 'i_product_name'.
+]
+res := res asArray.
+res)).
+result := Dictionary from: {'best_performing' -> best_name. 'worst_performing' -> worst_name}.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q44_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q45.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q45.st.out
@@ -1,0 +1,113 @@
+Smalltalk at: #base put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #item_ids put: nil.
+Smalltalk at: #qoy put: nil.
+Smalltalk at: #records put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #year put: nil.
+Smalltalk at: #zip_list put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q45_simplified
+    ((records = Array with: (Dictionary from: {'ca_zip' -> '85669'. 'sum_ws_sales_price' -> 50.000000}) with: (Dictionary from: {'ca_zip' -> '99999'. 'sum_ws_sales_price' -> 30.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__slice_string: s start: i end: j
+    | start end n |
+    start := i.
+    end := j.
+    n := s size.
+    start < 0 ifTrue: [ start := start + n ].
+    end < 0 ifTrue: [ end := end + n ].
+    start < 0 ifTrue: [ start := 0 ].
+    end > n ifTrue: [ end := n ].
+    end < start ifTrue: [ end := start ].
+    ^ (s copyFrom: start + 1 to: end)
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+web_sales := Array with: (Dictionary from: {'bill_customer_sk' -> 1. 'item_sk' -> 1. 'sold_date_sk' -> 1. 'sales_price' -> 50.000000}) with: (Dictionary from: {'bill_customer_sk' -> 2. 'item_sk' -> 2. 'sold_date_sk' -> 1. 'sales_price' -> 30.000000}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_addr_sk' -> 1}) with: (Dictionary from: {'c_customer_sk' -> 2. 'c_current_addr_sk' -> 2}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_zip' -> '85669'}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_zip' -> '99999'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'I1'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'I2'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_qoy' -> 1. 'd_year' -> 2020}).
+zip_list := Array with: '85669' with: '86197' with: '88274' with: '83405' with: '86475' with: '85392' with: '85460' with: '80348' with: '81792'.
+item_ids := Array with: 'I2'.
+qoy := 1.
+year := 2020.
+base := ((| rows groups |
+rows := OrderedCollection new.
+(web_sales) do: [:ws |
+    (((((((item_ids includes: (Main __slice_string: ca at: 'ca_zip' start: 0 end: 0 + 5))) and: [d at: 'd_qoy']) = qoy) and: [d at: 'd_year']) = year)) ifTrue: [ rows add: ws ].
+]
+groups := (Main _group_by: rows keyFn: [:ws | ca at: 'ca_zip']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'ca_zip' -> g at: 'key'. 'sum_ws_sales_price' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ws' at: 'sales_price'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+records := base.
+(records toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q45_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q46.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q46.st.out
@@ -1,0 +1,123 @@
+Smalltalk at: #base put: nil.
+Smalltalk at: #cities put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #depcnt put: nil.
+Smalltalk at: #dn put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #vehcnt put: nil.
+Smalltalk at: #year put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q46_simplified
+    ((result = Array with: (Dictionary from: {'c_last_name' -> 'Doe'. 'c_first_name' -> 'John'. 'ca_city' -> 'Seattle'. 'bought_city' -> 'Portland'. 'ss_ticket_number' -> 1. 'amt' -> 5.000000. 'profit' -> 20.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_addr_sk' -> 1. 'ss_hdemo_sk' -> 1. 'ss_store_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_coupon_amt' -> 5.000000. 'ss_net_profit' -> 20.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_dow' -> 6. 'd_year' -> 2020}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_city' -> 'CityA'}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_dep_count' -> 2. 'hd_vehicle_count' -> 0}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_city' -> 'Portland'}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_city' -> 'Seattle'}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_last_name' -> 'Doe'. 'c_first_name' -> 'John'. 'c_current_addr_sk' -> 2}).
+depcnt := 2.
+vehcnt := 0.
+year := 2020.
+cities := Array with: 'CityA'.
+dn := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+    ((cities includes: ((((hd at: 'hd_dep_count' = depcnt) or: [hd at: 'hd_vehicle_count']) = vehcnt)))) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'ss_ticket_number' -> ss at: 'ss_ticket_number'. 'ss_customer_sk' -> ss at: 'ss_customer_sk'. 'ca_city' -> ca at: 'ca_city'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'ss_ticket_number' -> g at: 'key' at: 'ss_ticket_number'. 'ss_customer_sk' -> g at: 'key' at: 'ss_customer_sk'. 'bought_city' -> g at: 'key' at: 'ca_city'. 'amt' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss' at: 'ss_coupon_amt'.
+]
+res := res asArray.
+res))). 'profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'ss' at: 'ss_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+base := ((| res |
+res := OrderedCollection new.
+((dn) select: [:dnrec | (((current_addr at: 'ca_city' ~= dnrec at: 'bought_city') and: [(dnrec at: 'ss_customer_sk' = c at: 'c_customer_sk')]) and: [(c at: 'c_current_addr_sk' = current_addr at: 'ca_address_sk')])]) do: [:dnrec |
+    (customer) do: [:c |
+        (customer_address) do: [:current_addr |
+            res add: { Array with: (c at: 'c_last_name') with: (c at: 'c_first_name') with: (current_addr at: 'ca_city') with: (dnrec at: 'bought_city') with: (dnrec at: 'ss_ticket_number') . Dictionary from: {'c_last_name' -> c at: 'c_last_name'. 'c_first_name' -> c at: 'c_first_name'. 'ca_city' -> current_addr at: 'ca_city'. 'bought_city' -> dnrec at: 'bought_city'. 'ss_ticket_number' -> dnrec at: 'ss_ticket_number'. 'amt' -> dnrec at: 'amt'. 'profit' -> dnrec at: 'profit'} }.
+        ]
+    ]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+result := base.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q46_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q47.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q47.st.out
@@ -1,0 +1,37 @@
+Smalltalk at: #orderby put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #v2 put: nil.
+Smalltalk at: #year put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+abs: x
+    ((x >= 0.000000)) ifTrue: [
+        x.
+    ] ifFalse: [
+        (x negated).
+    ]
+    .
+!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q47_simplified
+    ((result = Array with: (Dictionary from: {'d_year' -> 2019. 'item' -> 'C'. 'avg_monthly_sales' -> 50.000000. 'sum_sales' -> 60.000000}) with: (Dictionary from: {'d_year' -> 2020. 'item' -> 'A'. 'avg_monthly_sales' -> 100.000000. 'sum_sales' -> 120.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+v2 := Array with: (Dictionary from: {'d_year' -> 2020. 'item' -> 'A'. 'avg_monthly_sales' -> 100.000000. 'sum_sales' -> 120.000000}) with: (Dictionary from: {'d_year' -> 2020. 'item' -> 'B'. 'avg_monthly_sales' -> 80.000000. 'sum_sales' -> 70.000000}) with: (Dictionary from: {'d_year' -> 2019. 'item' -> 'C'. 'avg_monthly_sales' -> 50.000000. 'sum_sales' -> 60.000000}).
+year := 2020.
+orderby := 'item'.
+result := ((| res |
+res := OrderedCollection new.
+((v2) select: [:v | ((((((v at: 'd_year' = year) and: [v at: 'avg_monthly_sales']) > 0) and: [(Main abs: ((v at: 'sum_sales' - v at: 'avg_monthly_sales')))]) / v at: 'avg_monthly_sales') > 0.100000)]) do: [:v |
+    res add: { Array with: ((v at: 'sum_sales' - v at: 'avg_monthly_sales')) with: (v at: 'item') . v }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q47_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q48.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q48.st.out
@@ -1,0 +1,55 @@
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #qty put: nil.
+Smalltalk at: #qty_base put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #states1 put: nil.
+Smalltalk at: #states2 put: nil.
+Smalltalk at: #states3 put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #year put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q48_simplified
+    ((result = 35)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'cdemo_sk' -> 1. 'addr_sk' -> 1. 'sold_date_sk' -> 1. 'sales_price' -> 120.000000. 'net_profit' -> 1000.000000. 'quantity' -> 5}) with: (Dictionary from: {'cdemo_sk' -> 2. 'addr_sk' -> 2. 'sold_date_sk' -> 1. 'sales_price' -> 60.000000. 'net_profit' -> 2000.000000. 'quantity' -> 10}) with: (Dictionary from: {'cdemo_sk' -> 3. 'addr_sk' -> 3. 'sold_date_sk' -> 1. 'sales_price' -> 170.000000. 'net_profit' -> 10000.000000. 'quantity' -> 20}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_marital_status' -> 'S'. 'cd_education_status' -> 'E1'}) with: (Dictionary from: {'cd_demo_sk' -> 2. 'cd_marital_status' -> 'M'. 'cd_education_status' -> 'E2'}) with: (Dictionary from: {'cd_demo_sk' -> 3. 'cd_marital_status' -> 'W'. 'cd_education_status' -> 'E3'}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_country' -> 'United States'. 'ca_state' -> 'TX'}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_country' -> 'United States'. 'ca_state' -> 'CA'}) with: (Dictionary from: {'ca_address_sk' -> 3. 'ca_country' -> 'United States'. 'ca_state' -> 'NY'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000}).
+year := 2000.
+states1 := Array with: 'TX'.
+states2 := Array with: 'CA'.
+states3 := Array with: 'NY'.
+qty_base := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((((d at: 'd_year' = year) and: [(((((((((((cd at: 'cd_marital_status' = 'S') and: [cd at: 'cd_education_status']) = 'E1') and: [ss at: 'sales_price']) >= 100.000000) and: [ss at: 'sales_price']) <= 150.000000)) or: [((((((((cd at: 'cd_marital_status' = 'M') and: [cd at: 'cd_education_status']) = 'E2') and: [ss at: 'sales_price']) >= 50.000000) and: [ss at: 'sales_price']) <= 100.000000))]) or: [((((((((cd at: 'cd_marital_status' = 'W') and: [cd at: 'cd_education_status']) = 'E3') and: [ss at: 'sales_price']) >= 150.000000) and: [ss at: 'sales_price']) <= 200.000000))]))]) and: [(((((((((states1 includes: ca at: 'ca_state') and: [ss at: 'net_profit']) >= 0) and: [ss at: 'net_profit']) <= 2000)) or: [((((((states2 includes: ca at: 'ca_state') and: [ss at: 'net_profit']) >= 150) and: [ss at: 'net_profit']) <= 3000))]) or: [((((((states3 includes: ca at: 'ca_state') and: [ss at: 'net_profit']) >= 50) and: [ss at: 'net_profit']) <= 25000))]))]) and: [(ss at: 'cdemo_sk' = cd at: 'cd_demo_sk')]) and: [(ss at: 'addr_sk' = ca at: 'ca_address_sk')]) and: [(ss at: 'sold_date_sk' = d at: 'd_date_sk')])]) do: [:ss |
+    (customer_demographics) do: [:cd |
+        (customer_address) do: [:ca |
+            (date_dim) do: [:d |
+                res add: ss at: 'quantity'.
+            ]
+        ]
+    ]
+]
+res := res asArray.
+res)).
+qty := qty_base.
+result := (Main __sum: qty).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q48_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q49.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q49.st.out
@@ -1,0 +1,47 @@
+Smalltalk at: #catalog put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #web put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q49_simplified
+    ((result = Array with: (Dictionary from: {'channel' -> 'catalog'. 'item' -> 'A'. 'return_ratio' -> 0.300000. 'return_rank' -> 1. 'currency_rank' -> 1}) with: (Dictionary from: {'channel' -> 'store'. 'item' -> 'A'. 'return_ratio' -> 0.250000. 'return_rank' -> 1. 'currency_rank' -> 1}) with: (Dictionary from: {'channel' -> 'web'. 'item' -> 'A'. 'return_ratio' -> 0.200000. 'return_rank' -> 1. 'currency_rank' -> 1}) with: (Dictionary from: {'channel' -> 'web'. 'item' -> 'B'. 'return_ratio' -> 0.500000. 'return_rank' -> 2. 'currency_rank' -> 2}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+web := Array with: (Dictionary from: {'item' -> 'A'. 'return_ratio' -> 0.200000. 'currency_ratio' -> 0.300000. 'return_rank' -> 1. 'currency_rank' -> 1}) with: (Dictionary from: {'item' -> 'B'. 'return_ratio' -> 0.500000. 'currency_ratio' -> 0.600000. 'return_rank' -> 2. 'currency_rank' -> 2}).
+catalog := Array with: (Dictionary from: {'item' -> 'A'. 'return_ratio' -> 0.300000. 'currency_ratio' -> 0.400000. 'return_rank' -> 1. 'currency_rank' -> 1}).
+store := Array with: (Dictionary from: {'item' -> 'A'. 'return_ratio' -> 0.250000. 'currency_ratio' -> 0.350000. 'return_rank' -> 1. 'currency_rank' -> 1}).
+tmp := (concat value: ((| res |
+res := OrderedCollection new.
+((web) select: [:w | (((w at: 'return_rank' <= 10) or: [w at: 'currency_rank']) <= 10)]) do: [:w |
+    res add: Dictionary from: {'channel' -> 'web'. 'item' -> w at: 'item'. 'return_ratio' -> w at: 'return_ratio'. 'return_rank' -> w at: 'return_rank'. 'currency_rank' -> w at: 'currency_rank'}.
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((catalog) select: [:c | (((c at: 'return_rank' <= 10) or: [c at: 'currency_rank']) <= 10)]) do: [:c |
+    res add: Dictionary from: {'channel' -> 'catalog'. 'item' -> c at: 'item'. 'return_ratio' -> c at: 'return_ratio'. 'return_rank' -> c at: 'return_rank'. 'currency_rank' -> c at: 'currency_rank'}.
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((store) select: [:s | (((s at: 'return_rank' <= 10) or: [s at: 'currency_rank']) <= 10)]) do: [:s |
+    res add: Dictionary from: {'channel' -> 'store'. 'item' -> s at: 'item'. 'return_ratio' -> s at: 'return_ratio'. 'return_rank' -> s at: 'return_rank'. 'currency_rank' -> s at: 'currency_rank'}.
+]
+res := res asArray.
+res))).
+result := ((| res |
+res := OrderedCollection new.
+(tmp) do: [:r |
+    res add: { Array with: (r at: 'channel') with: (r at: 'return_rank') with: (r at: 'currency_rank') with: (r at: 'item') . r }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q49_simplified.


### PR DESCRIPTION
## Summary
- update Smalltalk backend tasks docs
- extend Smalltalk TPC-DS golden test to cover queries 1–49
- add generated q20–q49 Smalltalk code

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68641711eda48320a6372ac0f2706a93