### PR TITLE
Skip caching of correlated SLT subqueries

### DIFF
--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -440,7 +440,7 @@ func collectSubqueriesExpr(e sqlparser.Expr, subs map[string]struct{}) {
 	switch v := e.(type) {
 	case *sqlparser.Subquery:
 		expr := subqueryToMochi(v, "row")
-		if expr != "null" {
+		if expr != "null" && !strings.Contains(expr, "row.") {
 			subs[expr] = struct{}{}
 		}
 	case *sqlparser.ParenExpr:


### PR DESCRIPTION
## Summary
- avoid caching subqueries that reference the outer row

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68655ff8bb208320a625218381ec363a