### PR TITLE
Add source line comments to slt-generated Mochi

### DIFF
--- a/tests/dataset/slt/out/evidence/slt_lang_update/case1.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case1.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 48
 CREATE TABLE t1( x INTEGER, y VARCHAR(8) )
 INSERT INTO t1 VALUES(1,'true')
 INSERT INTO t1 VALUES(0,'false')
@@ -38,8 +39,8 @@ var t1 = [
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  if row.x > 0 {
-    row.x = 1
+  if row["x"] > 0 {
+    row["x"] = 1
     t1[i] = row
   }
   i = i + 1
@@ -49,8 +50,8 @@ while i < len(t1) {
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  if row.x > 0 {
-    row.x = 2
+  if row["x"] > 0 {
+    row["x"] = 2
     t1[i] = row
   }
   i = i + 1
@@ -60,8 +61,8 @@ while i < len(t1) {
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  if row.x > 0 {
-    row.y = "true"
+  if row["x"] > 0 {
+    row["y"] = "true"
     t1[i] = row
   }
   i = i + 1
@@ -71,8 +72,8 @@ while i < len(t1) {
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  if row.x > 0 {
-    row.y = "unknown"
+  if row["x"] > 0 {
+    row["y"] = "unknown"
     t1[i] = row
   }
   i = i + 1
@@ -82,14 +83,14 @@ while i < len(t1) {
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  row.x = 3
+  row["x"] = 3
   t1[i] = row
   i = i + 1
 }
 
 /* SELECT count(*) FROM t1 WHERE x=3 */
 let result = count(from row in t1
-  where row.x == 3
+  where row["x"] == 3
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case2.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case2.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 60
 # EVIDENCE-OF: R-42117-40023 Otherwise, the UPDATE affects only those
 # rows for which the result of evaluating the WHERE clause expression as
 # a boolean expression is true.
@@ -24,8 +25,8 @@ var t1 = [
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  if row.y == "unknown" {
-    row.x = 1
+  if row["y"] == "unknown" {
+    row["x"] = 1
     t1[i] = row
   }
   i = i + 1
@@ -33,7 +34,7 @@ while i < len(t1) {
 
 /* SELECT count(*) FROM t1 WHERE x=1 */
 let result = count(from row in t1
-  where row.x == 1
+  where row["x"] == 1
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case3.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case3.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 79
 # EVIDENCE-OF: R-58129-20729 It is not an error if the WHERE clause does
 # not evaluate to true for any row in the table - this just means that
 # the UPDATE statement affects zero rows.
@@ -28,8 +29,8 @@ var t1 = [
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  if row.y == "foo" {
-    row.x = 1
+  if row["y"] == "foo" {
+    row["x"] = 1
     t1[i] = row
   }
   i = i + 1
@@ -39,14 +40,14 @@ while i < len(t1) {
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  row.x = 3 + 1
+  row["x"] = 3 + 1
   t1[i] = row
   i = i + 1
 }
 
 /* SELECT count(*) FROM t1 WHERE x=4 */
 let result = count(from row in t1
-  where row.x == 4
+  where row["x"] == 4
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case4.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case4.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 93
 # EVIDENCE-OF: R-34751-18293 If a single column-name appears more than
 # once in the list of assignment expressions, all but the rightmost
 # occurrence is ignored.
@@ -26,16 +27,16 @@ var t1 = [
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  row.x = 3
-  row.x = 4
-  row.x = 5
+  row["x"] = 3
+  row["x"] = 4
+  row["x"] = 5
   t1[i] = row
   i = i + 1
 }
 
 /* SELECT count(*) FROM t1 WHERE x=3 */
 let result = count(from row in t1
-  where row.x == 3
+  where row["x"] == 3
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case5.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case5.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 99
 skipif mssql
 */
 
@@ -19,7 +20,7 @@ let t1 = [
 
 /* SELECT count(*) FROM t1 WHERE x=4 */
 let result = count(from row in t1
-  where row.x == 4
+  where row["x"] == 4
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case6.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case6.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 105
 skipif mssql
 */
 
@@ -19,7 +20,7 @@ let t1 = [
 
 /* SELECT count(*) FROM t1 WHERE x=5 */
 let result = count(from row in t1
-  where row.x == 5
+  where row["x"] == 5
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case7.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case7.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 113
 # EVIDENCE-OF: R-40472-60438 Columns that do not appear in the list of
 # assignments are left unmodified.
 */
@@ -20,7 +21,7 @@ let t1 = [
 
 /* SELECT count(*) FROM t1 WHERE y='unknown' */
 let result = count(from row in t1
-  where row.y == "unknown"
+  where row["y"] == "unknown"
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case8.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case8.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 121
 UPDATE t1 SET x=2
 */
 
@@ -21,14 +22,14 @@ var t1 = [
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  row.x = 2
+  row["x"] = 2
   t1[i] = row
   i = i + 1
 }
 
 /* SELECT count(*) FROM t1 WHERE y='unknown' */
 let result = count(from row in t1
-  where row.y == "unknown"
+  where row["y"] == "unknown"
   select row)
 print(result)
 

--- a/tests/dataset/slt/out/evidence/slt_lang_update/case9.mochi
+++ b/tests/dataset/slt/out/evidence/slt_lang_update/case9.mochi
@@ -1,4 +1,5 @@
 /*
+# line: 135
 # EVIDENCE-OF: R-36239-04077 The scalar expressions may refer to columns
 # of the row being updated.
 # EVIDENCE-OF: R-04558-24451 In this case all scalar expressions are
@@ -25,14 +26,14 @@ var t1 = [
 var i = 0
 while i < len(t1) {
   var row = t1[i]
-  row.x = row.x + 2
+  row["x"] = row["x"] + 2
   t1[i] = row
   i = i + 1
 }
 
 /* SELECT count(*) FROM t1 WHERE x=4 */
 let result = count(from row in t1
-  where row.x == 4
+  where row["x"] == 4
   select row)
 print(result)
 

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -282,8 +282,11 @@ func Generate(c Case) string {
 	}
 	var sb strings.Builder
 
-	if len(c.Comments) > 0 {
+	if len(c.Comments) > 0 || c.Line > 0 {
 		sb.WriteString("/*\n")
+		if c.Line > 0 {
+			sb.WriteString(fmt.Sprintf("# line: %d\n", c.Line))
+		}
 		for _, line := range c.Comments {
 			sb.WriteString(line + "\n")
 		}


### PR DESCRIPTION
## Summary
- include line numbers from `.test` files in parsed cases
- emit those numbers as `# line` comments in generated Mochi code
- regenerate `slt_lang_update` Mochi tests to include source line comments

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6864ed96d6e88320b44b7488620f5e9e