### PR TITLE
Add typed Mochi output for SLT generator

### DIFF
--- a/tests/dataset/slt/out/select1/case1.mochi
+++ b/tests/dataset/slt/out/select1/case1.mochi
@@ -33,211 +33,219 @@ INSERT INTO t1(e,c,b,a,d) VALUES(242,244,240,243,241)
 INSERT INTO t1(e,d,c,b,a) VALUES(246,248,247,249,245)
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -249,8 +257,8 @@ let t1 = [
 /* SELECT CASE WHEN c>(SELECT avg(c) FROM t1) THEN a*2 ELSE b*10 END FROM t1 ORDER BY 1 */
 let result = from row in t1
   order by 1
-  select (row["c"] > avg(from x in t1
-  select x["c"]) ? row["a"] * 2 : row["b"] * 10)
+  select (row.c > avg(from x in t1
+  select x.c) ? row.a * 2 : row.b * 10)
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case2.mochi
+++ b/tests/dataset/slt/out/select1/case2.mochi
@@ -2,211 +2,219 @@
 # line: 101
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,8 +225,8 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4+e*5, (a+b+c+d+e)/5 FROM t1 ORDER BY 1,2 */
 let result = from row in t1
-  order by row["a"] + row["b"] * 2 + row["c"] * 3 + row["d"] * 4 + row["e"] * 5, (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5
-  select [row["a"] + row["b"] * 2 + row["c"] * 3 + row["d"] * 4 + row["e"] * 5, (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5]
+  order by row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (row.a + row.b + row.c + row.d + row.e) / 5
+  select [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (row.a + row.b + row.c + row.d + row.e) / 5]
 let flatResult = from row in result
   from x in row
   select x

--- a/tests/dataset/slt/out/select1/case3.mochi
+++ b/tests/dataset/slt/out/select1/case3.mochi
@@ -2,211 +2,219 @@
 # line: 109
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,11 +225,11 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4+e*5, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, abs(b-c), (a+b+c+d+e)/5, a+b*2+c*3 FROM t1 WHERE (e>c OR e<d) AND d>e AND EXISTS(SELECT 1 FROM t1 AS x WHERE x.b<t1.b) ORDER BY 4,2,1,3,5 */
 let result = from row in t1
-  where ((((row["e"] > row["c"] || row["e"] < row["d"])) && row["d"] > row["e"]) && count(from x in t1
-  where x["b"] < row["b"]
+  where ((((row.e > row.c || row.e < row.d)) && row.d > row.e) && count(from x in t1
+  where x.b < row.b
   select x) > 0)
-  order by (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, (row["a"] < row["b"] - 3 ? 111 : (row["a"] <= row["b"] ? 222 : (row["a"] < row["b"] + 3 ? 333 : 444))), row["a"] + row["b"] * 2 + row["c"] * 3 + row["d"] * 4 + row["e"] * 5, abs(row["b"] - row["c"]), row["a"] + row["b"] * 2 + row["c"] * 3
-  select [row["a"] + row["b"] * 2 + row["c"] * 3 + row["d"] * 4 + row["e"] * 5, (row["a"] < row["b"] - 3 ? 111 : (row["a"] <= row["b"] ? 222 : (row["a"] < row["b"] + 3 ? 333 : 444))), abs(row["b"] - row["c"]), (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, row["a"] + row["b"] * 2 + row["c"] * 3]
+  order by (row.a + row.b + row.c + row.d + row.e) / 5, (row.a < row.b - 3 ? 111 : (row.a <= row.b ? 222 : (row.a < row.b + 3 ? 333 : 444))), row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, abs(row.b - row.c), row.a + row.b * 2 + row.c * 3
+  select [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (row.a < row.b - 3 ? 111 : (row.a <= row.b ? 222 : (row.a < row.b + 3 ? 333 : 444))), abs(row.b - row.c), (row.a + row.b + row.c + row.d + row.e) / 5, row.a + row.b * 2 + row.c * 3]
 let flatResult = from row in result
   from x in row
   select x


### PR DESCRIPTION
## Summary
- update SLT generator to emit typed record definitions
- update generated SLT samples to use field access instead of map indexing

## Testing
- `go build ./cmd/mochi-slt`

------
https://chatgpt.com/codex/tasks/task_e_6864ffc507348320a39b4c9c040b964b