### PR TITLE
Fix SLT generation for case29

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2190,18 +2190,9 @@ func constKey(v Value) (string, bool) {
 }
 
 func (fc *funcCompiler) constReg(pos lexer.Position, v Value) int {
-	if key, ok := constKey(v); ok {
-		if r, exists := fc.constRegs[key]; exists {
-			return r
-		}
-		r := fc.newReg()
-		fc.emit(pos, Instr{Op: OpConst, A: r, Val: v})
-		if fc.constRegs == nil {
-			fc.constRegs = map[string]int{}
-		}
-		fc.constRegs[key] = r
-		return r
-	}
+	// Avoid reusing constants defined later in the instruction stream since
+	// that may result in a use-before-definition when loops are involved.
+	// Deduplication isn't critical for tests, so always emit the constant.
 	r := fc.newReg()
 	fc.emit(pos, Instr{Op: OpConst, A: r, Val: v})
 	return r

--- a/tests/dataset/slt/out/select1/case29.error
+++ b/tests/dataset/slt/out/select1/case29.error
@@ -1,1 +1,0 @@
-timeout

--- a/tests/dataset/slt/out/select1/case29.mochi
+++ b/tests/dataset/slt/out/select1/case29.mochi
@@ -225,7 +225,7 @@ let t1 = [
 
 /* SELECT (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b) FROM t1 WHERE e+d BETWEEN a+b-10 AND c+130 AND a>b AND (a>b-2 AND a<b+2) ORDER BY 1 */
 let result = from row in t1
-  where ((((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)) && row.a > row.b) && ((row.a > (row.b - 2) && row.a < (row.b + 2))))
+  where ((((row.e + row.d) >= ((row.a + row.b) - 10.0) && (row.e + row.d) <= (row.c + 130.0)) && row.a > row.b) && ((row.a > (row.b - 2.0) && row.a < (row.b + 2.0))))
   order by count(from x in t1
   where x.b < row.b
   select x)
@@ -236,3 +236,6 @@ for x in result {
   print(x)
 }
 
+test "case29" {
+  expect result == []
+}

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -714,6 +714,8 @@ func Generate(c Case) string {
 		sb.WriteString("for x in result {\n  print(x)\n}\n\n")
 		if len(c.Expect) > 0 {
 			sb.WriteString(fmt.Sprintf("test \"%s\" {\n  expect result == %s\n}\n", c.Name, formatExpectList(c.Expect)))
+		} else {
+			sb.WriteString(fmt.Sprintf("test \"%s\" {\n  expect result == []\n}\n", c.Name))
 		}
 		return sb.String()
 	}


### PR DESCRIPTION
## Summary
- fix `constReg` to always emit constant instructions
- handle empty expectations for single-column SELECT queries in SLT generator
- regenerate select1 case29 with test block
- remove obsolete error file

## Testing
- `go run ./cmd/mochi-slt gen --case case29 --files select1.test --out /tmp/gen_output --run`
- `go test ./tools/slt/logic -run TestRunMochi -count=1` *(no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865d07185948320b5639f89efff931a