### PR TITLE
Regenerate SLT cases

### DIFF
--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -132,7 +132,7 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 				return "int"
 			case strings.Contains(typ, "real"), strings.Contains(typ, "float"), strings.Contains(typ, "double"), strings.Contains(typ, "numeric"), strings.Contains(typ, "decimal"):
 				return "float"
-			case strings.Contains(typ, "bool"):
+			case strings.Contains(typ, "bool"), strings.Contains(typ, "bit"):
 				return "bool"
 			case strings.Contains(typ, "char"), strings.Contains(typ, "text"):
 				return "string"
@@ -241,6 +241,12 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 				continue
 			}
 
+			if t == "" || t == "string" {
+				t = "string"
+			} else {
+				return "any"
+			}
+		case []byte:
 			if t == "" || t == "string" {
 				t = "string"
 			} else {


### PR DESCRIPTION
## Summary
- improve type detection to treat `bit` columns as booleans and handle `[]byte` values
- regenerate `select1` SQLLogicTest cases using updated generator

## Testing
- `go test ./tools/slt/...`
- `go vet ./...`
- `go run ./cmd/mochi-slt gen --cases case1-case5 --files select1.test --run`
- `go run ./cmd/mochi-slt gen --cases case1-case1000 --files select1.test --run`


------
https://chatgpt.com/codex/tasks/task_e_6865f2cfd5388320a63a8880670c163c