### PR TITLE
Improve SLT generator for repeated addition

### DIFF
--- a/tests/dataset/slt/out/select1/case30.mochi
+++ b/tests/dataset/slt/out/select1/case30.mochi
@@ -226,10 +226,10 @@ let t1 = [
 /* SELECT CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, b, a+b*2, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END FROM t1 WHERE a>b OR c BETWEEN b-2 AND d+2 OR c>d ORDER BY 3,2,1,4,5 */
 let result = from row in t1
   where ((row.a > row.b || (row.c >= (row.b - 2) && row.c <= (row.d + 2))) || row.c > row.d)
-  order by [(row.a + (row.b + row.b)), row.b, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), count(from x in t1
+  order by [(row.a + (row.b * 2)), row.b, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), count(from x in t1
   where x.b < row.b
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
-  select [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.b, (row.a + (row.b + row.b)), count(from x in t1
+  select [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.b, (row.a + (row.b * 2)), count(from x in t1
   where x.b < row.b
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
 var flatResult = []


### PR DESCRIPTION
## Summary
- support collapsing repeated column addition into multiplication
- regenerate `case30` from `select1.test`

## Testing
- `go vet ./...`
- `go build ./cmd/mochi-slt`


------
https://chatgpt.com/codex/tasks/task_e_6865f00128e48320837627e2199a8ad1