### PR TITLE
Enable TPC‑DS queries 10–19 for Go backend

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -382,7 +382,7 @@ func TestGoCompiler_JOBQueries(t *testing.T) {
 
 func TestGoCompiler_TPCDSQueries(t *testing.T) {
 	root := findRepoRoot(t)
-	for i := 1; i <= 9; i++ {
+	for i := 1; i <= 19; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -57,6 +57,9 @@ var goReserved = map[string]bool{
 }
 
 func sanitizeName(name string) string {
+	if name == "_" {
+		return "v"
+	}
 	var b strings.Builder
 	for i, r := range name {
 		if r == '_' || ('0' <= r && r <= '9' && i > 0) || ('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z') {

--- a/tests/dataset/tpc-ds/compiler/go/q10.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q10.go.out
@@ -39,36 +39,258 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q10_first() {
-	expect(_equal(result, 10))
+type Customer struct {
+	C_customer_sk      int `json:"c_customer_sk"`
+	C_current_addr_sk  int `json:"c_current_addr_sk"`
+	C_current_cdemo_sk int `json:"c_current_cdemo_sk"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type CustomerAddress struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_county     string `json:"ca_county"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type CustomerDemographics struct {
+	Cd_demo_sk            int    `json:"cd_demo_sk"`
+	Cd_gender             string `json:"cd_gender"`
+	Cd_marital_status     string `json:"cd_marital_status"`
+	Cd_education_status   string `json:"cd_education_status"`
+	Cd_purchase_estimate  int    `json:"cd_purchase_estimate"`
+	Cd_credit_rating      string `json:"cd_credit_rating"`
+	Cd_dep_count          int    `json:"cd_dep_count"`
+	Cd_dep_employed_count int    `json:"cd_dep_employed_count"`
+	Cd_dep_college_count  int    `json:"cd_dep_college_count"`
+}
+
+type StoreSale struct {
+	Ss_customer_sk  int `json:"ss_customer_sk"`
+	Ss_sold_date_sk int `json:"ss_sold_date_sk"`
+}
+
+type DateDim struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_moy     int `json:"d_moy"`
+}
+
+func test_TPCDS_Q10_demographics_count() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"cd_gender":             "F",
+		"cd_marital_status":     "M",
+		"cd_education_status":   "College",
+		"cnt1":                  1,
+		"cd_purchase_estimate":  5000,
+		"cnt2":                  1,
+		"cd_credit_rating":      "Good",
+		"cnt3":                  1,
+		"cd_dep_count":          1,
+		"cnt4":                  1,
+		"cd_dep_employed_count": 1,
+		"cnt5":                  1,
+		"cd_dep_college_count":  0,
+		"cnt6":                  1,
+	}}))
+}
+
+type CustomerItem struct {
+	C_customer_sk      int `json:"c_customer_sk"`
+	C_current_addr_sk  int `json:"c_current_addr_sk"`
+	C_current_cdemo_sk int `json:"c_current_cdemo_sk"`
+}
+
+var customer []CustomerItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_county     string `json:"ca_county"`
+}
+
+var customer_address []Customer_addressItem
+
+type Customer_demographicsItem struct {
+	Cd_demo_sk            int    `json:"cd_demo_sk"`
+	Cd_gender             string `json:"cd_gender"`
+	Cd_marital_status     string `json:"cd_marital_status"`
+	Cd_education_status   string `json:"cd_education_status"`
+	Cd_purchase_estimate  int    `json:"cd_purchase_estimate"`
+	Cd_credit_rating      string `json:"cd_credit_rating"`
+	Cd_dep_count          int    `json:"cd_dep_count"`
+	Cd_dep_employed_count int    `json:"cd_dep_employed_count"`
+	Cd_dep_college_count  int    `json:"cd_dep_college_count"`
+}
+
+var customer_demographics []Customer_demographicsItem
+
+type Store_salesItem struct {
+	Ss_customer_sk  int `json:"ss_customer_sk"`
+	Ss_sold_date_sk int `json:"ss_sold_date_sk"`
+}
+
+var store_sales []Store_salesItem
+var web_sales []any
+var catalog_sales []any
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_moy     int `json:"d_moy"`
+}
+
+var date_dim []Date_dimItem
+var active []Customer_demographicsItem
+var result []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  1,
-		Val: 10,
+	customer = _cast[[]CustomerItem]([]CustomerItem{CustomerItem{
+		C_customer_sk:      1,
+		C_current_addr_sk:  1,
+		C_current_cdemo_sk: 1,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_county:     "CountyA",
+	}})
+	customer_demographics = _cast[[]Customer_demographicsItem]([]Customer_demographicsItem{Customer_demographicsItem{
+		Cd_demo_sk:            1,
+		Cd_gender:             "F",
+		Cd_marital_status:     "M",
+		Cd_education_status:   "College",
+		Cd_purchase_estimate:  5000,
+		Cd_credit_rating:      "Good",
+		Cd_dep_count:          1,
+		Cd_dep_employed_count: 1,
+		Cd_dep_college_count:  0,
+	}})
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_customer_sk:  1,
+		Ss_sold_date_sk: 1,
+	}})
+	web_sales = []any{}
+	catalog_sales = []any{}
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+		D_moy:     2,
+	}})
+	active = func() []Customer_demographicsItem {
+		_res := []Customer_demographicsItem{}
+		for _, c := range customer {
+			if _exists(func() []Store_salesItem {
+				_res := []Store_salesItem{}
+				for _, ss := range store_sales {
+					for _, d := range date_dim {
+						if !(ss.Ss_sold_date_sk == d.D_date_sk) {
+							continue
+						}
+						if (((ss.Ss_customer_sk == c.C_customer_sk) && (d.D_year == 2000)) && (d.D_moy >= 2)) && (d.D_moy <= 5) {
+							if (((ss.Ss_customer_sk == c.C_customer_sk) && (d.D_year == 2000)) && (d.D_moy >= 2)) && (d.D_moy <= 5) {
+								_res = append(_res, ss)
+							}
+						}
+					}
+				}
+				return _res
+			}()) {
+				for _, ca := range customer_address {
+					if !((c.C_current_addr_sk == ca.Ca_address_sk) && (ca.Ca_county == "CountyA")) {
+						continue
+					}
+					for _, cd := range customer_demographics {
+						if !(c.C_current_cdemo_sk == cd.Cd_demo_sk) {
+							continue
+						}
+						_res = append(_res, cd)
+					}
+				}
+			}
 		}
 		return _res
 	}()
