### PR TITLE
Improve SLT generator logging

### DIFF
--- a/tools/slt/logic/utils.go
+++ b/tools/slt/logic/utils.go
@@ -256,6 +256,7 @@ func GenerateFiles(files []string, outDir string, run bool, start, end int) erro
 			if err := os.WriteFile(srcPath, []byte(code), 0o644); err != nil {
 				return err
 			}
+			fmt.Printf("generated %s\n", srcPath)
 			if run {
 				out, err := RunMochi(code)
 				outPath := filepath.Join(testDir, c.Name+".out")
@@ -268,6 +269,11 @@ func GenerateFiles(files []string, outDir string, run bool, start, end int) erro
 				}
 				if err := os.WriteFile(outPath, []byte(out+"\n"), 0o644); err != nil {
 					return err
+				}
+				if err != nil {
+					fmt.Printf("FAILED %s: %v\n", srcPath, err)
+				} else {
+					fmt.Printf("ran %s\n", srcPath)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- log each generated case when running mochi-slt
- report runtime failures when running generated programs

## Testing
- `go run ./cmd/mochi-slt gen --cases case29-case29 --files select1.test --out tests/dataset/slt/out --run | head`
- `go run ./cmd/mochi-slt gen --cases case29-case29 --files select1.test --out tests/dataset/slt/out/evidence --run | head`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865effe948c832093700d18966de5dd