### PR TITLE
Regenerate SLT case897 and improve type detection

### DIFF
--- a/tests/dataset/slt/out/evidence/select1/case897.mochi
+++ b/tests/dataset/slt/out/evidence/select1/case897.mochi
@@ -225,7 +225,7 @@ let t1 = [
 
 /* SELECT a-b, a+b*2 FROM t1 WHERE d NOT BETWEEN 110 AND 150 OR (c<=d-2 OR c>=d+2) OR a>b ORDER BY 1,2 */
 let result = from row in t1
-  where (((row.d < 110.0 || row.d > 150.0) || ((row.c <= (row.d - 2.0) || row.c >= (row.d + 2.0)))) || row.a > row.b)
+  where (((row.d < 110 || row.d > 150) || ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))) || row.a > row.b)
   order by [(row.a - row.b), (row.a + (row.b + row.b))]
   select [(row.a - row.b), (row.a + (row.b + row.b))]
 var flatResult = []

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -198,11 +198,21 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 				continue
 			}
 
-			if _, err := strconv.ParseFloat(sv, 64); err == nil {
-				if t == "" || t == "float" || t == "int" {
-					t = "float"
+			if f, err := strconv.ParseFloat(sv, 64); err == nil {
+				if math.Trunc(f) == f {
+					if t == "" {
+						t = "int"
+					} else if t == "float" {
+						// keep float when column was already float
+					} else if t != "int" {
+						return "any"
+					}
 				} else {
-					return "any"
+					if t == "" || t == "float" || t == "int" {
+						t = "float"
+					} else {
+						return "any"
+					}
 				}
 				continue
 			}


### PR DESCRIPTION
## Summary
- refine numeric type detection in tools/slt generator
- regenerate select1 case897 using new generator

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865d5293e5083209b19d1b53c01bd0f