### PR TITLE
Extend Go TPC‑DS coverage

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -2369,7 +2369,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	}
 	var sortExpr string
 	if q.Sort != nil {
-		sortExpr, err = c.compileExprHint(q.Sort, types.ListType{Elem: types.AnyType{}})
+		sortExpr, err = c.compileExpr(q.Sort)
 		if err != nil {
 			c.env = original
 			return "", err

--- a/tests/dataset/tpc-ds/compiler/go/q30.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q30.go.out
@@ -1,0 +1,436 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q30_simplified() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"c_customer_id":    "C1",
+		"c_first_name":     "John",
+		"c_last_name":      "Doe",
+		"ctr_total_return": 150.0,
+	}}))
+}
+
+type Web_returnsItem struct {
+	Wr_returning_customer_sk int     `json:"wr_returning_customer_sk"`
+	Wr_returned_date_sk      int     `json:"wr_returned_date_sk"`
+	Wr_return_amt            float64 `json:"wr_return_amt"`
+	Wr_returning_addr_sk     int     `json:"wr_returning_addr_sk"`
+}
+
+var web_returns []Web_returnsItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_state      string `json:"ca_state"`
+}
+
+var customer_address []Customer_addressItem
+
+type CustomerItem struct {
+	C_customer_sk     int    `json:"c_customer_sk"`
+	C_customer_id     string `json:"c_customer_id"`
+	C_first_name      string `json:"c_first_name"`
+	C_last_name       string `json:"c_last_name"`
+	C_current_addr_sk int    `json:"c_current_addr_sk"`
+}
+
+var customer []CustomerItem
+var customer_total_return []map[string]any
+var avg_by_state []map[string]any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	web_returns = _cast[[]Web_returnsItem]([]Web_returnsItem{Web_returnsItem{
+		Wr_returning_customer_sk: 1,
+		Wr_returned_date_sk:      1,
+		Wr_return_amt:            100.0,
+		Wr_returning_addr_sk:     1,
+	}, Web_returnsItem{
+		Wr_returning_customer_sk: 2,
+		Wr_returned_date_sk:      1,
+		Wr_return_amt:            30.0,
+		Wr_returning_addr_sk:     2,
+	}, Web_returnsItem{
+		Wr_returning_customer_sk: 1,
+		Wr_returned_date_sk:      1,
+		Wr_return_amt:            50.0,
+		Wr_returning_addr_sk:     1,
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_state:      "CA",
+	}, Customer_addressItem{
+		Ca_address_sk: 2,
+		Ca_state:      "CA",
+	}})
+	customer = _cast[[]CustomerItem]([]CustomerItem{CustomerItem{
+		C_customer_sk:     1,
+		C_customer_id:     "C1",
+		C_first_name:      "John",
+		C_last_name:       "Doe",
+		C_current_addr_sk: 1,
+	}, CustomerItem{
+		C_customer_sk:     2,
+		C_customer_id:     "C2",
+		C_first_name:      "Jane",
+		C_last_name:       "Smith",
+		C_current_addr_sk: 2,
+	}})
+	customer_total_return = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, wr := range web_returns {
+			for _, d := range date_dim {
+				if !(wr.Wr_returned_date_sk == d.D_date_sk) {
+					continue
+				}
+				for _, ca := range customer_address {
+					if !(wr.Wr_returning_addr_sk == ca.Ca_address_sk) {
+						continue
+					}
+					if (d.D_year == 2000) && (ca.Ca_state == "CA") {
+						key := map[string]any{"cust": wr.Wr_returning_customer_sk, "state": ca.Ca_state}
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, wr)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"ctr_customer_sk": _cast[map[string]any](g.Key)["cust"],
+				"ctr_state":       _cast[map[string]any](g.Key)["state"],
+				"ctr_total_return": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["wr_return_amt"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	avg_by_state = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ctr := range customer_total_return {
+			key := ctr["ctr_state"]
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, ctr)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{"state": g.Key, "avg_return": _avg(func() []any {
+				_res := []any{}
+				for _, x := range g.Items {
+					_res = append(_res, _cast[map[string]any](x)["ctr_total_return"])
+				}
+				return _res
+			}())})
+		}
+		return _res
+	}()
+	result = func() []map[string]any {
+		_res := []map[string]any{}
+		for _, ctr := range customer_total_return {
+			for _, avg := range avg_by_state {
+				if !(_equal(ctr["ctr_state"], avg["state"])) {
+					continue
+				}
+				if _cast[float64](ctr["ctr_total_return"]) > (_cast[float64](avg["avg_return"]) * _cast[float64](1.2)) {
+					for _, c := range customer {
+						if !(_equal(ctr["ctr_customer_sk"], c.C_customer_sk)) {
+							continue
+						}
+						_res = append(_res, map[string]any{
+							"c_customer_id":    c.C_customer_id,
+							"c_first_name":     c.C_first_name,
+							"c_last_name":      c.C_last_name,
+							"ctr_total_return": ctr["ctr_total_return"],
+						})
+					}
+				}
+			}
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q30 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q30_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}

--- a/tests/dataset/tpc-ds/compiler/go/q30.out
+++ b/tests/dataset/tpc-ds/compiler/go/q30.out
@@ -1,0 +1,2 @@
+[{"c_customer_id":"C1","c_first_name":"John","c_last_name":"Doe","ctr_total_return":150}]
+   test TPCDS Q30 simplified           ... ok (3.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q31.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q31.go.out
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q31_simplified() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"ca_county":            "A",
+		"d_year":               2000,
+		"web_q1_q2_increase":   1.5,
+		"store_q1_q2_increase": 1.2,
+		"web_q2_q3_increase":   1.6666666666666667,
+		"store_q2_q3_increase": 1.3333333333333333,
+	}}))
+}
+
+type Store_salesItem struct {
+	Ca_county          string  `json:"ca_county"`
+	D_qoy              int     `json:"d_qoy"`
+	D_year             int     `json:"d_year"`
+	Ss_ext_sales_price float64 `json:"ss_ext_sales_price"`
+}
+
+var store_sales []Store_salesItem
+
+type Web_salesItem struct {
+	Ca_county          string  `json:"ca_county"`
+	D_qoy              int     `json:"d_qoy"`
+	D_year             int     `json:"d_year"`
+	Ws_ext_sales_price float64 `json:"ws_ext_sales_price"`
+}
+
+var web_sales []Web_salesItem
+var counties []string
+var result []any
+
+func main() {
+	failures := 0
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{
+		Store_salesItem{
+			Ca_county:          "A",
+			D_qoy:              1,
+			D_year:             2000,
+			Ss_ext_sales_price: 100.0,
+		},
+		Store_salesItem{
+			Ca_county:          "A",
+			D_qoy:              2,
+			D_year:             2000,
+			Ss_ext_sales_price: 120.0,
+		},
+		Store_salesItem{
+			Ca_county:          "A",
+			D_qoy:              3,
+			D_year:             2000,
+			Ss_ext_sales_price: 160.0,
+		},
+		Store_salesItem{
+			Ca_county:          "B",
+			D_qoy:              1,
+			D_year:             2000,
+			Ss_ext_sales_price: 80.0,
+		},
+		Store_salesItem{
+			Ca_county:          "B",
+			D_qoy:              2,
+			D_year:             2000,
+			Ss_ext_sales_price: 90.0,
+		},
+		Store_salesItem{
+			Ca_county:          "B",
+			D_qoy:              3,
+			D_year:             2000,
+			Ss_ext_sales_price: 100.0,
+		},
+	})
+	web_sales = _cast[[]Web_salesItem]([]Web_salesItem{
+		Web_salesItem{
+			Ca_county:          "A",
+			D_qoy:              1,
+			D_year:             2000,
+			Ws_ext_sales_price: 100.0,
+		},
+		Web_salesItem{
+			Ca_county:          "A",
+			D_qoy:              2,
+			D_year:             2000,
+			Ws_ext_sales_price: 150.0,
+		},
+		Web_salesItem{
+			Ca_county:          "A",
+			D_qoy:              3,
+			D_year:             2000,
+			Ws_ext_sales_price: 250.0,
+		},
+		Web_salesItem{
+			Ca_county:          "B",
+			D_qoy:              1,
+			D_year:             2000,
+			Ws_ext_sales_price: 80.0,
+		},
+		Web_salesItem{
+			Ca_county:          "B",
+			D_qoy:              2,
+			D_year:             2000,
+			Ws_ext_sales_price: 90.0,
+		},
+		Web_salesItem{
+			Ca_county:          "B",
+			D_qoy:              3,
+			D_year:             2000,
+			Ws_ext_sales_price: 95.0,
+		},
+	})
+	counties = []string{"A", "B"}
+	result = []any{}
+	for _, county := range counties {
+		var ss1 float64 = _sum(func() []float64 {
+			_res := []float64{}
+			for _, s := range store_sales {
+				if (s.Ca_county == county) && (s.D_qoy == 1) {
+					if (s.Ca_county == county) && (s.D_qoy == 1) {
+						_res = append(_res, s.Ss_ext_sales_price)
+					}
+				}
+			}
+			return _res
+		}())
+		var ss2 float64 = _sum(func() []float64 {
+			_res := []float64{}
+			for _, s := range store_sales {
+				if (s.Ca_county == county) && (s.D_qoy == 2) {
+					if (s.Ca_county == county) && (s.D_qoy == 2) {
+						_res = append(_res, s.Ss_ext_sales_price)
+					}
+				}
+			}
+			return _res
+		}())
+		var ss3 float64 = _sum(func() []float64 {
+			_res := []float64{}
+			for _, s := range store_sales {
+				if (s.Ca_county == county) && (s.D_qoy == 3) {
+					if (s.Ca_county == county) && (s.D_qoy == 3) {
+						_res = append(_res, s.Ss_ext_sales_price)
+					}
+				}
+			}
+			return _res
+		}())
+		var ws1 float64 = _sum(func() []float64 {
+			_res := []float64{}
+			for _, w := range web_sales {
+				if (w.Ca_county == county) && (w.D_qoy == 1) {
+					if (w.Ca_county == county) && (w.D_qoy == 1) {
+						_res = append(_res, w.Ws_ext_sales_price)
+					}
+				}
+			}
+			return _res
+		}())
+		var ws2 float64 = _sum(func() []float64 {
+			_res := []float64{}
+			for _, w := range web_sales {
+				if (w.Ca_county == county) && (w.D_qoy == 2) {
+					if (w.Ca_county == county) && (w.D_qoy == 2) {
+						_res = append(_res, w.Ws_ext_sales_price)
+					}
+				}
+			}
+			return _res
+		}())
+		var ws3 float64 = _sum(func() []float64 {
+			_res := []float64{}
+			for _, w := range web_sales {
+				if (w.Ca_county == county) && (w.D_qoy == 3) {
+					if (w.Ca_county == county) && (w.D_qoy == 3) {
+						_res = append(_res, w.Ws_ext_sales_price)
+					}
+				}
+			}
+			return _res
+		}())
+		var web_g1 float64 = (ws2 / ws1)
+		var store_g1 float64 = (ss2 / ss1)
+		var web_g2 float64 = (ws3 / ws2)
+		var store_g2 float64 = (ss3 / ss2)
+		if (web_g1 > store_g1) && (web_g2 > store_g2) {
+			result = append(result, map[string]any{
+				"ca_county":            county,
+				"d_year":               2000,
+				"web_q1_q2_increase":   web_g1,
+				"store_q1_q2_increase": store_g1,
+				"web_q2_q3_increase":   web_g2,
+				"store_q2_q3_increase": store_g2,
+			})
+		}
+	}
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q31 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q31_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}

