### PR TITLE
Update SLT generator to preserve precedence

### DIFF
--- a/tests/dataset/slt/out/select1/case1.mochi
+++ b/tests/dataset/slt/out/select1/case1.mochi
@@ -257,9 +257,9 @@ let t1 = [
 /* SELECT CASE WHEN c>(SELECT avg(c) FROM t1) THEN a*2 ELSE b*10 END FROM t1 ORDER BY 1 */
 let result = from row in t1
   order by (if row.c > avg(from x in t1
-  select x.c) { row.a * 2 } else { row.b * 10 })
+  select x.c) { (row.a * 2) } else { (row.b * 10) })
   select (if row.c > avg(from x in t1
-  select x.c) { row.a * 2 } else { row.b * 10 })
+  select x.c) { (row.a * 2) } else { (row.b * 10) })
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case2.mochi
+++ b/tests/dataset/slt/out/select1/case2.mochi
@@ -225,17 +225,18 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4+e*5, (a+b+c+d+e)/5 FROM t1 ORDER BY 1,2 */
 let result = from row in t1
-  order by [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (row.a + row.b + row.c + row.d + row.e) / 5]
-  select [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (row.a + row.b + row.c + row.d + row.e) / 5]
+  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+  }
+}
+for x in flatResult {
+  print(x)
+}
 test "case2" {
-  var flatResult = []
-  for row in result {
-    for x in row {
-      flatResult = append(flatResult, x)
-    }
-  }
-  for x in flatResult {
-    print(x)
-  }
   expect flatResult == [1529, 102, 1612, 107, 1680, 112, 1757, 117, 1826, 122, 1902, 127, 1985, 132, 2046, 137, 2131, 142, 2202, 147, 2281, 152, 2349, 157, 2432, 162, 2501, 167, 2579, 172, 2654, 177, 2728, 182, 2806, 187, 2878, 192, 2949, 197, 3039, 202, 3114, 207, 3175, 212, 3260, 217, 3331, 222, 3399, 227, 3473, 232, 3553, 237, 3629, 242, 3706, 247]
 }
+

--- a/tests/dataset/slt/out/select1/case3.mochi
+++ b/tests/dataset/slt/out/select1/case3.mochi
@@ -228,17 +228,18 @@ let result = from row in t1
   where ((((row.e > row.c || row.e < row.d)) && row.d > row.e) && count(from x in t1
   where x.b < row.b
   select x) > 0)
-  order by [(row.a + row.b + row.c + row.d + row.e) / 5, (if row.a < row.b - 3 { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < row.b + 3 { 333 } else { 444 }) }) }), row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (if row.b - row.c < 0 { -(row.b - row.c) } else { row.b - row.c }), row.a + row.b * 2 + row.c * 3]
-  select [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (if row.a < row.b - 3 { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < row.b + 3 { 333 } else { 444 }) }) }), (if row.b - row.c < 0 { -(row.b - row.c) } else { row.b - row.c }), (row.a + row.b + row.c + row.d + row.e) / 5, row.a + row.b * 2 + row.c * 3]
+  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((row.a + (row.b * 2)) + (row.c * 3))]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), ((row.a + (row.b * 2)) + (row.c * 3))]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+  }
+}
+for x in flatResult {
+  print(x)
+}
 test "case3" {
-  var flatResult = []
-  for row in result {
-    for x in row {
-      flatResult = append(flatResult, x)
-    }
-  }
-  for x in flatResult {
-    print(x)
-  }
   expect flatResult == [1680, 222, 1, 112, 674, 1826, 222, 1, 122, 738, 1902, 222, 4, 127, 760, 1985, 333, 4, 132, 793, 2046, 222, 2, 137, 827, 2202, 444, 2, 147, 880, 2281, 333, 1, 152, 905, 2432, 444, 1, 162, 966, 2501, 333, 1, 167, 1000, 2654, 444, 1, 177, 1057, 2728, 333, 3, 182, 1096, 3175, 333, 3, 212, 1277, 3331, 222, 1, 222, 1338, 3473, 333, 1, 232, 1391, 3553, 444, 1, 237, 1416, 3706, 111, 2, 247, 1484]
 }
+

