### PR TITLE
Add v0.10.11 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # 📦 CHANGELOG.md
 
+## [0.10.11] – 2025-07-02T08:31:19+07:00
+
+### Added
+
+* Full TPC-DS query coverage with golden outputs across languages
+* `first` builtin for Ruby and Elixir
+* `exists` builtin for Python, TypeScript and Elixir with `append` support
+* Grouped sort operations in Prolog and Scheme
+* Join helpers for F# and null literal handling in Scheme
+
+### Changed
+
+* Updated TPC-DS IR outputs and dataset tests
+* Documentation updates for Pascal coverage
+* Additional golden files for C++, Go and Java compilers
+
+### Fixed
+
+* Query 39 variance calculation
+* Racket group query parentheses
+* Miscellaneous dataset example fixes
+
 ## [0.10.10] – 2025-07-01T18:41:01+07:00
 
 ### Added

--- a/releases/v0.10.11.md
+++ b/releases/v0.10.11.md
@@ -1,0 +1,24 @@
+# Jul 2025 (v0.10.11)
+
+Released on Wed Jul 2 08:31:19 2025 +0700.
+
+Mochi v0.10.11 completes TPC-DS query support across languages while adding new
+builtins and dataset helpers.
+
+## Runtime
+
+- `first` builtin now available in Ruby and Elixir
+- `exists` builtin introduced for Python, TypeScript and Elixir
+- Grouped sort operations supported in Prolog and Scheme
+- Join helpers added for F# with null literal handling in Scheme
+
+## Datasets
+
+- Full TPC-DS coverage with golden outputs for all languages
+- Updated IR results and additional tests for C and Elixir
+- Fixed query 39 variance calculation
+
+## Tooling
+
+- Documentation notes for Pascal dataset support
+- Racket group query parenthesis fix and helper updates


### PR DESCRIPTION
## Summary
- document changes for v0.10.11 in CHANGELOG
- add release notes file for v0.10.11

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_68648c274d50832088a3500e88247de5