--- a/tests/dataset/tpc-ds/compiler/go/q31.out
+++ b/tests/dataset/tpc-ds/compiler/go/q31.out
@@ -1,0 +1,2 @@
+[{"ca_county":"A","d_year":2000,"store_q1_q2_increase":1.2,"store_q2_q3_increase":1.3333333333333333,"web_q1_q2_increase":1.5,"web_q2_q3_increase":1.6666666666666667}]
+   test TPCDS Q31 simplified           ... ok (5.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q32.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q32.go.out
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q32_simplified() {
+	expect((result == 20.0))
+}
+
+type Catalog_salesItem struct {
+	Cs_item_sk          int     `json:"cs_item_sk"`
+	Cs_sold_date_sk     int     `json:"cs_sold_date_sk"`
+	Cs_ext_discount_amt float64 `json:"cs_ext_discount_amt"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type ItemItem struct {
+	I_item_sk     int `json:"i_item_sk"`
+	I_manufact_id int `json:"i_manufact_id"`
+}
+
+var item []ItemItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+var filtered []float64
+var avg_discount float64
+var result float64
+
+func main() {
+	failures := 0
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_item_sk:          1,
+		Cs_sold_date_sk:     1,
+		Cs_ext_discount_amt: 5.0,
+	}, Catalog_salesItem{
+		Cs_item_sk:          1,
+		Cs_sold_date_sk:     2,
+		Cs_ext_discount_amt: 10.0,
+	}, Catalog_salesItem{
+		Cs_item_sk:          1,
+		Cs_sold_date_sk:     3,
+		Cs_ext_discount_amt: 20.0,
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:     1,
+		I_manufact_id: 1,
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+	}, Date_dimItem{
+		D_date_sk: 2,
+		D_year:    2000,
+	}, Date_dimItem{
+		D_date_sk: 3,
+		D_year:    2000,
+	}})
+	filtered = func() []float64 {
+		_res := []float64{}
+		for _, cs := range catalog_sales {
+			for _, i := range item {
+				if !(cs.Cs_item_sk == i.I_item_sk) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(cs.Cs_sold_date_sk == d.D_date_sk) {
+						continue
+					}
+					if (i.I_manufact_id == 1) && (d.D_year == 2000) {
+						if (i.I_manufact_id == 1) && (d.D_year == 2000) {
+							_res = append(_res, cs.Cs_ext_discount_amt)
+						}
+					}
+				}
+			}
+		}
+		return _res
+	}()
+	avg_discount = _avg(filtered)
+	result = _sum(func() []float64 {
+		_res := []float64{}
+		for _, x := range filtered {
+			if x > (avg_discount * 1.3) {
+				if x > (avg_discount * 1.3) {
+					_res = append(_res, x)
+				}
+			}
+		}
+		return _res
+	}())
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q32 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q32_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}

--- a/tests/dataset/tpc-ds/compiler/go/q32.out
+++ b/tests/dataset/tpc-ds/compiler/go/q32.out
@@ -1,0 +1,2 @@
+20
+   test TPCDS Q32 simplified           ... ok (499ns)

--- a/tests/dataset/tpc-ds/compiler/go/q33.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q33.go.out
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q33_simplified() {
+	expect(_equal(result, []map[string]any{map[string]any{"i_manufact_id": 1, "total_sales": 150.0}, map[string]any{"i_manufact_id": 2, "total_sales": 50.0}}))
+}
+
+type ItemItem struct {
+	I_item_sk     int    `json:"i_item_sk"`
+	I_manufact_id int    `json:"i_manufact_id"`
+	I_category    string `json:"i_category"`
+}
+
+var item []ItemItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_moy     int `json:"d_moy"`
+}
+
+var date_dim []Date_dimItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int `json:"ca_address_sk"`
+	Ca_gmt_offset int `json:"ca_gmt_offset"`
+}
+
+var customer_address []Customer_addressItem
+
+type Store_salesItem struct {
+	Ss_item_sk         int     `json:"ss_item_sk"`
+	Ss_ext_sales_price float64 `json:"ss_ext_sales_price"`
+	Ss_sold_date_sk    int     `json:"ss_sold_date_sk"`
+	Ss_addr_sk         int     `json:"ss_addr_sk"`
+}
+
+var store_sales []Store_salesItem
+
+type Catalog_salesItem struct {
+	Cs_item_sk         int     `json:"cs_item_sk"`
+	Cs_ext_sales_price float64 `json:"cs_ext_sales_price"`
+	Cs_sold_date_sk    int     `json:"cs_sold_date_sk"`
+	Cs_bill_addr_sk    int     `json:"cs_bill_addr_sk"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type Web_salesItem struct {
+	Ws_item_sk         int     `json:"ws_item_sk"`
+	Ws_ext_sales_price float64 `json:"ws_ext_sales_price"`
+	Ws_sold_date_sk    int     `json:"ws_sold_date_sk"`
+	Ws_bill_addr_sk    int     `json:"ws_bill_addr_sk"`
+}
+
+var web_sales []Web_salesItem
+var month int
+var year int
+var union_sales []any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:     1,
+		I_manufact_id: 1,
+		I_category:    "Books",
+	}, ItemItem{
+		I_item_sk:     2,
+		I_manufact_id: 2,
+		I_category:    "Books",
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+		D_moy:     1,
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_gmt_offset: -5,
+	}, Customer_addressItem{
+		Ca_address_sk: 2,
+		Ca_gmt_offset: -5,
+	}})
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_item_sk:         1,
+		Ss_ext_sales_price: 100.0,
+		Ss_sold_date_sk:    1,
+		Ss_addr_sk:         1,
+	}, Store_salesItem{
+		Ss_item_sk:         2,
+		Ss_ext_sales_price: 50.0,
+		Ss_sold_date_sk:    1,
+		Ss_addr_sk:         2,
+	}})
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_item_sk:         1,
+		Cs_ext_sales_price: 20.0,
+		Cs_sold_date_sk:    1,
+		Cs_bill_addr_sk:    1,
+	}})
+	web_sales = _cast[[]Web_salesItem]([]Web_salesItem{Web_salesItem{
+		Ws_item_sk:         1,
+		Ws_ext_sales_price: 30.0,
+		Ws_sold_date_sk:    1,
+		Ws_bill_addr_sk:    1,
+	}})
+	month = 1
+	year = 2000
+	union_sales = _concat[any](_concat[any](_toAnySlice(_convSlice[map[string]any, any](func() []map[string]any {
+		_res := []map[string]any{}
+		for _, ss := range store_sales {
+			for _, d := range date_dim {
+				if !(ss.Ss_sold_date_sk == d.D_date_sk) {
+					continue
+				}
+				for _, ca := range customer_address {
+					if !(ss.Ss_addr_sk == ca.Ca_address_sk) {
+						continue
+					}
+					for _, i := range item {
+						if !(ss.Ss_item_sk == i.I_item_sk) {
+							continue
+						}
+						if (((i.I_category == "Books") && (d.D_year == year)) && (d.D_moy == month)) && (ca.Ca_gmt_offset == (-5)) {
+							if (((i.I_category == "Books") && (d.D_year == year)) && (d.D_moy == month)) && (ca.Ca_gmt_offset == (-5)) {
+								_res = append(_res, map[string]any{"manu": i.I_manufact_id, "price": ss.Ss_ext_sales_price})
+							}
+						}
+					}
+				}
+			}
+		}
+		return _res
+	}())), _toAnySlice(func() []map[string]any {
+		_res := []map[string]any{}
+		for _, cs := range catalog_sales {
+			for _, d := range date_dim {
+				if !(cs.Cs_sold_date_sk == d.D_date_sk) {
+					continue
+				}
+				for _, ca := range customer_address {
+					if !(cs.Cs_bill_addr_sk == ca.Ca_address_sk) {
+						continue
+					}
+					for _, i := range item {
+						if !(cs.Cs_item_sk == i.I_item_sk) {
+							continue
+						}
+						if (((i.I_category == "Books") && (d.D_year == year)) && (d.D_moy == month)) && (ca.Ca_gmt_offset == (-5)) {
+							if (((i.I_category == "Books") && (d.D_year == year)) && (d.D_moy == month)) && (ca.Ca_gmt_offset == (-5)) {
+								_res = append(_res, map[string]any{"manu": i.I_manufact_id, "price": cs.Cs_ext_sales_price})
+							}
+						}
+					}
+				}
+			}
+		}
+		return _res
+	}())), _toAnySlice(func() []map[string]any {
+		_res := []map[string]any{}
+		for _, ws := range web_sales {
+			for _, d := range date_dim {
+				if !(ws.Ws_sold_date_sk == d.D_date_sk) {
+					continue
+				}
+				for _, ca := range customer_address {
+					if !(ws.Ws_bill_addr_sk == ca.Ca_address_sk) {
+						continue
+					}
+					for _, i := range item {
+						if !(ws.Ws_item_sk == i.I_item_sk) {
+							continue
+						}
+						if (((i.I_category == "Books") && (d.D_year == year)) && (d.D_moy == month)) && (ca.Ca_gmt_offset == (-5)) {
+							if (((i.I_category == "Books") && (d.D_year == year)) && (d.D_moy == month)) && (ca.Ca_gmt_offset == (-5)) {
+								_res = append(_res, map[string]any{"manu": i.I_manufact_id, "price": ws.Ws_ext_sales_price})
+							}
+						}
+					}
+				}
+			}
+		}
+		return _res
+	}()))
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, s := range union_sales {
+			key := _cast[map[string]any](s)["manu"]
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, s)
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: -_sum(func() []any {
+				_res := []any{}
+				for _, x := range g.Items {
+					_res = append(_res, _cast[map[string]any](x)["price"])
+				}
+				return _res
+			}())}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{"i_manufact_id": g.Key, "total_sales": _sum(func() []any {
+				_res := []any{}
+				for _, x := range g.Items {
+					_res = append(_res, _cast[map[string]any](x)["price"])
+				}
+				return _res
+			}())})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q33 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q33_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _concat[T any](a, b []T) []T {
+	res := make([]T, 0, len(a)+len(b))
+	res = append(res, a...)
+	res = append(res, b...)
+	return res
+}
+
+func _convSlice[T any, U any](s []T) []U {
+	out := make([]U, len(s))
+	for i, v := range s {
+		out[i] = any(v).(U)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q33.out
+++ b/tests/dataset/tpc-ds/compiler/go/q33.out
@@ -1,0 +1,2 @@
+[{"i_manufact_id":1,"total_sales":150},{"i_manufact_id":2,"total_sales":50}]
+   test TPCDS Q33 simplified           ... ok (4.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q35.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q35.go.out
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q35_simplified() {
+	expect(_equal(groups, []map[string]any{map[string]any{
+		"ca_state":              "CA",
+		"cd_gender":             "M",
+		"cd_marital_status":     "S",
+		"cd_dep_count":          1,
+		"cd_dep_employed_count": 1,
+		"cd_dep_college_count":  0,
+		"cnt":                   1,
+	}}))
+}
+
+type CustomerItem struct {
+	C_customer_sk      int `json:"c_customer_sk"`
+	C_current_addr_sk  int `json:"c_current_addr_sk"`
+	C_current_cdemo_sk int `json:"c_current_cdemo_sk"`
+}
+
+var customer []CustomerItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_state      string `json:"ca_state"`
+}
+
+var customer_address []Customer_addressItem
+
+type Customer_demographicsItem struct {
+	Cd_demo_sk            int    `json:"cd_demo_sk"`
+	Cd_gender             string `json:"cd_gender"`
+	Cd_marital_status     string `json:"cd_marital_status"`
+	Cd_dep_count          int    `json:"cd_dep_count"`
+	Cd_dep_employed_count int    `json:"cd_dep_employed_count"`
+	Cd_dep_college_count  int    `json:"cd_dep_college_count"`
+}
+
+var customer_demographics []Customer_demographicsItem
+
+type Store_salesItem struct {
+	Ss_customer_sk  int `json:"ss_customer_sk"`
+	Ss_sold_date_sk int `json:"ss_sold_date_sk"`
+}
+
+var store_sales []Store_salesItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_qoy     int `json:"d_qoy"`
+}
+
+var date_dim []Date_dimItem
+var purchased []int
+var groups []map[string]any
+
+func main() {
+	failures := 0
+	customer = _cast[[]CustomerItem]([]CustomerItem{CustomerItem{
+		C_customer_sk:      1,
+		C_current_addr_sk:  1,
+		C_current_cdemo_sk: 1,
+	}, CustomerItem{
+		C_customer_sk:      2,
+		C_current_addr_sk:  2,
+		C_current_cdemo_sk: 2,
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_state:      "CA",
+	}, Customer_addressItem{
+		Ca_address_sk: 2,
+		Ca_state:      "NY",
+	}})
+	customer_demographics = _cast[[]Customer_demographicsItem]([]Customer_demographicsItem{Customer_demographicsItem{
+		Cd_demo_sk:            1,
+		Cd_gender:             "M",
+		Cd_marital_status:     "S",
+		Cd_dep_count:          1,
+		Cd_dep_employed_count: 1,
+		Cd_dep_college_count:  0,
+	}, Customer_demographicsItem{
+		Cd_demo_sk:            2,
+		Cd_gender:             "F",
+		Cd_marital_status:     "M",
+		Cd_dep_count:          2,
+		Cd_dep_employed_count: 1,
+		Cd_dep_college_count:  1,
+	}})
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_customer_sk:  1,
+		Ss_sold_date_sk: 1,
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+		D_qoy:     1,
+	}})
+	purchased = func() []int {
+		_res := []int{}
+		for _, ss := range store_sales {
+			for _, d := range date_dim {
+				if !(ss.Ss_sold_date_sk == d.D_date_sk) {
+					continue
+				}
+				if (d.D_year == 2000) && (d.D_qoy < 4) {
+					if (d.D_year == 2000) && (d.D_qoy < 4) {
+						_res = append(_res, ss.Ss_customer_sk)
+					}
+				}
+			}
+		}
+		return _res
+	}()
+	groups = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, c := range customer {
+			for _, ca := range customer_address {
+				if !(c.C_current_addr_sk == ca.Ca_address_sk) {
+					continue
+				}
+				for _, cd := range customer_demographics {
+					if !(c.C_current_cdemo_sk == cd.Cd_demo_sk) {
+						continue
+					}
+					if _contains[int](purchased, c.C_customer_sk) {
+						key := map[string]any{
+							"state":   ca.Ca_state,
+							"gender":  cd.Cd_gender,
+							"marital": cd.Cd_marital_status,
+							"dep":     cd.Cd_dep_count,
+							"emp":     cd.Cd_dep_employed_count,
+							"col":     cd.Cd_dep_college_count,
+						}
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						g.Items = append(g.Items, c)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"ca_state":              _cast[map[string]any](g.Key)["state"],
+				"cd_gender":             _cast[map[string]any](g.Key)["gender"],
+				"cd_marital_status":     _cast[map[string]any](g.Key)["marital"],
+				"cd_dep_count":          _cast[map[string]any](g.Key)["dep"],
+				"cd_dep_employed_count": _cast[map[string]any](g.Key)["emp"],
+				"cd_dep_college_count":  _cast[map[string]any](g.Key)["col"],
+				"cnt":                   _count(g),
+			})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(groups); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q35 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q35_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _contains[T comparable](s []T, v T) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _count(v any) int {
+	if g, ok := v.(*data.Group); ok {
+		return len(g.Items)
+	}
+	switch s := v.(type) {
+	case []any:
+		return len(s)
+	case []int:
+		return len(s)
+	case []float64:
+		return len(s)
+	case []string:
+		return len(s)
+	case []bool:
+		return len(s)
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	case string:
+		return len([]rune(s))
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len()
+	}
+	panic("count() expects list or group")
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}

--- a/tests/dataset/tpc-ds/compiler/go/q35.out
+++ b/tests/dataset/tpc-ds/compiler/go/q35.out
@@ -1,0 +1,2 @@
+[{"ca_state":"CA","cd_dep_college_count":0,"cd_dep_count":1,"cd_dep_employed_count":1,"cd_gender":"M","cd_marital_status":"S","cnt":1}]
+   test TPCDS Q35 simplified           ... ok (6.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q36.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q36.go.out
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q36_simplified() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"i_category":   "Books",
+		"i_class":      "C1",
+		"gross_margin": 0.2,
+	}, map[string]any{
+		"i_category":   "Books",
+		"i_class":      "C2",
+		"gross_margin": 0.25,
+	}, map[string]any{
+		"i_category":   "Electronics",
+		"i_class":      "C3",
+		"gross_margin": 0.2,
+	}}))
+}
+
+type Store_salesItem struct {
+	Ss_item_sk         int     `json:"ss_item_sk"`
+	Ss_store_sk        int     `json:"ss_store_sk"`
+	Ss_sold_date_sk    int     `json:"ss_sold_date_sk"`
+	Ss_ext_sales_price float64 `json:"ss_ext_sales_price"`
+	Ss_net_profit      float64 `json:"ss_net_profit"`
+}
+
+var store_sales []Store_salesItem
+
+type ItemItem struct {
+	I_item_sk  int    `json:"i_item_sk"`
+	I_category string `json:"i_category"`
+	I_class    string `json:"i_class"`
+}
+
+var item []ItemItem
+
+type StoreItem struct {
+	S_store_sk int    `json:"s_store_sk"`
+	S_state    string `json:"s_state"`
+}
+
+var store []StoreItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+var result []map[string]any
+
+func main() {
+	failures := 0
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_item_sk:         1,
+		Ss_store_sk:        1,
+		Ss_sold_date_sk:    1,
+		Ss_ext_sales_price: 100.0,
+		Ss_net_profit:      20.0,
+	}, Store_salesItem{
+		Ss_item_sk:         2,
+		Ss_store_sk:        1,
+		Ss_sold_date_sk:    1,
+		Ss_ext_sales_price: 200.0,
+		Ss_net_profit:      50.0,
+	}, Store_salesItem{
+		Ss_item_sk:         3,
+		Ss_store_sk:        2,
+		Ss_sold_date_sk:    1,
+		Ss_ext_sales_price: 150.0,
+		Ss_net_profit:      30.0,
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:  1,
+		I_category: "Books",
+		I_class:    "C1",
+	}, ItemItem{
+		I_item_sk:  2,
+		I_category: "Books",
+		I_class:    "C2",
+	}, ItemItem{
+		I_item_sk:  3,
+		I_category: "Electronics",
+		I_class:    "C3",
+	}})
+	store = _cast[[]StoreItem]([]StoreItem{StoreItem{
+		S_store_sk: 1,
+		S_state:    "A",
+	}, StoreItem{
+		S_store_sk: 2,
+		S_state:    "B",
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+	}})
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ss := range store_sales {
+			for _, d := range date_dim {
+				if !(ss.Ss_sold_date_sk == d.D_date_sk) {
+					continue
+				}
+				for _, i := range item {
+					if !(ss.Ss_item_sk == i.I_item_sk) {
+						continue
+					}
+					for _, s := range store {
+						if !(ss.Ss_store_sk == s.S_store_sk) {
+							continue
+						}
+						if (d.D_year == 2000) && ((s.S_state == "A") || (s.S_state == "B")) {
+							key := map[string]string{"category": i.I_category, "class": i.I_class}
+							ks := fmt.Sprint(key)
+							g, ok := groups[ks]
+							if !ok {
+								g = &data.Group{Key: key}
+								groups[ks] = g
+								order = append(order, ks)
+							}
+							g.Items = append(g.Items, ss)
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _toAnySlice([]any{_cast[map[string]any](g.Key)["category"], _cast[map[string]any](g.Key)["class"]})}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"i_category": _cast[map[string]any](g.Key)["category"],
+				"i_class":    _cast[map[string]any](g.Key)["class"],
+				"gross_margin": (_sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ss_net_profit"])
+					}
+					return _res
+				}()) / _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ss_ext_sales_price"])
+					}
+					return _res
+				}())),
+			})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q36 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q36_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q36.out
+++ b/tests/dataset/tpc-ds/compiler/go/q36.out
@@ -1,0 +1,2 @@
+[{"gross_margin":0.2,"i_category":"Books","i_class":"C1"},{"gross_margin":0.25,"i_category":"Books","i_class":"C2"},{"gross_margin":0.2,"i_category":"Electronics","i_class":"C3"}]
+   test TPCDS Q36 simplified           ... ok (5.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q37.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q37.go.out
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q37_simplified() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"i_item_id":       "I1",
+		"i_item_desc":     "Item1",
+		"i_current_price": 30.0,
+	}}))
+}
+
+type ItemItem struct {
+	I_item_sk       int     `json:"i_item_sk"`
+	I_item_id       string  `json:"i_item_id"`
+	I_item_desc     string  `json:"i_item_desc"`
+	I_current_price float64 `json:"i_current_price"`
+	I_manufact_id   int     `json:"i_manufact_id"`
+}
+
+var item []ItemItem
+
+type InventoryItem struct {
+	Inv_item_sk          int `json:"inv_item_sk"`
+	Inv_warehouse_sk     int `json:"inv_warehouse_sk"`
+	Inv_date_sk          int `json:"inv_date_sk"`
+	Inv_quantity_on_hand int `json:"inv_quantity_on_hand"`
+}
+
+var inventory []InventoryItem
+
+type Date_dimItem struct {
+	D_date_sk int    `json:"d_date_sk"`
+	D_date    string `json:"d_date"`
+}
+
+var date_dim []Date_dimItem
+
+type Catalog_salesItem struct {
+	Cs_item_sk      int `json:"cs_item_sk"`
+	Cs_sold_date_sk int `json:"cs_sold_date_sk"`
+}
+
+var catalog_sales []Catalog_salesItem
+var result []map[string]any
+
+func main() {
+	failures := 0
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:       1,
+		I_item_id:       "I1",
+		I_item_desc:     "Item1",
+		I_current_price: 30.0,
+		I_manufact_id:   800,
+	}, ItemItem{
+		I_item_sk:       2,
+		I_item_id:       "I2",
+		I_item_desc:     "Item2",
+		I_current_price: 60.0,
+		I_manufact_id:   801,
+	}})
+	inventory = _cast[[]InventoryItem]([]InventoryItem{InventoryItem{
+		Inv_item_sk:          1,
+		Inv_warehouse_sk:     1,
+		Inv_date_sk:          1,
+		Inv_quantity_on_hand: 200,
+	}, InventoryItem{
+		Inv_item_sk:          2,
+		Inv_warehouse_sk:     1,
+		Inv_date_sk:          1,
+		Inv_quantity_on_hand: 300,
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_date:    "2000-01-15",
+	}})
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_item_sk:      1,
+		Cs_sold_date_sk: 1,
+	}})
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, i := range item {
+			for _, inv := range inventory {
+				if !(i.I_item_sk == inv.Inv_item_sk) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(inv.Inv_date_sk == d.D_date_sk) {
+						continue
+					}
+					for _, cs := range catalog_sales {
+						if !(cs.Cs_item_sk == i.I_item_sk) {
+							continue
+						}
+						if (((((i.I_current_price >= 20) && (i.I_current_price <= 50)) && (i.I_manufact_id >= 800)) && (i.I_manufact_id <= 803)) && (inv.Inv_quantity_on_hand >= 100)) && (inv.Inv_quantity_on_hand <= 500) {
+							key := map[string]any{
+								"id":    i.I_item_id,
+								"desc":  i.I_item_desc,
+								"price": i.I_current_price,
+							}
+							ks := fmt.Sprint(key)
+							g, ok := groups[ks]
+							if !ok {
+								g = &data.Group{Key: key}
+								groups[ks] = g
+								order = append(order, ks)
+							}
+							g.Items = append(g.Items, i)
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _cast[map[string]any](g.Key)["id"]}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"i_item_id":       _cast[map[string]any](g.Key)["id"],
+				"i_item_desc":     _cast[map[string]any](g.Key)["desc"],
+				"i_current_price": _cast[map[string]any](g.Key)["price"],
+			})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q37 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q37_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}

