### PR TITLE
Extend ST TPC‑DS coverage

### DIFF
--- a/compile/x/st/TASKS.md
+++ b/compile/x/st/TASKS.md
@@ -8,7 +8,7 @@ golden tests cover `tpch_q1` and `tpch_q2` as well as simple `group_by` queries.
 Running the TPCH programs under `gst` still reports parse errors,
 so executing the compiled Smalltalk code remains TODO.
 
-The TPCDS suite now covers queries `q1` through `q49`. The Smalltalk backend
+The TPCDS suite now covers queries `q1` through `q99`. The Smalltalk backend
 successfully compiles these programs and golden output is stored under
 `tests/dataset/tpc-ds/compiler/st`.
 

--- a/compile/x/st/tpcds_golden_test.go
+++ b/compile/x/st/tpcds_golden_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSTCompiler_TPCDS_Golden(t *testing.T) {
 	root := testutil.FindRepoRoot(t)
-	for i := 1; i <= 49; i++ {
+	for i := 1; i <= 99; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")

--- a/tests/dataset/tpc-ds/compiler/st/q50.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q50.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q50_placeholder
+	((result = 50)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 50}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q50_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q51.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q51.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q51_placeholder
+	((result = 51)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 51}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q51_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q52.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q52.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q52_placeholder
+	((result = 52)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 52}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q52_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q53.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q53.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q53_placeholder
+	((result = 53)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 53}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q53_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q54.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q54.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q54_placeholder
+	((result = 54)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 54}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q54_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q55.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q55.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q55_placeholder
+	((result = 55)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 55}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q55_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q56.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q56.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q56_placeholder
+	((result = 56)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 56}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q56_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q57.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q57.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q57_placeholder
+	((result = 57)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 57}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q57_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q58.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q58.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q58_placeholder
+	((result = 58)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 58}).
+tmp := lower value: 'ignore'.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q58_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q59.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q59.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #t put: nil.
+Smalltalk at: #tmp put: nil.
+Smalltalk at: #vals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q59_placeholder
+	((result = 59)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+t := Array with: (Dictionary from: {'id' -> 1. 'val' -> 59}).
+tmp := lower value: 59.
+vals := ((| res |
+res := OrderedCollection new.
+(t) do: [:r |
+	res add: r at: 'val'.
+]
+res := res asArray.
+res)).
+result := first value: vals.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q59_placeholder.

--- a/tests/dataset/tpc-ds/compiler/st/q60.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q60.st.out
@@ -1,0 +1,42 @@
+Smalltalk at: #all_sales put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q60_simplified
+	((result = 60)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__union_all: a with: b
+	| out |
+	out := OrderedCollection new.
+	a ifNotNil: [ a do: [:v | out add: v ] ].
+	b ifNotNil: [ b do: [:v | out add: v ] ].
+	^ out asArray
+!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'item' -> 1. 'price' -> 10}) with: (Dictionary from: {'item' -> 1. 'price' -> 20}).
+catalog_sales := Array with: (Dictionary from: {'item' -> 1. 'price' -> 15}).
+web_sales := Array with: (Dictionary from: {'item' -> 1. 'price' -> 15}).
+all_sales := (Main __union_all: ((Main __union_all: (store_sales) with: (catalog_sales))) with: (web_sales)).
+result := (Main __sum: ((| res |
+res := OrderedCollection new.
+(all_sales) do: [:s |
+	res add: s at: 'price'.
+]
+res := res asArray.
+res))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q60_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q61.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q61.st.out
@@ -1,0 +1,39 @@
+Smalltalk at: #promotions put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #sales put: nil.
+Smalltalk at: #total put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q61_simplified
+	((result = 61)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+sales := Array with: (Dictionary from: {'promo' -> true. 'price' -> 20}) with: (Dictionary from: {'promo' -> true. 'price' -> 41}) with: (Dictionary from: {'promo' -> false. 'price' -> 39}).
+promotions := (Main __sum: ((| res |
+res := OrderedCollection new.
+((sales) select: [:s | s at: 'promo']) do: [:s |
+	res add: s at: 'price'.
+]
+res := res asArray.
+res))).
+total := (Main __sum: ((| res |
+res := OrderedCollection new.
+(sales) do: [:s |
+	res add: s at: 'price'.
+]
+res := res asArray.
+res))).
+result := ((promotions * 100) / total).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q61_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q62.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q62.st.out
@@ -1,0 +1,20 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q62_simplified
+	((result = 62)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+!!
+web_sales := Array with: (Dictionary from: {'days' -> 10}) with: (Dictionary from: {'days' -> 40}) with: (Dictionary from: {'days' -> 70}) with: (Dictionary from: {'days' -> 100}) with: (Dictionary from: {'days' -> 130}).
+result := (((Main __count: web_sales) * 12) + 2).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q62_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q63.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q63.st.out
@@ -1,0 +1,91 @@
+Smalltalk at: #by_mgr put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q63_simplified
+	((result = 63)) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+sales := Array with: (Dictionary from: {'mgr' -> 1. 'amount' -> 30}) with: (Dictionary from: {'mgr' -> 2. 'amount' -> 33}).
+by_mgr := ((| rows groups |
+rows := OrderedCollection new.
+(sales) do: [:s |
+	rows add: s.
+]
+groups := (Main _group_by: rows keyFn: [:s | Dictionary from: {'mgr' -> s at: 'mgr'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'mgr' -> g at: 'key' at: 'mgr'. 'sum_sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'amount'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := (Main __sum: ((| res |
+res := OrderedCollection new.
+(by_mgr) do: [:x |
+	res add: x at: 'sum_sales'.
+]
+res := res asArray.
+res))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q63_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q64.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q64.st.out
@@ -1,0 +1,17 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_returns put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q64_simplified
+	((result = 64)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+store_sales := Array with: (Dictionary from: {'item' -> 1. 'cost' -> 20. 'list' -> 30. 'coupon' -> 5}).
+store_returns := Array with: (Dictionary from: {'item' -> 1. 'ticket' -> 1}).
+result := (((20 + 30) - 5) + 19).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q64_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q65.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q65.st.out
@@ -1,0 +1,15 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q65_simplified
+	((result = 65)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+store_sales := Array with: (Dictionary from: {'store' -> 1. 'item' -> 1. 'price' -> 1}) with: (Dictionary from: {'store' -> 1. 'item' -> 1. 'price' -> 1}) with: (Dictionary from: {'store' -> 1. 'item' -> 2. 'price' -> 60}).
+result := 65.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q65_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q66.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q66.st.out
@@ -1,0 +1,37 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q66_simplified
+	((result = 66)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+web_sales := Array with: (Dictionary from: {'net' -> 30}).
+catalog_sales := Array with: (Dictionary from: {'net' -> 36}).
+result := ((Main __sum: ((| res |
+res := OrderedCollection new.
+(web_sales) do: [:w |
+	res add: w at: 'net'.
+]
+res := res asArray.
+res))) + (Main __sum: ((| res |
+res := OrderedCollection new.
+(catalog_sales) do: [:c |
+	res add: c at: 'net'.
+]
+res := res asArray.
+res)))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q66_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q67.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q67.st.out
@@ -1,0 +1,17 @@
+Smalltalk at: #reason put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q67_simplified
+	((result = 67)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+store_sales := Array with: (Dictionary from: {'reason' -> 1. 'price' -> 40}) with: (Dictionary from: {'reason' -> 2. 'price' -> 27}).
+reason := Array with: (Dictionary from: {'id' -> 1. 'name' -> 'PROMO'}) with: (Dictionary from: {'id' -> 2. 'name' -> 'RETURN'}).
+result := 67.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q67_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q68.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q68.st.out
@@ -1,0 +1,37 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q68_simplified
+	((result = 68)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'item' -> 1. 'profit' -> 30}) with: (Dictionary from: {'item' -> 2. 'profit' -> 38}).
+store_sales := Array with: (Dictionary from: {'item' -> 1. 'profit' -> 30}).
+result := (((Main __sum: ((| res |
+res := OrderedCollection new.
+(catalog_sales) do: [:c |
+	res add: c at: 'profit'.
+]
+res := res asArray.
+res))) - (Main __sum: ((| res |
+res := OrderedCollection new.
+(store_sales) do: [:s |
+	res add: s at: 'profit'.
+]
+res := res asArray.
+res)))) + 30).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q68_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q69.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q69.st.out
@@ -1,0 +1,37 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q69_simplified
+	((result = 69)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+web_sales := Array with: (Dictionary from: {'amount' -> 34}).
+store_sales := Array with: (Dictionary from: {'amount' -> 35}).
+result := ((Main __sum: ((| res |
+res := OrderedCollection new.
+(web_sales) do: [:w |
+	res add: w at: 'amount'.
+]
+res := res asArray.
+res))) + (Main __sum: ((| res |
+res := OrderedCollection new.
+(store_sales) do: [:s |
+	res add: s at: 'amount'.
+]
+res := res asArray.
+res)))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q69_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q70.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q70.st.out
@@ -1,0 +1,47 @@
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #dms put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q70_simplified
+	((result = Array with: (Dictionary from: {'s_state' -> 'CA'. 's_county' -> 'Orange'. 'total_sum' -> 15.000000}) with: (Dictionary from: {'s_state' -> 'TX'. 's_county' -> 'Travis'. 'total_sum' -> 20.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_state' -> 'CA'. 's_county' -> 'Orange'}) with: (Dictionary from: {'s_store_sk' -> 2. 's_state' -> 'CA'. 's_county' -> 'Orange'}) with: (Dictionary from: {'s_store_sk' -> 3. 's_state' -> 'TX'. 's_county' -> 'Travis'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_month_seq' -> 1200}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_month_seq' -> 1201}).
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_net_profit' -> 10.000000}) with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 2. 'ss_net_profit' -> 5.000000}) with: (Dictionary from: {'ss_sold_date_sk' -> 2. 'ss_store_sk' -> 3. 'ss_net_profit' -> 20.000000}).
+dms := 1200.
+result := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((((d at: 'd_month_seq' >= dms) and: [d at: 'd_month_seq']) <= dms) + 11) and: [(d at: 'd_date_sk' = ss at: 'ss_sold_date_sk')]) and: [(s at: 's_store_sk' = ss at: 'ss_store_sk')])]) do: [:ss |
+	(date_dim) do: [:d |
+		(store) do: [:s |
+			res add: { Array with: (g at: 'key' at: 'state') with: (g at: 'key' at: 'county') . Dictionary from: {'s_state' -> g at: 'key' at: 'state'. 's_county' -> g at: 'key' at: 'county'. 'total_sum' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_net_profit'.
+]
+res := res asArray.
+res)))} }.
+		]
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q70_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q71.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q71.st.out
@@ -1,0 +1,87 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #month put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #time_dim put: nil.
+Smalltalk at: #union_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #year put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q71_simplified
+	((result = Array with: (Dictionary from: {'i_brand_id' -> 10. 'i_brand' -> 'BrandA'. 't_hour' -> 18. 't_minute' -> 0. 'ext_price' -> 200.000000}) with: (Dictionary from: {'i_brand_id' -> 20. 'i_brand' -> 'BrandB'. 't_hour' -> 8. 't_minute' -> 30. 'ext_price' -> 150.000000}) with: (Dictionary from: {'i_brand_id' -> 10. 'i_brand' -> 'BrandA'. 't_hour' -> 8. 't_minute' -> 30. 'ext_price' -> 100.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_brand_id' -> 10. 'i_brand' -> 'BrandA'. 'i_manager_id' -> 1}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_brand_id' -> 20. 'i_brand' -> 'BrandB'. 'i_manager_id' -> 1}).
+time_dim := Array with: (Dictionary from: {'t_time_sk' -> 1. 't_hour' -> 8. 't_minute' -> 30. 't_meal_time' -> 'breakfast'}) with: (Dictionary from: {'t_time_sk' -> 2. 't_hour' -> 18. 't_minute' -> 0. 't_meal_time' -> 'dinner'}) with: (Dictionary from: {'t_time_sk' -> 3. 't_hour' -> 12. 't_minute' -> 0. 't_meal_time' -> 'lunch'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_moy' -> 12. 'd_year' -> 1998}).
+web_sales := Array with: (Dictionary from: {'ws_ext_sales_price' -> 100.000000. 'ws_sold_date_sk' -> 1. 'ws_item_sk' -> 1. 'ws_sold_time_sk' -> 1}).
+catalog_sales := Array with: (Dictionary from: {'cs_ext_sales_price' -> 200.000000. 'cs_sold_date_sk' -> 1. 'cs_item_sk' -> 1. 'cs_sold_time_sk' -> 2}).
+store_sales := Array with: (Dictionary from: {'ss_ext_sales_price' -> 150.000000. 'ss_sold_date_sk' -> 1. 'ss_item_sk' -> 2. 'ss_sold_time_sk' -> 1}).
+month := 12.
+year := 1998.
+union_sales := concat value: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | ((((d at: 'd_moy' = month) and: [d at: 'd_year']) = year) and: [(d at: 'd_date_sk' = ws at: 'ws_sold_date_sk')])]) do: [:ws |
+	(date_dim) do: [:d |
+		res add: Dictionary from: {'ext_price' -> ws at: 'ws_ext_sales_price'. 'item_sk' -> ws at: 'ws_item_sk'. 'time_sk' -> ws at: 'ws_sold_time_sk'}.
+	]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | ((((d at: 'd_moy' = month) and: [d at: 'd_year']) = year) and: [(d at: 'd_date_sk' = cs at: 'cs_sold_date_sk')])]) do: [:cs |
+	(date_dim) do: [:d |
+		res add: Dictionary from: {'ext_price' -> cs at: 'cs_ext_sales_price'. 'item_sk' -> cs at: 'cs_item_sk'. 'time_sk' -> cs at: 'cs_sold_time_sk'}.
+	]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((d at: 'd_moy' = month) and: [d at: 'd_year']) = year) and: [(d at: 'd_date_sk' = ss at: 'ss_sold_date_sk')])]) do: [:ss |
+	(date_dim) do: [:d |
+		res add: Dictionary from: {'ext_price' -> ss at: 'ss_ext_sales_price'. 'item_sk' -> ss at: 'ss_item_sk'. 'time_sk' -> ss at: 'ss_sold_time_sk'}.
+	]
+]
+res := res asArray.
+res)).
+result := ((| res |
+res := OrderedCollection new.
+((item) select: [:i | ((((i at: 'i_manager_id' = 1) and: [((((t at: 't_meal_time' = 'breakfast') or: [t at: 't_meal_time']) = 'dinner'))]) and: [(s at: 'item_sk' = i at: 'i_item_sk')]) and: [(t at: 't_time_sk' = s at: 'time_sk')])]) do: [:i |
+	(union_sales) do: [:s |
+		(time_dim) do: [:t |
+			res add: { Array with: (((Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 's' at: 'ext_price'.
+]
+res := res asArray.
+res))) negated)) with: (g at: 'key' at: 'brand_id') . Dictionary from: {'i_brand_id' -> g at: 'key' at: 'brand_id'. 'i_brand' -> g at: 'key' at: 'brand'. 't_hour' -> g at: 'key' at: 't_hour'. 't_minute' -> g at: 'key' at: 't_minute'. 'ext_price' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 's' at: 'ext_price'.
+]
+res := res asArray.
+res)))} }.
+		]
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q71_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q72.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q72.st.out
@@ -1,0 +1,98 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #inventory put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #warehouse put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q72_simplified
+	((result = Array with: (Dictionary from: {'i_item_desc' -> 'ItemA'. 'w_warehouse_name' -> 'Main'. 'd_week_seq' -> 10. 'no_promo' -> 1. 'promo' -> 0. 'total_cnt' -> 1}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_order_number' -> 1. 'cs_quantity' -> 1. 'cs_sold_date_sk' -> 1. 'cs_ship_date_sk' -> 3. 'cs_bill_cdemo_sk' -> 1. 'cs_bill_hdemo_sk' -> 1. 'cs_promo_sk' -> nil}).
+inventory := Array with: (Dictionary from: {'inv_item_sk' -> 1. 'inv_warehouse_sk' -> 1. 'inv_date_sk' -> 2. 'inv_quantity_on_hand' -> 0}).
+warehouse := Array with: (Dictionary from: {'w_warehouse_sk' -> 1. 'w_warehouse_name' -> 'Main'}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_desc' -> 'ItemA'}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_marital_status' -> 'M'}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_buy_potential' -> '5001-10000'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_week_seq' -> 10. 'd_date' -> 1. 'd_year' -> 2000}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_week_seq' -> 10. 'd_date' -> 1. 'd_year' -> 2000}) with: (Dictionary from: {'d_date_sk' -> 3. 'd_week_seq' -> 10. 'd_date' -> 7. 'd_year' -> 2000}).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_sales) do: [:cs |
+	(((((((((((((d1 at: 'd_week_seq' = d2 at: 'd_week_seq') and: [inv at: 'inv_quantity_on_hand']) < cs at: 'cs_quantity') and: [d3 at: 'd_date']) > d1 at: 'd_date') + 5) and: [hd at: 'hd_buy_potential']) = '5001-10000') and: [d1 at: 'd_year']) = 2000) and: [cd at: 'cd_marital_status']) = 'M')) ifTrue: [ rows add: cs ].
+]
+groups := (Main _group_by: rows keyFn: [:cs | Dictionary from: {'item_desc' -> i at: 'i_item_desc'. 'warehouse' -> w at: 'w_warehouse_name'. 'week_seq' -> d1 at: 'd_week_seq'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'i_item_desc' -> g at: 'key' at: 'item_desc'. 'w_warehouse_name' -> g at: 'key' at: 'warehouse'. 'd_week_seq' -> g at: 'key' at: 'week_seq'. 'no_promo' -> (Main __count: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'cs_promo_sk' = nil)]) do: [:x |
+	res add: x.
+]
+res := res asArray.
+res))). 'promo' -> (Main __count: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (x at: 'cs_promo_sk' ~= nil)]) do: [:x |
+	res add: x.
+]
+res := res asArray.
+res))). 'total_cnt' -> (Main __count: g)}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q72_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q73.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q73.st.out
@@ -1,0 +1,94 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #groups put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q73_simplified
+	((result = Array with: (Dictionary from: {'c_last_name' -> 'Smith'. 'c_first_name' -> 'Alice'. 'c_salutation' -> 'Ms.'. 'c_preferred_cust_flag' -> 'Y'. 'ss_ticket_number' -> 1. 'cnt' -> 1}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_hdemo_sk' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_dom' -> 1. 'd_year' -> 1998}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_county' -> 'A'}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_buy_potential' -> '1001-5000'. 'hd_vehicle_count' -> 2. 'hd_dep_count' -> 3}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_last_name' -> 'Smith'. 'c_first_name' -> 'Alice'. 'c_salutation' -> 'Ms.'. 'c_preferred_cust_flag' -> 'Y'}).
+groups := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+	(((((((((((((d at: 'd_dom' >= 1) and: [d at: 'd_dom']) <= 2) and: [((((hd at: 'hd_buy_potential' = '1001-5000') or: [hd at: 'hd_buy_potential']) = '0-500'))]) and: [hd at: 'hd_vehicle_count']) > 0) and: [hd at: 'hd_dep_count']) / hd at: 'hd_vehicle_count') > 1) and: [((((((d at: 'd_year' = 1998) or: [d at: 'd_year']) = 1999) or: [d at: 'd_year']) = 2000))]) and: [s at: 's_county']) = 'A')) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'ticket' -> ss at: 'ss_ticket_number'. 'cust' -> ss at: 'ss_customer_sk'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'key' -> g at: 'key'. 'cnt' -> (Main __count: g)}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((groups) select: [:g | ((((g at: 'cnt' >= 1) and: [g at: 'cnt']) <= 5) and: [(c at: 'c_customer_sk' = g at: 'key' at: 'cust')])]) do: [:g |
+	(customer) do: [:c |
+		res add: { Array with: ((g at: 'cnt' negated)) with: (c at: 'c_last_name') . Dictionary from: {'c_last_name' -> c at: 'c_last_name'. 'c_first_name' -> c at: 'c_first_name'. 'c_salutation' -> c at: 'c_salutation'. 'c_preferred_cust_flag' -> c at: 'c_preferred_cust_flag'. 'ss_ticket_number' -> g at: 'key' at: 'ticket'. 'cnt' -> g at: 'cnt'} }.
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q73_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q74.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q74.st.out
@@ -1,0 +1,140 @@
+Smalltalk at: #customer put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #s_firstyear put: nil.
+Smalltalk at: #s_secyear put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #w_firstyear put: nil.
+Smalltalk at: #w_secyear put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #year_total put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q74_simplified
+	((result = Array with: (Dictionary from: {'customer_id' -> 1. 'customer_first_name' -> 'Alice'. 'customer_last_name' -> 'Smith'}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_customer_id' -> 1. 'c_first_name' -> 'Alice'. 'c_last_name' -> 'Smith'}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1998}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_year' -> 1999}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_net_paid' -> 100.000000}) with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_sold_date_sk' -> 2. 'ss_net_paid' -> 110.000000}).
+web_sales := Array with: (Dictionary from: {'ws_bill_customer_sk' -> 1. 'ws_sold_date_sk' -> 1. 'ws_net_paid' -> 40.000000}) with: (Dictionary from: {'ws_bill_customer_sk' -> 1. 'ws_sold_date_sk' -> 2. 'ws_net_paid' -> 80.000000}).
+year_total := concat value: ((| rows groups |
+rows := OrderedCollection new.
+(customer) do: [:c |
+	((((d at: 'd_year' = 1998) or: [d at: 'd_year']) = 1999)) ifTrue: [ rows add: c ].
+]
+groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'year' -> d at: 'd_year'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'year' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_net_paid'.
+]
+res := res asArray.
+res))). 'sale_type' -> 's'}.
+]
+rows := rows asArray.
+rows)) value: ((| rows groups |
+rows := OrderedCollection new.
+(customer) do: [:c |
+	((((d at: 'd_year' = 1998) or: [d at: 'd_year']) = 1999)) ifTrue: [ rows add: c ].
+]
+groups := (Main _group_by: rows keyFn: [:c | Dictionary from: {'id' -> c at: 'c_customer_id'. 'first' -> c at: 'c_first_name'. 'last' -> c at: 'c_last_name'. 'year' -> d at: 'd_year'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'customer_id' -> g at: 'key' at: 'id'. 'customer_first_name' -> g at: 'key' at: 'first'. 'customer_last_name' -> g at: 'key' at: 'last'. 'year' -> g at: 'key' at: 'year'. 'year_total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ws' at: 'ws_net_paid'.
+]
+res := res asArray.
+res))). 'sale_type' -> 'w'}.
+]
+rows := rows asArray.
+rows)).
+s_firstyear := first value: ((| res |
+res := OrderedCollection new.
+((year_total) select: [:y | (((y at: 'sale_type' = 's') and: [y at: 'year']) = 1998)]) do: [:y |
+	res add: y.
+]
+res := res asArray.
+res)).
+s_secyear := first value: ((| res |
+res := OrderedCollection new.
+((year_total) select: [:y | (((y at: 'sale_type' = 's') and: [y at: 'year']) = 1999)]) do: [:y |
+	res add: y.
+]
+res := res asArray.
+res)).
+w_firstyear := first value: ((| res |
+res := OrderedCollection new.
+((year_total) select: [:y | (((y at: 'sale_type' = 'w') and: [y at: 'year']) = 1998)]) do: [:y |
+	res add: y.
+]
+res := res asArray.
+res)).
+w_secyear := first value: ((| res |
+res := OrderedCollection new.
+((year_total) select: [:y | (((y at: 'sale_type' = 'w') and: [y at: 'year']) = 1999)]) do: [:y |
+	res add: y.
+]
+res := res asArray.
+res)).
+result := (((((((s_firstyear at: 'year_total' > 0) and: [w_firstyear at: 'year_total']) > 0) and: [((w_secyear at: 'year_total' / w_firstyear at: 'year_total'))]) > ((s_secyear at: 'year_total' / s_firstyear at: 'year_total')))) ifTrue: [Array with: (Dictionary from: {'customer_id' -> s_secyear at: 'customer_id'. 'customer_first_name' -> s_secyear at: 'customer_first_name'. 'customer_last_name' -> s_secyear at: 'customer_last_name'})] ifFalse: [Array new]).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q74_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q75.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q75.st.out
@@ -1,0 +1,141 @@
+Smalltalk at: #all_sales put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #curr_yr put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #prev_yr put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #sales_detail put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q75_simplified
+	((result = Array with: (Dictionary from: {'prev_year' -> 2000. 'year' -> 2001. 'i_brand_id' -> 1. 'i_class_id' -> 2. 'i_category_id' -> 3. 'i_manufact_id' -> 4. 'prev_yr_cnt' -> 100. 'curr_yr_cnt' -> 80. 'sales_cnt_diff' -> (20 negated). 'sales_amt_diff' -> (200.000000 negated)}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2000}) with: (Dictionary from: {'d_date_sk' -> 2. 'd_year' -> 2001}).
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_quantity' -> 50. 'ss_sales_price' -> 500.000000. 'ss_sold_date_sk' -> 1}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_quantity' -> 40. 'ss_sales_price' -> 400.000000. 'ss_sold_date_sk' -> 2}).
+web_sales := Array with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_quantity' -> 30. 'ws_sales_price' -> 300.000000. 'ws_sold_date_sk' -> 1}) with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_quantity' -> 25. 'ws_sales_price' -> 250.000000. 'ws_sold_date_sk' -> 2}).
+catalog_sales := Array with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_quantity' -> 20. 'cs_sales_price' -> 200.000000. 'cs_sold_date_sk' -> 1}) with: (Dictionary from: {'cs_item_sk' -> 1. 'cs_quantity' -> 15. 'cs_sales_price' -> 150.000000. 'cs_sold_date_sk' -> 2}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_brand_id' -> 1. 'i_class_id' -> 2. 'i_category_id' -> 3. 'i_manufact_id' -> 4. 'i_category' -> 'Electronics'}).
+sales_detail := concat value: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (d at: 'd_date_sk' = ss at: 'ss_sold_date_sk')]) do: [:ss |
+	(date_dim) do: [:d |
+		res add: Dictionary from: {'d_year' -> d at: 'd_year'. 'i_item_sk' -> ss at: 'ss_item_sk'. 'quantity' -> ss at: 'ss_quantity'. 'amount' -> ss at: 'ss_sales_price'}.
+	]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | (d at: 'd_date_sk' = ws at: 'ws_sold_date_sk')]) do: [:ws |
+	(date_dim) do: [:d |
+		res add: Dictionary from: {'d_year' -> d at: 'd_year'. 'i_item_sk' -> ws at: 'ws_item_sk'. 'quantity' -> ws at: 'ws_quantity'. 'amount' -> ws at: 'ws_sales_price'}.
+	]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | (d at: 'd_date_sk' = cs at: 'cs_sold_date_sk')]) do: [:cs |
+	(date_dim) do: [:d |
+		res add: Dictionary from: {'d_year' -> d at: 'd_year'. 'i_item_sk' -> cs at: 'cs_item_sk'. 'quantity' -> cs at: 'cs_quantity'. 'amount' -> cs at: 'cs_sales_price'}.
+	]
+]
+res := res asArray.
+res)).
+all_sales := ((| rows groups |
+rows := OrderedCollection new.
+(sales_detail) do: [:sd |
+	((i at: 'i_category' = 'Electronics')) ifTrue: [ rows add: sd ].
+]
+groups := (Main _group_by: rows keyFn: [:sd | Dictionary from: {'year' -> sd at: 'd_year'. 'brand_id' -> i at: 'i_brand_id'. 'class_id' -> i at: 'i_class_id'. 'category_id' -> i at: 'i_category_id'. 'manuf_id' -> i at: 'i_manufact_id'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'d_year' -> g at: 'key' at: 'year'. 'i_brand_id' -> g at: 'key' at: 'brand_id'. 'i_class_id' -> g at: 'key' at: 'class_id'. 'i_category_id' -> g at: 'key' at: 'category_id'. 'i_manufact_id' -> g at: 'key' at: 'manuf_id'. 'sales_cnt' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'sd' at: 'quantity'.
+]
+res := res asArray.
+res))). 'sales_amt' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'sd' at: 'amount'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+prev_yr := first value: ((| res |
+res := OrderedCollection new.
+((all_sales) select: [:a | (a at: 'd_year' = 2000)]) do: [:a |
+	res add: a.
+]
+res := res asArray.
+res)).
+curr_yr := first value: ((| res |
+res := OrderedCollection new.
+((all_sales) select: [:a | (a at: 'd_year' = 2001)]) do: [:a |
+	res add: a.
+]
+res := res asArray.
+res)).
+result := (((((curr_yr at: 'sales_cnt' / prev_yr at: 'sales_cnt')) < 0.900000)) ifTrue: [Array with: (Dictionary from: {'prev_year' -> prev_yr at: 'd_year'. 'year' -> curr_yr at: 'd_year'. 'i_brand_id' -> curr_yr at: 'i_brand_id'. 'i_class_id' -> curr_yr at: 'i_class_id'. 'i_category_id' -> curr_yr at: 'i_category_id'. 'i_manufact_id' -> curr_yr at: 'i_manufact_id'. 'prev_yr_cnt' -> prev_yr at: 'sales_cnt'. 'curr_yr_cnt' -> curr_yr at: 'sales_cnt'. 'sales_cnt_diff' -> (curr_yr at: 'sales_cnt' - prev_yr at: 'sales_cnt'). 'sales_amt_diff' -> (curr_yr at: 'sales_amt' - prev_yr at: 'sales_amt')})] ifFalse: [Array new]).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q75_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q76.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q76.st.out
@@ -1,0 +1,87 @@
+Smalltalk at: #all_rows put: nil.
+Smalltalk at: #catalog_part put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_part put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_part put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q76_simplified
+	((result = Array with: (Dictionary from: {'channel' -> 'store'. 'col_name' -> nil. 'd_year' -> 1998. 'd_qoy' -> 1. 'i_category' -> 'CatA'. 'sales_cnt' -> 1. 'sales_amt' -> 10.000000}) with: (Dictionary from: {'channel' -> 'web'. 'col_name' -> nil. 'd_year' -> 1998. 'd_qoy' -> 1. 'i_category' -> 'CatB'. 'sales_cnt' -> 1. 'sales_amt' -> 15.000000}) with: (Dictionary from: {'channel' -> 'catalog'. 'col_name' -> nil. 'd_year' -> 1998. 'd_qoy' -> 1. 'i_category' -> 'CatC'. 'sales_cnt' -> 1. 'sales_amt' -> 20.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 1998. 'd_qoy' -> 1}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_category' -> 'CatA'}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_category' -> 'CatB'}) with: (Dictionary from: {'i_item_sk' -> 3. 'i_category' -> 'CatC'}).
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> nil. 'ss_item_sk' -> 1. 'ss_ext_sales_price' -> 10.000000. 'ss_sold_date_sk' -> 1}).
+web_sales := Array with: (Dictionary from: {'ws_bill_customer_sk' -> nil. 'ws_item_sk' -> 2. 'ws_ext_sales_price' -> 15.000000. 'ws_sold_date_sk' -> 1}).
+catalog_sales := Array with: (Dictionary from: {'cs_bill_customer_sk' -> nil. 'cs_item_sk' -> 3. 'cs_ext_sales_price' -> 20.000000. 'cs_sold_date_sk' -> 1}).
+store_part := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (((ss at: 'ss_customer_sk' = nil) and: [(i at: 'i_item_sk' = ss at: 'ss_item_sk')]) and: [(d at: 'd_date_sk' = ss at: 'ss_sold_date_sk')])]) do: [:ss |
+	(item) do: [:i |
+		(date_dim) do: [:d |
+			res add: Dictionary from: {'channel' -> 'store'. 'col_name' -> ss at: 'ss_customer_sk'. 'd_year' -> d at: 'd_year'. 'd_qoy' -> d at: 'd_qoy'. 'i_category' -> i at: 'i_category'. 'ext_sales_price' -> ss at: 'ss_ext_sales_price'}.
+		]
+	]
+]
+res := res asArray.
+res)).
+web_part := ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | (((ws at: 'ws_bill_customer_sk' = nil) and: [(i at: 'i_item_sk' = ws at: 'ws_item_sk')]) and: [(d at: 'd_date_sk' = ws at: 'ws_sold_date_sk')])]) do: [:ws |
+	(item) do: [:i |
+		(date_dim) do: [:d |
+			res add: Dictionary from: {'channel' -> 'web'. 'col_name' -> ws at: 'ws_bill_customer_sk'. 'd_year' -> d at: 'd_year'. 'd_qoy' -> d at: 'd_qoy'. 'i_category' -> i at: 'i_category'. 'ext_sales_price' -> ws at: 'ws_ext_sales_price'}.
+		]
+	]
+]
+res := res asArray.
+res)).
+catalog_part := ((| res |
+res := OrderedCollection new.
+((catalog_sales) select: [:cs | (((cs at: 'cs_bill_customer_sk' = nil) and: [(i at: 'i_item_sk' = cs at: 'cs_item_sk')]) and: [(d at: 'd_date_sk' = cs at: 'cs_sold_date_sk')])]) do: [:cs |
+	(item) do: [:i |
+		(date_dim) do: [:d |
+			res add: Dictionary from: {'channel' -> 'catalog'. 'col_name' -> cs at: 'cs_bill_customer_sk'. 'd_year' -> d at: 'd_year'. 'd_qoy' -> d at: 'd_qoy'. 'i_category' -> i at: 'i_category'. 'ext_sales_price' -> cs at: 'cs_ext_sales_price'}.
+		]
+	]
+]
+res := res asArray.
+res)).
+all_rows := concat value: store_part value: web_part value: catalog_part.
+result := ((| res |
+res := OrderedCollection new.
+(all_rows) do: [:r |
+	res add: { g at: 'key' at: 'channel' . Dictionary from: {'channel' -> g at: 'key' at: 'channel'. 'col_name' -> g at: 'key' at: 'col_name'. 'd_year' -> g at: 'key' at: 'd_year'. 'd_qoy' -> g at: 'key' at: 'd_qoy'. 'i_category' -> g at: 'key' at: 'i_category'. 'sales_cnt' -> (Main __count: g). 'sales_amt' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'r' at: 'ext_sales_price'.
+]
+res := res asArray.
+res)))} }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q76_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q77.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q77.st.out
@@ -1,0 +1,280 @@
+Smalltalk at: #catalog_returns put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #cr put: nil.
+Smalltalk at: #cs put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #per_channel put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #sr put: nil.
+Smalltalk at: #ss put: nil.
+Smalltalk at: #store_returns put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_returns put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #wr put: nil.
+Smalltalk at: #ws put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q77_simplified
+	((result = Array with: (Dictionary from: {'channel' -> 'catalog channel'. 'id' -> 1. 'sales' -> 150.000000. 'returns' -> 7.000000. 'profit' -> 12.000000}) with: (Dictionary from: {'channel' -> 'store channel'. 'id' -> 1. 'sales' -> 100.000000. 'returns' -> 5.000000. 'profit' -> 9.000000}) with: (Dictionary from: {'channel' -> 'web channel'. 'id' -> 1. 'sales' -> 200.000000. 'returns' -> 10.000000. 'profit' -> 18.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> 1}).
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 's_store_sk' -> 1. 'ss_ext_sales_price' -> 100.000000. 'ss_net_profit' -> 10.000000}).
+store_returns := Array with: (Dictionary from: {'sr_returned_date_sk' -> 1. 's_store_sk' -> 1. 'sr_return_amt' -> 5.000000. 'sr_net_loss' -> 1.000000}).
+catalog_sales := Array with: (Dictionary from: {'cs_sold_date_sk' -> 1. 'cs_call_center_sk' -> 1. 'cs_ext_sales_price' -> 150.000000. 'cs_net_profit' -> 15.000000}).
+catalog_returns := Array with: (Dictionary from: {'cr_returned_date_sk' -> 1. 'cr_call_center_sk' -> 1. 'cr_return_amount' -> 7.000000. 'cr_net_loss' -> 3.000000}).
+web_sales := Array with: (Dictionary from: {'ws_sold_date_sk' -> 1. 'ws_web_page_sk' -> 1. 'ws_ext_sales_price' -> 200.000000. 'ws_net_profit' -> 20.000000}).
+web_returns := Array with: (Dictionary from: {'wr_returned_date_sk' -> 1. 'wr_web_page_sk' -> 1. 'wr_return_amt' -> 10.000000. 'wr_net_loss' -> 2.000000}).
+ss := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+	rows add: ss.
+]
+groups := (Main _group_by: rows keyFn: [:ss | ss at: 's_store_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'s_store_sk' -> g at: 'key'. 'sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res))). 'profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+sr := ((| rows groups |
+rows := OrderedCollection new.
+(store_returns) do: [:sr |
+	rows add: sr.
+]
+groups := (Main _group_by: rows keyFn: [:sr | sr at: 's_store_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'s_store_sk' -> g at: 'key'. 'returns' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'sr' at: 'sr_return_amt'.
+]
+res := res asArray.
+res))). 'profit_loss' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'sr' at: 'sr_net_loss'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+cs := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_sales) do: [:cs |
+	rows add: cs.
+]
+groups := (Main _group_by: rows keyFn: [:cs | cs at: 'cs_call_center_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'cs_call_center_sk' -> g at: 'key'. 'sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'cs' at: 'cs_ext_sales_price'.
+]
+res := res asArray.
+res))). 'profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'cs' at: 'cs_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+cr := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_returns) do: [:cr |
+	rows add: cr.
+]
+groups := (Main _group_by: rows keyFn: [:cr | cr at: 'cr_call_center_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'cr_call_center_sk' -> g at: 'key'. 'returns' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'cr' at: 'cr_return_amount'.
+]
+res := res asArray.
+res))). 'profit_loss' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'cr' at: 'cr_net_loss'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+ws := ((| rows groups |
+rows := OrderedCollection new.
+(web_sales) do: [:ws |
+	rows add: ws.
+]
+groups := (Main _group_by: rows keyFn: [:ws | ws at: 'ws_web_page_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'wp_web_page_sk' -> g at: 'key'. 'sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ws' at: 'ws_ext_sales_price'.
+]
+res := res asArray.
+res))). 'profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ws' at: 'ws_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+wr := ((| rows groups |
+rows := OrderedCollection new.
+(web_returns) do: [:wr |
+	rows add: wr.
+]
+groups := (Main _group_by: rows keyFn: [:wr | wr at: 'wr_web_page_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'wp_web_page_sk' -> g at: 'key'. 'returns' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'wr' at: 'wr_return_amt'.
+]
+res := res asArray.
+res))). 'profit_loss' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'wr' at: 'wr_net_loss'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+per_channel := concat value: ((| res |
+res := OrderedCollection new.
+((ss) select: [:s | (s at: 's_store_sk' = r at: 's_store_sk')]) do: [:s |
+	(sr) do: [:r |
+		res add: Dictionary from: {'channel' -> 'store channel'. 'id' -> s at: 's_store_sk'. 'sales' -> s at: 'sales'. 'returns' -> (((r = nil)) ifTrue: [0.000000] ifFalse: [r at: 'returns']). 'profit' -> (s at: 'profit' - ((((r = nil)) ifTrue: [0.000000] ifFalse: [r at: 'profit_loss'])))}.
+	]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((cs) select: [:c | (c at: 'cs_call_center_sk' = r at: 'cr_call_center_sk')]) do: [:c |
+	(cr) do: [:r |
+		res add: Dictionary from: {'channel' -> 'catalog channel'. 'id' -> c at: 'cs_call_center_sk'. 'sales' -> c at: 'sales'. 'returns' -> r at: 'returns'. 'profit' -> (c at: 'profit' - r at: 'profit_loss')}.
+	]
+]
+res := res asArray.
+res)) value: ((| res |
+res := OrderedCollection new.
+((ws) select: [:w | (w at: 'wp_web_page_sk' = r at: 'wp_web_page_sk')]) do: [:w |
+	(wr) do: [:r |
+		res add: Dictionary from: {'channel' -> 'web channel'. 'id' -> w at: 'wp_web_page_sk'. 'sales' -> w at: 'sales'. 'returns' -> (((r = nil)) ifTrue: [0.000000] ifFalse: [r at: 'returns']). 'profit' -> (w at: 'profit' - ((((r = nil)) ifTrue: [0.000000] ifFalse: [r at: 'profit_loss'])))}.
+	]
+]
+res := res asArray.
+res)).
+result := ((| res |
+res := OrderedCollection new.
+(per_channel) do: [:p |
+	res add: { g at: 'key' at: 'channel' . Dictionary from: {'channel' -> g at: 'key' at: 'channel'. 'id' -> g at: 'key' at: 'id'. 'sales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'p' at: 'sales'.
+]
+res := res asArray.
+res))). 'returns' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'p' at: 'returns'.
+]
+res := res asArray.
+res))). 'profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'p' at: 'profit'.
+]
+res := res asArray.
+res)))} }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q77_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q78.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q78.st.out
@@ -1,0 +1,29 @@
+Smalltalk at: #cs put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #ss put: nil.
+Smalltalk at: #ws put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q78_simplified
+	((result = Array with: (Dictionary from: {'ss_sold_year' -> 1998. 'ss_item_sk' -> 1. 'ss_customer_sk' -> 1. 'ratio' -> 1.250000. 'store_qty' -> 10. 'store_wholesale_cost' -> 50.000000. 'store_sales_price' -> 100.000000. 'other_chan_qty' -> 8. 'other_chan_wholesale_cost' -> 40.000000. 'other_chan_sales_price' -> 80.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+ss := Array with: (Dictionary from: {'ss_sold_year' -> 1998. 'ss_item_sk' -> 1. 'ss_customer_sk' -> 1. 'ss_qty' -> 10. 'ss_wc' -> 50.000000. 'ss_sp' -> 100.000000}).
+ws := Array with: (Dictionary from: {'ws_sold_year' -> 1998. 'ws_item_sk' -> 1. 'ws_customer_sk' -> 1. 'ws_qty' -> 5. 'ws_wc' -> 25.000000. 'ws_sp' -> 50.000000}).
+cs := Array with: (Dictionary from: {'cs_sold_year' -> 1998. 'cs_item_sk' -> 1. 'cs_customer_sk' -> 1. 'cs_qty' -> 3. 'cs_wc' -> 15.000000. 'cs_sp' -> 30.000000}).
+result := ((| res |
+res := OrderedCollection new.
+((ss) select: [:s | ((((((((((((w = nil)) ifTrue: [0] ifFalse: [w at: 'ws_qty'])) > 0) or: [((((c = nil)) ifTrue: [0] ifFalse: [c at: 'cs_qty']))]) > 0)) and: [s at: 'ss_sold_year']) = 1998) and: [(((((w at: 'ws_sold_year' = s at: 'ss_sold_year') and: [w at: 'ws_item_sk']) = s at: 'ss_item_sk') and: [w at: 'ws_customer_sk']) = s at: 'ss_customer_sk')]) and: [(((((c at: 'cs_sold_year' = s at: 'ss_sold_year') and: [c at: 'cs_item_sk']) = s at: 'ss_item_sk') and: [c at: 'cs_customer_sk']) = s at: 'ss_customer_sk')])]) do: [:s |
+	(ws) do: [:w |
+		(cs) do: [:c |
+			res add: Dictionary from: {'ss_sold_year' -> s at: 'ss_sold_year'. 'ss_item_sk' -> s at: 'ss_item_sk'. 'ss_customer_sk' -> s at: 'ss_customer_sk'. 'ratio' -> (s at: 'ss_qty' / ((((((w = nil)) ifTrue: [0] ifFalse: [w at: 'ws_qty'])) + ((((c = nil)) ifTrue: [0] ifFalse: [c at: 'cs_qty']))))). 'store_qty' -> s at: 'ss_qty'. 'store_wholesale_cost' -> s at: 'ss_wc'. 'store_sales_price' -> s at: 'ss_sp'. 'other_chan_qty' -> (((((w = nil)) ifTrue: [0] ifFalse: [w at: 'ws_qty'])) + ((((c = nil)) ifTrue: [0] ifFalse: [c at: 'cs_qty']))). 'other_chan_wholesale_cost' -> (((((w = nil)) ifTrue: [0.000000] ifFalse: [w at: 'ws_wc'])) + ((((c = nil)) ifTrue: [0.000000] ifFalse: [c at: 'cs_wc']))). 'other_chan_sales_price' -> (((((w = nil)) ifTrue: [0.000000] ifFalse: [w at: 'ws_sp'])) + ((((c = nil)) ifTrue: [0.000000] ifFalse: [c at: 'cs_sp'])))}.
+		]
+	]
+]
+res := res asArray.
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q78_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q79.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q79.st.out
@@ -1,0 +1,109 @@
+Smalltalk at: #agg put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q79_simplified
+	((result = Array with: (Dictionary from: {'c_last_name' -> 'Smith'. 'c_first_name' -> 'Alice'. 's_city' -> 'CityA'. 'ss_ticket_number' -> 1. 'amt' -> 5.000000. 'profit' -> 10.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_dow' -> 1. 'd_year' -> 1999}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_city' -> 'CityA'. 's_number_employees' -> 250}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_dep_count' -> 2. 'hd_vehicle_count' -> 1}).
+store_sales := Array with: (Dictionary from: {'ss_sold_date_sk' -> 1. 'ss_store_sk' -> 1. 'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_hdemo_sk' -> 1. 'ss_coupon_amt' -> 5.000000. 'ss_net_profit' -> 10.000000}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_last_name' -> 'Smith'. 'c_first_name' -> 'Alice'}).
+agg := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+	((((((((((((hd at: 'hd_dep_count' = 2) or: [hd at: 'hd_vehicle_count']) > 1)) and: [d at: 'd_dow']) = 1) and: [((((((d at: 'd_year' = 1998) or: [d at: 'd_year']) = 1999) or: [d at: 'd_year']) = 2000))]) and: [s at: 's_number_employees']) >= 200) and: [s at: 's_number_employees']) <= 295)) ifTrue: [ rows add: ss ].
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'ticket' -> ss at: 'ss_ticket_number'. 'customer_sk' -> ss at: 'ss_customer_sk'. 'city' -> s at: 's_city'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'key' -> g at: 'key'. 'amt' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_coupon_amt'.
+]
+res := res asArray.
+res))). 'profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss' at: 'ss_net_profit'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((agg) select: [:a | (c at: 'c_customer_sk' = a at: 'key' at: 'customer_sk')]) do: [:a |
+	(customer) do: [:c |
+		res add: { Array with: (c at: 'c_last_name') with: (c at: 'c_first_name') with: (a at: 'key' at: 'city') with: (a at: 'profit') . Dictionary from: {'c_last_name' -> c at: 'c_last_name'. 'c_first_name' -> c at: 'c_first_name'. 's_city' -> a at: 'key' at: 'city'. 'ss_ticket_number' -> a at: 'key' at: 'ticket'. 'amt' -> a at: 'amt'. 'profit' -> a at: 'profit'} }.
+	]
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q79_simplified.

--- a/tests/dataset/tpc-ds/compiler/st/q80.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q80.st.out
@@ -1,0 +1,45 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #total_profit put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q80_sample
+	((total_profit = 80.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'price' -> 20.000000. 'ret' -> 5.000000}) with: (Dictionary from: {'price' -> 10.000000. 'ret' -> 2.000000}) with: (Dictionary from: {'price' -> 5.000000. 'ret' -> 0.000000}).
+catalog_sales := Array with: (Dictionary from: {'price' -> 15.000000. 'ret' -> 3.000000}) with: (Dictionary from: {'price' -> 8.000000. 'ret' -> 1.000000}).
+web_sales := Array with: (Dictionary from: {'price' -> 25.000000. 'ret' -> 5.000000}) with: (Dictionary from: {'price' -> 15.000000. 'ret' -> 8.000000}) with: (Dictionary from: {'price' -> 8.000000. 'ret' -> 2.000000}).
+total_profit := (((Main __sum: ((| res |
+res := OrderedCollection new.
+(store_sales) do: [:s |
+	res add: (s at: 'price' - s at: 'ret').
+]
+res := res asArray.
+res))) + (Main __sum: ((| res |
+res := OrderedCollection new.
+(catalog_sales) do: [:c |
+	res add: (c at: 'price' - c at: 'ret').
+]
+res := res asArray.
+res)))) + (Main __sum: ((| res |
+res := OrderedCollection new.
+(web_sales) do: [:w |
+	res add: (w at: 'price' - w at: 'ret').
+]
+res := res asArray.
+res)))).
+(total_profit toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q80_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q81.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q81.st.out
@@ -1,0 +1,102 @@
+Smalltalk at: #avg_list put: nil.
+Smalltalk at: #avg_state put: nil.
+Smalltalk at: #catalog_returns put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #result_list put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q81_sample
+	((result = 81.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__avg: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+	v size = 0 ifTrue: [ ^ 0 ]
+	| sum |
+	sum := 0.
+	v do: [:it | sum := sum + it].
+	^ sum / v size
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_returns := Array with: (Dictionary from: {'cust' -> 1. 'state' -> 'CA'. 'amt' -> 40.000000}) with: (Dictionary from: {'cust' -> 2. 'state' -> 'CA'. 'amt' -> 50.000000}) with: (Dictionary from: {'cust' -> 3. 'state' -> 'CA'. 'amt' -> 81.000000}) with: (Dictionary from: {'cust' -> 4. 'state' -> 'TX'. 'amt' -> 30.000000}) with: (Dictionary from: {'cust' -> 5. 'state' -> 'TX'. 'amt' -> 20.000000}).
+avg_list := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_returns) do: [:r |
+	rows add: r.
+]
+groups := (Main _group_by: rows keyFn: [:r | r at: 'state']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'state' -> g at: 'key'. 'avg_amt' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'amt'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+avg_state := first value: ((| res |
+res := OrderedCollection new.
+((avg_list) select: [:a | (a at: 'state' = 'CA')]) do: [:a |
+	res add: a.
+]
+res := res asArray.
+res)).
+result_list := ((| res |
+res := OrderedCollection new.
+((catalog_returns) select: [:r | ((((r at: 'state' = 'CA') and: [r at: 'amt']) > avg_state at: 'avg_amt') * 1.200000)]) do: [:r |
+	res add: r at: 'amt'.
+]
+res := res asArray.
+res)).
+result := first value: result_list.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q81_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q82.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q82.st.out
@@ -1,0 +1,29 @@
+Smalltalk at: #inventory put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q82_sample
+	((result = 82)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+item := Array with: (Dictionary from: {'id' -> 1}) with: (Dictionary from: {'id' -> 2}) with: (Dictionary from: {'id' -> 3}).
+inventory := Array with: (Dictionary from: {'item' -> 1. 'qty' -> 20}) with: (Dictionary from: {'item' -> 1. 'qty' -> 22}) with: (Dictionary from: {'item' -> 1. 'qty' -> 5}) with: (Dictionary from: {'item' -> 2. 'qty' -> 30}) with: (Dictionary from: {'item' -> 2. 'qty' -> 5}) with: (Dictionary from: {'item' -> 3. 'qty' -> 10}).
+store_sales := Array with: (Dictionary from: {'item' -> 1}) with: (Dictionary from: {'item' -> 2}).
+result := 0.
+(inventory) do: [:inv |
+	(store_sales) do: [:s |
+		((inv at: 'item' = s at: 'item')) ifTrue: [
+			result := (result + inv at: 'qty').
+		]
+		.
+	]
+	.
+]
+.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q82_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q83.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q83.st.out
@@ -1,0 +1,45 @@
+Smalltalk at: #cr_items put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #sr_items put: nil.
+Smalltalk at: #wr_items put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q83_sample
+	((result = 83)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+sr_items := Array with: (Dictionary from: {'qty' -> 10}) with: (Dictionary from: {'qty' -> 5}).
+cr_items := Array with: (Dictionary from: {'qty' -> 25}) with: (Dictionary from: {'qty' -> 20}).
+wr_items := Array with: (Dictionary from: {'qty' -> 10}) with: (Dictionary from: {'qty' -> 13}).
+result := (((Main __sum: ((| res |
+res := OrderedCollection new.
+(sr_items) do: [:x |
+	res add: x at: 'qty'.
+]
+res := res asArray.
+res))) + (Main __sum: ((| res |
+res := OrderedCollection new.
+(cr_items) do: [:x |
+	res add: x at: 'qty'.
+]
+res := res asArray.
+res)))) + (Main __sum: ((| res |
+res := OrderedCollection new.
+(wr_items) do: [:x |
+	res add: x at: 'qty'.
+]
+res := res asArray.
+res)))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q83_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q84.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q84.st.out
@@ -1,0 +1,25 @@
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #customers put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #income_band put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_returns put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q84_sample
+	((result = 84)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+customers := Array with: (Dictionary from: {'id' -> 1. 'city' -> 'A'. 'cdemo' -> 1}) with: (Dictionary from: {'id' -> 2. 'city' -> 'A'. 'cdemo' -> 2}) with: (Dictionary from: {'id' -> 3. 'city' -> 'B'. 'cdemo' -> 1}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1}) with: (Dictionary from: {'cd_demo_sk' -> 2}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'income_band_sk' -> 1}) with: (Dictionary from: {'hd_demo_sk' -> 2. 'income_band_sk' -> 2}).
+income_band := Array with: (Dictionary from: {'ib_income_band_sk' -> 1. 'ib_lower_bound' -> 0. 'ib_upper_bound' -> 50000}) with: (Dictionary from: {'ib_income_band_sk' -> 2. 'ib_lower_bound' -> 50001. 'ib_upper_bound' -> 100000}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_city' -> 'A'}) with: (Dictionary from: {'ca_address_sk' -> 2. 'ca_city' -> 'B'}).
+store_returns := Array with: (Dictionary from: {'sr_cdemo_sk' -> 1}) with: (Dictionary from: {'sr_cdemo_sk' -> 1}) with: (Dictionary from: {'sr_cdemo_sk' -> 2}) with: (Dictionary from: {'sr_cdemo_sk' -> 1}).
+result := (80 + (store_returns) size).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q84_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q85.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q85.st.out
@@ -1,0 +1,30 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_returns put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q85_sample
+	((result = 85.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__avg: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+	v size = 0 ifTrue: [ ^ 0 ]
+	| sum |
+	sum := 0.
+	v do: [:it | sum := sum + it].
+	^ sum / v size
+!
+!!
+web_returns := Array with: (Dictionary from: {'qty' -> 60. 'cash' -> 20.000000. 'fee' -> 1.000000}) with: (Dictionary from: {'qty' -> 100. 'cash' -> 30.000000. 'fee' -> 2.000000}) with: (Dictionary from: {'qty' -> 95. 'cash' -> 25.000000. 'fee' -> 3.000000}).
+result := (Main __avg: ((| res |
+res := OrderedCollection new.
+(web_returns) do: [:r |
+	res add: r at: 'qty'.
+]
+res := res asArray.
+res))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q85_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q86.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q86.st.out
@@ -1,0 +1,29 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q86_sample
+	((result = 86.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+web_sales := Array with: (Dictionary from: {'cat' -> 'A'. 'class' -> 'B'. 'net' -> 40.000000}) with: (Dictionary from: {'cat' -> 'A'. 'class' -> 'B'. 'net' -> 46.000000}) with: (Dictionary from: {'cat' -> 'A'. 'class' -> 'C'. 'net' -> 10.000000}) with: (Dictionary from: {'cat' -> 'B'. 'class' -> 'B'. 'net' -> 20.000000}).
+result := (Main __sum: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | (((ws at: 'cat' = 'A') and: [ws at: 'class']) = 'B')]) do: [:ws |
+	res add: ws at: 'net'.
+]
+res := res asArray.
+res))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q86_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q87.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q87.st.out
@@ -1,0 +1,47 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+distinct: xs | out x |
+	out := Array new.
+	(xs) do: [:x |
+		((contains value: out value: x) not) ifTrue: [
+			out := (out copyWith: x).
+		]
+		.
+	]
+	.
+	^ out
+!
+
+!Main class methodsFor: 'mochi'!
+concat: a b: b | out x |
+	out := a.
+	(b) do: [:x |
+		out := (out copyWith: x).
+	]
+	.
+	^ out
+!
+
+!Main class methodsFor: 'mochi'!
+to_list: xs
+	^ xs
+!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q87_sample
+	((result = 87)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+store_sales := Array with: (Dictionary from: {'cust' -> 'A'}) with: (Dictionary from: {'cust' -> 'B'}) with: (Dictionary from: {'cust' -> 'B'}) with: (Dictionary from: {'cust' -> 'C'}).
+catalog_sales := Array with: (Dictionary from: {'cust' -> 'A'}) with: (Dictionary from: {'cust' -> 'C'}) with: (Dictionary from: {'cust' -> 'D'}).
+web_sales := Array with: (Dictionary from: {'cust' -> 'A'}) with: (Dictionary from: {'cust' -> 'D'}).
+result := 87.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q87_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q88.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q88.st.out
@@ -1,0 +1,17 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #time_dim put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q88_sample
+	((result = 88)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!!
+time_dim := Array with: (Dictionary from: {'time_sk' -> 1. 'hour' -> 8. 'minute' -> 30}) with: (Dictionary from: {'time_sk' -> 2. 'hour' -> 9. 'minute' -> 0}) with: (Dictionary from: {'time_sk' -> 3. 'hour' -> 11. 'minute' -> 15}).
+store_sales := Array with: (Dictionary from: {'sold_time_sk' -> 1}) with: (Dictionary from: {'sold_time_sk' -> 2}) with: (Dictionary from: {'sold_time_sk' -> 3}).
+result := 88.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q88_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q89.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q89.st.out
@@ -1,0 +1,29 @@
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q89_sample
+	((result = 89.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+store_sales := Array with: (Dictionary from: {'price' -> 40.000000}) with: (Dictionary from: {'price' -> 30.000000}) with: (Dictionary from: {'price' -> 19.000000}).
+result := (Main __sum: ((| res |
+res := OrderedCollection new.
+(store_sales) do: [:s |
+	res add: s at: 'price'.
+]
+res := res asArray.
+res))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q89_sample.

--- a/tests/dataset/tpc-ds/compiler/st/q90.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q90.st.out
@@ -1,0 +1,65 @@
+Smalltalk at: #amc put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #pmc put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #time_dim put: nil.
+Smalltalk at: #web_page put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newWebSale: ws_sold_time_sk ws_ship_hdemo_sk: ws_ship_hdemo_sk ws_web_page_sk: ws_web_page_sk | dict |
+	dict := Dictionary new.
+	dict at: 'ws_sold_time_sk' put: ws_sold_time_sk.
+	dict at: 'ws_ship_hdemo_sk' put: ws_ship_hdemo_sk.
+	dict at: 'ws_web_page_sk' put: ws_web_page_sk.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q90_ratio
+	((result = 2.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+_cast: type value: v
+	^ v
+!
+!!
+web_sales := Array with: (Dictionary from: {'ws_sold_time_sk' -> 1. 'ws_ship_hdemo_sk' -> 1. 'ws_web_page_sk' -> 10}) with: (Dictionary from: {'ws_sold_time_sk' -> 1. 'ws_ship_hdemo_sk' -> 1. 'ws_web_page_sk' -> 10}) with: (Dictionary from: {'ws_sold_time_sk' -> 2. 'ws_ship_hdemo_sk' -> 1. 'ws_web_page_sk' -> 10}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_dep_count' -> 2}).
+time_dim := Array with: (Dictionary from: {'t_time_sk' -> 1. 't_hour' -> 7}) with: (Dictionary from: {'t_time_sk' -> 2. 't_hour' -> 14}).
+web_page := Array with: (Dictionary from: {'wp_web_page_sk' -> 10. 'wp_char_count' -> 5100}).
+amc := (Main __count: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | ((((((((((((t at: 't_hour' >= 7) and: [t at: 't_hour']) <= 8) and: [hd at: 'hd_dep_count']) = 2) and: [wp at: 'wp_char_count']) >= 5000) and: [wp at: 'wp_char_count']) <= 5200) and: [(ws at: 'ws_ship_hdemo_sk' = hd at: 'hd_demo_sk')]) and: [(ws at: 'ws_sold_time_sk' = t at: 't_time_sk')]) and: [(ws at: 'ws_web_page_sk' = wp at: 'wp_web_page_sk')])]) do: [:ws |
+	(household_demographics) do: [:hd |
+		(time_dim) do: [:t |
+			(web_page) do: [:wp |
+				res add: ws.
+			]
+		]
+	]
+]
+res := res asArray.
+res))).
+pmc := (Main __count: ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | ((((((((((((t at: 't_hour' >= 14) and: [t at: 't_hour']) <= 15) and: [hd at: 'hd_dep_count']) = 2) and: [wp at: 'wp_char_count']) >= 5000) and: [wp at: 'wp_char_count']) <= 5200) and: [(ws at: 'ws_ship_hdemo_sk' = hd at: 'hd_demo_sk')]) and: [(ws at: 'ws_sold_time_sk' = t at: 't_time_sk')]) and: [(ws at: 'ws_web_page_sk' = wp at: 'wp_web_page_sk')])]) do: [:ws |
+	(household_demographics) do: [:hd |
+		(time_dim) do: [:t |
+			(web_page) do: [:wp |
+				res add: ws.
+			]
+		]
+	]
+]
+res := res asArray.
+res))).
+result := (((Main _cast: 'float' value: amc)) / ((Main _cast: 'float' value: pmc))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q90_ratio.

--- a/tests/dataset/tpc-ds/compiler/st/q91.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q91.st.out
@@ -1,0 +1,152 @@
+Smalltalk at: #call_center put: nil.
+Smalltalk at: #catalog_returns put: nil.
+Smalltalk at: #customer put: nil.
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #customer_demographics put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCallCenter: cc_call_center_sk cc_call_center_id: cc_call_center_id cc_name: cc_name cc_manager: cc_manager | dict |
+	dict := Dictionary new.
+	dict at: 'cc_call_center_sk' put: cc_call_center_sk.
+	dict at: 'cc_call_center_id' put: cc_call_center_id.
+	dict at: 'cc_name' put: cc_name.
+	dict at: 'cc_manager' put: cc_manager.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogReturn: cr_call_center_sk cr_returned_date_sk: cr_returned_date_sk cr_returning_customer_sk: cr_returning_customer_sk cr_net_loss: cr_net_loss | dict |
+	dict := Dictionary new.
+	dict at: 'cr_call_center_sk' put: cr_call_center_sk.
+	dict at: 'cr_returned_date_sk' put: cr_returned_date_sk.
+	dict at: 'cr_returning_customer_sk' put: cr_returning_customer_sk.
+	dict at: 'cr_net_loss' put: cr_net_loss.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_year: d_year d_moy: d_moy | dict |
+	dict := Dictionary new.
+	dict at: 'd_date_sk' put: d_date_sk.
+	dict at: 'd_year' put: d_year.
+	dict at: 'd_moy' put: d_moy.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomer: c_customer_sk c_current_cdemo_sk: c_current_cdemo_sk c_current_hdemo_sk: c_current_hdemo_sk c_current_addr_sk: c_current_addr_sk | dict |
+	dict := Dictionary new.
+	dict at: 'c_customer_sk' put: c_customer_sk.
+	dict at: 'c_current_cdemo_sk' put: c_current_cdemo_sk.
+	dict at: 'c_current_hdemo_sk' put: c_current_hdemo_sk.
+	dict at: 'c_current_addr_sk' put: c_current_addr_sk.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_gmt_offset: ca_gmt_offset | dict |
+	dict := Dictionary new.
+	dict at: 'ca_address_sk' put: ca_address_sk.
+	dict at: 'ca_gmt_offset' put: ca_gmt_offset.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerDemographics: cd_demo_sk cd_marital_status: cd_marital_status cd_education_status: cd_education_status | dict |
+	dict := Dictionary new.
+	dict at: 'cd_demo_sk' put: cd_demo_sk.
+	dict at: 'cd_marital_status' put: cd_marital_status.
+	dict at: 'cd_education_status' put: cd_education_status.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newHouseholdDemographics: hd_demo_sk hd_buy_potential: hd_buy_potential | dict |
+	dict := Dictionary new.
+	dict at: 'hd_demo_sk' put: hd_demo_sk.
+	dict at: 'hd_buy_potential' put: hd_buy_potential.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q91_returns
+	((result = Dictionary from: {'Call_Center' -> 'CC1'. 'Call_Center_Name' -> 'Main'. 'Manager' -> 'Alice'. 'Returns_Loss' -> 10.000000})) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+call_center := Array with: (Dictionary from: {'cc_call_center_sk' -> 1. 'cc_call_center_id' -> 'CC1'. 'cc_name' -> 'Main'. 'cc_manager' -> 'Alice'}).
+catalog_returns := Array with: (Dictionary from: {'cr_call_center_sk' -> 1. 'cr_returned_date_sk' -> 1. 'cr_returning_customer_sk' -> 1. 'cr_net_loss' -> 10.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_year' -> 2001. 'd_moy' -> 5}).
+customer := Array with: (Dictionary from: {'c_customer_sk' -> 1. 'c_current_cdemo_sk' -> 1. 'c_current_hdemo_sk' -> 1. 'c_current_addr_sk' -> 1}).
+customer_demographics := Array with: (Dictionary from: {'cd_demo_sk' -> 1. 'cd_marital_status' -> 'M'. 'cd_education_status' -> 'Unknown'}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_buy_potential' -> '1001-5000'}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_gmt_offset' -> (6 negated)}).
+result := first value: ((| rows groups |
+rows := OrderedCollection new.
+(call_center) do: [:cc |
+	((((((((((((d at: 'd_year' = 2001) and: [d at: 'd_moy']) = 5) and: [cd at: 'cd_marital_status']) = 'M') and: [cd at: 'cd_education_status']) = 'Unknown') and: [hd at: 'hd_buy_potential']) = '1001-5000') and: [ca at: 'ca_gmt_offset']) = ((6 negated)))) ifTrue: [ rows add: cc ].
+]
+groups := (Main _group_by: rows keyFn: [:cc | Dictionary from: {'id' -> cc at: 'cc_call_center_id'. 'name' -> cc at: 'cc_name'. 'mgr' -> cc at: 'cc_manager'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'Call_Center' -> g at: 'key' at: 'id'. 'Call_Center_Name' -> g at: 'key' at: 'name'. 'Manager' -> g at: 'key' at: 'mgr'. 'Returns_Loss' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'cr_net_loss'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q91_returns.

--- a/tests/dataset/tpc-ds/compiler/st/q92.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q92.st.out
@@ -1,0 +1,59 @@
+Smalltalk at: #avg_amt put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #sum_amt put: nil.
+Smalltalk at: #web_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newWebSale: ws_item_sk ws_sold_date_sk: ws_sold_date_sk ws_ext_discount_amt: ws_ext_discount_amt | dict |
+	dict := Dictionary new.
+	dict at: 'ws_item_sk' put: ws_item_sk.
+	dict at: 'ws_sold_date_sk' put: ws_sold_date_sk.
+	dict at: 'ws_ext_discount_amt' put: ws_ext_discount_amt.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q92_threshold
+	((result = 4.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__avg: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+	v size = 0 ifTrue: [ ^ 0 ]
+	| sum |
+	sum := 0.
+	v do: [:it | sum := sum + it].
+	^ sum / v size
+!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+web_sales := Array with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_sold_date_sk' -> 1. 'ws_ext_discount_amt' -> 1.000000}) with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_sold_date_sk' -> 1. 'ws_ext_discount_amt' -> 1.000000}) with: (Dictionary from: {'ws_item_sk' -> 1. 'ws_sold_date_sk' -> 1. 'ws_ext_discount_amt' -> 2.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_manufact_id' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2000-01-02'}).
+sum_amt := (Main __sum: ((| res |
+res := OrderedCollection new.
+(web_sales) do: [:ws |
+	res add: ws at: 'ws_ext_discount_amt'.
+]
+res := res asArray.
+res))).
+avg_amt := (Main __avg: ((| res |
+res := OrderedCollection new.
+(web_sales) do: [:ws |
+	res add: ws at: 'ws_ext_discount_amt'.
+]
+res := res asArray.
+res))).
+result := ((((sum_amt > avg_amt) * 1.300000)) ifTrue: [sum_amt] ifFalse: [0.000000]).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q92_threshold.

--- a/tests/dataset/tpc-ds/compiler/st/q93.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q93.st.out
@@ -1,0 +1,125 @@
+Smalltalk at: #reason put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_returns put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #t put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_item_sk ss_ticket_number: ss_ticket_number ss_customer_sk: ss_customer_sk ss_quantity: ss_quantity ss_sales_price: ss_sales_price | dict |
+	dict := Dictionary new.
+	dict at: 'ss_item_sk' put: ss_item_sk.
+	dict at: 'ss_ticket_number' put: ss_ticket_number.
+	dict at: 'ss_customer_sk' put: ss_customer_sk.
+	dict at: 'ss_quantity' put: ss_quantity.
+	dict at: 'ss_sales_price' put: ss_sales_price.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newStoreReturn: sr_item_sk sr_ticket_number: sr_ticket_number sr_reason_sk: sr_reason_sk sr_return_quantity: sr_return_quantity | dict |
+	dict := Dictionary new.
+	dict at: 'sr_item_sk' put: sr_item_sk.
+	dict at: 'sr_ticket_number' put: sr_ticket_number.
+	dict at: 'sr_reason_sk' put: sr_reason_sk.
+	dict at: 'sr_return_quantity' put: sr_return_quantity.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newReason: r_reason_sk r_reason_desc: r_reason_desc | dict |
+	dict := Dictionary new.
+	dict at: 'r_reason_sk' put: r_reason_sk.
+	dict at: 'r_reason_desc' put: r_reason_desc.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q93_active_sales
+	((result = Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'sumsales' -> 40.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_ticket_number' -> 1. 'ss_customer_sk' -> 1. 'ss_quantity' -> 5. 'ss_sales_price' -> 10.000000}) with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_ticket_number' -> 2. 'ss_customer_sk' -> 2. 'ss_quantity' -> 3. 'ss_sales_price' -> 20.000000}).
+store_returns := Array with: (Dictionary from: {'sr_item_sk' -> 1. 'sr_ticket_number' -> 1. 'sr_reason_sk' -> 1. 'sr_return_quantity' -> 1}).
+reason := Array with: (Dictionary from: {'r_reason_sk' -> 1. 'r_reason_desc' -> 'ReasonA'}).
+t := ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | (((r at: 'r_reason_desc' = 'ReasonA') and: [(((ss at: 'ss_item_sk' = sr at: 'sr_item_sk') and: [ss at: 'ss_ticket_number']) = sr at: 'sr_ticket_number')]) and: [(sr at: 'sr_reason_sk' = r at: 'r_reason_sk')])]) do: [:ss |
+	(store_returns) do: [:sr |
+		(reason) do: [:r |
+			res add: Dictionary from: {'ss_customer_sk' -> ss at: 'ss_customer_sk'. 'act_sales' -> (((sr ~= nil)) ifTrue: [(((ss at: 'ss_quantity' - sr at: 'sr_return_quantity')) * ss at: 'ss_sales_price')] ifFalse: [(ss at: 'ss_quantity' * ss at: 'ss_sales_price')])}.
+		]
+	]
+]
+res := res asArray.
+res)).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(t) do: [:x |
+	rows add: x.
+]
+groups := (Main _group_by: rows keyFn: [:x | x at: 'ss_customer_sk']).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'ss_customer_sk' -> g at: 'key'. 'sumsales' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:y |
+	res add: y at: 'act_sales'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q93_active_sales.

--- a/tests/dataset/tpc-ds/compiler/st/q94.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q94.st.out
@@ -1,0 +1,121 @@
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_returns put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #web_site put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newWebSale: ws_order_number ws_ship_date_sk: ws_ship_date_sk ws_warehouse_sk: ws_warehouse_sk ws_ship_addr_sk: ws_ship_addr_sk ws_web_site_sk: ws_web_site_sk ws_net_profit: ws_net_profit ws_ext_ship_cost: ws_ext_ship_cost | dict |
+	dict := Dictionary new.
+	dict at: 'ws_order_number' put: ws_order_number.
+	dict at: 'ws_ship_date_sk' put: ws_ship_date_sk.
+	dict at: 'ws_warehouse_sk' put: ws_warehouse_sk.
+	dict at: 'ws_ship_addr_sk' put: ws_ship_addr_sk.
+	dict at: 'ws_web_site_sk' put: ws_web_site_sk.
+	dict at: 'ws_net_profit' put: ws_net_profit.
+	dict at: 'ws_ext_ship_cost' put: ws_ext_ship_cost.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newWebReturn: wr_order_number | dict |
+	dict := Dictionary new.
+	dict at: 'wr_order_number' put: wr_order_number.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_date: d_date | dict |
+	dict := Dictionary new.
+	dict at: 'd_date_sk' put: d_date_sk.
+	dict at: 'd_date' put: d_date.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_state: ca_state | dict |
+	dict := Dictionary new.
+	dict at: 'ca_address_sk' put: ca_address_sk.
+	dict at: 'ca_state' put: ca_state.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newWebSite: web_site_sk web_company_name: web_company_name | dict |
+	dict := Dictionary new.
+	dict at: 'web_site_sk' put: web_site_sk.
+	dict at: 'web_company_name' put: web_company_name.
+	^ dict
+!
+!Main class methodsFor: 'mochi'!
+distinct: xs | out x |
+	out := Array new.
+	(xs) do: [:x |
+		((contains value: out value: x) not) ifTrue: [
+			out := (out copyWith: x).
+		]
+		.
+	]
+	.
+	^ out
+!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q94_shipping
+	((result = Dictionary from: {'order_count' -> 1. 'total_shipping_cost' -> 2.000000. 'total_net_profit' -> 5.000000})) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+web_sales := Array with: (Dictionary from: {'ws_order_number' -> 1. 'ws_ship_date_sk' -> 1. 'ws_warehouse_sk' -> 1. 'ws_ship_addr_sk' -> 1. 'ws_web_site_sk' -> 1. 'ws_net_profit' -> 5.000000. 'ws_ext_ship_cost' -> 2.000000}) with: (Dictionary from: {'ws_order_number' -> 2. 'ws_ship_date_sk' -> 1. 'ws_warehouse_sk' -> 2. 'ws_ship_addr_sk' -> 1. 'ws_web_site_sk' -> 1. 'ws_net_profit' -> 3.000000. 'ws_ext_ship_cost' -> 1.000000}).
+web_returns := Array with: (Dictionary from: {'wr_order_number' -> 2}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2001-02-01'}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'}).
+web_site := Array with: (Dictionary from: {'web_site_sk' -> 1. 'web_company_name' -> 'pri'}).
+filtered := ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | ((((((((ca at: 'ca_state' = 'CA') and: [w at: 'web_company_name']) = 'pri') and: [exists value: ((| res |
+res := OrderedCollection new.
+((web_returns) select: [:wr | (wr at: 'wr_order_number' = ws at: 'ws_order_number')]) do: [:wr |
+	res add: wr.
+]
+res := res asArray.
+res))]) = false) and: [(ws at: 'ws_ship_date_sk' = d at: 'd_date_sk')]) and: [(ws at: 'ws_ship_addr_sk' = ca at: 'ca_address_sk')]) and: [(ws at: 'ws_web_site_sk' = w at: 'web_site_sk')])]) do: [:ws |
+	(date_dim) do: [:d |
+		(customer_address) do: [:ca |
+			(web_site) do: [:w |
+				res add: ws.
+			]
+		]
+	]
+]
+res := res asArray.
+res)).
+result := Dictionary from: {'order_count' -> ((Main distinct: (((| res |
+res := OrderedCollection new.
+(filtered) do: [:x |
+	res add: x at: 'ws_order_number'.
+]
+res := res asArray.
+res))))) size. 'total_shipping_cost' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(filtered) do: [:x |
+	res add: x at: 'ws_ext_ship_cost'.
+]
+res := res asArray.
+res))). 'total_net_profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(filtered) do: [:x |
+	res add: x at: 'ws_net_profit'.
+]
+res := res asArray.
+res)))}.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q94_shipping.

--- a/tests/dataset/tpc-ds/compiler/st/q95.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q95.st.out
@@ -1,0 +1,133 @@
+Smalltalk at: #customer_address put: nil.
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #filtered put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #web_returns put: nil.
+Smalltalk at: #web_sales put: nil.
+Smalltalk at: #web_site put: nil.
+Smalltalk at: #ws_wh put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newWebSale: ws_order_number ws_warehouse_sk: ws_warehouse_sk ws_ship_date_sk: ws_ship_date_sk ws_ship_addr_sk: ws_ship_addr_sk ws_web_site_sk: ws_web_site_sk ws_ext_ship_cost: ws_ext_ship_cost ws_net_profit: ws_net_profit | dict |
+	dict := Dictionary new.
+	dict at: 'ws_order_number' put: ws_order_number.
+	dict at: 'ws_warehouse_sk' put: ws_warehouse_sk.
+	dict at: 'ws_ship_date_sk' put: ws_ship_date_sk.
+	dict at: 'ws_ship_addr_sk' put: ws_ship_addr_sk.
+	dict at: 'ws_web_site_sk' put: ws_web_site_sk.
+	dict at: 'ws_ext_ship_cost' put: ws_ext_ship_cost.
+	dict at: 'ws_net_profit' put: ws_net_profit.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newWebReturn: wr_order_number | dict |
+	dict := Dictionary new.
+	dict at: 'wr_order_number' put: wr_order_number.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_date: d_date | dict |
+	dict := Dictionary new.
+	dict at: 'd_date_sk' put: d_date_sk.
+	dict at: 'd_date' put: d_date.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCustomerAddress: ca_address_sk ca_state: ca_state | dict |
+	dict := Dictionary new.
+	dict at: 'ca_address_sk' put: ca_address_sk.
+	dict at: 'ca_state' put: ca_state.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newWebSite: web_site_sk web_company_name: web_company_name | dict |
+	dict := Dictionary new.
+	dict at: 'web_site_sk' put: web_site_sk.
+	dict at: 'web_company_name' put: web_company_name.
+	^ dict
+!
+!Main class methodsFor: 'mochi'!
+distinct: xs | out x |
+	out := Array new.
+	(xs) do: [:x |
+		((contains value: out value: x) not) ifTrue: [
+			out := (out copyWith: x).
+		]
+		.
+	]
+	.
+	^ out
+!
+
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q95_shipping_returns
+	((result = Dictionary from: {'order_count' -> 1. 'total_shipping_cost' -> 2.000000. 'total_net_profit' -> 5.000000})) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+!!
+web_sales := Array with: (Dictionary from: {'ws_order_number' -> 1. 'ws_warehouse_sk' -> 1. 'ws_ship_date_sk' -> 1. 'ws_ship_addr_sk' -> 1. 'ws_web_site_sk' -> 1. 'ws_ext_ship_cost' -> 2.000000. 'ws_net_profit' -> 5.000000}) with: (Dictionary from: {'ws_order_number' -> 1. 'ws_warehouse_sk' -> 2. 'ws_ship_date_sk' -> 1. 'ws_ship_addr_sk' -> 1. 'ws_web_site_sk' -> 1. 'ws_ext_ship_cost' -> 0.000000. 'ws_net_profit' -> 0.000000}).
+web_returns := Array with: (Dictionary from: {'wr_order_number' -> 1}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2001-02-01'}).
+customer_address := Array with: (Dictionary from: {'ca_address_sk' -> 1. 'ca_state' -> 'CA'}).
+web_site := Array with: (Dictionary from: {'web_site_sk' -> 1. 'web_company_name' -> 'pri'}).
+ws_wh := ((| res |
+res := OrderedCollection new.
+(web_sales) do: [:ws1 |
+	(web_sales) do: [:ws2 |
+		((((ws1 at: 'ws_order_number' = ws2 at: 'ws_order_number') and: [ws1 at: 'ws_warehouse_sk']) ~= ws2 at: 'ws_warehouse_sk')) ifTrue: [
+			res add: Dictionary from: {'ws_order_number' -> ws1 at: 'ws_order_number'}.
+		]
+	]
+]
+res := res asArray.
+res)).
+filtered := ((| res |
+res := OrderedCollection new.
+((web_sales) select: [:ws | (((((((| res |
+res := OrderedCollection new.
+(web_returns) do: [:wr |
+	res add: wr at: 'wr_order_number'.
+]
+res := res asArray.
+res))) includes: ca at: 'ca_state') and: [(ws at: 'ws_ship_date_sk' = d at: 'd_date_sk')]) and: [(ws at: 'ws_ship_addr_sk' = ca at: 'ca_address_sk')]) and: [(ws at: 'ws_web_site_sk' = w at: 'web_site_sk')])]) do: [:ws |
+	(date_dim) do: [:d |
+		(customer_address) do: [:ca |
+			(web_site) do: [:w |
+				res add: ws.
+			]
+		]
+	]
+]
+res := res asArray.
+res)).
+result := Dictionary from: {'order_count' -> ((Main distinct: (((| res |
+res := OrderedCollection new.
+(filtered) do: [:x |
+	res add: x at: 'ws_order_number'.
+]
+res := res asArray.
+res))))) size. 'total_shipping_cost' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(filtered) do: [:x |
+	res add: x at: 'ws_ext_ship_cost'.
+]
+res := res asArray.
+res))). 'total_net_profit' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(filtered) do: [:x |
+	res add: x at: 'ws_net_profit'.
+]
+res := res asArray.
+res)))}.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q95_shipping_returns.

--- a/tests/dataset/tpc-ds/compiler/st/q96.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q96.st.out
@@ -1,0 +1,68 @@
+Smalltalk at: #household_demographics put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #time_dim put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_sold_time_sk ss_hdemo_sk: ss_hdemo_sk ss_store_sk: ss_store_sk | dict |
+	dict := Dictionary new.
+	dict at: 'ss_sold_time_sk' put: ss_sold_time_sk.
+	dict at: 'ss_hdemo_sk' put: ss_hdemo_sk.
+	dict at: 'ss_store_sk' put: ss_store_sk.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newHouseholdDemographics: hd_demo_sk hd_dep_count: hd_dep_count | dict |
+	dict := Dictionary new.
+	dict at: 'hd_demo_sk' put: hd_demo_sk.
+	dict at: 'hd_dep_count' put: hd_dep_count.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newTimeDim: t_time_sk t_hour: t_hour t_minute: t_minute | dict |
+	dict := Dictionary new.
+	dict at: 't_time_sk' put: t_time_sk.
+	dict at: 't_hour' put: t_hour.
+	dict at: 't_minute' put: t_minute.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newStore: s_store_sk s_store_name: s_store_name | dict |
+	dict := Dictionary new.
+	dict at: 's_store_sk' put: s_store_sk.
+	dict at: 's_store_name' put: s_store_name.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q96_count
+	((result = 3)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_sold_time_sk' -> 1. 'ss_hdemo_sk' -> 1. 'ss_store_sk' -> 1}) with: (Dictionary from: {'ss_sold_time_sk' -> 1. 'ss_hdemo_sk' -> 1. 'ss_store_sk' -> 1}) with: (Dictionary from: {'ss_sold_time_sk' -> 2. 'ss_hdemo_sk' -> 1. 'ss_store_sk' -> 1}).
+household_demographics := Array with: (Dictionary from: {'hd_demo_sk' -> 1. 'hd_dep_count' -> 3}).
+time_dim := Array with: (Dictionary from: {'t_time_sk' -> 1. 't_hour' -> 20. 't_minute' -> 35}) with: (Dictionary from: {'t_time_sk' -> 2. 't_hour' -> 20. 't_minute' -> 45}).
+store := Array with: (Dictionary from: {'s_store_sk' -> 1. 's_store_name' -> 'ese'}).
+result := (Main __count: ((| res |
+res := OrderedCollection new.
+((store_sales) select: [:ss | ((((((((((t at: 't_hour' = 20) and: [t at: 't_minute']) >= 30) and: [hd at: 'hd_dep_count']) = 3) and: [s at: 's_store_name']) = 'ese') and: [(ss at: 'ss_hdemo_sk' = hd at: 'hd_demo_sk')]) and: [(ss at: 'ss_sold_time_sk' = t at: 't_time_sk')]) and: [(ss at: 'ss_store_sk' = s at: 's_store_sk')])]) do: [:ss |
+	(household_demographics) do: [:hd |
+		(time_dim) do: [:t |
+			(store) do: [:s |
+				res add: ss.
+			]
+		]
+	]
+]
+res := res asArray.
+res))).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q96_count.

--- a/tests/dataset/tpc-ds/compiler/st/q97.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q97.st.out
@@ -1,0 +1,136 @@
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #csci put: nil.
+Smalltalk at: #joined put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #ssci put: nil.
+Smalltalk at: #store_sales put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_customer_sk ss_item_sk: ss_item_sk | dict |
+	dict := Dictionary new.
+	dict at: 'ss_customer_sk' put: ss_customer_sk.
+	dict at: 'ss_item_sk' put: ss_item_sk.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_bill_customer_sk cs_item_sk: cs_item_sk | dict |
+	dict := Dictionary new.
+	dict at: 'cs_bill_customer_sk' put: cs_bill_customer_sk.
+	dict at: 'cs_item_sk' put: cs_item_sk.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q97_overlap
+	((((((result at: 'store_only' = 1) and: [result at: 'catalog_only']) = 1) and: [result at: 'store_and_catalog']) = 1)) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_customer_sk' -> 1. 'ss_item_sk' -> 1}) with: (Dictionary from: {'ss_customer_sk' -> 2. 'ss_item_sk' -> 1}).
+catalog_sales := Array with: (Dictionary from: {'cs_bill_customer_sk' -> 1. 'cs_item_sk' -> 1}) with: (Dictionary from: {'cs_bill_customer_sk' -> 3. 'cs_item_sk' -> 2}).
+ssci := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+	rows add: ss.
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'customer_sk' -> ss at: 'ss_customer_sk'. 'item_sk' -> ss at: 'ss_item_sk'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'customer_sk' -> g at: 'key' at: 'customer_sk'. 'item_sk' -> g at: 'key' at: 'item_sk'}.
+]
+rows := rows asArray.
+rows)).
+csci := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_sales) do: [:cs |
+	rows add: cs.
+]
+groups := (Main _group_by: rows keyFn: [:cs | Dictionary from: {'customer_sk' -> cs at: 'cs_bill_customer_sk'. 'item_sk' -> cs at: 'cs_item_sk'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'customer_sk' -> g at: 'key' at: 'customer_sk'. 'item_sk' -> g at: 'key' at: 'item_sk'}.
+]
+rows := rows asArray.
+rows)).
+joined := ((| res |
+res := OrderedCollection new.
+((ssci) select: [:s | (((s at: 'customer_sk' = c at: 'customer_sk') and: [s at: 'item_sk']) = c at: 'item_sk')]) do: [:s |
+	(csci) do: [:c |
+		res add: Dictionary from: {'store_only' -> (((((s at: 'customer_sk' ~= nil) and: [c at: 'customer_sk']) = nil)) ifTrue: [1] ifFalse: [0]). 'catalog_only' -> (((((s at: 'customer_sk' = nil) and: [c at: 'customer_sk']) ~= nil)) ifTrue: [1] ifFalse: [0]). 'both' -> (((((s at: 'customer_sk' ~= nil) and: [c at: 'customer_sk']) ~= nil)) ifTrue: [1] ifFalse: [0])}.
+	]
+]
+res := res asArray.
+res)).
+result := Dictionary from: {'store_only' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(joined) do: [:x |
+	res add: x at: 'store_only'.
+]
+res := res asArray.
+res))). 'catalog_only' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(joined) do: [:x |
+	res add: x at: 'catalog_only'.
+]
+res := res asArray.
+res))). 'store_and_catalog' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(joined) do: [:x |
+	res add: x at: 'both'.
+]
+res := res asArray.
+res)))}.
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q97_overlap.

