### PR TITLE
Fix constant reuse bug and regenerate select1 case4

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2190,9 +2190,21 @@ func constKey(v Value) (string, bool) {
 }
 
 func (fc *funcCompiler) constReg(pos lexer.Position, v Value) int {
-	// Avoid reusing constants defined later in the instruction stream since
-	// that may result in a use-before-definition when loops are involved.
-	// Deduplication isn't critical for tests, so always emit the constant.
+	if key, ok := constKey(v); ok {
+		if r, exists := fc.constRegs[key]; exists {
+			// Emit the constant again so the register is initialized
+			// along all control-flow paths.
+			fc.emit(pos, Instr{Op: OpConst, A: r, Val: v})
+			return r
+		}
+		r := fc.newReg()
+		fc.emit(pos, Instr{Op: OpConst, A: r, Val: v})
+		if fc.constRegs == nil {
+			fc.constRegs = map[string]int{}
+		}
+		fc.constRegs[key] = r
+		return r
+	}
 	r := fc.newReg()
 	fc.emit(pos, Instr{Op: OpConst, A: r, Val: v})
 	return r

--- a/tests/dataset/slt/out/evidence/select1/case4.mochi
+++ b/tests/dataset/slt/out/evidence/select1/case4.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT c, d-e, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, a+b*2+c*3+d*4, e FROM t1 WHERE d NOT BETWEEN 110 AND 150 OR c BETWEEN b-2 AND d+2 OR (e>c OR e<d) ORDER BY 1,5,3,2,4 */
 let result = from row in t1
   where (((row.d < 110 || row.d > 150) || (row.c >= (row.b - 2) && row.c <= (row.d + 2))) || ((row.e > row.c || row.e < row.d)))
-  order by [row.c, row.e, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.d - row.e), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))]
-  select [row.c, (row.d - row.e), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), row.e]
+  order by [row.c, row.e, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.d - row.e), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+  select [row.c, (row.d - row.e), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.e]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -304,19 +304,6 @@ func exprToMochiRow(e sqlparser.Expr, rowVar, outer string, subs map[string]stri
 	case *sqlparser.UnaryExpr:
 		return fmt.Sprintf("%s%s", v.Operator, exprToMochiRow(v.Expr, rowVar, outer, subs))
 	case *sqlparser.BinaryExpr:
-		// Work around a VM bug where multiplication by the constant
-		// 2 sometimes yields an incorrect result. Rewrite such
-		// expressions using addition instead of multiplication.
-		if v.Operator == "*" {
-			if rv, ok := v.Right.(*sqlparser.SQLVal); ok && string(rv.Val) == "2" {
-				ex := exprToMochiRow(v.Left, rowVar, outer, subs)
-				return fmt.Sprintf("(%s + %s)", ex, ex)
-			}
-			if lv, ok := v.Left.(*sqlparser.SQLVal); ok && string(lv.Val) == "2" {
-				ex := exprToMochiRow(v.Right, rowVar, outer, subs)
-				return fmt.Sprintf("(%s + %s)", ex, ex)
-			}
-		}
 		l := exprToMochiRow(v.Left, rowVar, outer, subs)
 		r := exprToMochiRow(v.Right, rowVar, outer, subs)
 		return fmt.Sprintf("(%s %s %s)", l, v.Operator, r)


### PR DESCRIPTION
## Summary
- deduplicate constants in the VM compiler again
- remove multiplication workaround from SLT generator
- regenerate select1 case4 with updated generator

## Testing
- `go test ./...`
- `go run ./cmd/mochi-slt gen --case case4 --files select1.test --out tests/dataset/slt/out/evidence --run`

------
https://chatgpt.com/codex/tasks/task_e_6865e374726c83209851373e162510a8