### PR TITLE
Add Pascal update statement support

### DIFF
--- a/compile/x/pas/README.md
+++ b/compile/x/pas/README.md
@@ -150,6 +150,7 @@ constructs:
  - Built-in string helpers `substr` and `reverse`
  - Dataset queries with `from`/`where`/`select`, joins, sorting and pagination
  - Simple `group by` queries without filters or joins
+ - Dataset updates using `update` with `set`/`where`
 - Package declarations and importing of local packages
 
 ## Unsupported features

--- a/compile/x/pas/helpers.go
+++ b/compile/x/pas/helpers.go
@@ -395,3 +395,25 @@ func selectorName(e *parser.Expr) (string, bool) {
 	}
 	return post.Target.Selector.Root, true
 }
+
+// stringKey returns the literal or selector name if e is a simple map key.
+func stringKey(e *parser.Expr) (string, bool) {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if p == nil || len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return *p.Target.Lit.Str, true
+	}
+	return "", false
+}

--- a/tests/compiler/pas/update_statement.mochi
+++ b/tests/compiler/pas/update_statement.mochi
@@ -1,0 +1,32 @@
+// Define the data schema
+type Person {
+  name: string
+  age: int
+  status: string
+}
+
+// Inline dataset
+let people: list<Person> = [
+  Person { name: "Alice", age: 17, status: "minor" },
+  Person { name: "Bob", age: 25, status: "unknown" },
+  Person { name: "Charlie", age: 18, status: "unknown" },
+  Person { name: "Diana", age: 16, status: "minor" }
+]
+
+// Apply update to people age >= 18
+update people
+set {
+  status: "adult",
+  age: age + 1
+}
+where age >= 18
+
+// Inline test
+test "update adult status" {
+  expect people == [
+    Person { name: "Alice", age: 17, status: "minor" },
+    Person { name: "Bob", age: 26, status: "adult" },
+    Person { name: "Charlie", age: 19, status: "adult" },
+    Person { name: "Diana", age: 16, status: "minor" }
+  ]
+}

--- a/tests/compiler/pas/update_statement.pas.out
+++ b/tests/compiler/pas/update_statement.pas.out
@@ -1,0 +1,69 @@
+program main;
+{$mode objfpc}
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, fpjsonrtti, jsonparser, Math;
+
+type
+  generic TArray<T> = array of T;
+type Person = record
+  name: string;
+  age: integer;
+  status: string;
+end;
+
+var
+  _tmp0: Person;
+  _tmp1: Person;
+  _tmp2: Person;
+  _tmp3: Person;
+  _tmp4: integer;
+  _tmp5: Person;
+  people: specialize TArray<Person>;
+
+procedure test_update_adult_status;
+var
+  _tmp6: Person;
+  _tmp7: Person;
+  _tmp8: Person;
+  _tmp9: Person;
+begin
+  _tmp6.name := 'Alice';
+  _tmp6.age := 17;
+  _tmp6.status := 'minor';
+  _tmp7.name := 'Bob';
+  _tmp7.age := 26;
+  _tmp7.status := 'adult';
+  _tmp8.name := 'Charlie';
+  _tmp8.age := 19;
+  _tmp8.status := 'adult';
+  _tmp9.name := 'Diana';
+  _tmp9.age := 16;
+  _tmp9.status := 'minor';
+  if not ((people = specialize TArray<Person>([_tmp6, _tmp7, _tmp8, _tmp9]))) then raise Exception.Create('expect failed');
+end;
+
+begin
+  _tmp0.name := 'Alice';
+  _tmp0.age := 17;
+  _tmp0.status := 'minor';
+  _tmp1.name := 'Bob';
+  _tmp1.age := 25;
+  _tmp1.status := 'unknown';
+  _tmp2.name := 'Charlie';
+  _tmp2.age := 18;
+  _tmp2.status := 'unknown';
+  _tmp3.name := 'Diana';
+  _tmp3.age := 16;
+  _tmp3.status := 'minor';
+  people := specialize TArray<Person>([_tmp0, _tmp1, _tmp2, _tmp3]);
+  for _tmp4 := 0 to High(people) do
+  begin
+    _tmp5 := people[_tmp4];
+    if (_tmp5.age >= 18) then
+    begin
+      _tmp5.status := 'adult';
+      _tmp5.age := _tmp5.age + 1;
+    end;
+    people[_tmp4] := _tmp5;
+  end;
+  test_update_adult_status;
+end.


### PR DESCRIPTION
## Summary
- extend Pascal compiler with `update` statement handling
- map struct field references during updates
- mention dataset updates in the Pascal backend README
- add compiler golden test for `update_statement.mochi`

## Testing
- `go test ./...`
- `go test -tags slow ./compile/x/pas -run TestPascalCompiler_GoldenOutput -update`

------
https://chatgpt.com/codex/tasks/task_e_6864ef89d3e083208f7fb6fd48473702