### PR TITLE
Fix SQLLogicTest generation

### DIFF
--- a/tests/dataset/slt/out/select1/case40.mochi
+++ b/tests/dataset/slt/out/select1/case40.mochi
@@ -2,211 +2,219 @@
 # line: 602
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,20 +225,21 @@ let t1 = [
 
 /* SELECT (a+b+c+d+e)/5, e, (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d) FROM t1 WHERE (e>c OR e<d) OR EXISTS(SELECT 1 FROM t1 AS x WHERE x.b<t1.b) ORDER BY 3,1,2 */
 let result = from row in t1
-  where (((row["e"] > row["c"] || row["e"] < row["d"])) || count(from x in t1
-  where x["b"] < row["b"]
+  where (((row.e > row.c || row.e < row.d)) || count(from x in t1
+  where x.b < row.b
   select x) > 0)
-  order by count(from x in t1
-  where (x["c"] > row["c"] && x["d"] < row["d"])
-  select x), (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, row["e"]
-  select [(row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, row["e"], count(from x in t1
-  where (x["c"] > row["c"] && x["d"] < row["d"])
+  order by [count(from x in t1
+  where (x.c > row.c && x.d < row.d)
+  select x), (row.a + row.b + row.c + row.d + row.e) / 5, row.e]
+  select [(row.a + row.b + row.c + row.d + row.e) / 5, row.e, count(from x in t1
+  where (x.c > row.c && x.d < row.d)
   select x)]
-let flatResult = from row in result
-  from x in row
-  select x
-for x in flatResult {
-  print(x)
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+    print(x)
+  }
 }
 
 test "case40" {

--- a/tests/dataset/slt/out/select1/case41.mochi
+++ b/tests/dataset/slt/out/select1/case41.mochi
@@ -2,211 +2,219 @@
 # line: 613
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,18 +225,19 @@ let t1 = [
 
 /* SELECT a-b, a+b*2, (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d), d-e FROM t1 WHERE d>e OR (e>a AND e<b) ORDER BY 4,1,3,2 */
 let result = from row in t1
-  where (row["d"] > row["e"] || ((row["e"] > row["a"] && row["e"] < row["b"])))
-  order by row["d"] - row["e"], row["a"] - row["b"], count(from x in t1
-  where (x["c"] > row["c"] && x["d"] < row["d"])
-  select x), row["a"] + row["b"] * 2
-  select [row["a"] - row["b"], row["a"] + row["b"] * 2, count(from x in t1
-  where (x["c"] > row["c"] && x["d"] < row["d"])
-  select x), row["d"] - row["e"]]
-let flatResult = from row in result
-  from x in row
-  select x
-for x in flatResult {
-  print(x)
+  where (row.d > row.e || ((row.e > row.a && row.e < row.b)))
+  order by [row.d - row.e, row.a - row.b, count(from x in t1
+  where (x.c > row.c && x.d < row.d)
+  select x), row.a + row.b * 2]
+  select [row.a - row.b, row.a + row.b * 2, count(from x in t1
+  where (x.c > row.c && x.d < row.d)
+  select x), row.d - row.e]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+    print(x)
+  }
 }
 
 test "case41" {

--- a/tests/dataset/slt/out/select1/case42.mochi
+++ b/tests/dataset/slt/out/select1/case42.mochi
@@ -2,211 +2,219 @@
 # line: 625
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,9 +225,9 @@ let t1 = [
 
 /* SELECT a+b*2 FROM t1 WHERE e+d BETWEEN a+b-10 AND c+130 OR a>b ORDER BY 1 */
 let result = from row in t1
-  where ((row["e"] + row["d"] >= row["a"] + row["b"] - 10 && row["e"] + row["d"] <= row["c"] + 130) || row["a"] > row["b"])
-  order by 1
-  select row["a"] + row["b"] * 2
+  where ((row.e + row.d >= row.a + row.b - 10 && row.e + row.d <= row.c + 130) || row.a > row.b)
+  order by row.a + row.b * 2
+  select row.a + row.b * 2
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case43.mochi
+++ b/tests/dataset/slt/out/select1/case43.mochi
@@ -1,5 +1,5 @@
 /*
-# line: 719
+# line: 634
 */
 
 type t1Row {
@@ -223,17 +223,21 @@ let t1 = [
   },
 ]
 
-/* SELECT d-e, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), abs(a), a+b*2+c*3+d*4 FROM t1 WHERE EXISTS(SELECT 1 FROM t1 AS x WHERE x.b<t1.b) OR c>d ORDER BY 2,3,4,1 */
+/* SELECT CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d), d-e, b, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), a+b*2 FROM t1 WHERE EXISTS(SELECT 1 FROM t1 AS x WHERE x.b<t1.b) OR (a>b-2 AND a<b+2) ORDER BY 2,6,3,5,4,1 */
 let result = from row in t1
   where (count(from x in t1
   where x.b < row.b
-  select x) > 0 || row.c > row.d)
+  select x) > 0 || ((row.a > row.b - 2 && row.a < row.b + 2)))
   order by [count(from x in t1
+  where (x.c > row.c && x.d < row.d)
+  select x), row.a + row.b * 2, row.d - row.e, count(from x in t1
   where x.b < row.b
-  select x), (if row.a < 0 { -row.a } else { row.a }), row.a + row.b * 2 + row.c * 3 + row.d * 4, row.d - row.e]
-  select [row.d - row.e, count(from x in t1
+  select x), row.b, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) })]
+  select [(if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), count(from x in t1
+  where (x.c > row.c && x.d < row.d)
+  select x), row.d - row.e, row.b, count(from x in t1
   where x.b < row.b
-  select x), (if row.a < 0 { -row.a } else { row.a }), row.a + row.b * 2 + row.c * 3 + row.d * 4]
+  select x), row.a + row.b * 2]
 var flatResult = []
 for row in result {
   for x in row {
@@ -242,6 +246,6 @@ for row in result {
   }
 }
 
-test "case49" {
-  expect flatResult == [4, 1, 107, 1079, -2, 2, 110, 1118, -3, 3, 116, 1165, -1, 4, 123, 1219, 1, 5, 127, 1274, 3, 6, 132, 1325, -2, 7, 138, 1367, -1, 8, 144, 1414, 1, 9, 145, 1473, 2, 10, 151, 1526, -2, 11, 155, 1570, 2, 12, 161, 1626, -1, 13, 167, 1669, -1, 14, 171, 1719, 3, 15, 177, 1778, -1, 16, 181, 1819, 4, 17, 187, 1877, 1, 18, 190, 1925, 1, 19, 199, 1971, -3, 20, 200, 2017, -1, 21, 208, 2065, 1, 22, 214, 2121, -2, 23, 218, 2164, -4, 24, 223, 2211, 4, 25, 226, 2280, -3, 26, 234, 2312, -3, 27, 237, 2366, 2, 28, 242, 2422, 4, 29, 246, 2479]
+test "case43" {
+  expect flatResult == [444, 0, -3, 102, 0, 307, 222, 0, 4, 106, 1, 319, 333, 0, -2, 114, 2, 338, 222, 0, -3, 119, 3, 354, 222, 0, -1, 122, 4, 367, 111, 0, 1, 128, 5, 383, 333, 0, 3, 134, 6, 400, 222, 0, -2, 136, 7, 410, 555, 0, -1, 141, 8, 426, 222, 0, 1, 149, 9, 443, 444, 0, 2, 150, 10, 451, 333, 0, -2, 157, 11, 469, 444, 0, 2, 160, 12, 481, 222, 0, -1, 169, 13, 505, 222, 0, -1, 170, 14, 511, 333, 0, 3, 176, 15, 529, 222, 0, -1, 180, 16, 541, 111, 0, 4, 188, 17, 563, 444, 0, 1, 194, 18, 578, 555, 0, 1, 197, 19, 593, 333, 0, -3, 202, 20, 604, 111, 0, -1, 209, 21, 626, 555, 0, 1, 210, 22, 634, 444, 0, -2, 215, 23, 648, 444, 0, -4, 221, 24, 665, 111, 0, 4, 227, 25, 680, 555, 0, -3, 231, 26, 696, 444, 0, -3, 236, 27, 709, 333, 0, 2, 244, 28, 730, 222, 0, 4, 248, 29, 742]
 }

--- a/tests/dataset/slt/out/select1/case44.mochi
+++ b/tests/dataset/slt/out/select1/case44.mochi
@@ -2,211 +2,219 @@
 # line: 649
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,14 +225,15 @@ let t1 = [
 
 /* SELECT a, c-d, d FROM t1 WHERE c>d AND a>b AND (a>b-2 AND a<b+2) ORDER BY 1,2,3 */
 let result = from row in t1
-  where ((row["c"] > row["d"] && row["a"] > row["b"]) && ((row["a"] > row["b"] - 2 && row["a"] < row["b"] + 2)))
-  order by row["a"], row["c"] - row["d"], row["d"]
-  select [row["a"], row["c"] - row["d"], row["d"]]
-let flatResult = from row in result
-  from x in row
-  select x
-for x in flatResult {
-  print(x)
+  where ((row.c > row.d && row.a > row.b) && ((row.a > row.b - 2 && row.a < row.b + 2)))
+  order by [row.a, row.c - row.d, row.d]
+  select [row.a, row.c - row.d, row.d]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+    print(x)
+  }
 }
 
 test "case44" {

--- a/tests/dataset/slt/out/select1/case45.mochi
+++ b/tests/dataset/slt/out/select1/case45.mochi
@@ -2,211 +2,219 @@
 # line: 666
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,13 +225,14 @@ let t1 = [
 
 /* SELECT a+b*2+c*3, a+b*2+c*3+d*4+e*5, c, (a+b+c+d+e)/5, b FROM t1 ORDER BY 5,4,1,3,2 */
 let result = from row in t1
-  order by row["b"], (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, row["a"] + row["b"] * 2 + row["c"] * 3, row["c"], row["a"] + row["b"] * 2 + row["c"] * 3 + row["d"] * 4 + row["e"] * 5
-  select [row["a"] + row["b"] * 2 + row["c"] * 3, row["a"] + row["b"] * 2 + row["c"] * 3 + row["d"] * 4 + row["e"] * 5, row["c"], (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, row["b"]]
-let flatResult = from row in result
-  from x in row
-  select x
-for x in flatResult {
-  print(x)
+  order by [row.b, (row.a + row.b + row.c + row.d + row.e) / 5, row.a + row.b * 2 + row.c * 3, row.c, row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5]
+  select [row.a + row.b * 2 + row.c * 3, row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, row.c, (row.a + row.b + row.c + row.d + row.e) / 5, row.b]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+    print(x)
+  }
 }
 
 test "case45" {

--- a/tests/dataset/slt/out/select1/case46.mochi
+++ b/tests/dataset/slt/out/select1/case46.mochi
@@ -2,211 +2,219 @@
 # line: 677
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -218,19 +226,20 @@ let t1 = [
 /* SELECT CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, c-d, abs(a), abs(b-c), (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d) FROM t1 WHERE EXISTS(SELECT 1 FROM t1 AS x WHERE x.b<t1.b) ORDER BY 1,5,3,2,4 */
 let result = from row in t1
   where count(from x in t1
-  where x["b"] < row["b"]
+  where x.b < row.b
   select x) > 0
-  order by (row["a"] < row["b"] - 3 ? 111 : (row["a"] <= row["b"] ? 222 : (row["a"] < row["b"] + 3 ? 333 : 444))), count(from x in t1
-  where (x["c"] > row["c"] && x["d"] < row["d"])
-  select x), abs(row["a"]), row["c"] - row["d"], abs(row["b"] - row["c"])
-  select [(row["a"] < row["b"] - 3 ? 111 : (row["a"] <= row["b"] ? 222 : (row["a"] < row["b"] + 3 ? 333 : 444))), row["c"] - row["d"], abs(row["a"]), abs(row["b"] - row["c"]), count(from x in t1
-  where (x["c"] > row["c"] && x["d"] < row["d"])
+  order by [(if row.a < row.b - 3 { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < row.b + 3 { 333 } else { 444 }) }) }), count(from x in t1
+  where (x.c > row.c && x.d < row.d)
+  select x), (if row.a < 0 { -row.a } else { row.a }), row.c - row.d, (if row.b - row.c < 0 { -row.b - row.c } else { row.b - row.c })]
+  select [(if row.a < row.b - 3 { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < row.b + 3 { 333 } else { 444 }) }) }), row.c - row.d, (if row.a < 0 { -row.a } else { row.a }), (if row.b - row.c < 0 { -row.b - row.c } else { row.b - row.c }), count(from x in t1
+  where (x.c > row.c && x.d < row.d)
   select x)]
-let flatResult = from row in result
-  from x in row
-  select x
-for x in flatResult {
-  print(x)
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+    print(x)
+  }
 }
 
 test "case46" {

--- a/tests/dataset/slt/out/select1/case47.mochi
+++ b/tests/dataset/slt/out/select1/case47.mochi
@@ -2,211 +2,219 @@
 # line: 690
 */
 
+type t1Row {
+  a: int
+  b: int
+  c: int
+  d: int
+  e: int
+}
+
 let t1 = [
-  {
+  t1Row {
     a: 103,
     b: 102,
     c: 100,
     d: 101,
     e: 104,
   },
-  {
+  t1Row {
     a: 107,
     b: 106,
     c: 108,
     d: 109,
     e: 105,
   },
-  {
+  t1Row {
     a: 110,
     b: 114,
     c: 112,
     d: 111,
     e: 113,
   },
-  {
+  t1Row {
     a: 116,
     b: 119,
     c: 117,
     d: 115,
     e: 118,
   },
-  {
+  t1Row {
     a: 123,
     b: 122,
     c: 124,
     d: 120,
     e: 121,
   },
-  {
+  t1Row {
     a: 127,
     b: 128,
     c: 129,
     d: 126,
     e: 125,
   },
-  {
+  t1Row {
     a: 132,
     b: 134,
     c: 131,
     d: 133,
     e: 130,
   },
-  {
+  t1Row {
     a: 138,
     b: 136,
     c: 139,
     d: 135,
     e: 137,
   },
-  {
+  t1Row {
     a: 144,
     b: 141,
     c: 140,
     d: 142,
     e: 143,
   },
-  {
+  t1Row {
     a: 145,
     b: 149,
     c: 146,
     d: 148,
     e: 147,
   },
-  {
+  t1Row {
     a: 151,
     b: 150,
     c: 153,
     d: 154,
     e: 152,
   },
-  {
+  t1Row {
     a: 155,
     b: 157,
     c: 159,
     d: 156,
     e: 158,
   },
-  {
+  t1Row {
     a: 161,
     b: 160,
     c: 163,
     d: 164,
     e: 162,
   },
-  {
+  t1Row {
     a: 167,
     b: 169,
     c: 168,
     d: 165,
     e: 166,
   },
-  {
+  t1Row {
     a: 171,
     b: 170,
     c: 172,
     d: 173,
     e: 174,
   },
-  {
+  t1Row {
     a: 177,
     b: 176,
     c: 179,
     d: 178,
     e: 175,
   },
-  {
+  t1Row {
     a: 181,
     b: 180,
     c: 182,
     d: 183,
     e: 184,
   },
-  {
+  t1Row {
     a: 187,
     b: 188,
     c: 186,
     d: 189,
     e: 185,
   },
-  {
+  t1Row {
     a: 190,
     b: 194,
     c: 193,
     d: 192,
     e: 191,
   },
-  {
+  t1Row {
     a: 199,
     b: 197,
     c: 198,
     d: 196,
     e: 195,
   },
-  {
+  t1Row {
     a: 200,
     b: 202,
     c: 203,
     d: 201,
     e: 204,
   },
-  {
+  t1Row {
     a: 208,
     b: 209,
     c: 205,
     d: 206,
     e: 207,
   },
-  {
+  t1Row {
     a: 214,
     b: 210,
     c: 213,
     d: 212,
     e: 211,
   },
-  {
+  t1Row {
     a: 218,
     b: 215,
     c: 216,
     d: 217,
     e: 219,
   },
-  {
+  t1Row {
     a: 223,
     b: 221,
     c: 222,
     d: 220,
     e: 224,
   },
-  {
+  t1Row {
     a: 226,
     b: 227,
     c: 228,
     d: 229,
     e: 225,
   },
-  {
+  t1Row {
     a: 234,
     b: 231,
     c: 232,
     d: 230,
     e: 233,
   },
-  {
+  t1Row {
     a: 237,
     b: 236,
     c: 239,
     d: 235,
     e: 238,
   },
-  {
+  t1Row {
     a: 242,
     b: 244,
     c: 240,
     d: 243,
     e: 241,
   },
-  {
+  t1Row {
     a: 246,
     b: 248,
     c: 247,
@@ -217,14 +225,15 @@ let t1 = [
 
 /* SELECT c, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, abs(a), (a+b+c+d+e)/5, a+b*2, d-e FROM t1 WHERE b>c AND (a>b-2 AND a<b+2) AND d NOT BETWEEN 110 AND 150 ORDER BY 4,5,3,1,2,6 */
 let result = from row in t1
-  where ((row["b"] > row["c"] && ((row["a"] > row["b"] - 2 && row["a"] < row["b"] + 2))) && (row["d"] < 110 || row["d"] > 150))
-  order by (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, row["a"] + row["b"] * 2, abs(row["a"]), row["c"], (row["a"] < row["b"] - 3 ? 111 : (row["a"] <= row["b"] ? 222 : (row["a"] < row["b"] + 3 ? 333 : 444))), row["d"] - row["e"]
-  select [row["c"], (row["a"] < row["b"] - 3 ? 111 : (row["a"] <= row["b"] ? 222 : (row["a"] < row["b"] + 3 ? 333 : 444))), abs(row["a"]), (row["a"] + row["b"] + row["c"] + row["d"] + row["e"]) / 5, row["a"] + row["b"] * 2, row["d"] - row["e"]]
-let flatResult = from row in result
-  from x in row
-  select x
-for x in flatResult {
-  print(x)
+  where ((row.b > row.c && ((row.a > row.b - 2 && row.a < row.b + 2))) && (row.d < 110 || row.d > 150))
+  order by [(row.a + row.b + row.c + row.d + row.e) / 5, row.a + row.b * 2, (if row.a < 0 { -row.a } else { row.a }), row.c, (if row.a < row.b - 3 { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < row.b + 3 { 333 } else { 444 }) }) }), row.d - row.e]
+  select [row.c, (if row.a < row.b - 3 { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < row.b + 3 { 333 } else { 444 }) }) }), (if row.a < 0 { -row.a } else { row.a }), (row.a + row.b + row.c + row.d + row.e) / 5, row.a + row.b * 2, row.d - row.e]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+    print(x)
+  }
 }
 
 test "case47" {

--- a/tests/dataset/slt/out/select1/case48.mochi
+++ b/tests/dataset/slt/out/select1/case48.mochi
@@ -1,5 +1,5 @@
 /*
-# line: 719
+# line: 706
 */
 
 type t1Row {
@@ -223,17 +223,13 @@ let t1 = [
   },
 ]
 
-/* SELECT d-e, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), abs(a), a+b*2+c*3+d*4 FROM t1 WHERE EXISTS(SELECT 1 FROM t1 AS x WHERE x.b<t1.b) OR c>d ORDER BY 2,3,4,1 */
+/* SELECT CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, CASE WHEN c>(SELECT avg(c) FROM t1) THEN a*2 ELSE b*10 END, a+b*2+c*3+d*4+e*5, d FROM t1 WHERE d>e OR (a>b-2 AND a<b+2) ORDER BY 3,2,4,1 */
 let result = from row in t1
-  where (count(from x in t1
-  where x.b < row.b
-  select x) > 0 || row.c > row.d)
-  order by [count(from x in t1
-  where x.b < row.b
-  select x), (if row.a < 0 { -row.a } else { row.a }), row.a + row.b * 2 + row.c * 3 + row.d * 4, row.d - row.e]
-  select [row.d - row.e, count(from x in t1
-  where x.b < row.b
-  select x), (if row.a < 0 { -row.a } else { row.a }), row.a + row.b * 2 + row.c * 3 + row.d * 4]
+  where (row.d > row.e || ((row.a > row.b - 2 && row.a < row.b + 2)))
+  order by [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (if row.c > avg(from x in t1
+  select x.c) { row.a * 2 } else { row.b * 10 }), row.d, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) })]
+  select [(if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), (if row.c > avg(from x in t1
+  select x.c) { row.a * 2 } else { row.b * 10 }), row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, row.d]
 var flatResult = []
 for row in result {
   for x in row {
@@ -242,6 +238,6 @@ for row in result {
   }
 }
 
-test "case49" {
-  expect flatResult == [4, 1, 107, 1079, -2, 2, 110, 1118, -3, 3, 116, 1165, -1, 4, 123, 1219, 1, 5, 127, 1274, 3, 6, 132, 1325, -2, 7, 138, 1367, -1, 8, 144, 1414, 1, 9, 145, 1473, 2, 10, 151, 1526, -2, 11, 155, 1570, 2, 12, 161, 1626, -1, 13, 167, 1669, -1, 14, 171, 1719, 3, 15, 177, 1778, -1, 16, 181, 1819, 4, 17, 187, 1877, 1, 18, 190, 1925, 1, 19, 199, 1971, -3, 20, 200, 2017, -1, 21, 208, 2065, 1, 22, 214, 2121, -2, 23, 218, 2164, -4, 24, 223, 2211, 4, 25, 226, 2280, -3, 26, 234, 2312, -3, 27, 237, 2366, 2, 28, 242, 2422, 4, 29, 246, 2479]
+test "case48" {
+  expect flatResult == [444, 1020, 1531, 101, 222, 1060, 1604, 109, 222, 1220, 1824, 120, 111, 1280, 1899, 126, 333, 1340, 1975, 133, 222, 1490, 2208, 148, 444, 1500, 2286, 154, 444, 1600, 2436, 164, 222, 1700, 2589, 173, 333, 354, 2653, 178, 222, 362, 2739, 183, 111, 374, 2802, 189, 444, 380, 2880, 192, 555, 398, 2946, 196, 111, 416, 3100, 206, 555, 428, 3176, 212, 111, 452, 3405, 229, 444, 474, 3556, 235, 333, 484, 3627, 243, 222, 492, 3704, 249]
 }

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -498,8 +498,13 @@ func Generate(c Case) string {
 			}
 		}
 		sb.WriteString("\n  select [" + strings.Join(exprs, ", ") + "]\n")
-		sb.WriteString("let flatResult = from row in result\n  from x in row\n  select x\n")
-		sb.WriteString("for x in flatResult {\n  print(x)\n}\n\n")
+		sb.WriteString("var flatResult = []\n")
+		sb.WriteString("for row in result {\n")
+		sb.WriteString("  for x in row {\n")
+		sb.WriteString("    flatResult = append(flatResult, x)\n")
+		sb.WriteString("    print(x)\n")
+		sb.WriteString("  }\n")
+		sb.WriteString("}\n\n")
 		if len(c.Expect) > 0 {
 			sb.WriteString(fmt.Sprintf("test \"%s\" {\n  expect flatResult == %s\n}\n", c.Name, formatExpectList(c.Expect)))
 		}


### PR DESCRIPTION
## Summary
- enhance SLT generation by avoiding nested query flattening
- regenerate select1 cases 40..49

## Testing
- `go run ./cmd/mochi-slt gen --files select1.test --out /tmp/out_select1 --run --start 40 --end 40`


------
https://chatgpt.com/codex/tasks/task_e_68651ef146a48320be25fea7ff59f0e6