-	result = _first(_toAnySlice(_convSlice[int, any](vals)))
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, a := range active {
+			key := map[string]any{
+				"gender":    a.Cd_gender,
+				"marital":   a.Cd_marital_status,
+				"education": a.Cd_education_status,
+				"purchase":  a.Cd_purchase_estimate,
+				"credit":    a.Cd_credit_rating,
+				"dep":       a.Cd_dep_count,
+				"depemp":    a.Cd_dep_employed_count,
+				"depcol":    a.Cd_dep_college_count,
+			}
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, a)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{
+				"cd_gender":           _cast[map[string]any](g.Key)["gender"],
+				"cd_marital_status":   _cast[map[string]any](g.Key)["marital"],
+				"cd_education_status": _cast[map[string]any](g.Key)["education"],
+				"cnt1": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"cd_purchase_estimate": _cast[map[string]any](g.Key)["purchase"],
+				"cnt2": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"cd_credit_rating": _cast[map[string]any](g.Key)["credit"],
+				"cnt3": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"cd_dep_count": _cast[map[string]any](g.Key)["dep"],
+				"cnt4": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"cd_dep_employed_count": _cast[map[string]any](g.Key)["depemp"],
+				"cnt5": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"cd_dep_college_count": _cast[map[string]any](g.Key)["depcol"],
+				"cnt6": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q10 first")
+		printTestStart("TPCDS Q10 demographics count")
 		start := time.Now()
 		var failed error
 		func() {
@@ -77,7 +299,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q10_first()
+			test_TPCDS_Q10_demographics_count()
 		}()
 		if failed != nil {
 			failures++
@@ -138,14 +360,6 @@ func _cast[T any](v any) T {
 	return out
 }
 
-func _convSlice[T any, U any](s []T) []U {
-	out := make([]U, len(s))
-	for i, v := range s {
-		out[i] = any(v).(U)
-	}
-	return out
-}
-
 func _convertMapAny(m map[any]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
@@ -157,6 +371,35 @@ func _convertMapAny(m map[any]any) map[string]any {
 		}
 	}
 	return out
+}
+
+func _count(v any) int {
+	if g, ok := v.(*data.Group); ok {
+		return len(g.Items)
+	}
+	switch s := v.(type) {
+	case []any:
+		return len(s)
+	case []int:
+		return len(s)
+	case []float64:
+		return len(s)
+	case []string:
+		return len(s)
+	case []bool:
+		return len(s)
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	case string:
+		return len([]rune(s))
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len()
+	}
+	panic("count() expects list or group")
 }
 
 func _equal(a, b any) bool {
@@ -195,55 +438,31 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
+func _exists(v any) bool {
 	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
+		return len(g.Items) > 0
 	}
 	switch s := v.(type) {
 	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
+		return len(s) > 0
 	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
+		return len(s) > 0
 	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
+		return len(s) > 0
 	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
+		return len(s) > 0
 	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
+		return len(s) > 0
+	case []map[string]any:
+		return len(s) > 0
+	case map[string]any:
+		return len(s) > 0
+	case string:
+		return len([]rune(s)) > 0
 	}
-	return nil
-}
-
-func _toAnySlice[T any](s []T) []any {
-	out := make([]any, len(s))
-	for i, v := range s {
-		out[i] = v
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len() > 0
 	}
-	return out
+	return false
 }

--- a/tests/dataset/tpc-ds/compiler/go/q10.out
+++ b/tests/dataset/tpc-ds/compiler/go/q10.out
@@ -1,2 +1,2 @@
-10
-   test TPCDS Q10 first                ... ok (1.0µs)
+[{"cd_credit_rating":"Good","cd_dep_college_count":0,"cd_dep_count":1,"cd_dep_employed_count":1,"cd_education_status":"College","cd_gender":"F","cd_marital_status":"M","cd_purchase_estimate":5000,"cnt1":1,"cnt2":1,"cnt3":1,"cnt4":1,"cnt5":1,"cnt6":1}]
+   test TPCDS Q10 demographics count   ... ok (7.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q11.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q11.go.out
@@ -39,39 +39,149 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q11_first() {
-	expect(_equal(result, 11))
+type Customer struct {
+	C_customer_sk int    `json:"c_customer_sk"`
+	C_customer_id string `json:"c_customer_id"`
+	C_first_name  string `json:"c_first_name"`
+	C_last_name   string `json:"c_last_name"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type StoreSale struct {
+	Ss_customer_sk    int     `json:"ss_customer_sk"`
+	Ss_sold_date_sk   int     `json:"ss_sold_date_sk"`
+	Ss_ext_list_price float64 `json:"ss_ext_list_price"`
 }
 
-var t []TItem
-var vals []int
+type WebSale struct {
+	Ws_bill_customer_sk int     `json:"ws_bill_customer_sk"`
+	Ws_sold_date_sk     int     `json:"ws_sold_date_sk"`
+	Ws_ext_list_price   float64 `json:"ws_ext_list_price"`
+}
+
+func test_TPCDS_Q11_growth() {
+	expect(_equal(result, []map[string]string{map[string]string{
+		"customer_id":         "C1",
+		"customer_first_name": "John",
+		"customer_last_name":  "Doe",
+	}}))
+}
+
+type CustomerItem struct {
+	C_customer_sk int    `json:"c_customer_sk"`
+	C_customer_id string `json:"c_customer_id"`
+	C_first_name  string `json:"c_first_name"`
+	C_last_name   string `json:"c_last_name"`
+}
+
+var customer []CustomerItem
+
+type Store_salesItem struct {
+	Ss_customer_sk    int     `json:"ss_customer_sk"`
+	Ss_sold_date_sk   int     `json:"ss_sold_date_sk"`
+	Ss_ext_list_price float64 `json:"ss_ext_list_price"`
+}
+
+var store_sales []Store_salesItem
+
+type Web_salesItem struct {
+	Ws_bill_customer_sk int     `json:"ws_bill_customer_sk"`
+	Ws_sold_date_sk     int     `json:"ws_sold_date_sk"`
+	Ws_ext_list_price   float64 `json:"ws_ext_list_price"`
+}
+
+var web_sales []Web_salesItem
+var ss98 float64
+var ss99 float64
+var ws98 float64
+var ws99 float64
+var growth_ok bool
 var result any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 11,
+	customer = _cast[[]CustomerItem]([]CustomerItem{CustomerItem{
+		C_customer_sk: 1,
+		C_customer_id: "C1",
+		C_first_name:  "John",
+		C_last_name:   "Doe",
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_customer_sk:    1,
+		Ss_sold_date_sk:   1998,
+		Ss_ext_list_price: 60.0,
+	}, Store_salesItem{
+		Ss_customer_sk:    1,
+		Ss_sold_date_sk:   1999,
+		Ss_ext_list_price: 90.0,
+	}})
+	web_sales = _cast[[]Web_salesItem]([]Web_salesItem{Web_salesItem{
+		Ws_bill_customer_sk: 1,
+		Ws_sold_date_sk:     1998,
+		Ws_ext_list_price:   50.0,
+	}, Web_salesItem{
+		Ws_bill_customer_sk: 1,
+		Ws_sold_date_sk:     1999,
+		Ws_ext_list_price:   150.0,
+	}})
+	ss98 = _sum(func() []float64 {
+		_res := []float64{}
+		for _, ss := range store_sales {
+			if ss.Ss_sold_date_sk == 1998 {
+				if ss.Ss_sold_date_sk == 1998 {
+					_res = append(_res, ss.Ss_ext_list_price)
+				}
+			}
 		}
 		return _res
+	}())
+	ss99 = _sum(func() []float64 {
+		_res := []float64{}
+		for _, ss := range store_sales {
+			if ss.Ss_sold_date_sk == 1999 {
+				if ss.Ss_sold_date_sk == 1999 {
+					_res = append(_res, ss.Ss_ext_list_price)
+				}
+			}
+		}
+		return _res
+	}())
+	ws98 = _sum(func() []float64 {
+		_res := []float64{}
+		for _, ws := range web_sales {
+			if ws.Ws_sold_date_sk == 1998 {
+				if ws.Ws_sold_date_sk == 1998 {
+					_res = append(_res, ws.Ws_ext_list_price)
+				}
+			}
+		}
+		return _res
+	}())
+	ws99 = _sum(func() []float64 {
+		_res := []float64{}
+		for _, ws := range web_sales {
+			if ws.Ws_sold_date_sk == 1999 {
+				if ws.Ws_sold_date_sk == 1999 {
+					_res = append(_res, ws.Ws_ext_list_price)
+				}
+			}
+		}
+		return _res
+	}())
+	growth_ok = (((ws98 > 0) && (ss98 > 0)) && ((ws99 / ws98) > (ss99 / ss98)))
+	result = func() any {
+		if growth_ok {
+			return []map[string]string{map[string]string{
+				"customer_id":         "C1",
+				"customer_first_name": "John",
+				"customer_last_name":  "Doe",
+			}}
+		} else {
+			return []any{}
+		}
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q11 first")
+		printTestStart("TPCDS Q11 growth")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +190,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q11_first()
+			test_TPCDS_Q11_growth()
 		}()
 		if failed != nil {
 			failures++
@@ -190,55 +300,42 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
+func _sum(v any) float64 {
+	var items []any
 	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
-	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
 		}
 	}
-	return nil
-}
-
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
 	}
-	return out
+	return sum
 }

--- a/tests/dataset/tpc-ds/compiler/go/q11.out
+++ b/tests/dataset/tpc-ds/compiler/go/q11.out
@@ -1,2 +1,2 @@
-11
-   test TPCDS Q11 first                ... ok (1.0µs)
+[{"customer_first_name":"John","customer_id":"C1","customer_last_name":"Doe"}]
+   test TPCDS Q11 growth               ... ok (25.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q12.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q12.go.out
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -39,39 +41,271 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q12_first() {
-	expect(_equal(result, 12))
+type WebSale struct {
+	Ws_item_sk         int     `json:"ws_item_sk"`
+	Ws_sold_date_sk    int     `json:"ws_sold_date_sk"`
+	Ws_ext_sales_price float64 `json:"ws_ext_sales_price"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type Item struct {
+	I_item_sk       int     `json:"i_item_sk"`
+	I_item_id       string  `json:"i_item_id"`
+	I_item_desc     string  `json:"i_item_desc"`
+	I_category      string  `json:"i_category"`
+	I_class         string  `json:"i_class"`
+	I_current_price float64 `json:"i_current_price"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type DateDim struct {
+	D_date_sk int    `json:"d_date_sk"`
+	D_date    string `json:"d_date"`
+}
+
+func test_TPCDS_Q12_revenue_ratio() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"i_item_id":       "ITEM1",
+		"i_item_desc":     "Item One",
+		"i_category":      "A",
+		"i_class":         "C1",
+		"i_current_price": 10.0,
+		"itemrevenue":     200.0,
+		"revenueratio":    50.0,
+	}, map[string]any{
+		"i_item_id":       "ITEM2",
+		"i_item_desc":     "Item Two",
+		"i_category":      "A",
+		"i_class":         "C1",
+		"i_current_price": 20.0,
+		"itemrevenue":     200.0,
+		"revenueratio":    50.0,
+	}}))
+}
+
+type Web_salesItem struct {
+	Ws_item_sk         int     `json:"ws_item_sk"`
+	Ws_sold_date_sk    int     `json:"ws_sold_date_sk"`
+	Ws_ext_sales_price float64 `json:"ws_ext_sales_price"`
+}
+
+var web_sales []Web_salesItem
+
+type ItemItem struct {
+	I_item_sk       int     `json:"i_item_sk"`
+	I_item_id       string  `json:"i_item_id"`
+	I_item_desc     string  `json:"i_item_desc"`
+	I_category      string  `json:"i_category"`
+	I_class         string  `json:"i_class"`
+	I_current_price float64 `json:"i_current_price"`
+}
+
+var item []ItemItem
+
+type Date_dimItem struct {
+	D_date_sk int    `json:"d_date_sk"`
+	D_date    string `json:"d_date"`
+}
+
+var date_dim []Date_dimItem
+var filtered []map[string]any
+var class_totals []map[string]any
+var result []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 12,
+	web_sales = _cast[[]Web_salesItem]([]Web_salesItem{
+		Web_salesItem{
+			Ws_item_sk:         1,
+			Ws_sold_date_sk:    1,
+			Ws_ext_sales_price: 100.0,
+		},
+		Web_salesItem{
+			Ws_item_sk:         1,
+			Ws_sold_date_sk:    2,
+			Ws_ext_sales_price: 100.0,
+		},
+		Web_salesItem{
+			Ws_item_sk:         2,
+			Ws_sold_date_sk:    2,
+			Ws_ext_sales_price: 200.0,
+		},
+		Web_salesItem{
+			Ws_item_sk:         3,
+			Ws_sold_date_sk:    3,
+			Ws_ext_sales_price: 50.0,
+		},
+	})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:       1,
+		I_item_id:       "ITEM1",
+		I_item_desc:     "Item One",
+		I_category:      "A",
+		I_class:         "C1",
+		I_current_price: 10.0,
+	}, ItemItem{
+		I_item_sk:       2,
+		I_item_id:       "ITEM2",
+		I_item_desc:     "Item Two",
+		I_category:      "A",
+		I_class:         "C1",
+		I_current_price: 20.0,
+	}, ItemItem{
+		I_item_sk:       3,
+		I_item_id:       "ITEM3",
+		I_item_desc:     "Item Three",
+		I_category:      "B",
+		I_class:         "C2",
+		I_current_price: 30.0,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_date:    "2001-01-20",
+	}, Date_dimItem{
+		D_date_sk: 2,
+		D_date:    "2001-02-05",
+	}, Date_dimItem{
+		D_date_sk: 3,
+		D_date:    "2001-03-05",
+	}})
+	filtered = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ws := range web_sales {
+			for _, i := range item {
+				if !(ws.Ws_item_sk == i.I_item_sk) {
+					continue
+				}
+				for _, d := range date_dim {
+					if !(ws.Ws_sold_date_sk == d.D_date_sk) {
+						continue
+					}
+					if (_contains([]string{"A", "B", "C"}, i.I_category) && (d.D_date >= "2001-01-15")) && (d.D_date <= "2001-02-14") {
+						key := map[string]any{
+							"id":    i.I_item_id,
+							"desc":  i.I_item_desc,
+							"cat":   i.I_category,
+							"class": i.I_class,
+							"price": i.I_current_price,
+						}
+						ks := fmt.Sprint(key)
+						g, ok := groups[ks]
+						if !ok {
+							g = &data.Group{Key: key}
+							groups[ks] = g
+							order = append(order, ks)
+						}
+						_item := map[string]any{}
+						for k, v := range _cast[map[string]any](ws) {
+							_item[k] = v
+						}
+						_item["ws"] = ws
+						for k, v := range _cast[map[string]any](i) {
+							_item[k] = v
+						}
+						_item["i"] = i
+						for k, v := range _cast[map[string]any](d) {
+							_item[k] = v
+						}
+						_item["d"] = d
+						g.Items = append(g.Items, _item)
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"i_item_id":       _cast[map[string]any](g.Key)["id"],
+				"i_item_desc":     _cast[map[string]any](g.Key)["desc"],
+				"i_category":      _cast[map[string]any](g.Key)["cat"],
+				"i_class":         _cast[map[string]any](g.Key)["class"],
+				"i_current_price": _cast[map[string]any](g.Key)["price"],
+				"itemrevenue": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ws_ext_sales_price"])
+					}
+					return _res
+				}()),
+			})
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
+	class_totals = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, f := range filtered {
+			key := f["i_class"]
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, f)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{"class": g.Key, "total": _sum(func() []any {
+				_res := []any{}
+				for _, x := range g.Items {
+					_res = append(_res, _cast[map[string]any](x)["itemrevenue"])
+				}
+				return _res
+			}())})
+		}
+		return _res
+	}()
+	result = func() []map[string]any {
+		src := _toAnySlice(filtered)
+		resAny := _query(src, []_joinSpec{
+			{items: _toAnySlice(class_totals), on: func(_a ...any) bool {
+				f := _cast[map[string]any](_a[0])
+				_ = f
+				t := _cast[map[string]any](_a[1])
+				_ = t
+				return _equal(f["i_class"], t["class"])
+			}},
+		}, _queryOpts{selectFn: func(_a ...any) any {
+			f := _cast[map[string]any](_a[0])
+			_ = f
+			t := _cast[map[string]any](_a[1])
+			_ = t
+			return map[string]any{
+				"i_item_id":       f["i_item_id"],
+				"i_item_desc":     f["i_item_desc"],
+				"i_category":      f["i_category"],
+				"i_class":         f["i_class"],
+				"i_current_price": f["i_current_price"],
+				"itemrevenue":     f["itemrevenue"],
+				"revenueratio":    (_cast[float64]((_cast[float64](f["itemrevenue"]) * _cast[float64](100.0))) / _cast[float64](t["total"])),
+			}
+		}, sortKey: func(_a ...any) any {
+			f := _cast[map[string]any](_a[0])
+			_ = f
+			t := _cast[map[string]any](_a[1])
+			_ = t
+			return []any{
+				f["i_category"],
+				f["i_class"],
+				f["i_item_id"],
+				f["i_item_desc"],
+			}
+		}, skip: -1, take: -1})
+		out := make([]map[string]any, len(resAny))
+		for i, v := range resAny {
+			out[i] = _cast[map[string]any](v)
+		}
+		return out
+	}()
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q12 first")
+		printTestStart("TPCDS Q12 revenue ratio")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +314,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q12_first()
+			test_TPCDS_Q12_revenue_ratio()
 		}()
 		if failed != nil {
 			failures++
@@ -141,6 +375,26 @@ func _cast[T any](v any) T {
 	return out
 }
 
+func _contains(c any, v any) bool {
+	switch s := c.(type) {
+	case string:
+		return strings.Contains(s, fmt.Sprint(v))
+	case map[string]any:
+		_, ok := s[fmt.Sprint(v)]
+		return ok
+	}
+	rv := reflect.ValueOf(c)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		for i := 0; i < rv.Len(); i++ {
+			if _equal(rv.Index(i).Interface(), v) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
 func _convertMapAny(m map[any]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
@@ -190,55 +444,204 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
-	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
-	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-	}
-	return nil
+type _joinSpec struct {
+	items []any
+	on    func(...any) bool
+	left  bool
+	right bool
+}
+type _queryOpts struct {
+	selectFn func(...any) any
+	where    func(...any) bool
+	sortKey  func(...any) any
+	skip     int
+	take     int
 }
 
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
+func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
+	items := make([][]any, len(src))
+	for i, v := range src {
+		items[i] = []any{v}
+	}
+	for _, j := range joins {
+		joined := [][]any{}
+		if j.right && j.left {
+			matched := make([]bool, len(j.items))
+			for _, left := range items {
+				m := false
+				for ri, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					matched[ri] = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+			for ri, right := range j.items {
+				if !matched[ri] {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else if j.right {
+			for _, right := range j.items {
+				m := false
+				for _, left := range items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if !m {
+					undef := make([]any, len(items[0]))
+					joined = append(joined, append(undef, right))
+				}
+			}
+		} else {
+			for _, left := range items {
+				m := false
+				for _, right := range j.items {
+					keep := true
+					if j.on != nil {
+						args := append(append([]any(nil), left...), right)
+						keep = j.on(args...)
+					}
+					if !keep {
+						continue
+					}
+					m = true
+					joined = append(joined, append(append([]any(nil), left...), right))
+				}
+				if j.left && !m {
+					joined = append(joined, append(append([]any(nil), left...), nil))
+				}
+			}
+		}
+		items = joined
+	}
+	if opts.where != nil {
+		filtered := [][]any{}
+		for _, r := range items {
+			if opts.where(r...) {
+				filtered = append(filtered, r)
+			}
+		}
+		items = filtered
+	}
+	if opts.sortKey != nil {
+		type pair struct {
+			item []any
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for i, it := range items {
+			pairs[i] = pair{it, opts.sortKey(it...)}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for i, p := range pairs {
+			items[i] = p.item
+		}
+	}
+	if opts.skip >= 0 {
+		if opts.skip < len(items) {
+			items = items[opts.skip:]
+		} else {
+			items = [][]any{}
+		}
+	}
+	if opts.take >= 0 {
+		if opts.take < len(items) {
+			items = items[:opts.take]
+		}
+	}
+	res := make([]any, len(items))
+	for i, r := range items {
+		res[i] = opts.selectFn(r...)
+	}
+	return res
+}
+
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/dataset/tpc-ds/compiler/go/q12.out
+++ b/tests/dataset/tpc-ds/compiler/go/q12.out
@@ -1,2 +1,2 @@
-12
-   test TPCDS Q12 first                ... ok (1.0µs)
+[{"i_category":"A","i_class":"C1","i_current_price":10,"i_item_desc":"Item One","i_item_id":"ITEM1","itemrevenue":200,"revenueratio":50},{"i_category":"A","i_class":"C1","i_current_price":20,"i_item_desc":"Item Two","i_item_id":"ITEM2","itemrevenue":200,"revenueratio":50}]
+   test TPCDS Q12 revenue ratio        ... ok (16.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q13.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q13.go.out
@@ -39,39 +39,230 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q13_first() {
-	expect(_equal(result, 13))
+type StoreSale struct {
+	Ss_store_sk           int     `json:"ss_store_sk"`
+	Ss_sold_date_sk       int     `json:"ss_sold_date_sk"`
+	Ss_hdemo_sk           int     `json:"ss_hdemo_sk"`
+	Ss_cdemo_sk           int     `json:"ss_cdemo_sk"`
+	Ss_addr_sk            int     `json:"ss_addr_sk"`
+	Ss_sales_price        float64 `json:"ss_sales_price"`
+	Ss_net_profit         float64 `json:"ss_net_profit"`
+	Ss_quantity           int     `json:"ss_quantity"`
+	Ss_ext_sales_price    float64 `json:"ss_ext_sales_price"`
+	Ss_ext_wholesale_cost float64 `json:"ss_ext_wholesale_cost"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type Store struct {
+	S_store_sk int    `json:"s_store_sk"`
+	S_state    string `json:"s_state"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type CustomerDemographics struct {
+	Cd_demo_sk          int    `json:"cd_demo_sk"`
+	Cd_marital_status   string `json:"cd_marital_status"`
+	Cd_education_status string `json:"cd_education_status"`
+}
+
+type HouseholdDemographics struct {
+	Hd_demo_sk   int `json:"hd_demo_sk"`
+	Hd_dep_count int `json:"hd_dep_count"`
+}
+
+type CustomerAddress struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_country    string `json:"ca_country"`
+	Ca_state      string `json:"ca_state"`
+}
+
+type DateDim struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+func test_TPCDS_Q13_averages() {
+	expect(_equal(result, []map[string]float64{map[string]float64{
+		"avg_ss_quantity":           10.0,
+		"avg_ss_ext_sales_price":    100.0,
+		"avg_ss_ext_wholesale_cost": 50.0,
+		"sum_ss_ext_wholesale_cost": 50.0,
+	}}))
+}
+
+type Store_salesItem struct {
+	Ss_store_sk           int     `json:"ss_store_sk"`
+	Ss_sold_date_sk       int     `json:"ss_sold_date_sk"`
+	Ss_hdemo_sk           int     `json:"ss_hdemo_sk"`
+	Ss_cdemo_sk           int     `json:"ss_cdemo_sk"`
+	Ss_addr_sk            int     `json:"ss_addr_sk"`
+	Ss_sales_price        float64 `json:"ss_sales_price"`
+	Ss_net_profit         float64 `json:"ss_net_profit"`
+	Ss_quantity           int     `json:"ss_quantity"`
+	Ss_ext_sales_price    float64 `json:"ss_ext_sales_price"`
+	Ss_ext_wholesale_cost float64 `json:"ss_ext_wholesale_cost"`
+}
+
+var store_sales []Store_salesItem
+
+type StoreItem struct {
+	S_store_sk int    `json:"s_store_sk"`
+	S_state    string `json:"s_state"`
+}
+
+var store []StoreItem
+
+type Customer_demographicsItem struct {
+	Cd_demo_sk          int    `json:"cd_demo_sk"`
+	Cd_marital_status   string `json:"cd_marital_status"`
+	Cd_education_status string `json:"cd_education_status"`
+}
+
+var customer_demographics []Customer_demographicsItem
+
+type Household_demographicsItem struct {
+	Hd_demo_sk   int `json:"hd_demo_sk"`
+	Hd_dep_count int `json:"hd_dep_count"`
+}
+
+var household_demographics []Household_demographicsItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_country    string `json:"ca_country"`
+	Ca_state      string `json:"ca_state"`
+}
+
+var customer_address []Customer_addressItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+var filtered []Store_salesItem
+var result []map[string]float64
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 13,
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_store_sk:           1,
+		Ss_sold_date_sk:       1,
+		Ss_hdemo_sk:           1,
+		Ss_cdemo_sk:           1,
+		Ss_addr_sk:            1,
+		Ss_sales_price:        120.0,
+		Ss_net_profit:         150.0,
+		Ss_quantity:           10,
+		Ss_ext_sales_price:    100.0,
+		Ss_ext_wholesale_cost: 50.0,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	store = _cast[[]StoreItem]([]StoreItem{StoreItem{
+		S_store_sk: 1,
+		S_state:    "CA",
+	}})
+	customer_demographics = _cast[[]Customer_demographicsItem]([]Customer_demographicsItem{Customer_demographicsItem{
+		Cd_demo_sk:          1,
+		Cd_marital_status:   "M1",
+		Cd_education_status: "ES1",
+	}})
+	household_demographics = _cast[[]Household_demographicsItem]([]Household_demographicsItem{Household_demographicsItem{
+		Hd_demo_sk:   1,
+		Hd_dep_count: 3,
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_country:    "United States",
+		Ca_state:      "CA",
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2001,
+	}})
+	filtered = func() []Store_salesItem {
+		_res := []Store_salesItem{}
+		for _, ss := range store_sales {
+			for _, s := range store {
+				if !(ss.Ss_store_sk == s.S_store_sk) {
+					continue
+				}
+				for _, cd := range customer_demographics {
+					if !(((ss.Ss_cdemo_sk == cd.Cd_demo_sk) && (cd.Cd_marital_status == "M1")) && (cd.Cd_education_status == "ES1")) {
+						continue
+					}
+					for _, hd := range household_demographics {
+						if !((ss.Ss_hdemo_sk == hd.Hd_demo_sk) && (hd.Hd_dep_count == 3)) {
+							continue
+						}
+						for _, ca := range customer_address {
+							if !(((ss.Ss_addr_sk == ca.Ca_address_sk) && (ca.Ca_country == "United States")) && (ca.Ca_state == "CA")) {
+								continue
+							}
+							for _, d := range date_dim {
+								if !((ss.Ss_sold_date_sk == d.D_date_sk) && (d.D_year == 2001)) {
+									continue
+								}
+								_res = append(_res, ss)
+							}
+						}
+					}
+				}
+			}
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
+	result = func() []map[string]float64 {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, r := range filtered {
+			key := map[any]any{}
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, r)
+		}
+		_res := []map[string]float64{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]float64{
+				"avg_ss_quantity": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ss_quantity"])
+					}
+					return _res
+				}()),
+				"avg_ss_ext_sales_price": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ss_ext_sales_price"])
+					}
+					return _res
+				}()),
+				"avg_ss_ext_wholesale_cost": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ss_ext_wholesale_cost"])
+					}
+					return _res
+				}()),
+				"sum_ss_ext_wholesale_cost": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ss_ext_wholesale_cost"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q13 first")
+		printTestStart("TPCDS Q13 averages")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +271,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q13_first()
+			test_TPCDS_Q13_averages()
 		}()
 		if failed != nil {
 			failures++
@@ -92,6 +283,57 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
 }
 
 func _cast[T any](v any) T {
@@ -190,55 +432,42 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
+func _sum(v any) float64 {
+	var items []any
 	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
-	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
 		}
 	}
-	return nil
-}
-
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
 	}
-	return out
+	return sum
 }

--- a/tests/dataset/tpc-ds/compiler/go/q13.out
+++ b/tests/dataset/tpc-ds/compiler/go/q13.out
@@ -1,2 +1,2 @@
-13
-   test TPCDS Q13 first                ... ok (1.0µs)
+[{"avg_ss_ext_sales_price":100,"avg_ss_ext_wholesale_cost":50,"avg_ss_quantity":10,"sum_ss_ext_wholesale_cost":50}]
+   test TPCDS Q13 averages             ... ok (3.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q14.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q14.go.out
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -39,39 +40,233 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q14_first() {
-	expect(_equal(result, 14))
+type StoreSale struct {
+	Ss_item_sk      int     `json:"ss_item_sk"`
+	Ss_list_price   float64 `json:"ss_list_price"`
+	Ss_quantity     int     `json:"ss_quantity"`
+	Ss_sold_date_sk int     `json:"ss_sold_date_sk"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type CatalogSale struct {
+	Cs_item_sk      int     `json:"cs_item_sk"`
+	Cs_list_price   float64 `json:"cs_list_price"`
+	Cs_quantity     int     `json:"cs_quantity"`
+	Cs_sold_date_sk int     `json:"cs_sold_date_sk"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type WebSale struct {
+	Ws_item_sk      int     `json:"ws_item_sk"`
+	Ws_list_price   float64 `json:"ws_list_price"`
+	Ws_quantity     int     `json:"ws_quantity"`
+	Ws_sold_date_sk int     `json:"ws_sold_date_sk"`
+}
+
+type Item struct {
+	I_item_sk     int `json:"i_item_sk"`
+	I_brand_id    int `json:"i_brand_id"`
+	I_class_id    int `json:"i_class_id"`
+	I_category_id int `json:"i_category_id"`
+}
+
+type DateDim struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_moy     int `json:"d_moy"`
+}
+
+func test_TPCDS_Q14_cross_channel() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"channel":       "store",
+		"i_brand_id":    1,
+		"i_class_id":    1,
+		"i_category_id": 1,
+		"sales":         60.0,
+		"number_sales":  1,
+	}}))
+}
+
+type Store_salesItem struct {
+	Ss_item_sk      int     `json:"ss_item_sk"`
+	Ss_list_price   float64 `json:"ss_list_price"`
+	Ss_quantity     int     `json:"ss_quantity"`
+	Ss_sold_date_sk int     `json:"ss_sold_date_sk"`
+}
+
+var store_sales []Store_salesItem
+
+type Catalog_salesItem struct {
+	Cs_item_sk      int     `json:"cs_item_sk"`
+	Cs_list_price   float64 `json:"cs_list_price"`
+	Cs_quantity     int     `json:"cs_quantity"`
+	Cs_sold_date_sk int     `json:"cs_sold_date_sk"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type Web_salesItem struct {
+	Ws_item_sk      int     `json:"ws_item_sk"`
+	Ws_list_price   float64 `json:"ws_list_price"`
+	Ws_quantity     int     `json:"ws_quantity"`
+	Ws_sold_date_sk int     `json:"ws_sold_date_sk"`
+}
+
+var web_sales []Web_salesItem
+
+type ItemItem struct {
+	I_item_sk     int `json:"i_item_sk"`
+	I_brand_id    int `json:"i_brand_id"`
+	I_class_id    int `json:"i_class_id"`
+	I_category_id int `json:"i_category_id"`
+}
+
+var item []ItemItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_moy     int `json:"d_moy"`
+}
+
+var date_dim []Date_dimItem
+
+type Cross_itemsItem struct {
+	Ss_item_sk int `json:"ss_item_sk"`
+}
+
+var cross_items []Cross_itemsItem
+var avg_sales float64
+var store_filtered []map[string]any
+var result []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 14,
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_item_sk:      1,
+		Ss_list_price:   10.0,
+		Ss_quantity:     2,
+		Ss_sold_date_sk: 1,
+	}, Store_salesItem{
+		Ss_item_sk:      1,
+		Ss_list_price:   20.0,
+		Ss_quantity:     3,
+		Ss_sold_date_sk: 2,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_item_sk:      1,
+		Cs_list_price:   10.0,
+		Cs_quantity:     2,
+		Cs_sold_date_sk: 1,
+	}})
+	web_sales = _cast[[]Web_salesItem]([]Web_salesItem{Web_salesItem{
+		Ws_item_sk:      1,
+		Ws_list_price:   30.0,
+		Ws_quantity:     1,
+		Ws_sold_date_sk: 1,
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:     1,
+		I_brand_id:    1,
+		I_class_id:    1,
+		I_category_id: 1,
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    2000,
+		D_moy:     12,
+	}, Date_dimItem{
+		D_date_sk: 2,
+		D_year:    2002,
+		D_moy:     11,
+	}})
+	cross_items = _cast[[]Cross_itemsItem]([]Cross_itemsItem{Cross_itemsItem{Ss_item_sk: 1}})
+	avg_sales = _avg([]float64{20.0, 20.0, 30.0})
+	store_filtered = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, ss := range store_sales {
+			for _, d := range date_dim {
+				if !(((ss.Ss_sold_date_sk == d.D_date_sk) && (d.D_year == 2002)) && (d.D_moy == 11)) {
+					continue
+				}
+				if _contains((func() []int {
+					_res := []int{}
+					for _, ci := range cross_items {
+						_res = append(_res, ci.Ss_item_sk)
+					}
+					return _res
+				}()), ss.Ss_item_sk) {
+					key := map[string]int{
+						"brand_id":    1,
+						"class_id":    1,
+						"category_id": 1,
+					}
+					ks := fmt.Sprint(key)
+					g, ok := groups[ks]
+					if !ok {
+						g = &data.Group{Key: key}
+						groups[ks] = g
+						order = append(order, ks)
+					}
+					_item := map[string]any{}
+					for k, v := range _cast[map[string]any](ss) {
+						_item[k] = v
+					}
+					_item["ss"] = ss
+					for k, v := range _cast[map[string]any](d) {
+						_item[k] = v
+					}
+					_item["d"] = d
+					g.Items = append(g.Items, _item)
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"channel": "store",
+				"sales": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, (_cast[float64](_cast[map[string]any](x)["ss_quantity"]) * _cast[float64](_cast[map[string]any](x)["ss_list_price"])))
+					}
+					return _res
+				}()),
+				"number_sales": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+			})
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
+	result = func() []map[string]any {
+		_res := []map[string]any{}
+		for _, r := range store_filtered {
+			if _cast[float64](r["sales"]) > avg_sales {
+				if _cast[float64](r["sales"]) > avg_sales {
+					_res = append(_res, map[string]any{
+						"channel":       r["channel"],
+						"i_brand_id":    1,
+						"i_class_id":    1,
+						"i_category_id": 1,
+						"sales":         r["sales"],
+						"number_sales":  r["number_sales"],
+					})
+				}
+			}
+		}
+		return _res
+	}()
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q14 first")
+		printTestStart("TPCDS Q14 cross channel")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +275,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q14_first()
+			test_TPCDS_Q14_cross_channel()
 		}()
 		if failed != nil {
 			failures++
@@ -92,6 +287,57 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
 }
 
 func _cast[T any](v any) T {
@@ -141,6 +387,26 @@ func _cast[T any](v any) T {
 	return out
 }
 
+func _contains(c any, v any) bool {
+	switch s := c.(type) {
+	case string:
+		return strings.Contains(s, fmt.Sprint(v))
+	case map[string]any:
+		_, ok := s[fmt.Sprint(v)]
+		return ok
+	}
+	rv := reflect.ValueOf(c)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		for i := 0; i < rv.Len(); i++ {
+			if _equal(rv.Index(i).Interface(), v) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
 func _convertMapAny(m map[any]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
@@ -152,6 +418,35 @@ func _convertMapAny(m map[any]any) map[string]any {
 		}
 	}
 	return out
+}
+
+func _count(v any) int {
+	if g, ok := v.(*data.Group); ok {
+		return len(g.Items)
+	}
+	switch s := v.(type) {
+	case []any:
+		return len(s)
+	case []int:
+		return len(s)
+	case []float64:
+		return len(s)
+	case []string:
+		return len(s)
+	case []bool:
+		return len(s)
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	case string:
+		return len([]rune(s))
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len()
+	}
+	panic("count() expects list or group")
 }
 
 func _equal(a, b any) bool {
@@ -190,55 +485,42 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
+func _sum(v any) float64 {
+	var items []any
 	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
-	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
 		}
 	}
-	return nil
-}
-
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
 	}
