### PR TITLE
Add update statement support to Go compiler

### DIFF
--- a/tests/compiler/go/update_statement.go.out
+++ b/tests/compiler/go/update_statement.go.out
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+type Person struct {
+	Name   string `json:"name"`
+	Age    int    `json:"age"`
+	Status string `json:"status"`
+}
+
+func test_update_adult_status() {
+	expect(_equal(people, []Person{
+		Person{Name: "Alice", Age: 17, Status: "minor"},
+		Person{Name: "Bob", Age: 26, Status: "adult"},
+		Person{Name: "Charlie", Age: 19, Status: "adult"},
+		Person{Name: "Diana", Age: 16, Status: "minor"},
+	}))
+}
+
+var people []Person
+
+func main() {
+	failures := 0
+	people = []Person{
+		Person{Name: "Alice", Age: 17, Status: "minor"},
+		Person{Name: "Bob", Age: 25, Status: "unknown"},
+		Person{Name: "Charlie", Age: 18, Status: "unknown"},
+		Person{Name: "Diana", Age: 16, Status: "minor"},
+	}
+	for _tmp0, _tmp1 := range people {
+		age := _tmp1.Age
+		if !(age >= 18) {
+			continue
+		}
+		_tmp1.Status = "adult"
+		_tmp1.Age = (age + 1)
+		people[_tmp0] = _tmp1
+	}
+	{
+		printTestStart("update adult status")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_update_adult_status()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}

--- a/tests/compiler/go/update_statement.mochi
+++ b/tests/compiler/go/update_statement.mochi
@@ -1,0 +1,28 @@
+type Person {
+  name: string
+  age: int
+  status: string
+}
+
+let people: list<Person> = [
+  Person { name: "Alice", age: 17, status: "minor" },
+  Person { name: "Bob", age: 25, status: "unknown" },
+  Person { name: "Charlie", age: 18, status: "unknown" },
+  Person { name: "Diana", age: 16, status: "minor" }
+]
+
+update people
+set {
+  status: "adult",
+  age: age + 1
+}
+where age >= 18
+
+test "update adult status" {
+  expect people == [
+    Person { name: "Alice", age: 17, status: "minor" },
+    Person { name: "Bob", age: 26, status: "adult" },
+    Person { name: "Charlie", age: 19, status: "adult" },
+    Person { name: "Diana", age: 16, status: "minor" }
+  ]
+}

--- a/tests/compiler/go/update_statement.out
+++ b/tests/compiler/go/update_statement.out
@@ -1,0 +1,1 @@
+test update adult status            ... ok (X)


### PR DESCRIPTION
## Summary
- support `update` statements in the Go compiler
- create golden test `update_statement.mochi`

## Testing
- `go test -tags=slow ./compile/go -run TestGoCompiler_SubsetPrograms/update_statement -v`

------
https://chatgpt.com/codex/tasks/task_e_6864ef6400fc8320be451aa72335bde1