### PR TITLE
Add F# update statement support

### DIFF
--- a/tests/compiler/fs/update_statement.fs.out
+++ b/tests/compiler/fs/update_statement.fs.out
@@ -1,0 +1,37 @@
+open System
+
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+type Person =
+    {
+        name: string;
+        age: int;
+        status: string
+    }
+
+let people: Person[] = [|{ name = "Alice"; age = 17; status = "minor" }; { name = "Bob"; age = 25; status = "unknown" }; { name = "Charlie"; age = 18; status = "unknown" }; { name = "Diana"; age = 16; status = "minor" }|]
+for i = 0 to people.Length - 1 do
+    let mutable item = people.[i]
+    let name = item.name
+    let age = item.age
+    let status = item.status
+    if (age >= 18) then
+        item <- { item with status = "adult"; age = (age + 1) }
+    people.[i] <- item
+let test_update_adult_status() =
+    if not ((people = [|{ name = "Alice"; age = 17; status = "minor" }; { name = "Bob"; age = 26; status = "adult" }; { name = "Charlie"; age = 19; status = "adult" }; { name = "Diana"; age = 16; status = "minor" }|])) then failwith "expect failed"
+
+ignore (printfn "%A" ("ok"))
+let mutable failures = 0
+if not (_run_test "update adult status" test_update_adult_status) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures
+

--- a/tests/compiler/fs/update_statement.mochi
+++ b/tests/compiler/fs/update_statement.mochi
@@ -1,0 +1,29 @@
+type Person {
+  name: string
+  age: int
+  status: string
+}
+
+let people: list<Person> = [
+  Person { name: "Alice", age: 17, status: "minor" },
+  Person { name: "Bob", age: 25, status: "unknown" },
+  Person { name: "Charlie", age: 18, status: "unknown" },
+  Person { name: "Diana", age: 16, status: "minor" }
+]
+
+update people
+set {
+  status: "adult",
+  age: age + 1
+}
+where age >= 18
+
+test "update adult status" {
+  expect people == [
+    Person { name: "Alice", age: 17, status: "minor" },
+    Person { name: "Bob", age: 26, status: "adult" },
+    Person { name: "Charlie", age: 19, status: "adult" },
+    Person { name: "Diana", age: 16, status: "minor" }
+  ]
+}
+print("ok")

--- a/tests/compiler/fs/update_statement.out
+++ b/tests/compiler/fs/update_statement.out
@@ -1,0 +1,2 @@
+"ok"
+update adult status ... PASS


### PR DESCRIPTION
## Summary
- implement compileUpdate in F# backend
- skip duplicate type declarations
- add update_statement compiler test

## Testing
- `go test ./compile/x/fs -tags slow -run TestFSCompiler_GoldenOutput/update_statement -count=1`
- `go test ./compile/x/fs -tags slow -run TestFSCompiler_SubsetPrograms/update_statement -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6864ef7847008320bdcb49f8452f5950