### PR TITLE
Improve SLT generation and VM comparisons

### DIFF
--- a/cmd/mochi-slt/main.go
+++ b/cmd/mochi-slt/main.go
@@ -19,7 +19,8 @@ var (
 	gitCommit = ""
 )
 
-var files = []string{"evidence/slt_lang_update.test", "test/select1.test"}
+// Default set of SLT files bundled with the repository.
+var files = []string{"evidence/slt_lang_update.test", "select1.test"}
 
 func fetchCmd() *cobra.Command {
 	var repo string

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -7219,6 +7219,12 @@ func valueLess(a, b Value) bool {
 			return a.Int < b.Int
 		case ValueFloat:
 			return float64(a.Int) < b.Float
+		case ValueBool:
+			bi := 0
+			if b.Bool {
+				bi = 1
+			}
+			return a.Int < bi
 		}
 	case ValueFloat:
 		switch b.Tag {
@@ -7226,6 +7232,12 @@ func valueLess(a, b Value) bool {
 			return a.Float < float64(b.Int)
 		case ValueFloat:
 			return a.Float < b.Float
+		case ValueBool:
+			bi := 0
+			if b.Bool {
+				bi = 1
+			}
+			return a.Float < float64(bi)
 		}
 	case ValueStr:
 		if b.Tag == ValueStr {
@@ -7234,6 +7246,20 @@ func valueLess(a, b Value) bool {
 	case ValueBool:
 		if b.Tag == ValueBool {
 			return !a.Bool && b.Bool
+		}
+		if b.Tag == ValueInt {
+			ai := 0
+			if a.Bool {
+				ai = 1
+			}
+			return ai < b.Int
+		}
+		if b.Tag == ValueFloat {
+			ai := 0
+			if a.Bool {
+				ai = 1
+			}
+			return float64(ai) < b.Float
 		}
 	case ValueList:
 		if b.Tag == ValueList {


### PR DESCRIPTION
## Summary
- include `select1.test` by default in `mochi-slt`
- support cross-type boolean comparisons in the VM

## Testing
- `go vet ./...`
- `go run ./cmd/mochi-slt gen --cases case7 --files select1.test --run --out /tmp/outcase`

------
https://chatgpt.com/codex/tasks/task_e_6865407de18c8320b8622ecaf534d14e