-	return out
+	return sum
 }

--- a/tests/dataset/tpc-ds/compiler/go/q14.out
+++ b/tests/dataset/tpc-ds/compiler/go/q14.out
@@ -1,2 +1,2 @@
-14
-   test TPCDS Q14 first                ... ok (1.0µs)
+[{"channel":"store","i_brand_id":1,"i_category_id":1,"i_class_id":1,"number_sales":1,"sales":60}]
+   test TPCDS Q14 cross channel        ... ok (4.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q15.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q15.go.out
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -39,39 +41,198 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q15_first() {
-	expect(_equal(result, 15))
+type CatalogSale struct {
+	Cs_bill_customer_sk int     `json:"cs_bill_customer_sk"`
+	Cs_sales_price      float64 `json:"cs_sales_price"`
+	Cs_sold_date_sk     int     `json:"cs_sold_date_sk"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type Customer struct {
+	C_customer_sk     int `json:"c_customer_sk"`
+	C_current_addr_sk int `json:"c_current_addr_sk"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type CustomerAddress struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_zip        string `json:"ca_zip"`
+	Ca_state      string `json:"ca_state"`
+}
+
+type DateDim struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_qoy     int `json:"d_qoy"`
+	D_year    int `json:"d_year"`
+}
+
+func test_TPCDS_Q15_zip() {
+	expect(_equal(filtered, []map[string]any{map[string]any{"ca_zip": "85669", "sum_sales": 600.0}}))
+}
+
+type Catalog_salesItem struct {
+	Cs_bill_customer_sk int     `json:"cs_bill_customer_sk"`
+	Cs_sales_price      float64 `json:"cs_sales_price"`
+	Cs_sold_date_sk     int     `json:"cs_sold_date_sk"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type CustomerItem struct {
+	C_customer_sk     int `json:"c_customer_sk"`
+	C_current_addr_sk int `json:"c_current_addr_sk"`
+}
+
+var customer []CustomerItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_zip        string `json:"ca_zip"`
+	Ca_state      string `json:"ca_state"`
+}
+
+var customer_address []Customer_addressItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_qoy     int `json:"d_qoy"`
+	D_year    int `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+var filtered []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 15,
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_bill_customer_sk: 1,
+		Cs_sales_price:      600.0,
+		Cs_sold_date_sk:     1,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	customer = _cast[[]CustomerItem]([]CustomerItem{CustomerItem{
+		C_customer_sk:     1,
+		C_current_addr_sk: 1,
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_zip:        "85669",
+		Ca_state:      "CA",
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_qoy:     1,
+		D_year:    2000,
+	}})
+	filtered = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, cs := range catalog_sales {
+			for _, c := range customer {
+				if !(cs.Cs_bill_customer_sk == c.C_customer_sk) {
+					continue
+				}
+				for _, ca := range customer_address {
+					if !(c.C_current_addr_sk == ca.Ca_address_sk) {
+						continue
+					}
+					for _, d := range date_dim {
+						if !(cs.Cs_sold_date_sk == d.D_date_sk) {
+							continue
+						}
+						if (((_contains([]string{
+							"85669",
+							"86197",
+							"88274",
+							"83405",
+							"86475",
+							"85392",
+							"85460",
+							"80348",
+							"81792",
+						}, _sliceString(ca.Ca_zip, 0, 5)) || _contains([]string{"CA", "WA", "GA"}, ca.Ca_state)) || (cs.Cs_sales_price > 500)) && (d.D_qoy == 1)) && (d.D_year == 2000) {
+							key := map[string]string{"zip": ca.Ca_zip}
+							ks := fmt.Sprint(key)
+							g, ok := groups[ks]
+							if !ok {
+								g = &data.Group{Key: key}
+								groups[ks] = g
+								order = append(order, ks)
+							}
+							_item := map[string]any{}
+							for k, v := range _cast[map[string]any](cs) {
+								_item[k] = v
+							}
+							_item["cs"] = cs
+							for k, v := range _cast[map[string]any](c) {
+								_item[k] = v
+							}
+							_item["c"] = c
+							for k, v := range _cast[map[string]any](ca) {
+								_item[k] = v
+							}
+							_item["ca"] = ca
+							for k, v := range _cast[map[string]any](d) {
+								_item[k] = v
+							}
+							_item["d"] = d
+							g.Items = append(g.Items, _item)
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _cast[map[string]any](g.Key)["zip"]}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{"ca_zip": _cast[map[string]any](g.Key)["zip"], "sum_sales": _sum(func() []any {
+				_res := []any{}
+				for _, x := range g.Items {
+					_res = append(_res, _cast[map[string]any](x)["cs_sales_price"])
+				}
+				return _res
+			}())})
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
-	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	func() { b, _ := json.Marshal(filtered); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q15 first")
+		printTestStart("TPCDS Q15 zip")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +241,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q15_first()
+			test_TPCDS_Q15_zip()
 		}()
 		if failed != nil {
 			failures++
@@ -141,6 +302,26 @@ func _cast[T any](v any) T {
 	return out
 }
 
+func _contains(c any, v any) bool {
+	switch s := c.(type) {
+	case string:
+		return strings.Contains(s, fmt.Sprint(v))
+	case map[string]any:
+		_, ok := s[fmt.Sprint(v)]
+		return ok
+	}
+	rv := reflect.ValueOf(c)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		for i := 0; i < rv.Len(); i++ {
+			if _equal(rv.Index(i).Interface(), v) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
 func _convertMapAny(m map[any]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
@@ -190,55 +371,64 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
-	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
+func _sliceString(s string, i, j int) string {
+	start := i
+	end := j
+	n := len([]rune(s))
+	if start < 0 {
+		start += n
 	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
+	if end < 0 {
+		end += n
 	}
-	return nil
+	if start < 0 {
+		start = 0
+	}
+	if end > n {
+		end = n
+	}
+	if end < start {
+		end = start
+	}
+	return string([]rune(s)[start:end])
 }
 
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
 	}
-	return out
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
 }

--- a/tests/dataset/tpc-ds/compiler/go/q15.out
+++ b/tests/dataset/tpc-ds/compiler/go/q15.out
@@ -1,2 +1,2 @@
-15
-   test TPCDS Q15 first                ... ok (1.0µs)
+[{"ca_zip":"85669","sum_sales":600}]
+   test TPCDS Q15 zip                  ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q16.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q16.go.out
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -39,39 +40,223 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q16_first() {
-	expect(_equal(result, 16))
+type CatalogSale struct {
+	Cs_order_number   int     `json:"cs_order_number"`
+	Cs_ship_date_sk   int     `json:"cs_ship_date_sk"`
+	Cs_ship_addr_sk   int     `json:"cs_ship_addr_sk"`
+	Cs_call_center_sk int     `json:"cs_call_center_sk"`
+	Cs_warehouse_sk   int     `json:"cs_warehouse_sk"`
+	Cs_ext_ship_cost  float64 `json:"cs_ext_ship_cost"`
+	Cs_net_profit     float64 `json:"cs_net_profit"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type DateDim struct {
+	D_date_sk int    `json:"d_date_sk"`
+	D_date    string `json:"d_date"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type CustomerAddress struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_state      string `json:"ca_state"`
+}
+
+type CallCenter struct {
+	Cc_call_center_sk int    `json:"cc_call_center_sk"`
+	Cc_county         string `json:"cc_county"`
+}
+
+type CatalogReturn struct {
+	Cr_order_number int `json:"cr_order_number"`
+}
+
+var distinct = func(xs []any) []any {
+	var out []any = []any{}
+	for _, x := range xs {
+		if !_contains(out, x) {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+func test_TPCDS_Q16_shipping() {
+	expect(_equal(filtered, []map[string]any{map[string]any{
+		"order_count":         1,
+		"total_shipping_cost": 5.0,
+		"total_net_profit":    20.0,
+	}}))
+}
+
+type Catalog_salesItem struct {
+	Cs_order_number   int     `json:"cs_order_number"`
+	Cs_ship_date_sk   int     `json:"cs_ship_date_sk"`
+	Cs_ship_addr_sk   int     `json:"cs_ship_addr_sk"`
+	Cs_call_center_sk int     `json:"cs_call_center_sk"`
+	Cs_warehouse_sk   int     `json:"cs_warehouse_sk"`
+	Cs_ext_ship_cost  float64 `json:"cs_ext_ship_cost"`
+	Cs_net_profit     float64 `json:"cs_net_profit"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type Date_dimItem struct {
+	D_date_sk int    `json:"d_date_sk"`
+	D_date    string `json:"d_date"`
+}
+
+var date_dim []Date_dimItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_state      string `json:"ca_state"`
+}
+
+var customer_address []Customer_addressItem
+
+type Call_centerItem struct {
+	Cc_call_center_sk int    `json:"cc_call_center_sk"`
+	Cc_county         string `json:"cc_county"`
+}
+
+var call_center []Call_centerItem
+var catalog_returns []any
+var filtered []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 16,
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_order_number:   1,
+		Cs_ship_date_sk:   1,
+		Cs_ship_addr_sk:   1,
+		Cs_call_center_sk: 1,
+		Cs_warehouse_sk:   1,
+		Cs_ext_ship_cost:  5.0,
+		Cs_net_profit:     20.0,
+	}, Catalog_salesItem{
+		Cs_order_number:   1,
+		Cs_ship_date_sk:   1,
+		Cs_ship_addr_sk:   1,
+		Cs_call_center_sk: 1,
+		Cs_warehouse_sk:   2,
+		Cs_ext_ship_cost:  0.0,
+		Cs_net_profit:     0.0,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_date:    "2000-03-01",
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_state:      "CA",
+	}})
+	call_center = _cast[[]Call_centerItem]([]Call_centerItem{Call_centerItem{
+		Cc_call_center_sk: 1,
+		Cc_county:         "CountyA",
+	}})
+	catalog_returns = []any{}
+	filtered = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, cs1 := range catalog_sales {
+			for _, d := range date_dim {
+				if !(((cs1.Cs_ship_date_sk == d.D_date_sk) && (d.D_date >= "2000-03-01")) && (d.D_date <= "2000-04-30")) {
+					continue
+				}
+				for _, ca := range customer_address {
+					if !((cs1.Cs_ship_addr_sk == ca.Ca_address_sk) && (ca.Ca_state == "CA")) {
+						continue
+					}
+					for _, cc := range call_center {
+						if !((cs1.Cs_call_center_sk == cc.Cc_call_center_sk) && (cc.Cc_county == "CountyA")) {
+							continue
+						}
+						if _exists(func() []Catalog_salesItem {
+							_res := []Catalog_salesItem{}
+							for _, cs2 := range catalog_sales {
+								if (cs1.Cs_order_number == cs2.Cs_order_number) && (cs1.Cs_warehouse_sk != cs2.Cs_warehouse_sk) {
+									if (cs1.Cs_order_number == cs2.Cs_order_number) && (cs1.Cs_warehouse_sk != cs2.Cs_warehouse_sk) {
+										_res = append(_res, cs2)
+									}
+								}
+							}
+							return _res
+						}()) && (_exists(func() []any {
+							_res := []any{}
+							for _, cr := range catalog_returns {
+								if _equal(cs1.Cs_order_number, _cast[map[string]any](cr)["cr_order_number"]) {
+									if _equal(cs1.Cs_order_number, _cast[map[string]any](cr)["cr_order_number"]) {
+										_res = append(_res, cr)
+									}
+								}
+							}
+							return _res
+						}()) == false) {
+							key := map[any]any{}
+							ks := fmt.Sprint(key)
+							g, ok := groups[ks]
+							if !ok {
+								g = &data.Group{Key: key}
+								groups[ks] = g
+								order = append(order, ks)
+							}
+							_item := map[string]any{}
+							for k, v := range _cast[map[string]any](cs1) {
+								_item[k] = v
+							}
+							_item["cs1"] = cs1
+							for k, v := range _cast[map[string]any](d) {
+								_item[k] = v
+							}
+							_item["d"] = d
+							for k, v := range _cast[map[string]any](ca) {
+								_item[k] = v
+							}
+							_item["ca"] = ca
+							for k, v := range _cast[map[string]any](cc) {
+								_item[k] = v
+							}
+							_item["cc"] = cc
+							g.Items = append(g.Items, _item)
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"order_count": len(distinct(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["cs_order_number"])
+					}
+					return _res
+				}())),
+				"total_shipping_cost": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["cs_ext_ship_cost"])
+					}
+					return _res
+				}()),
+				"total_net_profit": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["cs_net_profit"])
+					}
+					return _res
+				}()),
+			})
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
-	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
+	func() { b, _ := json.Marshal(filtered); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q16 first")
+		printTestStart("TPCDS Q16 shipping")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +265,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q16_first()
+			test_TPCDS_Q16_shipping()
 		}()
 		if failed != nil {
 			failures++
@@ -141,6 +326,26 @@ func _cast[T any](v any) T {
 	return out
 }
 
+func _contains(c any, v any) bool {
+	switch s := c.(type) {
+	case string:
+		return strings.Contains(s, fmt.Sprint(v))
+	case map[string]any:
+		_, ok := s[fmt.Sprint(v)]
+		return ok
+	}
+	rv := reflect.ValueOf(c)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		for i := 0; i < rv.Len(); i++ {
+			if _equal(rv.Index(i).Interface(), v) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
 func _convertMapAny(m map[any]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
@@ -190,55 +395,71 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
+func _exists(v any) bool {
 	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
+		return len(g.Items) > 0
 	}
 	switch s := v.(type) {
 	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
+		return len(s) > 0
 	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
+		return len(s) > 0
 	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
+		return len(s) > 0
 	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
+		return len(s) > 0
 	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
+		return len(s) > 0
+	case []map[string]any:
+		return len(s) > 0
+	case map[string]any:
+		return len(s) > 0
+	case string:
+		return len([]rune(s)) > 0
 	}
-	return nil
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len() > 0
+	}
+	return false
 }
 
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
 	}
-	return out
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
 }

--- a/tests/dataset/tpc-ds/compiler/go/q16.out
+++ b/tests/dataset/tpc-ds/compiler/go/q16.out
@@ -1,2 +1,2 @@
-16
-   test TPCDS Q16 first                ... ok (1.0µs)
+[{"order_count":1,"total_net_profit":20,"total_shipping_cost":5}]
+   test TPCDS Q16 shipping             ... ok (2.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q17.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q17.go.out
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -39,39 +40,291 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q17_first() {
-	expect(_equal(result, 17))
+type StoreSale struct {
+	Ss_sold_date_sk  int `json:"ss_sold_date_sk"`
+	Ss_item_sk       int `json:"ss_item_sk"`
+	Ss_customer_sk   int `json:"ss_customer_sk"`
+	Ss_ticket_number int `json:"ss_ticket_number"`
+	Ss_quantity      int `json:"ss_quantity"`
+	Ss_store_sk      int `json:"ss_store_sk"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type StoreReturn struct {
+	Sr_returned_date_sk int `json:"sr_returned_date_sk"`
+	Sr_customer_sk      int `json:"sr_customer_sk"`
+	Sr_item_sk          int `json:"sr_item_sk"`
+	Sr_ticket_number    int `json:"sr_ticket_number"`
+	Sr_return_quantity  int `json:"sr_return_quantity"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type CatalogSale struct {
+	Cs_sold_date_sk     int `json:"cs_sold_date_sk"`
+	Cs_item_sk          int `json:"cs_item_sk"`
+	Cs_bill_customer_sk int `json:"cs_bill_customer_sk"`
+	Cs_quantity         int `json:"cs_quantity"`
+}
+
+type DateDim struct {
+	D_date_sk      int    `json:"d_date_sk"`
+	D_quarter_name string `json:"d_quarter_name"`
+}
+
+type Store struct {
+	S_store_sk int    `json:"s_store_sk"`
+	S_state    string `json:"s_state"`
+}
+
+type Item struct {
+	I_item_sk   int    `json:"i_item_sk"`
+	I_item_id   string `json:"i_item_id"`
+	I_item_desc string `json:"i_item_desc"`
+}
+
+func test_TPCDS_Q17_stats() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"i_item_id":                   "I1",
+		"i_item_desc":                 "Item 1",
+		"s_state":                     "CA",
+		"store_sales_quantitycount":   1,
+		"store_sales_quantityave":     10.0,
+		"store_sales_quantitystdev":   0.0,
+		"store_sales_quantitycov":     0.0,
+		"store_returns_quantitycount": 1,
+		"store_returns_quantityave":   2.0,
+		"store_returns_quantitystdev": 0.0,
+		"store_returns_quantitycov":   0.0,
+		"catalog_sales_quantitycount": 1,
+		"catalog_sales_quantityave":   5.0,
+		"catalog_sales_quantitystdev": 0.0,
+		"catalog_sales_quantitycov":   0.0,
+	}}))
+}
+
+type Store_salesItem struct {
+	Ss_sold_date_sk  int `json:"ss_sold_date_sk"`
+	Ss_item_sk       int `json:"ss_item_sk"`
+	Ss_customer_sk   int `json:"ss_customer_sk"`
+	Ss_ticket_number int `json:"ss_ticket_number"`
+	Ss_quantity      int `json:"ss_quantity"`
+	Ss_store_sk      int `json:"ss_store_sk"`
+}
+
+var store_sales []Store_salesItem
+
+type Store_returnsItem struct {
+	Sr_returned_date_sk int `json:"sr_returned_date_sk"`
+	Sr_customer_sk      int `json:"sr_customer_sk"`
+	Sr_item_sk          int `json:"sr_item_sk"`
+	Sr_ticket_number    int `json:"sr_ticket_number"`
+	Sr_return_quantity  int `json:"sr_return_quantity"`
+}
+
+var store_returns []Store_returnsItem
+
+type Catalog_salesItem struct {
+	Cs_sold_date_sk     int `json:"cs_sold_date_sk"`
+	Cs_item_sk          int `json:"cs_item_sk"`
+	Cs_bill_customer_sk int `json:"cs_bill_customer_sk"`
+	Cs_quantity         int `json:"cs_quantity"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type Date_dimItem struct {
+	D_date_sk      int    `json:"d_date_sk"`
+	D_quarter_name string `json:"d_quarter_name"`
+}
+
+var date_dim []Date_dimItem
+
+type StoreItem struct {
+	S_store_sk int    `json:"s_store_sk"`
+	S_state    string `json:"s_state"`
+}
+
+var store []StoreItem
+
+type ItemItem struct {
+	I_item_sk   int    `json:"i_item_sk"`
+	I_item_id   string `json:"i_item_id"`
+	I_item_desc string `json:"i_item_desc"`
+}
+
+var item []ItemItem
+var joined []map[string]any
+var result []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 17,
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_sold_date_sk:  1,
+		Ss_item_sk:       1,
+		Ss_customer_sk:   1,
+		Ss_ticket_number: 1,
+		Ss_quantity:      10,
+		Ss_store_sk:      1,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	store_returns = _cast[[]Store_returnsItem]([]Store_returnsItem{Store_returnsItem{
+		Sr_returned_date_sk: 2,
+		Sr_customer_sk:      1,
+		Sr_item_sk:          1,
+		Sr_ticket_number:    1,
+		Sr_return_quantity:  2,
+	}})
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_sold_date_sk:     3,
+		Cs_item_sk:          1,
+		Cs_bill_customer_sk: 1,
+		Cs_quantity:         5,
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk:      1,
+		D_quarter_name: "1998Q1",
+	}, Date_dimItem{
+		D_date_sk:      2,
+		D_quarter_name: "1998Q2",
+	}, Date_dimItem{
+		D_date_sk:      3,
+		D_quarter_name: "1998Q3",
+	}})
+	store = _cast[[]StoreItem]([]StoreItem{StoreItem{
+		S_store_sk: 1,
+		S_state:    "CA",
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:   1,
+		I_item_id:   "I1",
+		I_item_desc: "Item 1",
+	}})
+	joined = func() []map[string]any {
+		_res := []map[string]any{}
+		for _, ss := range store_sales {
+			for _, sr := range store_returns {
+				if !(((ss.Ss_customer_sk == sr.Sr_customer_sk) && (ss.Ss_item_sk == sr.Sr_item_sk)) && (ss.Ss_ticket_number == sr.Sr_ticket_number)) {
+					continue
+				}
+				for _, cs := range catalog_sales {
+					if !((sr.Sr_customer_sk == cs.Cs_bill_customer_sk) && (sr.Sr_item_sk == cs.Cs_item_sk)) {
+						continue
+					}
+					for _, d1 := range date_dim {
+						if !((ss.Ss_sold_date_sk == d1.D_date_sk) && (d1.D_quarter_name == "1998Q1")) {
+							continue
+						}
+						for _, d2 := range date_dim {
+							if !((sr.Sr_returned_date_sk == d2.D_date_sk) && _contains([]string{"1998Q1", "1998Q2", "1998Q3"}, d2.D_quarter_name)) {
+								continue
+							}
+							for _, d3 := range date_dim {
+								if !((cs.Cs_sold_date_sk == d3.D_date_sk) && _contains([]string{"1998Q1", "1998Q2", "1998Q3"}, d3.D_quarter_name)) {
+									continue
+								}
+								for _, s := range store {
+									if !(ss.Ss_store_sk == s.S_store_sk) {
+										continue
+									}
+									for _, i := range item {
+										if !(ss.Ss_item_sk == i.I_item_sk) {
+											continue
+										}
+										_res = append(_res, map[string]any{
+											"qty":         ss.Ss_quantity,
+											"ret":         sr.Sr_return_quantity,
+											"csq":         cs.Cs_quantity,
+											"i_item_id":   i.I_item_id,
+											"i_item_desc": i.I_item_desc,
+											"s_state":     s.S_state,
+										})
+									}
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, j := range joined {
+			key := map[string]any{
+				"i_item_id":   j["i_item_id"],
+				"i_item_desc": j["i_item_desc"],
+				"s_state":     j["s_state"],
+			}
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, j)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{
+				"i_item_id":   _cast[map[string]any](g.Key)["i_item_id"],
+				"i_item_desc": _cast[map[string]any](g.Key)["i_item_desc"],
+				"s_state":     _cast[map[string]any](g.Key)["s_state"],
+				"store_sales_quantitycount": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"store_sales_quantityave": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["qty"])
+					}
+					return _res
+				}()),
+				"store_sales_quantitystdev": 0.0,
+				"store_sales_quantitycov":   0.0,
+				"store_returns_quantitycount": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"store_returns_quantityave": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ret"])
+					}
+					return _res
+				}()),
+				"store_returns_quantitystdev": 0.0,
+				"store_returns_quantitycov":   0.0,
+				"catalog_sales_quantitycount": _count(func() []any {
+					_res := []any{}
+					for _, v := range g.Items {
+						_res = append(_res, v)
+					}
+					return _res
+				}()),
+				"catalog_sales_quantityave": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["csq"])
+					}
+					return _res
+				}()),
+				"catalog_sales_quantitystdev": 0.0,
+				"catalog_sales_quantitycov":   0.0,
+			})
+		}
+		return _res
+	}()
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q17 first")
+		printTestStart("TPCDS Q17 stats")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +333,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q17_first()
+			test_TPCDS_Q17_stats()
 		}()
 		if failed != nil {
 			failures++
@@ -92,6 +345,57 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
 }
 
 func _cast[T any](v any) T {
@@ -141,6 +445,26 @@ func _cast[T any](v any) T {
 	return out
 }
 
+func _contains(c any, v any) bool {
+	switch s := c.(type) {
+	case string:
+		return strings.Contains(s, fmt.Sprint(v))
+	case map[string]any:
+		_, ok := s[fmt.Sprint(v)]
+		return ok
+	}
+	rv := reflect.ValueOf(c)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		for i := 0; i < rv.Len(); i++ {
+			if _equal(rv.Index(i).Interface(), v) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
 func _convertMapAny(m map[any]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
@@ -152,6 +476,35 @@ func _convertMapAny(m map[any]any) map[string]any {
 		}
 	}
 	return out
+}
+
+func _count(v any) int {
+	if g, ok := v.(*data.Group); ok {
+		return len(g.Items)
+	}
+	switch s := v.(type) {
+	case []any:
+		return len(s)
+	case []int:
+		return len(s)
+	case []float64:
+		return len(s)
+	case []string:
+		return len(s)
+	case []bool:
+		return len(s)
+	case []map[string]any:
+		return len(s)
+	case map[string]any:
+		return len(s)
+	case string:
+		return len([]rune(s))
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		return rv.Len()
+	}
+	panic("count() expects list or group")
 }
 
 func _equal(a, b any) bool {
@@ -188,57 +541,4 @@ func _equal(a, b any) bool {
 		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
 	}
 	return reflect.DeepEqual(a, b)
-}
-
-func _first(v any) any {
-	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
-	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-	}
-	return nil
-}
-
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
-	}
-	return out
 }

--- a/tests/dataset/tpc-ds/compiler/go/q17.out
+++ b/tests/dataset/tpc-ds/compiler/go/q17.out
@@ -1,2 +1,2 @@
-17
-   test TPCDS Q17 first                ... ok (1.0µs)
+[{"catalog_sales_quantityave":5,"catalog_sales_quantitycount":1,"catalog_sales_quantitycov":0,"catalog_sales_quantitystdev":0,"i_item_desc":"Item 1","i_item_id":"I1","s_state":"CA","store_returns_quantityave":2,"store_returns_quantitycount":1,"store_returns_quantitycov":0,"store_returns_quantitystdev":0,"store_sales_quantityave":10,"store_sales_quantitycount":1,"store_sales_quantitycov":0,"store_sales_quantitystdev":0}]
+   test TPCDS Q17 stats                ... ok (33.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q18.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q18.go.out
@@ -39,39 +39,301 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q18_first() {
-	expect(_equal(result, 18))
+type CatalogSale struct {
+	Cs_quantity         int     `json:"cs_quantity"`
+	Cs_list_price       float64 `json:"cs_list_price"`
+	Cs_coupon_amt       float64 `json:"cs_coupon_amt"`
+	Cs_sales_price      float64 `json:"cs_sales_price"`
+	Cs_net_profit       float64 `json:"cs_net_profit"`
+	Cs_bill_cdemo_sk    int     `json:"cs_bill_cdemo_sk"`
+	Cs_bill_customer_sk int     `json:"cs_bill_customer_sk"`
+	Cs_sold_date_sk     int     `json:"cs_sold_date_sk"`
+	Cs_item_sk          int     `json:"cs_item_sk"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type CustomerDemographics struct {
+	Cd_demo_sk          int    `json:"cd_demo_sk"`
+	Cd_gender           string `json:"cd_gender"`
+	Cd_education_status string `json:"cd_education_status"`
+	Cd_dep_count        int    `json:"cd_dep_count"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type Customer struct {
+	C_customer_sk      int `json:"c_customer_sk"`
+	C_current_cdemo_sk int `json:"c_current_cdemo_sk"`
+	C_current_addr_sk  int `json:"c_current_addr_sk"`
+	C_birth_year       int `json:"c_birth_year"`
+	C_birth_month      int `json:"c_birth_month"`
+}
+
+type CustomerAddress struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_country    string `json:"ca_country"`
+	Ca_state      string `json:"ca_state"`
+	Ca_county     string `json:"ca_county"`
+}
+
+type DateDim struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+type Item struct {
+	I_item_sk int    `json:"i_item_sk"`
+	I_item_id string `json:"i_item_id"`
+}
+
+func test_TPCDS_Q18_averages() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"i_item_id":  "I1",
+		"ca_country": "US",
+		"ca_state":   "CA",
+		"ca_county":  "County1",
+		"agg1":       1.0,
+		"agg2":       10.0,
+		"agg3":       1.0,
+		"agg4":       9.0,
+		"agg5":       2.0,
+		"agg6":       1980.0,
+		"agg7":       2.0,
+	}}))
+}
+
+type Catalog_salesItem struct {
+	Cs_quantity         int     `json:"cs_quantity"`
+	Cs_list_price       float64 `json:"cs_list_price"`
+	Cs_coupon_amt       float64 `json:"cs_coupon_amt"`
+	Cs_sales_price      float64 `json:"cs_sales_price"`
+	Cs_net_profit       float64 `json:"cs_net_profit"`
+	Cs_bill_cdemo_sk    int     `json:"cs_bill_cdemo_sk"`
+	Cs_bill_customer_sk int     `json:"cs_bill_customer_sk"`
+	Cs_sold_date_sk     int     `json:"cs_sold_date_sk"`
+	Cs_item_sk          int     `json:"cs_item_sk"`
+}
+
+var catalog_sales []Catalog_salesItem
+
+type Customer_demographicsItem struct {
+	Cd_demo_sk          int    `json:"cd_demo_sk"`
+	Cd_gender           string `json:"cd_gender"`
+	Cd_education_status string `json:"cd_education_status"`
+	Cd_dep_count        int    `json:"cd_dep_count"`
+}
+
+var customer_demographics []Customer_demographicsItem
+
+type CustomerItem struct {
+	C_customer_sk      int `json:"c_customer_sk"`
+	C_current_cdemo_sk int `json:"c_current_cdemo_sk"`
+	C_current_addr_sk  int `json:"c_current_addr_sk"`
+	C_birth_year       int `json:"c_birth_year"`
+	C_birth_month      int `json:"c_birth_month"`
+}
+
+var customer []CustomerItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_country    string `json:"ca_country"`
+	Ca_state      string `json:"ca_state"`
+	Ca_county     string `json:"ca_county"`
+}
+
+var customer_address []Customer_addressItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+}
+
+var date_dim []Date_dimItem
+
+type ItemItem struct {
+	I_item_sk int    `json:"i_item_sk"`
+	I_item_id string `json:"i_item_id"`
+}
+
+var item []ItemItem
+var joined []map[string]any
+var result []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 18,
+	catalog_sales = _cast[[]Catalog_salesItem]([]Catalog_salesItem{Catalog_salesItem{
+		Cs_quantity:         1,
+		Cs_list_price:       10.0,
+		Cs_coupon_amt:       1.0,
+		Cs_sales_price:      9.0,
+		Cs_net_profit:       2.0,
+		Cs_bill_cdemo_sk:    1,
+		Cs_bill_customer_sk: 1,
+		Cs_sold_date_sk:     1,
+		Cs_item_sk:          1,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	customer_demographics = _cast[[]Customer_demographicsItem]([]Customer_demographicsItem{Customer_demographicsItem{
+		Cd_demo_sk:          1,
+		Cd_gender:           "M",
+		Cd_education_status: "College",
+		Cd_dep_count:        2,
+	}, Customer_demographicsItem{
+		Cd_demo_sk:          2,
+		Cd_gender:           "F",
+		Cd_education_status: "College",
+		Cd_dep_count:        2,
+	}})
+	customer = _cast[[]CustomerItem]([]CustomerItem{CustomerItem{
+		C_customer_sk:      1,
+		C_current_cdemo_sk: 2,
+		C_current_addr_sk:  1,
+		C_birth_year:       1980,
+		C_birth_month:      1,
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_country:    "US",
+		Ca_state:      "CA",
+		Ca_county:     "County1",
+	}})
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    1999,
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk: 1,
+		I_item_id: "I1",
+	}})
+	joined = func() []map[string]any {
+		_res := []map[string]any{}
+		for _, cs := range catalog_sales {
+			for _, cd1 := range customer_demographics {
+				if !(((cs.Cs_bill_cdemo_sk == cd1.Cd_demo_sk) && (cd1.Cd_gender == "M")) && (cd1.Cd_education_status == "College")) {
+					continue
+				}
+				for _, c := range customer {
+					if !(cs.Cs_bill_customer_sk == c.C_customer_sk) {
+						continue
+					}
+					for _, cd2 := range customer_demographics {
+						if !(c.C_current_cdemo_sk == cd2.Cd_demo_sk) {
+							continue
+						}
+						for _, ca := range customer_address {
+							if !(c.C_current_addr_sk == ca.Ca_address_sk) {
+								continue
+							}
+							for _, d := range date_dim {
+								if !((cs.Cs_sold_date_sk == d.D_date_sk) && (d.D_year == 1999)) {
+									continue
+								}
+								for _, i := range item {
+									if !(cs.Cs_item_sk == i.I_item_sk) {
+										continue
+									}
+									_res = append(_res, map[string]any{
+										"i_item_id":  i.I_item_id,
+										"ca_country": ca.Ca_country,
+										"ca_state":   ca.Ca_state,
+										"ca_county":  ca.Ca_county,
+										"q":          cs.Cs_quantity,
+										"lp":         cs.Cs_list_price,
+										"cp":         cs.Cs_coupon_amt,
+										"sp":         cs.Cs_sales_price,
+										"np":         cs.Cs_net_profit,
+										"by":         c.C_birth_year,
+										"dep":        cd1.Cd_dep_count,
+									})
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, j := range joined {
+			key := map[string]any{
+				"i_item_id":  j["i_item_id"],
+				"ca_country": j["ca_country"],
+				"ca_state":   j["ca_state"],
+				"ca_county":  j["ca_county"],
+			}
+			ks := fmt.Sprint(key)
+			g, ok := groups[ks]
+			if !ok {
+				g = &data.Group{Key: key}
+				groups[ks] = g
+				order = append(order, ks)
+			}
+			g.Items = append(g.Items, j)
+		}
+		_res := []map[string]any{}
+		for _, ks := range order {
+			g := groups[ks]
+			_res = append(_res, map[string]any{
+				"i_item_id":  _cast[map[string]any](g.Key)["i_item_id"],
+				"ca_country": _cast[map[string]any](g.Key)["ca_country"],
+				"ca_state":   _cast[map[string]any](g.Key)["ca_state"],
+				"ca_county":  _cast[map[string]any](g.Key)["ca_county"],
+				"agg1": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["q"])
+					}
+					return _res
+				}()),
+				"agg2": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["lp"])
+					}
+					return _res
+				}()),
+				"agg3": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["cp"])
+					}
+					return _res
+				}()),
+				"agg4": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["sp"])
+					}
+					return _res
+				}()),
+				"agg5": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["np"])
+					}
+					return _res
+				}()),
+				"agg6": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["by"])
+					}
+					return _res
+				}()),
+				"agg7": _avg(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["dep"])
+					}
+					return _res
+				}()),
+			})
+		}
+		return _res
+	}()
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q18 first")
+		printTestStart("TPCDS Q18 averages")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +342,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q18_first()
+			test_TPCDS_Q18_averages()
 		}()
 		if failed != nil {
 			failures++
@@ -92,6 +354,57 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _avg(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []bool:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		default:
+			panic("avg() expects list or group")
+		}
+	}
+	if len(items) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("avg() expects numbers")
+		}
+	}
+	return sum / float64(len(items))
 }
 
 func _cast[T any](v any) T {
@@ -188,57 +501,4 @@ func _equal(a, b any) bool {
 		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
 	}
 	return reflect.DeepEqual(a, b)
-}
-
-func _first(v any) any {
-	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
-	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-	}
-	return nil
-}
-
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
-	}
-	return out
 }

