### PR TITLE
Fix CASE translation in SLT generator

### DIFF
--- a/tests/dataset/slt/out/select1/case1.mochi
+++ b/tests/dataset/slt/out/select1/case1.mochi
@@ -256,9 +256,10 @@ let t1 = [
 
 /* SELECT CASE WHEN c>(SELECT avg(c) FROM t1) THEN a*2 ELSE b*10 END FROM t1 ORDER BY 1 */
 let result = from row in t1
-  order by 1
-  select (row.c > avg(from x in t1
-  select x.c) ? row.a * 2 : row.b * 10)
+  order by (if row.c > avg(from x in t1
+  select x.c) { row.a * 2 } else { row.b * 10 })
+  select (if row.c > avg(from x in t1
+  select x.c) { row.a * 2 } else { row.b * 10 })
 for x in result {
   print(x)
 }

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -166,7 +166,7 @@ func exprToMochiRow(e sqlparser.Expr, rowVar, outer string) string {
 			for i := len(v.Whens) - 1; i >= 0; i-- {
 				cond := fmt.Sprintf("%s == %s", expr, exprToMochiRow(v.Whens[i].Cond, rowVar, outer))
 				val := exprToMochiRow(v.Whens[i].Val, rowVar, outer)
-				out = fmt.Sprintf("(%s ? %s : %s)", cond, val, out)
+				out = fmt.Sprintf("(if %s { %s } else { %s })", cond, val, out)
 			}
 		} else {
 			for i := len(v.Whens) - 1; i >= 0; i-- {
@@ -175,7 +175,7 @@ func exprToMochiRow(e sqlparser.Expr, rowVar, outer string) string {
 				if cond == "" {
 					return "null"
 				}
-				out = fmt.Sprintf("(%s ? %s : %s)", cond, val, out)
+				out = fmt.Sprintf("(if %s { %s } else { %s })", cond, val, out)
 			}
 		}
 		return out
@@ -433,7 +433,7 @@ func Generate(c Case) string {
 			sb.WriteString("\n  where " + cond)
 		}
 		if len(sel.OrderBy) == 1 {
-			sb.WriteString("\n  order by " + exprToMochi(sel.OrderBy[0].Expr))
+			sb.WriteString("\n  order by " + orderExprToMochi(sel.OrderBy[0].Expr, []*sqlparser.AliasedExpr{ae}))
 		}
 		sb.WriteString("\n  select " + expr + "\n")
 		sb.WriteString("for x in result {\n  print(x)\n}\n\n")


### PR DESCRIPTION
## Summary
- convert SQL CASE expressions to `if` blocks
- handle `ORDER BY 1` for single column selects
- update generated example for select1 test

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/dataset/slt/out/select1/case1.mochi > /tmp/case1_run.out && tail -n 5 /tmp/case1_run.out`

------
https://chatgpt.com/codex/tasks/task_e_6865034d83a88320b57d802377fd15c8