### PR TITLE
Add Scala support for more TPC‑DS queries

### DIFF
--- a/compile/x/scala/compiler.go
+++ b/compile/x/scala/compiler.go
@@ -1129,6 +1129,46 @@ func (c *Compiler) compileCall(call *parser.CallExpr, recv string) (string, erro
 			return "", fmt.Errorf("append expects 2 args")
 		}
 		return fmt.Sprintf("%s.append(%s)", args[0], args[1]), nil
+	case "concat":
+		if len(args) == 0 {
+			return "scala.collection.mutable.ArrayBuffer()", nil
+		}
+		expr := args[0]
+		for _, a := range args[1:] {
+			expr = fmt.Sprintf("%s ++ %s", expr, a)
+		}
+		return expr, nil
+	case "substr", "substring":
+		if len(args) != 3 {
+			return "", fmt.Errorf("substr expects 3 args")
+		}
+		if isStringExpr(call.Args[0], c.env) {
+			c.use("_sliceString")
+			return fmt.Sprintf("_sliceString(%s, %s, %s)", args[0], args[1], args[2]), nil
+		}
+		c.use("_slice")
+		return fmt.Sprintf("_slice(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "exists":
+		if len(args) != 1 {
+			return "", fmt.Errorf("exists expects 1 arg")
+		}
+		c.use("_exists")
+		return fmt.Sprintf("_exists(%s)", args[0]), nil
+	case "contains":
+		if len(args) != 2 {
+			return "", fmt.Errorf("contains expects 2 args")
+		}
+		return fmt.Sprintf("%s.contains(%s)", args[0], args[1]), nil
+	case "values":
+		if len(args) != 1 {
+			return "", fmt.Errorf("values expects 1 arg")
+		}
+		return fmt.Sprintf("%s.values.toSeq", args[0]), nil
+	case "strings.ToUpper":
+		if len(args) != 1 {
+			return "", fmt.Errorf("strings.ToUpper expects 1 arg")
+		}
+		return fmt.Sprintf("%s.toUpperCase()", args[0]), nil
 	case "eval":
 		if len(args) != 1 {
 			return "", fmt.Errorf("eval expects 1 arg")

--- a/compile/x/scala/runtime.go
+++ b/compile/x/scala/runtime.go
@@ -195,6 +195,17 @@ const (
                 acc = fn(acc, it)
         }
         acc
+        }`
+	helperExists = `def _exists(v: Any): Boolean = v match {
+        case null => false
+        case s: String => s.nonEmpty
+        case seq: Iterable[_] => seq.nonEmpty
+        case m: scala.collection.Map[_, _] =>
+                if (m.contains("items") && m("items").isInstanceOf[Iterable[_]]) m("items").asInstanceOf[Iterable[_]].nonEmpty
+                else if (m.contains("Items") && m("Items").isInstanceOf[Iterable[_]]) m("Items").asInstanceOf[Iterable[_]].nonEmpty
+                else m.nonEmpty
+        case g: _Group => g.Items.nonEmpty
+        case _ => false
 }`
 	helperGroup = `class _Group(var key: Any) {
         val Items = scala.collection.mutable.ArrayBuffer[Any]()
@@ -335,6 +346,7 @@ var helperMap = map[string]string{
 	"_group_by":    helperGroupBy,
 	"_query":       helperQuery,
 	"_reduce":      helperReduce,
+	"_exists":      helperExists,
 	"_pyAttr":      helperPyAttr,
 	"_extern":      helperExtern,
 	"_eval":        helperEval,

--- a/compile/x/scala/tpcds_test.go
+++ b/compile/x/scala/tpcds_test.go
@@ -1,0 +1,27 @@
+//go:build slow
+
+package scalacode_test
+
+import (
+	"fmt"
+	"testing"
+
+	scalacode "mochi/compile/x/scala"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestScalaCompiler_TPCDS(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	for i := 10; i <= 49; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			testutil.CompileTPCDS(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+				return scalacode.New(env).Compile(prog)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- extend Scala backend with built-ins needed for more TPC-DS queries
- expose `_exists` runtime helper in Scala runtime
- test compiling TPC-DS queries `q10`–`q49`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68641dde21308320b7fdd8539d954fc5