### PR TITLE
Add dynamic comparisons for Swift tpc-ds

### DIFF
--- a/compile/x/swift/runtime.go
+++ b/compile/x/swift/runtime.go
@@ -101,6 +101,46 @@ func _sum<T: BinaryFloatingPoint>(_ arr: [T]) -> Double {
     return isFloat ? m : Int(m)
 }
 `
+
+	helperNum = `func _num(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let s = v as? String, let dv = Double(s) { return dv }
+    return 0
+}`
+
+	helperAnyEq = `func _any_eq(_ a: Any, _ b: Any) -> Bool {
+    switch (a, b) {
+    case let (ai as Int, bi as Int): return ai == bi
+    case let (af as Double, bf as Double): return af == bf
+    case let (ai as Int, bf as Double): return Double(ai) == bf
+    case let (af as Double, bi as Int): return af == Double(bi)
+    case let (sa as String, sb as String): return sa == sb
+    case let (ba as Bool, bb as Bool): return ba == bb
+    default: return String(describing: a) == String(describing: b)
+    }
+}`
+
+	helperAnyLT = `func _any_lt(_ a: Any, _ b: Any) -> Bool {
+    if let ai = a as? Int, let bi = b as? Int { return ai < bi }
+    if let af = a as? Double, let bf = b as? Double { return af < bf }
+    if let ai = a as? Int, let bf = b as? Double { return Double(ai) < bf }
+    if let af = a as? Double, let bi = b as? Int { return af < Double(bi) }
+    if let sa = a as? String, let sb = b as? String { return sa < sb }
+    return String(describing: a) < String(describing: b)
+}`
+
+	helperAnyLE = `func _any_le(_ a: Any, _ b: Any) -> Bool {
+    return _any_lt(a, b) || _any_eq(a, b)
+}`
+
+	helperAnyGT = `func _any_gt(_ a: Any, _ b: Any) -> Bool {
+    return !_any_le(a, b)
+}`
+
+	helperAnyGE = `func _any_ge(_ a: Any, _ b: Any) -> Bool {
+    return !_any_lt(a, b)
+}`
 	helperUnionAll = `func _union_all<T>(_ a: [T], _ b: [T]) -> [T] {
     var res = a
     res.append(contentsOf: b)
@@ -334,6 +374,12 @@ var helperMap = map[string]string{
 	"_avg":         helperAvg,
 	"_sum":         helperSum,
 	"_min":         helperMin,
+	"_num":         helperNum,
+	"_any_eq":      helperAnyEq,
+	"_any_lt":      helperAnyLT,
+	"_any_le":      helperAnyLE,
+	"_any_gt":      helperAnyGT,
+	"_any_ge":      helperAnyGE,
 	"_indexString": helperIndexString,
 	"_index":       helperIndex,
 	"_slice":       helperSlice,

--- a/tests/dataset/tpc-ds/compiler/swift/q1.swift.out
+++ b/tests/dataset/tpc-ds/compiler/swift/q1.swift.out
@@ -4,6 +4,20 @@ func expect(_ cond: Bool) {
   if !cond { fatalError("expect failed") }
 }
 
+func _any_eq(_ a: Any, _ b: Any) -> Bool {
+  switch (a, b) {
+  case let (ai as Int, bi as Int): return ai == bi
+  case let (af as Double, bf as Double): return af == bf
+  case let (ai as Int, bf as Double): return Double(ai) == bf
+  case let (af as Double, bi as Int): return af == Double(bi)
+  case let (sa as String, sb as String): return sa == sb
+  case let (ba as Bool, bb as Bool): return ba == bb
+  default: return String(describing: a) == String(describing: b)
+  }
+}
+func _any_gt(_ a: Any, _ b: Any) -> Bool {
+  return !_any_le(a, b)
+}
 func _avg<T: BinaryInteger>(_ arr: [T]) -> Double {
   if arr.isEmpty { return 0 }
   var sum = 0.0
@@ -37,7 +51,7 @@ func _sum<T: BinaryFloatingPoint>(_ arr: [T]) -> Double {
 }
 
 func test_TPCDS_Q1_result() {
-  expect(result == [["c_customer_id": "C2"]])
+  expect(_any_eq(result, [["c_customer_id": "C2"]]))
 }
 
 let store_returns = [
@@ -54,7 +68,9 @@ let customer_total_return =
     var _res: [[String: Any]] = []
     for sr in store_returns {
       for d in date_dim {
-        if !(sr["sr_returned_date_sk"]! == d["d_date_sk"]! && d["d_year"]! == 1998) { continue }
+        if !(_any_eq(_any_eq(sr["sr_returned_date_sk"]!, d["d_date_sk"]!) && d["d_year"]!, 1998)) {
+          continue
+        }
         _res.append([
           "ctr_customer_sk": g.key.customer_sk, "ctr_store_sk": g.key.store_sk,
           "ctr_total_return": _sum(
@@ -77,20 +93,23 @@ let result =
     var _pairs: [(item: [String: Any], key: Any)] = []
     for ctr1 in customer_total_return {
       for s in store {
-        if !(ctr1["ctr_store_sk"]! == s["s_store_sk"]!) { continue }
+        if !(_any_eq(ctr1["ctr_store_sk"]!, s["s_store_sk"]!)) { continue }
         for c in customer {
-          if !(ctr1["ctr_customer_sk"]! == c["c_customer_sk"]!) { continue }
-          if ctr1["ctr_total_return"]! > _avg(
-            ({
-              var _res: [Any] = []
-              for ctr2 in customer_total_return {
-                if ctr1["ctr_store_sk"]! == ctr2["ctr_store_sk"]! {
-                  _res.append(ctr2["ctr_total_return"]!)
-                }
-              }
-              var _items = _res
-              return _items
-            }()).map { Double($0) }) * 1.2 && s["s_state"]! == "TN"
+          if !(_any_eq(ctr1["ctr_customer_sk"]!, c["c_customer_sk"]!)) { continue }
+          if _any_eq(
+            _any_gt(
+              ctr1["ctr_total_return"]!,
+              _avg(
+                ({
+                  var _res: [Any] = []
+                  for ctr2 in customer_total_return {
+                    if _any_eq(ctr1["ctr_store_sk"]!, ctr2["ctr_store_sk"]!) {
+                      _res.append(ctr2["ctr_total_return"]!)
+                    }
+                  }
+                  var _items = _res
+                  return _items
+                }()).map { Double($0) })) * 1.2 && s["s_state"]!, "TN")
           {
             _pairs.append((item: ["c_customer_id": c["c_customer_id"]!], key: c["c_customer_id"]!))
           }


### PR DESCRIPTION
## Summary
- enhance Swift runtime with dynamic comparison helpers
- use dynamic helpers when compiling binary expressions
- update golden output for TPC‑DS q1

## Testing
- `make test`
- `go test -tags slow ./compile/x/swift -run TestSwiftCompiler_TPCDS_Golden/q1$ -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68641cddebc4832087e0175642da1cbc