--- a/tests/dataset/slt/out/select1/case4.mochi
+++ b/tests/dataset/slt/out/select1/case4.mochi
@@ -225,18 +225,19 @@ let t1 = [
 
 /* SELECT c, d-e, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, a+b*2+c*3+d*4, e FROM t1 WHERE d NOT BETWEEN 110 AND 150 OR c BETWEEN b-2 AND d+2 OR (e>c OR e<d) ORDER BY 1,5,3,2,4 */
 let result = from row in t1
-  where (((row.d < 110 || row.d > 150) || (row.c >= row.b - 2 && row.c <= row.d + 2)) || ((row.e > row.c || row.e < row.d)))
-  order by [row.c, row.e, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), row.d - row.e, row.a + row.b * 2 + row.c * 3 + row.d * 4]
-  select [row.c, row.d - row.e, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), row.a + row.b * 2 + row.c * 3 + row.d * 4, row.e]
+  where (((row.d < 110 || row.d > 150) || (row.c >= (row.b - 2) && row.c <= (row.d + 2))) || ((row.e > row.c || row.e < row.d)))
+  order by [row.c, row.e, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.d - row.e), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+  select [row.c, (row.d - row.e), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.e]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+  }
+}
+for x in flatResult {
+  print(x)
+}
 test "case4" {
-  var flatResult = []
-  for row in result {
-    for x in row {
-      flatResult = append(flatResult, x)
-    }
-  }
-  for x in flatResult {
-    print(x)
-  }
   expect flatResult == [102, -2, 555, 1014, 103, 106, -1, 333, 1067, 109, 113, 4, 111, 1130, 110, 123, 2, 333, 1226, 120, 125, 2, 333, 1272, 126, 134, 1, 444, 1325, 132, 137, 1, 111, 1371, 135, 141, -4, 111, 1411, 144, 147, 2, 555, 1472, 146, 150, 2, 333, 1521, 152, 155, -1, 555, 1564, 157, 161, 2, 333, 1622, 162, 166, 4, 333, 1676, 165, 172, -2, 555, 1714, 173, 176, 1, 555, 1769, 177, 184, 3, 333, 1828, 180, 187, -4, 444, 1861, 189, 193, -2, 444, 1918, 192, 195, -1, 555, 1964, 197, 202, -1, 222, 2019, 204, 208, -2, 111, 2069, 209, 214, 2, 222, 2125, 210, 215, -2, 333, 2165, 219, 224, 1, 444, 2226, 221, 225, -1, 555, 2264, 227, 231, 3, 555, 2323, 230, 235, 1, 555, 2368, 237, 244, -1, 222, 2419, 242, 247, 2, 444, 2476, 246]
 }
+

--- a/tests/dataset/slt/out/select1/case5.mochi
+++ b/tests/dataset/slt/out/select1/case5.mochi
@@ -226,17 +226,18 @@ let t1 = [
 /* SELECT a+b*2+c*3+d*4, (a+b+c+d+e)/5, abs(a), e, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, d FROM t1 WHERE b>c AND c>d ORDER BY 3,4,5,1,2,6 */
 let result = from row in t1
   where (row.b > row.c && row.c > row.d)
-  order by [(if row.a < 0 { -(row.a) } else { row.a }), row.e, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), row.a + row.b * 2 + row.c * 3 + row.d * 4, (row.a + row.b + row.c + row.d + row.e) / 5, row.d]
-  select [row.a + row.b * 2 + row.c * 3 + row.d * 4, (row.a + row.b + row.c + row.d + row.e) / 5, (if row.a < 0 { -(row.a) } else { row.a }), row.e, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), row.d]
+  order by [(if row.a < 0 { -(row.a) } else { row.a }), row.e, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), row.d]
+  select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < 0 { -(row.a) } else { row.a }), row.e, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.d]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+  }
+}
+for x in flatResult {
+  print(x)
+}
 test "case5" {
-  var flatResult = []
-  for row in result {
-    for x in row {
-      flatResult = append(flatResult, x)
-    }
-  }
-  for x in flatResult {
-    print(x)
-  }
   expect flatResult == [1226, 122, 121, 120, 333, 122, 1371, 137, 138, 135, 111, 136, 1411, 142, 142, 144, 111, 140, 1918, 192, 191, 192, 444, 190]
 }
+

--- a/tests/dataset/slt/out/select1/case6.mochi
+++ b/tests/dataset/slt/out/select1/case6.mochi
@@ -225,22 +225,23 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d), c FROM t1 WHERE (c<=d-2 OR c>=d+2) ORDER BY 4,2,1,3 */
 let result = from row in t1
-  where ((row.c <= row.d - 2 || row.c >= row.d + 2))
-  order by [row.c, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), row.a + row.b * 2 + row.c * 3 + row.d * 4, count(from x in t1
+  where ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))
+  order by [row.c, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
-  select [row.a + row.b * 2 + row.c * 3 + row.d * 4, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) }), count(from x in t1
+  select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), row.c]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+  }
+}
+for x in flatResult {
+  print(x)
+}
 test "case6" {
-  var flatResult = []
-  for row in result {
-    for x in row {
-      flatResult = append(flatResult, x)
-    }
-  }
-  for x in flatResult {
-    print(x)
-  }
   expect flatResult == [1067, 333, 0, 106, 1172, 333, 0, 119, 1272, 333, 0, 125, 1521, 333, 0, 150, 1622, 333, 0, 161, 1676, 333, 0, 166, 1769, 555, 0, 176, 1861, 444, 0, 187, 1918, 444, 0, 193, 2125, 222, 0, 214, 2165, 333, 0, 215, 2226, 444, 0, 224, 2323, 555, 0, 231, 2368, 555, 0, 235, 2419, 222, 0, 244]
 }