--- a/tests/dataset/tpc-ds/compiler/st/q98.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q98.st.out
@@ -1,0 +1,142 @@
+Smalltalk at: #date_dim put: nil.
+Smalltalk at: #grouped put: nil.
+Smalltalk at: #item put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #store_sales put: nil.
+Smalltalk at: #totals put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newStoreSale: ss_item_sk ss_sold_date_sk: ss_sold_date_sk ss_ext_sales_price: ss_ext_sales_price | dict |
+	dict := Dictionary new.
+	dict at: 'ss_item_sk' put: ss_item_sk.
+	dict at: 'ss_sold_date_sk' put: ss_sold_date_sk.
+	dict at: 'ss_ext_sales_price' put: ss_ext_sales_price.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newItem: i_item_sk i_item_id: i_item_id i_item_desc: i_item_desc i_category: i_category i_class: i_class i_current_price: i_current_price | dict |
+	dict := Dictionary new.
+	dict at: 'i_item_sk' put: i_item_sk.
+	dict at: 'i_item_id' put: i_item_id.
+	dict at: 'i_item_desc' put: i_item_desc.
+	dict at: 'i_category' put: i_category.
+	dict at: 'i_class' put: i_class.
+	dict at: 'i_current_price' put: i_current_price.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newDateDim: d_date_sk d_date: d_date | dict |
+	dict := Dictionary new.
+	dict at: 'd_date_sk' put: d_date_sk.
+	dict at: 'd_date' put: d_date.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q98_revenue
+	((result = Array with: (Dictionary from: {'i_item_id' -> 'I1'. 'i_item_desc' -> 'desc1'. 'i_category' -> 'CatA'. 'i_class' -> 'Class1'. 'i_current_price' -> 100.000000. 'itemrevenue' -> 50.000000. 'revenueratio' -> 33.333333}) with: (Dictionary from: {'i_item_id' -> 'I2'. 'i_item_desc' -> 'desc2'. 'i_category' -> 'CatB'. 'i_class' -> 'Class1'. 'i_current_price' -> 200.000000. 'itemrevenue' -> 100.000000. 'revenueratio' -> 66.666667}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__sum: v
+	(v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+	| s |
+	s := 0.
+	v do: [:it | s := s + it].
+	^ s
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+store_sales := Array with: (Dictionary from: {'ss_item_sk' -> 1. 'ss_sold_date_sk' -> 1. 'ss_ext_sales_price' -> 50.000000}) with: (Dictionary from: {'ss_item_sk' -> 2. 'ss_sold_date_sk' -> 1. 'ss_ext_sales_price' -> 100.000000}).
+item := Array with: (Dictionary from: {'i_item_sk' -> 1. 'i_item_id' -> 'I1'. 'i_item_desc' -> 'desc1'. 'i_category' -> 'CatA'. 'i_class' -> 'Class1'. 'i_current_price' -> 100.000000}) with: (Dictionary from: {'i_item_sk' -> 2. 'i_item_id' -> 'I2'. 'i_item_desc' -> 'desc2'. 'i_category' -> 'CatB'. 'i_class' -> 'Class1'. 'i_current_price' -> 200.000000}).
+date_dim := Array with: (Dictionary from: {'d_date_sk' -> 1. 'd_date' -> '2000-02-01'}).
+grouped := ((| rows groups |
+rows := OrderedCollection new.
+(store_sales) do: [:ss |
+	rows add: ss.
+]
+groups := (Main _group_by: rows keyFn: [:ss | Dictionary from: {'item_id' -> i at: 'i_item_id'. 'item_desc' -> i at: 'i_item_desc'. 'category' -> i at: 'i_category'. 'class' -> i at: 'i_class'. 'price' -> i at: 'i_current_price'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'i_item_id' -> g at: 'key' at: 'item_id'. 'i_item_desc' -> g at: 'key' at: 'item_desc'. 'i_category' -> g at: 'key' at: 'category'. 'i_class' -> g at: 'key' at: 'class'. 'i_current_price' -> g at: 'key' at: 'price'. 'itemrevenue' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+	res add: x at: 'ss_ext_sales_price'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+totals := ((| rows groups |
+rows := OrderedCollection new.
+(grouped) do: [:g |
+	rows add: g.
+]
+groups := (Main _group_by: rows keyFn: [:g | g at: 'i_class']).
+rows := OrderedCollection new.
+(groups) do: [:cg |
+	rows add: Dictionary from: {'class' -> cg at: 'key'. 'total' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(cg) do: [:x |
+	res add: x at: 'itemrevenue'.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+result := ((| res |
+res := OrderedCollection new.
+((grouped) select: [:g | (g at: 'i_class' = t at: 'class')]) do: [:g |
+	(totals) do: [:t |
+		res add: Dictionary from: {'i_item_id' -> g at: 'i_item_id'. 'i_item_desc' -> g at: 'i_item_desc'. 'i_category' -> g at: 'i_category'. 'i_class' -> g at: 'i_class'. 'i_current_price' -> g at: 'i_current_price'. 'itemrevenue' -> g at: 'itemrevenue'. 'revenueratio' -> ((g at: 'itemrevenue' * 100) / t at: 'total')}.
+	]
+]
+res := res asArray.
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q98_revenue.

--- a/tests/dataset/tpc-ds/compiler/st/q99.st.out
+++ b/tests/dataset/tpc-ds/compiler/st/q99.st.out
@@ -1,0 +1,153 @@
+Smalltalk at: #call_center put: nil.
+Smalltalk at: #catalog_sales put: nil.
+Smalltalk at: #grouped put: nil.
+Smalltalk at: #ship_mode put: nil.
+Smalltalk at: #warehouse put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newCatalogSale: cs_ship_date_sk cs_sold_date_sk: cs_sold_date_sk cs_warehouse_sk: cs_warehouse_sk cs_ship_mode_sk: cs_ship_mode_sk cs_call_center_sk: cs_call_center_sk | dict |
+	dict := Dictionary new.
+	dict at: 'cs_ship_date_sk' put: cs_ship_date_sk.
+	dict at: 'cs_sold_date_sk' put: cs_sold_date_sk.
+	dict at: 'cs_warehouse_sk' put: cs_warehouse_sk.
+	dict at: 'cs_ship_mode_sk' put: cs_ship_mode_sk.
+	dict at: 'cs_call_center_sk' put: cs_call_center_sk.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newWarehouse: w_warehouse_sk w_warehouse_name: w_warehouse_name | dict |
+	dict := Dictionary new.
+	dict at: 'w_warehouse_sk' put: w_warehouse_sk.
+	dict at: 'w_warehouse_name' put: w_warehouse_name.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newShipMode: sm_ship_mode_sk sm_type: sm_type | dict |
+	dict := Dictionary new.
+	dict at: 'sm_ship_mode_sk' put: sm_ship_mode_sk.
+	dict at: 'sm_type' put: sm_type.
+	^ dict
+!
+!Main class methodsFor: 'types'!
+newCallCenter: cc_call_center_sk cc_name: cc_name | dict |
+	dict := Dictionary new.
+	dict at: 'cc_call_center_sk' put: cc_call_center_sk.
+	dict at: 'cc_name' put: cc_name.
+	^ dict
+!
+!Main class methodsFor: 'tests'!
+test_TPCDS_Q99_buckets
+	((grouped = Array with: (Dictionary from: {'warehouse' -> 'Warehouse1'. 'sm_type' -> 'EXP'. 'cc_name' -> 'CC1'. 'd30' -> 1. 'd60' -> 1. 'd90' -> 1. 'd120' -> 1. 'dmore' -> 1}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+	g := self new.
+	g key: k.
+	g initialize.
+	^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+	items := OrderedCollection new.
+	^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+	^ key
+!
+key: k
+	key := k
+!
+add: it
+	items add: it
+!
+do: blk
+	items do: blk
+!
+size
+	^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+	(v respondsTo: #size) ifTrue: [ ^ v size ]
+	^ self error: 'count() expects collection'
+!
+__slice_string: s start: i end: j
+	| start end n |
+	start := i.
+	end := j.
+	n := s size.
+	start < 0 ifTrue: [ start := start + n ].
+	end < 0 ifTrue: [ end := end + n ].
+	start < 0 ifTrue: [ start := 0 ].
+	end > n ifTrue: [ end := n ].
+	end < start ifTrue: [ end := start ].
+	^ (s copyFrom: start + 1 to: end)
+!
+_group_by: src keyFn: blk
+	| groups order |
+	groups := Dictionary new.
+	order := OrderedCollection new.
+	src do: [:it |
+		| key ks g |
+		key := blk value: it.
+		ks := key printString.
+		g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+		g add: it.
+	]
+	^ order collect: [:k | groups at: k ]
+!
+!!
+catalog_sales := Array with: (Dictionary from: {'cs_ship_date_sk' -> 31. 'cs_sold_date_sk' -> 1. 'cs_warehouse_sk' -> 1. 'cs_ship_mode_sk' -> 1. 'cs_call_center_sk' -> 1}) with: (Dictionary from: {'cs_ship_date_sk' -> 51. 'cs_sold_date_sk' -> 1. 'cs_warehouse_sk' -> 1. 'cs_ship_mode_sk' -> 1. 'cs_call_center_sk' -> 1}) with: (Dictionary from: {'cs_ship_date_sk' -> 71. 'cs_sold_date_sk' -> 1. 'cs_warehouse_sk' -> 1. 'cs_ship_mode_sk' -> 1. 'cs_call_center_sk' -> 1}) with: (Dictionary from: {'cs_ship_date_sk' -> 101. 'cs_sold_date_sk' -> 1. 'cs_warehouse_sk' -> 1. 'cs_ship_mode_sk' -> 1. 'cs_call_center_sk' -> 1}) with: (Dictionary from: {'cs_ship_date_sk' -> 131. 'cs_sold_date_sk' -> 1. 'cs_warehouse_sk' -> 1. 'cs_ship_mode_sk' -> 1. 'cs_call_center_sk' -> 1}).
+warehouse := Array with: (Dictionary from: {'w_warehouse_sk' -> 1. 'w_warehouse_name' -> 'Warehouse1'}).
+ship_mode := Array with: (Dictionary from: {'sm_ship_mode_sk' -> 1. 'sm_type' -> 'EXP'}).
+call_center := Array with: (Dictionary from: {'cc_call_center_sk' -> 1. 'cc_name' -> 'CC1'}).
+grouped := ((| rows groups |
+rows := OrderedCollection new.
+(catalog_sales) do: [:cs |
+	rows add: cs.
+]
+groups := (Main _group_by: rows keyFn: [:cs | Dictionary from: {'warehouse' -> (Main __slice_string: w at: 'w_warehouse_name' start: 0 end: 0 + 20). 'sm_type' -> sm at: 'sm_type'. 'cc_name' -> cc at: 'cc_name'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+	rows add: Dictionary from: {'warehouse' -> g at: 'key' at: 'warehouse'. 'sm_type' -> g at: 'key' at: 'sm_type'. 'cc_name' -> g at: 'key' at: 'cc_name'. 'd30' -> (Main __count: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | ((x at: 'cs_ship_date_sk' - x at: 'cs_sold_date_sk') <= 30)]) do: [:x |
+	res add: x.
+]
+res := res asArray.
+res))). 'd60' -> (Main __count: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (((((x at: 'cs_ship_date_sk' - x at: 'cs_sold_date_sk') > 30) and: [x at: 'cs_ship_date_sk']) - x at: 'cs_sold_date_sk') <= 60)]) do: [:x |
+	res add: x.
+]
+res := res asArray.
+res))). 'd90' -> (Main __count: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (((((x at: 'cs_ship_date_sk' - x at: 'cs_sold_date_sk') > 60) and: [x at: 'cs_ship_date_sk']) - x at: 'cs_sold_date_sk') <= 90)]) do: [:x |
+	res add: x.
+]
+res := res asArray.
+res))). 'd120' -> (Main __count: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | (((((x at: 'cs_ship_date_sk' - x at: 'cs_sold_date_sk') > 90) and: [x at: 'cs_ship_date_sk']) - x at: 'cs_sold_date_sk') <= 120)]) do: [:x |
+	res add: x.
+]
+res := res asArray.
+res))). 'dmore' -> (Main __count: ((| res |
+res := OrderedCollection new.
+((g) select: [:x | ((x at: 'cs_ship_date_sk' - x at: 'cs_sold_date_sk') > 120)]) do: [:x |
+	res add: x.
+]
+res := res asArray.
+res)))}.
+]
+rows := rows asArray.
+rows)).
+(grouped toJSON) displayOn: Transcript. Transcript cr.
+Main test_TPCDS_Q99_buckets.


### PR DESCRIPTION
## Summary
- compile TPC-DS queries q50 to q99 using the Smalltalk backend
- update TPC-DS Smalltalk golden test to check all queries
- document that q1‒q99 are supported

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68641be044a483208b4efe21d70273b8