### PR TITLE
Fix Pascal map literal generation

### DIFF
--- a/compile/x/pas/TASKS.md
+++ b/compile/x/pas/TASKS.md
@@ -11,7 +11,7 @@ support for complex record field accesses.
 
 ## TPCDS dataset
 
-Queries `q1` through `q9` from the TPCDS suite now compile. The generated
+Queries `q1` through `q19` from the TPCDS suite now compile. The generated
 sources are stored under `tests/dataset/tpc-ds/compiler/pas` and executed as
 part of the slow test suite when `fpc` is available.
 

--- a/compile/x/pas/compiler.go
+++ b/compile/x/pas/compiler.go
@@ -1394,8 +1394,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 				}
 			}
 		}
-		pairs := make([]string, len(p.Map.Items))
-		for i, it := range p.Map.Items {
+		tmp := c.newTypedVar(fmt.Sprintf("specialize TFPGMap<%s, %s>", keyType, valType))
+		c.writeln(fmt.Sprintf("%s := specialize TFPGMap<%s, %s>.Create;", tmp, keyType, valType))
+		for _, it := range p.Map.Items {
 			k, err := c.compileExpr(it.Key)
 			if err != nil {
 				return "", err
@@ -1407,12 +1408,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			pairs[i] = fmt.Sprintf("m.AddOrSetData(%s, %s);", k, v)
-		}
-		tmp := c.newTypedVar(fmt.Sprintf("specialize TFPGMap<%s, %s>", keyType, valType))
-		c.writeln(fmt.Sprintf("%s := specialize TFPGMap<%s, %s>.Create;", tmp, keyType, valType))
-		for _, p := range pairs {
-			c.writeln(strings.ReplaceAll(p, "m", tmp))
+			c.writeln(fmt.Sprintf("%s.AddOrSetData(%s, %s);", tmp, k, v))
 		}
 		return tmp, nil
 	case p.Query != nil:


### PR DESCRIPTION
## Summary
- fix AddOrSetData generation to avoid corrupting field names
- update task docs to note TPC-DS q1–19 support

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6864239927908320b463ab5d2b2e1e22