### PR TITLE
Add Scheme update statement support

### DIFF
--- a/compile/x/scheme/compiler.go
+++ b/compile/x/scheme/compiler.go
@@ -691,6 +691,8 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		return c.compileBreak()
 	case s.Continue != nil:
 		return c.compileContinue()
+	case s.Update != nil:
+		return c.compileUpdate(s.Update)
 	case s.Expect != nil:
 		return c.compileExpect(s.Expect)
 	default:

--- a/compile/x/scheme/update.go
+++ b/compile/x/scheme/update.go
@@ -1,0 +1,97 @@
+package schemecode
+
+import (
+	"fmt"
+	"sort"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+func (c *Compiler) compileUpdate(u *parser.UpdateStmt) error {
+	name := sanitizeName(u.Target)
+	idx := sanitizeName(name + "_idx")
+	c.writeln(fmt.Sprintf("(let loop ((%s 0))", idx))
+	c.indent++
+	c.writeln(fmt.Sprintf("(if (< %s (length %s))", idx, name))
+	c.indent++
+	c.writeln("(begin")
+	c.indent++
+	c.writeln(fmt.Sprintf("(let ((item (list-ref %s %s)))", name, idx))
+	c.indent++
+
+	// load struct fields if known
+	var fields []string
+	if c.env != nil {
+		if typ, err := c.env.GetVar(u.Target); err == nil {
+			if lt, ok := typ.(types.ListType); ok {
+				if st, ok := lt.Elem.(types.StructType); ok {
+					fields = st.Order
+					if len(fields) == 0 {
+						for fname := range st.Fields {
+							fields = append(fields, fname)
+						}
+						sort.Strings(fields)
+					}
+				}
+			}
+		}
+	}
+	if len(fields) > 0 {
+		c.writeln("(let (")
+		c.indent++
+		for _, f := range fields {
+			c.writeln(fmt.Sprintf("(%s (map-get item '%s))", sanitizeName(f), sanitizeName(f)))
+		}
+		c.indent--
+		c.writeln(")")
+		c.indent++
+	}
+
+	if u.Where != nil {
+		cond, err := c.compileExpr(u.Where)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("(when %s", cond))
+		c.indent++
+		for _, it := range u.Set.Items {
+			key, _ := identName(it.Key)
+			val, err := c.compileExpr(it.Value)
+			if err != nil {
+				return err
+			}
+			c.needMapHelpers = true
+			c.writeln(fmt.Sprintf("(set! item (map-set item '%s %s))", sanitizeName(key), val))
+		}
+		c.indent--
+		c.writeln(")")
+	} else {
+		for _, it := range u.Set.Items {
+			key, _ := identName(it.Key)
+			val, err := c.compileExpr(it.Value)
+			if err != nil {
+				return err
+			}
+			c.needMapHelpers = true
+			c.writeln(fmt.Sprintf("(set! item (map-set item '%s %s))", sanitizeName(key), val))
+		}
+	}
+
+	if len(fields) > 0 {
+		c.indent--
+		c.writeln(")")
+	}
+
+	c.writeln(fmt.Sprintf("(set! %s (list-set %s %s item))", name, name, idx))
+	c.writeln(fmt.Sprintf("(loop (+ %s 1))", idx))
+	c.indent--
+	c.writeln(")")
+	c.indent--
+	c.writeln("'()")
+	c.indent--
+	c.writeln(")")
+	c.indent--
+	c.writeln(")")
+	return nil
+}

