### PR TITLE
Fix TPC‑DS q90‑99 datasets

### DIFF
--- a/tests/dataset/tpc-ds/q93.mochi
+++ b/tests/dataset/tpc-ds/q93.mochi
@@ -27,12 +27,14 @@ let t =
 let result =
   from x in t
   group by x.ss_customer_sk into g
+  sort by [sum(from y in g select y.act_sales), g.key]
   select {ss_customer_sk: g.key, sumsales: sum(from y in g select y.act_sales)}
 
 json(result)
 
 test "TPCDS Q93 active sales" {
   expect result == [
-    {ss_customer_sk: 1, sumsales: 40.0}
+    {ss_customer_sk: 1, sumsales: 40.0},
+    {ss_customer_sk: 2, sumsales: 60.0}
   ]
 }

--- a/tests/dataset/tpc-ds/q94.mochi
+++ b/tests/dataset/tpc-ds/q94.mochi
@@ -7,7 +7,8 @@ type WebSite { web_site_sk: int, web_company_name: string }
 
 let web_sales = [
   {ws_order_number: 1, ws_ship_date_sk: 1, ws_warehouse_sk: 1, ws_ship_addr_sk: 1, ws_web_site_sk: 1, ws_net_profit: 5.0, ws_ext_ship_cost: 2.0},
-  {ws_order_number: 2, ws_ship_date_sk: 1, ws_warehouse_sk: 2, ws_ship_addr_sk: 1, ws_web_site_sk: 1, ws_net_profit: 3.0, ws_ext_ship_cost: 1.0}
+  {ws_order_number: 1, ws_ship_date_sk: 1, ws_warehouse_sk: 2, ws_ship_addr_sk: 1, ws_web_site_sk: 1, ws_net_profit: 0.0, ws_ext_ship_cost: 0.0},
+  {ws_order_number: 2, ws_ship_date_sk: 1, ws_warehouse_sk: 3, ws_ship_addr_sk: 1, ws_web_site_sk: 1, ws_net_profit: 3.0, ws_ext_ship_cost: 1.0}
 ]
 
 let web_returns = [{wr_order_number: 2}]
@@ -31,6 +32,10 @@ let filtered =
   join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
   join w in web_site on ws.ws_web_site_sk == w.web_site_sk
   where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+        exists(from ws2 in web_sales
+               where ws.ws_order_number == ws2.ws_order_number &&
+                     ws.ws_warehouse_sk != ws2.ws_warehouse_sk
+               select ws2) &&
         exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr) == false
   select ws
 

--- a/tests/dataset/tpc-ds/q98.mochi
+++ b/tests/dataset/tpc-ds/q98.mochi
@@ -37,6 +37,7 @@ let totals =
 let result =
   from g in grouped
   join t in totals on g.i_class == t.class
+  sort by [g.i_category, g.i_class, g.i_item_id]
   select {
     i_item_id: g.i_item_id,
     i_item_desc: g.i_item_desc,


### PR DESCRIPTION
## Summary
- fix q93 to return both customers and sort by total sales
- update q94 dataset and query to require multiple warehouses
- sort q98 results by category, class and item id

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6864ef0a9eac832095bdc09bc95e51e7