### PR TITLE
Fix float formatting in SLT generator

### DIFF
--- a/tests/dataset/slt/out/select1/case29.mochi
+++ b/tests/dataset/slt/out/select1/case29.mochi
@@ -225,7 +225,7 @@ let t1 = [
 
 /* SELECT (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b) FROM t1 WHERE e+d BETWEEN a+b-10 AND c+130 AND a>b AND (a>b-2 AND a<b+2) ORDER BY 1 */
 let result = from row in t1
-  where ((((row.e + row.d) >= ((row.a + row.b) - 10.0) && (row.e + row.d) <= (row.c + 130.0)) && row.a > row.b) && ((row.a > (row.b - 2.0) && row.a < (row.b + 2.0))))
+  where ((((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)) && row.a > row.b) && ((row.a > (row.b - 2) && row.a < (row.b + 2))))
   order by count(from x in t1
   where x.b < row.b
   select x)

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -113,6 +113,9 @@ func formatValue(v any) string {
 	case int:
 		return fmt.Sprintf("%d", t)
 	case float64:
+		if t == math.Trunc(t) {
+			return fmt.Sprintf("%d", int64(t))
+		}
 		s := fmt.Sprintf("%g", t)
 		if !strings.ContainsRune(s, '.') {
 			s += ".0"


### PR DESCRIPTION
## Summary
- normalize float formatting in `tools/slt` so whole numbers print as integers
- regenerate select1 case29 to remove `.0` suffixes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865d639558c832086cb508e6a018ac1