--- a/compile/x/scheme/util.go
+++ b/compile/x/scheme/util.go
@@ -49,3 +49,21 @@ func simpleStringKey(e *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+func identName(e *parser.Expr) (string, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
+}

--- a/tests/compiler/scheme/update_stmt.mochi
+++ b/tests/compiler/scheme/update_stmt.mochi
@@ -1,0 +1,32 @@
+// Define the data schema
+type Person {
+  name: string
+  age: int
+  status: string
+}
+
+// Inline dataset
+let people: list<Person> = [
+  Person { name: "Alice", age: 17, status: "minor" },
+  Person { name: "Bob", age: 25, status: "unknown" },
+  Person { name: "Charlie", age: 18, status: "unknown" },
+  Person { name: "Diana", age: 16, status: "minor" }
+]
+
+// Apply update to people age >= 18
+update people
+set {
+  status: "adult",
+  age: age + 1
+}
+where age >= 18
+
+// Inline test
+test "update adult status" {
+  expect people == [
+    Person { name: "Alice", age: 17, status: "minor" },
+    Person { name: "Bob", age: 26, status: "adult" },
+    Person { name: "Charlie", age: 19, status: "adult" },
+    Person { name: "Diana", age: 16, status: "minor" }
+  ]
+}

--- a/tests/compiler/scheme/update_stmt.out
+++ b/tests/compiler/scheme/update_stmt.out
@@ -1,0 +1,1 @@
+   test update adult status ... ok

--- a/tests/compiler/scheme/update_stmt.scm.out
+++ b/tests/compiler/scheme/update_stmt.scm.out
@@ -1,0 +1,66 @@
+(define (map-get m k)
+    (let ((p (assoc k m)))
+        (if p (cdr p) '())))
+(define (map-set m k v)
+    (let ((p (assoc k m)))
+        (if p
+            (begin (set-cdr! p v) m)
+            (cons (cons k v) m))))
+
+(define (list-set lst idx val)
+    (let loop ((i idx) (l lst))
+        (if (null? l)
+            '()
+            (if (= i 0)
+                (cons val (cdr l))
+                (cons (car l) (loop (- i 1) (cdr l)))))))
+
+(define failures 0)
+(define (print-test-start name)
+  (display "   test ") (display name) (display " ..."))
+(define (print-test-pass) (display " ok") (newline))
+(define (print-test-fail err) (display " fail ") (display err) (newline))
+(define (run-test name thunk)
+  (print-test-start name)
+  (let ((ok #t))
+    (with-exception-handler
+      (lambda (e)
+        (set! ok #f)
+        (set! failures (+ failures 1))
+        (print-test-fail e))
+      (lambda () (thunk)))
+    (when ok (print-test-pass))))
+
+(define (new-Person name age status)
+  (list (cons 'name name) (cons 'age age) (cons 'status status)))
+
+(define people
+  (list
+    (list (cons 'name "Alice") (cons 'age 17) (cons 'status "minor"))
+    (list (cons 'name "Bob") (cons 'age 25) (cons 'status "unknown"))
+    (list (cons 'name "Charlie") (cons 'age 18) (cons 'status "unknown"))
+    (list (cons 'name "Diana") (cons 'age 16) (cons 'status "minor"))))
+
+(let loop ((people_idx 0))
+  (if (< people_idx (length people))
+      (begin
+        (let ((item (list-ref people people_idx)))
+          (let ((name (map-get item 'name))
+                (age (map-get item 'age))
+                (status (map-get item 'status)))
+            (when (>= age 18)
+              (set! item (map-set item 'status "adult"))
+              (set! item (map-set item 'age (+ age 1)))))
+          (set! people (list-set people people_idx item))
+          (loop (+ people_idx 1))))
+      '()))
+(define (test_update_adult_status)
+  (when (not (equal? people
+     (list
+       (list (cons 'name "Alice") (cons 'age 17) (cons 'status "minor"))
+       (list (cons 'name "Bob") (cons 'age 26) (cons 'status "adult"))
+       (list (cons 'name "Charlie") (cons 'age 19) (cons 'status "adult"))
+       (list (cons 'name "Diana") (cons 'age 16) (cons 'status "minor")))))
+    (error "expect failed")))
+(run-test "update adult status" test_update_adult_status)
+(when (> failures 0) (display "\n[FAIL] ") (display failures) (display " test(s) failed.\n"))


### PR DESCRIPTION
## Summary
- implement update statement compilation for Scheme backend
- create Scheme golden test for update_statement

## Testing
- `chibi-scheme -m chibi tests/compiler/scheme/update_stmt.scm.out`

------
https://chatgpt.com/codex/tasks/task_e_6864ef90d1708320992f530d5c7e782f