### PR TITLE
Update SLT parser boolean handling

### DIFF
--- a/tools/slt/logic/parser.go
+++ b/tools/slt/logic/parser.go
@@ -236,6 +236,13 @@ func evalExpr(expr sqlparser.Expr, row map[string]any, table *Table) any {
 	case *sqlparser.SQLVal:
 		switch v.Type {
 		case sqlparser.StrVal:
+			s := strings.TrimSpace(strings.ToLower(string(v.Val)))
+			if s == "true" {
+				return true
+			}
+			if s == "false" {
+				return false
+			}
 			return string(v.Val)
 		case sqlparser.IntVal:
 			n, _ := strconv.Atoi(string(v.Val))


### PR DESCRIPTION
## Summary
- parse `true` and `false` string literals in SLT tables as booleans
- regenerate SLT select1 cases 100-199

## Testing
- `go test ./...`
- `go run ./cmd/mochi-slt gen --cases case100-case199 --files select1.test --out tests/dataset/slt/out/evidence --run`

------
https://chatgpt.com/codex/tasks/task_e_6865f2dbf51c832082d506080466f109