### PR TITLE
Improve slt generator

### DIFF
--- a/tests/dataset/slt/out/evidence/select1/case4.err
+++ b/tests/dataset/slt/out/evidence/select1/case4.err
@@ -1,1 +1,0 @@
-expect condition failed

--- a/tools/slt/logic/utils.go
+++ b/tools/slt/logic/utils.go
@@ -259,8 +259,12 @@ func GenerateFiles(files []string, outDir string, run bool, start, end int) erro
 			if run {
 				out, err := RunMochi(code)
 				outPath := filepath.Join(testDir, c.Name+".out")
+				errPath := strings.TrimSuffix(outPath, ".out") + ".error"
 				if err != nil {
-					_ = os.WriteFile(strings.TrimSuffix(outPath, ".out")+".error", []byte(err.Error()+"\n"), 0o644)
+					_ = os.WriteFile(errPath, []byte(err.Error()+"\n"), 0o644)
+				} else {
+					_ = os.Remove(errPath)
+					_ = os.Remove(strings.TrimSuffix(outPath, ".out") + ".err")
 				}
 				if err := os.WriteFile(outPath, []byte(out+"\n"), 0o644); err != nil {
 					return err


### PR DESCRIPTION
## Summary
- update SQLLogicTest generator to clean up stale `.error` files
- remove an old `.err` file from the select1 dataset

## Testing
- `go vet ./tools/slt/...`
- `go test ./tools/slt/...`


------
https://chatgpt.com/codex/tasks/task_e_686549c058e883209d9c8f8509d1ced1