+

--- a/tests/dataset/slt/out/select1/case7.mochi
+++ b/tests/dataset/slt/out/select1/case7.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END FROM t1 ORDER BY 1 */
 let result = from row in t1
-  order by (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) })
-  select (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) })
+  order by (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })
+  select (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case8.mochi
+++ b/tests/dataset/slt/out/select1/case8.mochi
@@ -225,7 +225,7 @@ let t1 = [
 
 /* SELECT (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b) FROM t1 WHERE (a>b-2 AND a<b+2) OR c>d ORDER BY 1 */
 let result = from row in t1
-  where (((row.a > row.b - 2 && row.a < row.b + 2)) || row.c > row.d)
+  where (((row.a > (row.b - 2) && row.a < (row.b + 2))) || row.c > row.d)
   order by count(from x in t1
   where x.b < row.b
   select x)

--- a/tests/dataset/slt/out/select1/case9.mochi
+++ b/tests/dataset/slt/out/select1/case9.mochi
@@ -225,22 +225,23 @@ let t1 = [
 
 /* SELECT a, (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d), b-c, a-b, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END FROM t1 WHERE c BETWEEN b-2 AND d+2 OR a>b OR b>c ORDER BY 1,4,3,2,5 */
 let result = from row in t1
-  where (((row.c >= row.b - 2 && row.c <= row.d + 2) || row.a > row.b) || row.b > row.c)
-  order by [row.a, row.a - row.b, row.b - row.c, count(from x in t1
+  where (((row.c >= (row.b - 2) && row.c <= (row.d + 2)) || row.a > row.b) || row.b > row.c)
+  order by [row.a, (row.a - row.b), (row.b - row.c), count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) })]
+  select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
   select [row.a, count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), row.b - row.c, row.a - row.b, (if row.a + 1 == row.b { 111 } else { (if row.a + 1 == row.c { 222 } else { (if row.a + 1 == row.d { 333 } else { (if row.a + 1 == row.e { 444 } else { 555 }) }) }) })]
+  select x), (row.b - row.c), (row.a - row.b), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
+var flatResult = []
+for row in result {
+  for x in row {
+    flatResult = append(flatResult, x)
+  }
+}
+for x in flatResult {
+  print(x)
+}
 test "case9" {
-  var flatResult = []
-  for row in result {
-    for x in row {
-      flatResult = append(flatResult, x)
-    }
-  }
-  for x in flatResult {
-    print(x)
-  }
   expect flatResult == [104, 0, -2, 4, 555, 107, 0, -1, 2, 333, 111, 0, -1, -1, 111, 121, 0, 1, -3, 333, 127, 0, 4, -2, 333, 131, 0, -4, 1, 444, 138, 0, 2, -1, 111, 142, 0, 2, -1, 111, 149, 0, -2, 4, 555, 153, 0, 1, 2, 333, 159, 0, 3, 1, 555, 163, 0, -1, 3, 333, 168, 0, 1, 1, 333, 174, 0, -2, 4, 555, 179, 0, -1, 4, 555, 182, 0, -3, 1, 333, 188, 0, -1, 2, 444, 191, 0, 1, -3, 444, 199, 0, 3, 1, 555, 201, 0, -2, 1, 222, 205, 0, -2, -1, 111, 213, 0, -3, 2, 222, 216, 0, 3, -2, 333, 220, 0, -1, -3, 444, 229, 0, 3, 1, 555, 234, 0, 1, 2, 555, 239, 0, 1, 3, 555, 243, 0, -4, 3, 222, 245, 0, 2, -4, 444]
 }
+

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -195,7 +195,7 @@ func exprToMochiRow(e sqlparser.Expr, rowVar, outer string) string {
 	case *sqlparser.BinaryExpr:
 		l := exprToMochiRow(v.Left, rowVar, outer)
 		r := exprToMochiRow(v.Right, rowVar, outer)
-		return fmt.Sprintf("%s %s %s", l, v.Operator, r)
+		return fmt.Sprintf("(%s %s %s)", l, v.Operator, r)
 	case *sqlparser.FuncExpr:
 		name := strings.ToLower(v.Name.String())
 		if name == "abs" && len(v.Exprs) == 1 {


### PR DESCRIPTION
## Summary
- tweak SLT generator to wrap binary expressions in parentheses so the
  Mochi parser preserves intended operator precedence
- regenerate SLT cases 1–9 from `select1.test`

## Testing
- `go test ./tools/slt/logic -run .`

------
https://chatgpt.com/codex/tasks/task_e_68654a0afa748320add9afbf629192d7