--- a/tests/dataset/tpc-ds/compiler/go/q37.out
+++ b/tests/dataset/tpc-ds/compiler/go/q37.out
@@ -1,0 +1,2 @@
+[{"i_current_price":30,"i_item_desc":"Item1","i_item_id":"I1"}]
+   test TPCDS Q37 simplified           ... ok (6.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q40.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q40.go.out
@@ -1,0 +1,588 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q40_simplified() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"w_state":      "CA",
+		"i_item_id":    "I1",
+		"sales_before": 100.0,
+		"sales_after":  0.0,
+	}}))
+}
+
+type Catalog_salesItem struct {
+	Order        int     `json:"order"`
+	Item_sk      int     `json:"item_sk"`
+	Warehouse_sk int     `json:"warehouse_sk"`
+	Date_sk      int     `json:"date_sk"`
+	Price        float64 `json:"price"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type Catalog_returnsItem struct {
+	Order    int     `json:"order"`
+	Item_sk  int     `json:"item_sk"`
+	Refunded float64 `json:"refunded"`
+}
+
+var catalog_returns []Catalog_returnsItem
+
+type ItemItem struct {
+	Item_sk       int     `json:"item_sk"`
+	Item_id       string  `json:"item_id"`
+	Current_price float64 `json:"current_price"`
+}
+
+var item []ItemItem
+
+type WarehouseItem struct {
+	Warehouse_sk int    `json:"warehouse_sk"`
+	State        string `json:"state"`
+}
+
+var warehouse []WarehouseItem
+
+type Date_dimItem struct {
+	Date_sk int    `json:"date_sk"`
+	Date    string `json:"date"`
+}
+
+var date_dim []Date_dimItem
+var sales_date string
+var records []map[string]any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Order:        1,
+		Item_sk:      1,
+		Warehouse_sk: 1,
+		Date_sk:      1,
+		Price:        100.0,
+	}, Catalog_salesItem{
+		Order:        2,
+		Item_sk:      1,
+		Warehouse_sk: 1,
+		Date_sk:      2,
+		Price:        150.0,
+	}})
+	catalog_returns = _cast[[]Catalog_returnsItem]([]Catalog_returnsItem{Catalog_returnsItem{
+		Order:    2,
+		Item_sk:  1,
+		Refunded: 150.0,
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		Item_sk:       1,
+		Item_id:       "I1",
+		Current_price: 1.2,
+	}})
+	warehouse = _cast[[]WarehouseItem]([]WarehouseItem{WarehouseItem{
+		Warehouse_sk: 1,
+		State:        "CA",
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		Date_sk: 1,
+		Date:    "2020-01-10",
+	}, Date_dimItem{
+		Date_sk: 2,
+		Date:    "2020-01-20",
+	}})
+	sales_date = "2020-01-15"
+	records = func() []map[string]any {
+		src := _toAnySlice(catalog_sales)
+		resAny := _query(src, []_joinSpec{
+			{items: _toAnySlice(catalog_returns), on: func(_a ...any) bool {
+				cs := _cast[Catalog_salesItem](_a[0])
+				_ = cs
+				cr := _cast[Catalog_returnsItem](_a[1])
+				_ = cr
+				return ((cs.Order == cr.Order) && (cs.Item_sk == cr.Item_sk))
+			}, left: true},
+			{items: _toAnySlice(warehouse), on: func(_a ...any) bool {
+				cs := _cast[Catalog_salesItem](_a[0])
+				_ = cs
+				cr := _cast[Catalog_returnsItem](_a[1])
+				_ = cr
+				w := _cast[WarehouseItem](_a[2])
+				_ = w
+				return (cs.Warehouse_sk == w.Warehouse_sk)
+			}},
+			{items: _toAnySlice(item), on: func(_a ...any) bool {
+				cs := _cast[Catalog_salesItem](_a[0])
+				_ = cs
+				cr := _cast[Catalog_returnsItem](_a[1])
+				_ = cr
+				w := _cast[WarehouseItem](_a[2])
+				_ = w
+				i := _cast[ItemItem](_a[3])
+				_ = i
+				return (cs.Item_sk == i.Item_sk)
+			}},
+			{items: _toAnySlice(date_dim), on: func(_a ...any) bool {
+				cs := _cast[Catalog_salesItem](_a[0])
+				_ = cs
+				cr := _cast[Catalog_returnsItem](_a[1])
+				_ = cr
+				w := _cast[WarehouseItem](_a[2])
+				_ = w
+				i := _cast[ItemItem](_a[3])
+				_ = i
+				d := _cast[Date_dimItem](_a[4])
+				_ = d
+				return (cs.Date_sk == d.Date_sk)
+			}},
+		}, _queryOpts{selectFn: func(_a ...any) any {
+			cs := _cast[Catalog_salesItem](_a[0])
+			_ = cs
+			cr := _cast[Catalog_returnsItem](_a[1])
+			_ = cr
+			w := _cast[WarehouseItem](_a[2])
+			_ = w
+			i := _cast[ItemItem](_a[3])
+			_ = i
+			d := _cast[Date_dimItem](_a[4])
+			_ = d
+			return map[string]any{
+				"w_state":   w.State,
+				"i_item_id": i.Item_id,
+				"sold_date": d.Date,
+				"net": (cs.Price - (func() float64 {
+					if _equal(cr, nil) {
+						return 0.0
+					} else {
+						return cr.Refunded
+					}
+				}())),
+			}
+		}, where: func(_a ...any) bool {
+			cs := _cast[Catalog_salesItem](_a[0])
+			_ = cs
+			cr := _cast[Catalog_returnsItem](_a[1])
+			_ = cr
+			w := _cast[WarehouseItem](_a[2])
+			_ = w
+			i := _cast[ItemItem](_a[3])
+			_ = i
+			d := _cast[Date_dimItem](_a[4])
+			_ = d
+			return ((i.Current_price >= 0.99) && (i.Current_price <= 1.49))
+		}, skip: -1, take: -1})
+		out := make([]map[string]any, len(resAny))
+		for i, v := range resAny {
+			out[i] = _cast[map[string]any](v)
+		}
+		return out
+	}()
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, r := range records {
+			key := map[string]any{"w_state": r["w_state"], "i_item_id": r["i_item_id"]}
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, r)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{
+				"w_state":   _cast[map[string]any](g.Key)["w_state"],
+				"i_item_id": _cast[map[string]any](g.Key)["i_item_id"],
+				"sales_before": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _cast[string](_cast[map[string]any](x)["sold_date"]) < sales_date {
+								return _cast[map[string]any](x)["net"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+				"sales_after": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _cast[string](_cast[map[string]any](x)["sold_date"]) >= sales_date {
+								return _cast[map[string]any](x)["net"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q40 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q40_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+type _joinSpec struct {
+	items []any
+	on    func(...any) bool
+	left  bool
+	right bool
+}
+type _queryOpts struct {
+	selectFn func(...any) any
+	where    func(...any) bool
+	sortKey  func(...any) any
+	skip     int
+	take     int
+}
+
+func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
+	items := make([][]any, len(src))
+	for i, v := range src {
+		items[i] = []any{v}
+	}
+	for _, j := range joins {
+		joined := [][]any{}
+		if j.right && j.left {
+			matched := make([]bool, len(j.items))
+			for _, left := range items {
+				m := false
+				for ri, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					matched[ri] = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+			for ri, right := range j.items {
+				if !matched[ri] {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else if j.right {
+			for _, right := range j.items {
+				m := false
+				for _, left := range items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else {
+			for _, left := range items {
+				m := false
+				for _, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if j.left && !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+		}
+		items = joined
+	}
+	if opts.where != nil {
+		filtered := [][]any{}
+		for _, r := range items {
+			if opts.where(r...) {
+				filtered = append(filtered, r)
+			}
+		}
+		items = filtered
+	}
+	if opts.sortKey != nil {
+		type pair struct {
+			item []any
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for i, it := range items {
+			pairs[i] = pair{it, opts.sortKey(it...)}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for i, p := range pairs {
+			items[i] = p.item
+		}
+	}
+	if opts.skip >= 0 {
+		if opts.skip < len(items) {
+			items = items[opts.skip:]
+		} else {
+			items = [][]any{}
+		}
+	}
+	if opts.take >= 0 {
+		if opts.take < len(items) {
+			items = items[:opts.take]
+		}
+	}
+	res := make([]any, len(items))
+	for i, r := range items {
+		res[i] = opts.selectFn(r...)
+	}
+	return res
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q40.out
+++ b/tests/dataset/tpc-ds/compiler/go/q40.out
@@ -1,0 +1,2 @@
+[{"i_item_id":"I1","sales_after":0,"sales_before":100,"w_state":"CA"}]
+   test TPCDS Q40 simplified           ... ok (4.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q41.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q41.go.out
@@ -1,0 +1,422 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q41_simplified() {
+	expect(_equal(result, []string{"Blue Shirt", "Red Dress"}))
+}
+
+type ItemItem struct {
+	Product_name string `json:"product_name"`
+	Manufact_id  int    `json:"manufact_id"`
+	Manufact     int    `json:"manufact"`
+	Category     string `json:"category"`
+	Color        string `json:"color"`
+	Units        string `json:"units"`
+	Size         string `json:"size"`
+}
+
+var item []ItemItem
+var lower int
+var result []string
+
+func main() {
+	failures := 0
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		Product_name: "Blue Shirt",
+		Manufact_id:  100,
+		Manufact:     1,
+		Category:     "Women",
+		Color:        "blue",
+		Units:        "pack",
+		Size:         "M",
+	}, ItemItem{
+		Product_name: "Red Dress",
+		Manufact_id:  120,
+		Manufact:     1,
+		Category:     "Women",
+		Color:        "red",
+		Units:        "pack",
+		Size:         "M",
+	}, ItemItem{
+		Product_name: "Pants",
+		Manufact_id:  200,
+		Manufact:     2,
+		Category:     "Men",
+		Color:        "black",
+		Units:        "pair",
+		Size:         "L",
+	}})
+	lower = 100
+	result = func() []string {
+		src := _toAnySlice(item)
+		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any { i1 := _cast[ItemItem](_a[0]); _ = i1; return i1.Product_name }, where: func(_a ...any) bool {
+			i1 := _cast[ItemItem](_a[0])
+			_ = i1
+			return (((i1.Manufact_id >= lower) && (i1.Manufact_id <= (lower + 40))) && (_count(_toAnySlice(func() []ItemItem {
+				_res := []ItemItem{}
+				for _, i2 := range item {
+					if (i2.Manufact == i1.Manufact) && (i2.Category == i1.Category) {
+						if (i2.Manufact == i1.Manufact) && (i2.Category == i1.Category) {
+							_res = append(_res, i2)
+						}
+					}
+				}
+				return _res
+			}())) > 1))
+		}, sortKey: func(_a ...any) any { i1 := _cast[ItemItem](_a[0]); _ = i1; return i1.Product_name }, skip: -1, take: -1})
+		out := make([]string, len(resAny))
+		for i, v := range resAny {
+			out[i] = _cast[string](v)
+		}
+		return out
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q41 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q41_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _count(v any) int {
+	if g, ok := v.(*data.Group); ok {
+		return len(g.Items)
+	}
+	switch s := v.(type) {
+	case []any:
+		return len(s)
+	case []int:
+		return len(s)
+	case []float64:
+		return len(s)
+	case []string:
+		return len(s)
+	case []bool:
+		return len(s)
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	case string:
+		return len([]rune(s))
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len()
+	}
+	panic("count() expects list or group")
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+type _joinSpec struct {
+	items []any
+	on    func(...any) bool
+	left  bool
+	right bool
+}
+type _queryOpts struct {
+	selectFn func(...any) any
+	where    func(...any) bool
+	sortKey  func(...any) any
+	skip     int
+	take     int
+}
+
+func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
+	items := make([][]any, len(src))
+	for i, v := range src {
+		items[i] = []any{v}
+	}
+	for _, j := range joins {
+		joined := [][]any{}
+		if j.right && j.left {
+			matched := make([]bool, len(j.items))
+			for _, left := range items {
+				m := false
+				for ri, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					matched[ri] = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+			for ri, right := range j.items {
+				if !matched[ri] {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else if j.right {
+			for _, right := range j.items {
+				m := false
+				for _, left := range items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else {
+			for _, left := range items {
+				m := false
+				for _, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if j.left && !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+		}
+		items = joined
+	}
+	if opts.where != nil {
+		filtered := [][]any{}
+		for _, r := range items {
+			if opts.where(r...) {
+				filtered = append(filtered, r)
+			}
+		}
+		items = filtered
+	}
+	if opts.sortKey != nil {
+		type pair struct {
+			item []any
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for i, it := range items {
+			pairs[i] = pair{it, opts.sortKey(it...)}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for i, p := range pairs {
+			items[i] = p.item
+		}
+	}
+	if opts.skip >= 0 {
+		if opts.skip < len(items) {
+			items = items[opts.skip:]
+		} else {
+			items = [][]any{}
+		}
+	}
+	if opts.take >= 0 {
+		if opts.take < len(items) {
+			items = items[:opts.take]
+		}
+	}
+	res := make([]any, len(items))
+	for i, r := range items {
+		res[i] = opts.selectFn(r...)
+	}
+	return res
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q41.out
+++ b/tests/dataset/tpc-ds/compiler/go/q41.out
@@ -1,0 +1,2 @@
+["Blue Shirt","Red Dress"]
+   test TPCDS Q41 simplified           ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q43.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q43.go.out
@@ -1,0 +1,471 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q43_simplified() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"s_store_name": "Main",
+		"s_store_id":   "S1",
+		"sun_sales":    10.0,
+		"mon_sales":    20.0,
+		"tue_sales":    30.0,
+		"wed_sales":    40.0,
+		"thu_sales":    50.0,
+		"fri_sales":    60.0,
+		"sat_sales":    70.0,
+	}}))
+}
+
+type Date_dimItem struct {
+	Date_sk    int    `json:"date_sk"`
+	D_day_name string `json:"d_day_name"`
+	D_year     int    `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+
+type StoreItem struct {
+	Store_sk   int    `json:"store_sk"`
+	Store_id   string `json:"store_id"`
+	Store_name string `json:"store_name"`
+	Gmt_offset int    `json:"gmt_offset"`
+}
+
+var store []StoreItem
+
+type Store_salesItem struct {
+	Sold_date_sk int     `json:"sold_date_sk"`
+	Store_sk     int     `json:"store_sk"`
+	Sales_price  float64 `json:"sales_price"`
+}
+
+var store_sales []Store_salesItem
+var year int
+var gmt int
+var records []map[string]any
+var base []map[string]any
+var result []map[string]any
+
+func main() {
+	failures := 0
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{
+		Date_dimItem{
+			Date_sk:    1,
+			D_day_name: "Sunday",
+			D_year:     2020,
+		},
+		Date_dimItem{
+			Date_sk:    2,
+			D_day_name: "Monday",
+			D_year:     2020,
+		},
+		Date_dimItem{
+			Date_sk:    3,
+			D_day_name: "Tuesday",
+			D_year:     2020,
+		},
+		Date_dimItem{
+			Date_sk:    4,
+			D_day_name: "Wednesday",
+			D_year:     2020,
+		},
+		Date_dimItem{
+			Date_sk:    5,
+			D_day_name: "Thursday",
+			D_year:     2020,
+		},
+		Date_dimItem{
+			Date_sk:    6,
+			D_day_name: "Friday",
+			D_year:     2020,
+		},
+		Date_dimItem{
+			Date_sk:    7,
+			D_day_name: "Saturday",
+			D_year:     2020,
+		},
+	})
+	store = _cast[[]StoreItem]([]StoreItem{StoreItem{
+		Store_sk:   1,
+		Store_id:   "S1",
+		Store_name: "Main",
+		Gmt_offset: 0,
+	}})
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{
+		Store_salesItem{
+			Sold_date_sk: 1,
+			Store_sk:     1,
+			Sales_price:  10.0,
+		},
+		Store_salesItem{
+			Sold_date_sk: 2,
+			Store_sk:     1,
+			Sales_price:  20.0,
+		},
+		Store_salesItem{
+			Sold_date_sk: 3,
+			Store_sk:     1,
+			Sales_price:  30.0,
+		},
+		Store_salesItem{
+			Sold_date_sk: 4,
+			Store_sk:     1,
+			Sales_price:  40.0,
+		},
+		Store_salesItem{
+			Sold_date_sk: 5,
+			Store_sk:     1,
+			Sales_price:  50.0,
+		},
+		Store_salesItem{
+			Sold_date_sk: 6,
+			Store_sk:     1,
+			Sales_price:  60.0,
+		},
+		Store_salesItem{
+			Sold_date_sk: 7,
+			Store_sk:     1,
+			Sales_price:  70.0,
+		},
+	})
+	year = 2020
+	gmt = 0
+	records = func() []map[string]any {
+		_res := []map[string]any{}
+		for _, d := range date_dim {
+			for _, ss := range store_sales {
+				if !(ss.Sold_date_sk == d.Date_sk) {
+					continue
+				}
+				for _, s := range store {
+					if !(ss.Store_sk == s.Store_sk) {
+						continue
+					}
+					if (s.Gmt_offset == gmt) && (d.D_year == year) {
+						if (s.Gmt_offset == gmt) && (d.D_year == year) {
+							_res = append(_res, map[string]any{
+								"d_day_name":   d.D_day_name,
+								"s_store_name": s.Store_name,
+								"s_store_id":   s.Store_id,
+								"price":        ss.Sales_price,
+							})
+						}
+					}
+				}
+			}
+		}
+		return _res
+	}()
+	base = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, r := range records {
+			key := map[string]any{"name": r["s_store_name"], "id": r["s_store_id"]}
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, r)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{
+				"s_store_name": _cast[map[string]any](g.Key)["name"],
+				"s_store_id":   _cast[map[string]any](g.Key)["id"],
+				"sun_sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _equal(_cast[map[string]any](x)["d_day_name"], "Sunday") {
+								return _cast[map[string]any](x)["price"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+				"mon_sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _equal(_cast[map[string]any](x)["d_day_name"], "Monday") {
+								return _cast[map[string]any](x)["price"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+				"tue_sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _equal(_cast[map[string]any](x)["d_day_name"], "Tuesday") {
+								return _cast[map[string]any](x)["price"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+				"wed_sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _equal(_cast[map[string]any](x)["d_day_name"], "Wednesday") {
+								return _cast[map[string]any](x)["price"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+				"thu_sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _equal(_cast[map[string]any](x)["d_day_name"], "Thursday") {
+								return _cast[map[string]any](x)["price"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+				"fri_sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _equal(_cast[map[string]any](x)["d_day_name"], "Friday") {
+								return _cast[map[string]any](x)["price"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+				"sat_sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, func() any {
+							if _equal(_cast[map[string]any](x)["d_day_name"], "Saturday") {
+								return _cast[map[string]any](x)["price"]
+							} else {
+								return 0.0
+							}
+						}())
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
+	result = base
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q43 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q43_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}

--- a/tests/dataset/tpc-ds/compiler/go/q43.out
+++ b/tests/dataset/tpc-ds/compiler/go/q43.out
@@ -1,0 +1,2 @@
+[{"fri_sales":60,"mon_sales":20,"s_store_id":"S1","s_store_name":"Main","sat_sales":70,"sun_sales":10,"thu_sales":50,"tue_sales":30,"wed_sales":40}]
+   test TPCDS Q43 simplified           ... ok (4.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q44.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q44.go.out
@@ -1,0 +1,545 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q44_simplified() {
+	expect(_equal(result, map[string]string{"best_performing": "ItemA", "worst_performing": "ItemB"}))
+}
+
+type Store_salesItem struct {
+	Ss_item_sk    int     `json:"ss_item_sk"`
+	Ss_store_sk   int     `json:"ss_store_sk"`
+	Ss_net_profit float64 `json:"ss_net_profit"`
+}
+
+var store_sales []Store_salesItem
+
+type ItemItem struct {
+	I_item_sk      int    `json:"i_item_sk"`
+	I_product_name string `json:"i_product_name"`
+}
+
+var item []ItemItem
+var grouped_base []map[string]any
+var grouped []map[string]any
+var best any
+var worst any
+var best_name any
+var worst_name any
+var result map[string]any
+
+func main() {
+	failures := 0
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_item_sk:    1,
+		Ss_store_sk:   1,
+		Ss_net_profit: 5.0,
+	}, Store_salesItem{
+		Ss_item_sk:    1,
+		Ss_store_sk:   1,
+		Ss_net_profit: 5.0,
+	}, Store_salesItem{
+		Ss_item_sk:    2,
+		Ss_store_sk:   1,
+		Ss_net_profit: -1.0,
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:      1,
+		I_product_name: "ItemA",
+	}, ItemItem{
+		I_item_sk:      2,
+		I_product_name: "ItemB",
+	}})
+	grouped_base = (func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ss := range store_sales {
+			key := ss.Ss_item_sk
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, ss)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{"item_sk": g.Key, "avg_profit": _avg(func() []any {
+				_res := []any{}
+				for _, x := range g.Items {
+					_res = append(_res, _cast[map[string]any](x)["ss_net_profit"])
+				}
+				return _res
+			}())})
+		}
+		return _res
+	}())
+	grouped = grouped_base
+	best = _first(_toAnySlice(_convSlice[map[string]any, any](func() []map[string]any {
+		src := _toAnySlice(grouped)
+		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any { x := _cast[map[string]any](_a[0]); _ = x; return x }, sortKey: func(_a ...any) any { x := _cast[map[string]any](_a[0]); _ = x; return -_cast[float64](x["avg_profit"]) }, skip: -1, take: -1})
+		out := make([]map[string]any, len(resAny))
+		for i, v := range resAny {
+			out[i] = _cast[map[string]any](v)
+		}
+		return out
+	}())))
+	worst = _first(_toAnySlice(_convSlice[map[string]any, any](func() []map[string]any {
+		src := _toAnySlice(grouped)
+		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any { x := _cast[map[string]any](_a[0]); _ = x; return x }, sortKey: func(_a ...any) any { x := _cast[map[string]any](_a[0]); _ = x; return x["avg_profit"] }, skip: -1, take: -1})
+		out := make([]map[string]any, len(resAny))
+		for i, v := range resAny {
+			out[i] = _cast[map[string]any](v)
+		}
+		return out
+	}())))
+	best_name = _first(_toAnySlice(_convSlice[string, any](func() []string {
+		_res := []string{}
+		for _, i := range item {
+			if _equal(i.I_item_sk, _cast[map[string]any](best)["item_sk"]) {
+				if _equal(i.I_item_sk, _cast[map[string]any](best)["item_sk"]) {
+					_res = append(_res, i.I_product_name)
+				}
+			}
+		}
+		return _res
+	}())))
+	worst_name = _first(_toAnySlice(_convSlice[string, any](func() []string {
+		_res := []string{}
+		for _, i := range item {
+			if _equal(i.I_item_sk, _cast[map[string]any](worst)["item_sk"]) {
+				if _equal(i.I_item_sk, _cast[map[string]any](worst)["item_sk"]) {
+					_res = append(_res, i.I_product_name)
+				}
+			}
+		}
+		return _res
+	}())))
+	result = map[string]any{"best_performing": best_name, "worst_performing": worst_name}
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q44 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q44_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convSlice[T any, U any](s []T) []U {
+	out := make([]U, len(s))
+	for i, v := range s {
+		out[i] = any(v).(U)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _first(v any) any {
+	if g, ok := v.(*data.Group); ok {
+		if len(g.Items) == 0 {
+			return nil
+		}
+		return g.Items[0]
+	}
+	switch s := v.(type) {
+	case []any:
+		if len(s) == 0 {
+			return nil
+		}
+		return s[0]
+	case []int:
+		if len(s) == 0 {
+			return 0
+		}
+		return s[0]
+	case []float64:
+		if len(s) == 0 {
+			return 0.0
+		}
+		return s[0]
+	case []string:
+		if len(s) == 0 {
+			return ""
+		}
+		return s[0]
+	case []bool:
+		if len(s) == 0 {
+			return false
+		}
+		return s[0]
+	default:
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
+			return rv.Index(0).Interface()
+		}
+		if rv.Kind() == reflect.Array && rv.Len() > 0 {
+			return rv.Index(0).Interface()
+		}
+	}
+	return nil
+}
+
+type _joinSpec struct {
+	items []any
+	on    func(...any) bool
+	left  bool
+	right bool
+}
+type _queryOpts struct {
+	selectFn func(...any) any
+	where    func(...any) bool
+	sortKey  func(...any) any
+	skip     int
+	take     int
+}
+
+func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
+	items := make([][]any, len(src))
+	for i, v := range src {
+		items[i] = []any{v}
+	}
+	for _, j := range joins {
+		joined := [][]any{}
+		if j.right && j.left {
+			matched := make([]bool, len(j.items))
+			for _, left := range items {
+				m := false
+				for ri, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					matched[ri] = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+			for ri, right := range j.items {
+				if !matched[ri] {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else if j.right {
+			for _, right := range j.items {
+				m := false
+				for _, left := range items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else {
+			for _, left := range items {
+				m := false
+				for _, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if j.left && !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+		}
+		items = joined
+	}
+	if opts.where != nil {
+		filtered := [][]any{}
+		for _, r := range items {
+			if opts.where(r...) {
+				filtered = append(filtered, r)
+			}
+		}
+		items = filtered
+	}
+	if opts.sortKey != nil {
+		type pair struct {
+			item []any
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for i, it := range items {
+			pairs[i] = pair{it, opts.sortKey(it...)}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for i, p := range pairs {
+			items[i] = p.item
+		}
+	}
+	if opts.skip >= 0 {
+		if opts.skip < len(items) {
+			items = items[opts.skip:]
+		} else {
+			items = [][]any{}
+		}
+	}
+	if opts.take >= 0 {
+		if opts.take < len(items) {
+			items = items[:opts.take]
+		}
+	}
+	res := make([]any, len(items))
+	for i, r := range items {
+		res[i] = opts.selectFn(r...)
+	}
+	return res
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q44.out
+++ b/tests/dataset/tpc-ds/compiler/go/q44.out
@@ -1,0 +1,2 @@
+{"best_performing":"ItemA","worst_performing":"ItemB"}
+   test TPCDS Q44 simplified           ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q48.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q48.go.out
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q48_simplified() {
+	expect((result == 35))
+}
+
+type Store_salesItem struct {
+	Cdemo_sk     int     `json:"cdemo_sk"`
+	Addr_sk      int     `json:"addr_sk"`
+	Sold_date_sk int     `json:"sold_date_sk"`
+	Sales_price  float64 `json:"sales_price"`
+	Net_profit   float64 `json:"net_profit"`
+	Quantity     int     `json:"quantity"`
+}
+
+var store_sales []Store_salesItem
+
+type StoreItem struct {
+	S_store_sk int `json:"s_store_sk"`
+}
+
+var store []StoreItem
+
+type Customer_demographicsItem struct {
+	Cd_demo_sk          int    `json:"cd_demo_sk"`
+	Cd_marital_status   string `json:"cd_marital_status"`
+	Cd_education_status string `json:"cd_education_status"`
+}
+
+var customer_demographics []Customer_demographicsItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_country    string `json:"ca_country"`
+	Ca_state      string `json:"ca_state"`
+}
+
+var customer_address []Customer_addressItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+var year int
+var states1 []string
+var states2 []string
+var states3 []string
+var qty_base []int
+var qty []int
+var result float64
+
+func main() {
+	failures := 0
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Cdemo_sk:     1,
+		Addr_sk:      1,
+		Sold_date_sk: 1,
+		Sales_price:  120.0,
+		Net_profit:   1000.0,
+		Quantity:     5,
+	}, Store_salesItem{
+		Cdemo_sk:     2,
+		Addr_sk:      2,
+		Sold_date_sk: 1,
+		Sales_price:  60.0,
+		Net_profit:   2000.0,
+		Quantity:     10,
+	}, Store_salesItem{
+		Cdemo_sk:     3,
+		Addr_sk:      3,
+		Sold_date_sk: 1,
+		Sales_price:  170.0,
+		Net_profit:   10000.0,
+		Quantity:     20,
+	}})
+	store = _cast[[]StoreItem]([]StoreItem{StoreItem{S_store_sk: 1}})
+	customer_demographics = _cast[[]Customer_demographicsItem]([]Customer_demographicsItem{Customer_demographicsItem{
+		Cd_demo_sk:          1,
+		Cd_marital_status:   "S",
+		Cd_education_status: "E1",
+	}, Customer_demographicsItem{
+		Cd_demo_sk:          2,
+		Cd_marital_status:   "M",
+		Cd_education_status: "E2",
+	}, Customer_demographicsItem{
+		Cd_demo_sk:          3,
+		Cd_marital_status:   "W",
+		Cd_education_status: "E3",
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_country:    "United States",
+		Ca_state:      "TX",
+	}, Customer_addressItem{
+		Ca_address_sk: 2,
+		Ca_country:    "United States",
+		Ca_state:      "CA",
+	}, Customer_addressItem{
+		Ca_address_sk: 3,
+		Ca_country:    "United States",
+		Ca_state:      "NY",
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+	}})
+	year = 2000
+	states1 = []string{"TX"}
+	states2 = []string{"CA"}
+	states3 = []string{"NY"}
+	qty_base = func() []int {
+		_res := []int{}
+		for _, ss := range store_sales {
+			for _, cd := range customer_demographics {
+				if !(ss.Cdemo_sk == cd.Cd_demo_sk) {
+					continue
+				}
+				for _, ca := range customer_address {
+					if !(ss.Addr_sk == ca.Ca_address_sk) {
+						continue
+					}
+					for _, d := range date_dim {
+						if !(ss.Sold_date_sk == d.D_date_sk) {
+							continue
+						}
+						if ((d.D_year == year) && ((((((cd.Cd_marital_status == "S") && (cd.Cd_education_status == "E1")) && (ss.Sales_price >= 100.0)) && (ss.Sales_price <= 150.0)) || ((((cd.Cd_marital_status == "M") && (cd.Cd_education_status == "E2")) && (ss.Sales_price >= 50.0)) && (ss.Sales_price <= 100.0))) || ((((cd.Cd_marital_status == "W") && (cd.Cd_education_status == "E3")) && (ss.Sales_price >= 150.0)) && (ss.Sales_price <= 200.0)))) && ((((_contains[string](states1, ca.Ca_state) && (ss.Net_profit >= 0)) && (ss.Net_profit <= 2000)) || ((_contains[string](states2, ca.Ca_state) && (ss.Net_profit >= 150)) && (ss.Net_profit <= 3000))) || ((_contains[string](states3, ca.Ca_state) && (ss.Net_profit >= 50)) && (ss.Net_profit <= 25000))) {
+							if ((d.D_year == year) && ((((((cd.Cd_marital_status == "S") && (cd.Cd_education_status == "E1")) && (ss.Sales_price >= 100.0)) && (ss.Sales_price <= 150.0)) || ((((cd.Cd_marital_status == "M") && (cd.Cd_education_status == "E2")) && (ss.Sales_price >= 50.0)) && (ss.Sales_price <= 100.0))) || ((((cd.Cd_marital_status == "W") && (cd.Cd_education_status == "E3")) && (ss.Sales_price >= 150.0)) && (ss.Sales_price <= 200.0)))) && ((((_contains[string](states1, ca.Ca_state) && (ss.Net_profit >= 0)) && (ss.Net_profit <= 2000)) || ((_contains[string](states2, ca.Ca_state) && (ss.Net_profit >= 150)) && (ss.Net_profit <= 3000))) || ((_contains[string](states3, ca.Ca_state) && (ss.Net_profit >= 50)) && (ss.Net_profit <= 25000))) {
+								_res = append(_res, ss.Quantity)
+							}
+						}
+					}
+				}
+			}
+		}
+		return _res
+	}()
+	qty = qty_base
+	result = _sum(qty)
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q48 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q48_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _contains[T comparable](s []T, v T) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}

--- a/tests/dataset/tpc-ds/compiler/go/q48.out
+++ b/tests/dataset/tpc-ds/compiler/go/q48.out
@@ -1,0 +1,2 @@
+35
+   test TPCDS Q48 simplified           ... ok (290ns)

--- a/tests/dataset/tpc-ds/compiler/go/q49.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q49.go.out
@@ -1,0 +1,499 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_TPCDS_Q49_simplified() {
+	expect(_equal(result, []map[string]any{
+		map[string]any{
+			"channel":       "catalog",
+			"item":          "A",
+			"return_ratio":  0.3,
+			"return_rank":   1,
+			"currency_rank": 1,
+		},
+		map[string]any{
+			"channel":       "store",
+			"item":          "A",
+			"return_ratio":  0.25,
+			"return_rank":   1,
+			"currency_rank": 1,
+		},
+		map[string]any{
+			"channel":       "web",
+			"item":          "A",
+			"return_ratio":  0.2,
+			"return_rank":   1,
+			"currency_rank": 1,
+		},
+		map[string]any{
+			"channel":       "web",
+			"item":          "B",
+			"return_ratio":  0.5,
+			"return_rank":   2,
+			"currency_rank": 2,
+		},
+	}))
+}
+
+type WebItem struct {
+	Item           string  `json:"item"`
+	Return_ratio   float64 `json:"return_ratio"`
+	Currency_ratio float64 `json:"currency_ratio"`
+	Return_rank    int     `json:"return_rank"`
+	Currency_rank  int     `json:"currency_rank"`
+}
+
+var web []WebItem
+
+type CatalogItem struct {
+	Item           string  `json:"item"`
+	Return_ratio   float64 `json:"return_ratio"`
+	Currency_ratio float64 `json:"currency_ratio"`
+	Return_rank    int     `json:"return_rank"`
+	Currency_rank  int     `json:"currency_rank"`
+}
+
+var catalog []CatalogItem
+
+type StoreItem struct {
+	Item           string  `json:"item"`
+	Return_ratio   float64 `json:"return_ratio"`
+	Currency_ratio float64 `json:"currency_ratio"`
+	Return_rank    int     `json:"return_rank"`
+	Currency_rank  int     `json:"currency_rank"`
+}
+
+var store []StoreItem
+var tmp []any
+var result []any
+
+func main() {
+	failures := 0
+	web = _cast[[]WebItem]([]WebItem{WebItem{
+		Item:           "A",
+		Return_ratio:   0.2,
+		Currency_ratio: 0.3,
+		Return_rank:    1,
+		Currency_rank:  1,
+	}, WebItem{
+		Item:           "B",
+		Return_ratio:   0.5,
+		Currency_ratio: 0.6,
+		Return_rank:    2,
+		Currency_rank:  2,
+	}})
+	catalog = _cast[[]CatalogItem]([]CatalogItem{CatalogItem{
+		Item:           "A",
+		Return_ratio:   0.3,
+		Currency_ratio: 0.4,
+		Return_rank:    1,
+		Currency_rank:  1,
+	}})
+	store = _cast[[]StoreItem]([]StoreItem{StoreItem{
+		Item:           "A",
+		Return_ratio:   0.25,
+		Currency_ratio: 0.35,
+		Return_rank:    1,
+		Currency_rank:  1,
+	}})
+	tmp = (_concat[any](_concat[any](_toAnySlice(_convSlice[map[string]any, any](func() []map[string]any {
+		_res := []map[string]any{}
+		for _, w := range web {
+			if (w.Return_rank <= 10) || (w.Currency_rank <= 10) {
+				if (w.Return_rank <= 10) || (w.Currency_rank <= 10) {
+					_res = append(_res, map[string]any{
+						"channel":       "web",
+						"item":          w.Item,
+						"return_ratio":  w.Return_ratio,
+						"return_rank":   w.Return_rank,
+						"currency_rank": w.Currency_rank,
+					})
+				}
+			}
+		}
+		return _res
+	}())), _toAnySlice(func() []map[string]any {
+		_res := []map[string]any{}
+		for _, c := range catalog {
+			if (c.Return_rank <= 10) || (c.Currency_rank <= 10) {
+				if (c.Return_rank <= 10) || (c.Currency_rank <= 10) {
+					_res = append(_res, map[string]any{
+						"channel":       "catalog",
+						"item":          c.Item,
+						"return_ratio":  c.Return_ratio,
+						"return_rank":   c.Return_rank,
+						"currency_rank": c.Currency_rank,
+					})
+				}
+			}
+		}
+		return _res
+	}())), _toAnySlice(func() []map[string]any {
+		_res := []map[string]any{}
+		for _, s := range store {
+			if (s.Return_rank <= 10) || (s.Currency_rank <= 10) {
+				if (s.Return_rank <= 10) || (s.Currency_rank <= 10) {
+					_res = append(_res, map[string]any{
+						"channel":       "store",
+						"item":          s.Item,
+						"return_ratio":  s.Return_ratio,
+						"return_rank":   s.Return_rank,
+						"currency_rank": s.Currency_rank,
+					})
+				}
+			}
+		}
+		return _res
+	}())))
+	result = func() []any {
+		src := tmp
+		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any { r := _a[0]; _ = r; return r }, sortKey: func(_a ...any) any {
+			r := _a[0]
+			_ = r
+			return []any{
+				_cast[map[string]any](r)["channel"],
+				_cast[map[string]any](r)["return_rank"],
+				_cast[map[string]any](r)["currency_rank"],
+				_cast[map[string]any](r)["item"],
+			}
+		}, skip: -1, take: -1})
+		out := make([]any, len(resAny))
+		for i, v := range resAny {
+			out[i] = v
+		}
+		return out
+	}()
+	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	{
+		printTestStart("TPCDS Q49 simplified")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_TPCDS_Q49_simplified()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _concat[T any](a, b []T) []T {
+	res := make([]T, 0, len(a)+len(b))
+	res = append(res, a...)
+	res = append(res, b...)
+	return res
+}
+
+func _convSlice[T any, U any](s []T) []U {
+	out := make([]U, len(s))
+	for i, v := range s {
+		out[i] = any(v).(U)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+type _joinSpec struct {
+	items []any
+	on    func(...any) bool
+	left  bool
+	right bool
+}
+type _queryOpts struct {
+	selectFn func(...any) any
+	where    func(...any) bool
+	sortKey  func(...any) any
+	skip     int
+	take     int
+}
+
+func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
+	items := make([][]any, len(src))
+	for i, v := range src {
+		items[i] = []any{v}
+	}
+	for _, j := range joins {
+		joined := [][]any{}
+		if j.right && j.left {
+			matched := make([]bool, len(j.items))
+			for _, left := range items {
+				m := false
+				for ri, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					matched[ri] = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+			for ri, right := range j.items {
+				if !matched[ri] {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else if j.right {
+			for _, right := range j.items {
+				m := false
+				for _, left := range items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else {
+			for _, left := range items {
+				m := false
+				for _, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if j.left && !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+		}
+		items = joined
+	}
+	if opts.where != nil {
+		filtered := [][]any{}
+		for _, r := range items {
+			if opts.where(r...) {
+				filtered = append(filtered, r)
+			}
+		}
+		items = filtered
+	}
+	if opts.sortKey != nil {
+		type pair struct {
+			item []any
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for i, it := range items {
+			pairs[i] = pair{it, opts.sortKey(it...)}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for i, p := range pairs {
+			items[i] = p.item
+		}
+	}
+	if opts.skip >= 0 {
+		if opts.skip < len(items) {
+			items = items[opts.skip:]
+		} else {
+			items = [][]any{}
+		}
+	}
+	if opts.take >= 0 {
+		if opts.take < len(items) {
+			items = items[:opts.take]
+		}
+	}
+	res := make([]any, len(items))
+	for i, r := range items {
+		res[i] = opts.selectFn(r...)
+	}
+	return res
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}

--- a/tests/dataset/tpc-ds/compiler/go/q49.out
+++ b/tests/dataset/tpc-ds/compiler/go/q49.out
@@ -1,0 +1,2 @@
+[{"channel":"catalog","currency_rank":1,"item":"A","return_rank":1,"return_ratio":0.3},{"channel":"store","currency_rank":1,"item":"A","return_rank":1,"return_ratio":0.25},{"channel":"web","currency_rank":1,"item":"A","return_rank":1,"return_ratio":0.2},{"channel":"web","currency_rank":2,"item":"B","return_rank":2,"return_ratio":0.5}]
+   test TPCDS Q49 simplified           ... ok (17.0µs)


### PR DESCRIPTION
## Summary
- update Go compiler sort handling
- add generated code and output for TPC‑DS queries q30–q49 that now pass

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68641b4fe7c4832084182fc3355aa3e0