### PR TITLE
Add Streamlit CSV explorer with tests

### DIFF
--- a/python_app/app.py
+++ b/python_app/app.py
@@ -1,0 +1,74 @@
+import os
+import pandas as pd
+import streamlit as st
+import openai
+
+
+def load_csv(file) -> pd.DataFrame:
+    """Load a CSV file into a pandas DataFrame."""
+    return pd.read_csv(file)
+
+
+def ask_question(df: pd.DataFrame, question: str) -> str:
+    """Use OpenAI to answer a question about the DataFrame."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return "OPENAI_API_KEY not set"
+    openai.api_key = api_key
+    sample = df.head(20).to_csv(index=False)
+    prompt = (
+        "You are a data analyst. Given the following CSV data:\n" + sample +
+        f"\nAnswer the following question about this data:\n{question}"
+    )
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception as e:
+        return f"Error from OpenAI: {e}"
+
+
+def main():
+    st.title("CSV Explorer")
+
+    if "data_frames" not in st.session_state:
+        st.session_state["data_frames"] = {}
+
+    with st.form("upload_form"):
+        uploaded_file = st.file_uploader("Upload CSV", type="csv")
+        submitted = st.form_submit_button("Upload")
+        if submitted and uploaded_file:
+            df = load_csv(uploaded_file)
+            st.session_state["data_frames"][uploaded_file.name] = df
+
+    if not st.session_state["data_frames"]:
+        st.info("Upload one or more CSV files to get started.")
+        return
+
+    tabs = st.tabs(list(st.session_state["data_frames"].keys()))
+
+    for i, (name, df) in enumerate(st.session_state["data_frames"].items()):
+        with tabs[i]:
+            st.subheader(name)
+            st.dataframe(df)
+            key_prefix = name.replace(" ", "_")
+            chat_key = f"chat_{key_prefix}"
+            if chat_key not in st.session_state:
+                st.session_state[chat_key] = []
+
+            with st.form(f"chat_form_{key_prefix}"):
+                question = st.text_input("Ask a question about this data")
+                ask = st.form_submit_button("Ask")
+                if ask and question:
+                    answer = ask_question(df, question)
+                    st.session_state[chat_key].append(("You", question))
+                    st.session_state[chat_key].append(("Assistant", answer))
+
+            for speaker, text in st.session_state[chat_key]:
+                st.markdown(f"**{speaker}:** {text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python_app/requirements.txt
+++ b/python_app/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+openai

--- a/tests/python_app/test_app.py
+++ b/tests/python_app/test_app.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+import pandas as pd
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import python_app.app as app
+
+
+def test_load_csv(tmp_path):
+    csv_content = 'a,b\n1,2\n3,4\n'
+    file_path = tmp_path / 'data.csv'
+    file_path.write_text(csv_content)
+    with file_path.open('r') as f:
+        df = app.load_csv(f)
+    assert list(df.columns) == ['a', 'b']
+    assert df.iloc[0]['a'] == 1
+    assert df.iloc[1]['b'] == 4
+
+
+def test_ask_question(monkeypatch):
+    df = pd.DataFrame({'a': [1, 2]})
+    captured = {}
+
+    class DummyResp:
+        class Choice:
+            def __init__(self, content):
+                self.message = types.SimpleNamespace(content=content)
+        def __init__(self, content):
+            self.choices = [self.Choice(content)]
+
+    def fake_create(**kwargs):
+        captured['prompt'] = kwargs
+        return DummyResp('dummy answer')
+
+    monkeypatch.setenv('OPENAI_API_KEY', 'x')
+    monkeypatch.setattr(app.openai.ChatCompletion, 'create', fake_create)
+    answer = app.ask_question(df, 'What is a?')
+    assert 'dummy answer' == answer
+    assert 'messages' in captured['prompt']
+


### PR DESCRIPTION
## Summary
- add `python_app` with `app.py` for uploading CSVs and chat interface
- support multiple tabs for uploaded files and OpenAI querying
- include requirements file
- add tests for CSV loading and OpenAI integration

## Testing
- `pip install -q -r python_app/requirements.txt`
- `pytest -q tests/python_app/test_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68651144b7888320a8d494a6a7d87078