--- a/tests/dataset/tpc-ds/compiler/go/q18.out
+++ b/tests/dataset/tpc-ds/compiler/go/q18.out
@@ -1,2 +1,2 @@
-18
-   test TPCDS Q18 first                ... ok (1.0µs)
+[{"agg1":1,"agg2":10,"agg3":1,"agg4":9,"agg5":2,"agg6":1980,"agg7":2,"ca_country":"US","ca_county":"County1","ca_state":"CA","i_item_id":"I1"}]
+   test TPCDS Q18 averages             ... ok (31.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q19.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q19.go.out
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"sort"
 	"time"
 )
 
@@ -39,39 +40,270 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_TPCDS_Q19_first() {
-	expect(_equal(result, 19))
+type StoreSale struct {
+	Ss_sold_date_sk    int     `json:"ss_sold_date_sk"`
+	Ss_item_sk         int     `json:"ss_item_sk"`
+	Ss_customer_sk     int     `json:"ss_customer_sk"`
+	Ss_store_sk        int     `json:"ss_store_sk"`
+	Ss_ext_sales_price float64 `json:"ss_ext_sales_price"`
 }
 
-type TItem struct {
-	Id  int `json:"id"`
-	Val int `json:"val"`
+type DateDim struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_moy     int `json:"d_moy"`
 }
 
-var t []TItem
-var vals []int
-var result any
+type Item struct {
+	I_item_sk     int    `json:"i_item_sk"`
+	I_brand_id    int    `json:"i_brand_id"`
+	I_brand       string `json:"i_brand"`
+	I_manufact_id int    `json:"i_manufact_id"`
+	I_manufact    string `json:"i_manufact"`
+	I_manager_id  int    `json:"i_manager_id"`
+}
+
+type Customer struct {
+	C_customer_sk     int `json:"c_customer_sk"`
+	C_current_addr_sk int `json:"c_current_addr_sk"`
+}
+
+type CustomerAddress struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_zip        string `json:"ca_zip"`
+}
+
+type Store struct {
+	S_store_sk int    `json:"s_store_sk"`
+	S_zip      string `json:"s_zip"`
+}
+
+func test_TPCDS_Q19_brand() {
+	expect(_equal(result, []map[string]any{map[string]any{
+		"i_brand":       "B1",
+		"i_brand_id":    1,
+		"i_manufact_id": 1,
+		"i_manufact":    "M1",
+		"ext_price":     100.0,
+	}}))
+}
+
+type Store_salesItem struct {
+	Ss_sold_date_sk    int     `json:"ss_sold_date_sk"`
+	Ss_item_sk         int     `json:"ss_item_sk"`
+	Ss_customer_sk     int     `json:"ss_customer_sk"`
+	Ss_store_sk        int     `json:"ss_store_sk"`
+	Ss_ext_sales_price float64 `json:"ss_ext_sales_price"`
+}
+
+var store_sales []Store_salesItem
+
+type Date_dimItem struct {
+	D_date_sk int `json:"d_date_sk"`
+	D_year    int `json:"d_year"`
+	D_moy     int `json:"d_moy"`
+}
+
+var date_dim []Date_dimItem
+
+type ItemItem struct {
+	I_item_sk     int    `json:"i_item_sk"`
+	I_brand_id    int    `json:"i_brand_id"`
+	I_brand       string `json:"i_brand"`
+	I_manufact_id int    `json:"i_manufact_id"`
+	I_manufact    string `json:"i_manufact"`
+	I_manager_id  int    `json:"i_manager_id"`
+}
+
+var item []ItemItem
+
+type CustomerItem struct {
+	C_customer_sk     int `json:"c_customer_sk"`
+	C_current_addr_sk int `json:"c_current_addr_sk"`
+}
+
+var customer []CustomerItem
+
+type Customer_addressItem struct {
+	Ca_address_sk int    `json:"ca_address_sk"`
+	Ca_zip        string `json:"ca_zip"`
+}
+
+var customer_address []Customer_addressItem
+
+type StoreItem struct {
+	S_store_sk int    `json:"s_store_sk"`
+	S_zip      string `json:"s_zip"`
+}
+
+var store []StoreItem
+var result []map[string]any
 
 func main() {
 	failures := 0
-	t = _cast[[]TItem]([]TItem{TItem{
-		Id:  0,
-		Val: 0,
-	}, TItem{
-		Id:  1,
-		Val: 19,
+	store_sales = _cast[[]Store_salesItem]([]Store_salesItem{Store_salesItem{
+		Ss_sold_date_sk:    1,
+		Ss_item_sk:         1,
+		Ss_customer_sk:     1,
+		Ss_store_sk:        1,
+		Ss_ext_sales_price: 100.0,
 	}})
-	vals = func() []int {
-		_res := []int{}
-		for _, r := range t {
-			_res = append(_res, r.Val)
+	date_dim = _cast[[]Date_dimItem]([]Date_dimItem{Date_dimItem{
+		D_date_sk: 1,
+		D_year:    1999,
+		D_moy:     11,
+	}})
+	item = _cast[[]ItemItem]([]ItemItem{ItemItem{
+		I_item_sk:     1,
+		I_brand_id:    1,
+		I_brand:       "B1",
+		I_manufact_id: 1,
+		I_manufact:    "M1",
+		I_manager_id:  10,
+	}})
+	customer = _cast[[]CustomerItem]([]CustomerItem{CustomerItem{
+		C_customer_sk:     1,
+		C_current_addr_sk: 1,
+	}})
+	customer_address = _cast[[]Customer_addressItem]([]Customer_addressItem{Customer_addressItem{
+		Ca_address_sk: 1,
+		Ca_zip:        "11111",
+	}})
+	store = _cast[[]StoreItem]([]StoreItem{StoreItem{
+		S_store_sk: 1,
+		S_zip:      "99999",
+	}})
+	result = func() []map[string]any {
+		groups := map[string]*data.Group{}
+		order := []string{}
+		for _, d := range date_dim {
+			for _, ss := range store_sales {
+				if !(ss.Ss_sold_date_sk == d.D_date_sk) {
+					continue
+				}
+				for _, i := range item {
+					if !((ss.Ss_item_sk == i.I_item_sk) && (i.I_manager_id == 10)) {
+						continue
+					}
+					for _, c := range customer {
+						if !(ss.Ss_customer_sk == c.C_customer_sk) {
+							continue
+						}
+						for _, ca := range customer_address {
+							if !(c.C_current_addr_sk == ca.Ca_address_sk) {
+								continue
+							}
+							for _, s := range store {
+								if !((ss.Ss_store_sk == s.S_store_sk) && (_sliceString(ca.Ca_zip, 0, 5) != _sliceString(s.S_zip, 0, 5))) {
+									continue
+								}
+								if (d.D_moy == 11) && (d.D_year == 1999) {
+									key := map[string]any{
+										"brand":    i.I_brand,
+										"brand_id": i.I_brand_id,
+										"man_id":   i.I_manufact_id,
+										"man":      i.I_manufact,
+									}
+									ks := fmt.Sprint(key)
+									g, ok := groups[ks]
+									if !ok {
+										g = &data.Group{Key: key}
+										groups[ks] = g
+										order = append(order, ks)
+									}
+									_item := map[string]any{}
+									for k, v := range _cast[map[string]any](d) {
+										_item[k] = v
+									}
+									_item["d"] = d
+									for k, v := range _cast[map[string]any](ss) {
+										_item[k] = v
+									}
+									_item["ss"] = ss
+									for k, v := range _cast[map[string]any](i) {
+										_item[k] = v
+									}
+									_item["i"] = i
+									for k, v := range _cast[map[string]any](c) {
+										_item[k] = v
+									}
+									_item["c"] = c
+									for k, v := range _cast[map[string]any](ca) {
+										_item[k] = v
+									}
+									_item["ca"] = ca
+									for k, v := range _cast[map[string]any](s) {
+										_item[k] = v
+									}
+									_item["s"] = s
+									g.Items = append(g.Items, _item)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		items := []*data.Group{}
+		for _, ks := range order {
+			items = append(items, groups[ks])
+		}
+		type pair struct {
+			item *data.Group
+			key  any
+		}
+		pairs := make([]pair, len(items))
+		for idx, it := range items {
+			g := it
+			pairs[idx] = pair{item: it, key: _toAnySlice([]any{_cast[map[string]any](g.Key)["brand"]})}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			a, b := pairs[i].key, pairs[j].key
+			switch av := a.(type) {
+			case int:
+				switch bv := b.(type) {
+				case int:
+					return av < bv
+				case float64:
+					return float64(av) < bv
+				}
+			case float64:
+				switch bv := b.(type) {
+				case int:
+					return av < float64(bv)
+				case float64:
+					return av < bv
+				}
+			case string:
+				bs, _ := b.(string)
+				return av < bs
+			}
+			return fmt.Sprint(a) < fmt.Sprint(b)
+		})
+		for idx, p := range pairs {
+			items[idx] = p.item
+		}
+		_res := []map[string]any{}
+		for _, g := range items {
+			_res = append(_res, map[string]any{
+				"i_brand":       _cast[map[string]any](g.Key)["brand"],
+				"i_brand_id":    _cast[map[string]any](g.Key)["brand_id"],
+				"i_manufact_id": _cast[map[string]any](g.Key)["man_id"],
+				"i_manufact":    _cast[map[string]any](g.Key)["man"],
+				"ext_price": _sum(func() []any {
+					_res := []any{}
+					for _, x := range g.Items {
+						_res = append(_res, _cast[map[string]any](x)["ss_ext_sales_price"])
+					}
+					return _res
+				}()),
+			})
 		}
 		return _res
 	}()
-	result = _first(_cast[[]any](_reverseSlice[int](vals)))
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("TPCDS Q19 first")
+		printTestStart("TPCDS Q19 brand")
 		start := time.Now()
 		var failed error
 		func() {
@@ -80,7 +312,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_TPCDS_Q19_first()
+			test_TPCDS_Q19_brand()
 		}()
 		if failed != nil {
 			failures++
@@ -190,55 +422,72 @@ func _equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func _first(v any) any {
-	if g, ok := v.(*data.Group); ok {
-		if len(g.Items) == 0 {
-			return nil
-		}
-		return g.Items[0]
+func _sliceString(s string, i, j int) string {
+	start := i
+	end := j
+	n := len([]rune(s))
+	if start < 0 {
+		start += n
 	}
-	switch s := v.(type) {
-	case []any:
-		if len(s) == 0 {
-			return nil
-		}
-		return s[0]
-	case []int:
-		if len(s) == 0 {
-			return 0
-		}
-		return s[0]
-	case []float64:
-		if len(s) == 0 {
-			return 0.0
-		}
-		return s[0]
-	case []string:
-		if len(s) == 0 {
-			return ""
-		}
-		return s[0]
-	case []bool:
-		if len(s) == 0 {
-			return false
-		}
-		return s[0]
-	default:
-		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Slice && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
-		if rv.Kind() == reflect.Array && rv.Len() > 0 {
-			return rv.Index(0).Interface()
-		}
+	if end < 0 {
+		end += n
 	}
-	return nil
+	if start < 0 {
+		start = 0
+	}
+	if end > n {
+		end = n
+	}
+	if end < start {
+		end = start
+	}
+	return string([]rune(s)[start:end])
 }
 
-func _reverseSlice[T any](s []T) []T {
-	out := append([]T{}, s...)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
+func _sum(v any) float64 {
+	var items []any
+	if g, ok := v.(*data.Group); ok {
+		items = g.Items
+	} else {
+		switch s := v.(type) {
+		case []any:
+			items = s
+		case []int:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []float64:
+			items = make([]any, len(s))
+			for i, v := range s {
+				items[i] = v
+			}
+		case []string, []bool:
+			panic("sum() expects numbers")
+		default:
+			panic("sum() expects list or group")
+		}
+	}
+	var sum float64
+	for _, it := range items {
+		switch n := it.(type) {
+		case int:
+			sum += float64(n)
+		case int64:
+			sum += float64(n)
+		case float64:
+			sum += n
+		default:
+			panic("sum() expects numbers")
+		}
+	}
+	return sum
+}
+
+func _toAnySlice[T any](s []T) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/dataset/tpc-ds/compiler/go/q19.out
+++ b/tests/dataset/tpc-ds/compiler/go/q19.out
@@ -1,2 +1,2 @@
-19
-   test TPCDS Q19 first                ... ok (1.0µs)
+[{"ext_price":100,"i_brand":"B1","i_brand_id":1,"i_manufact":"M1","i_manufact_id":1}]
+   test TPCDS Q19 brand                ... ok (32.0µs)

--- a/tests/dataset/tpc-ds/compiler/go/q8.go.out
+++ b/tests/dataset/tpc-ds/compiler/go/q8.go.out
@@ -6,6 +6,7 @@ import (
 	"mochi/runtime/data"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -132,7 +133,7 @@ func main() {
 							if !((ca.Ca_address_sk == c.C_current_addr_sk) && (c.C_preferred_cust_flag == "Y")) {
 								continue
 							}
-							if _contains[string](zip_list, _sliceString(ca.Ca_zip, 0, 5)) {
+							if _contains(zip_list, _sliceString(ca.Ca_zip, 0, 5)) {
 								key := s.S_store_name
 								ks := fmt.Sprint(key)
 								g, ok := groups[ks]
@@ -293,11 +294,22 @@ func _cast[T any](v any) T {
 	return out
 }
 
-func _contains[T comparable](s []T, v T) bool {
-	for _, x := range s {
-		if x == v {
-			return true
+func _contains(c any, v any) bool {
+	switch s := c.(type) {
+	case string:
+		return strings.Contains(s, fmt.Sprint(v))
+	case map[string]any:
+		_, ok := s[fmt.Sprint(v)]
+		return ok
+	}
+	rv := reflect.ValueOf(c)
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		for i := 0; i < rv.Len(); i++ {
+			if _equal(rv.Index(i).Interface(), v) {
+				return true
+			}
 		}
+		return false
 	}
 	return false
 }

--- a/tests/dataset/tpc-ds/compiler/go/q8.out
+++ b/tests/dataset/tpc-ds/compiler/go/q8.out
@@ -1,2 +1,2 @@
 [{"net_profit":10,"s_store_name":"Store1"}]
-   test TPCDS Q8 result                ... ok (4.0µs)
+   test TPCDS Q8 result                ... ok (2.0µs)


### PR DESCRIPTION
## Summary
- support the `exists` and `contains` built‑ins in Go compiler runtime
- avoid invalid variable names in generated Go code
- update helper `sanitizeName`
- extend dataset tests to cover queries 10–19 and update goldens

## Testing
- `go test ./compile/go -tags slow -run TestGoCompiler_TPCDSQueries -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6864bf8e190883208395dfe35b402dab