### PR TITLE
Add update statement support for Erlang backend

### DIFF
--- a/tests/compiler/erl/update_statement.erl.out
+++ b/tests/compiler/erl/update_statement.erl.out
@@ -1,0 +1,33 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1]).
+
+-record(person, {name, age, status}).
+
+
+main(_) ->
+    People = [#person{name="Alice", age=17, status="minor"}, #person{name="Bob", age=25, status="unknown"}, #person{name="Charlie", age=18, status="unknown"}, #person{name="Diana", age=16, status="minor"}],
+    People_1 = [ (case (Item#person.age >= 18) of true -> Item#person{status="adult", age=(Item#person.age + 1)}; _ -> Item end) || Item <- People ]
+,
+    mochi_run_test("update adult status", fun() ->
+        mochi_expect((People_1 == [#person{name="Alice", age=17, status="minor"}, #person{name="Bob", age=26, status="adult"}, #person{name="Charlie", age=19, status="adult"}, #person{name="Diana", age=16, status="minor"}]))
+    end).
+
+
+mochi_expect(true) -> ok;
+mochi_expect(_) -> erlang:error(expect_failed).
+
+mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
+mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
+mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
+
+mochi_run_test(Name, Fun) ->
+    mochi_test_start(Name),
+    Start = erlang:monotonic_time(millisecond),
+    try Fun() of _ ->
+        Duration = erlang:monotonic_time(millisecond) - Start,
+        mochi_test_pass(Duration)
+    catch C:R ->
+        Duration = erlang:monotonic_time(millisecond) - Start,
+        mochi_test_fail({C,R}, Duration)
+    end.

--- a/tests/compiler/erl/update_statement.mochi
+++ b/tests/compiler/erl/update_statement.mochi
@@ -1,0 +1,32 @@
+// Define the data schema
+type Person {
+  name: string
+  age: int
+  status: string
+}
+
+// Inline dataset
+let people: list<Person> = [
+  Person { name: "Alice", age: 17, status: "minor" },
+  Person { name: "Bob", age: 25, status: "unknown" },
+  Person { name: "Charlie", age: 18, status: "unknown" },
+  Person { name: "Diana", age: 16, status: "minor" }
+]
+
+// Apply update to people age >= 18
+update people
+set {
+  status: "adult",
+  age: age + 1
+}
+where age >= 18
+
+// Inline test
+test "update adult status" {
+  expect people == [
+    Person { name: "Alice", age: 17, status: "minor" },
+    Person { name: "Bob", age: 26, status: "adult" },
+    Person { name: "Charlie", age: 19, status: "adult" },
+    Person { name: "Diana", age: 16, status: "minor" }
+  ]
+}


### PR DESCRIPTION
## Summary
- support `update` statements in Erlang compiler
- add golden tests for `update_statement.mochi`

## Testing
- `go test ./compile/x/erlang -tags slow -run GoldenOutput -update -count=1` *(fails: unable to locate package erlfmt)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6864ef76d16c832092638cae185e5775