### PR TITLE
Improve SLT parser unary handling

### DIFF
--- a/tools/slt/logic/parser.go
+++ b/tools/slt/logic/parser.go
@@ -250,6 +250,25 @@ func evalExpr(expr sqlparser.Expr, row map[string]any, table *Table) any {
 		if row != nil {
 			return row[v.Name.String()]
 		}
+	case *sqlparser.UnaryExpr:
+		val := evalExpr(v.Expr, row, table)
+		if f, ok := toFloat(val); ok {
+			switch v.Operator {
+			case "+":
+				if isInt(val) {
+					return int(f)
+				}
+				return f
+			case "-":
+				if isInt(val) {
+					return int(-f)
+				}
+				return -f
+			}
+		}
+		return nil
+	case *sqlparser.ParenExpr:
+		return evalExpr(v.Expr, row, table)
 	case *sqlparser.BinaryExpr:
 		l := evalExpr(v.Left, row, table)
 		r := evalExpr(v.Right, row, table)


### PR DESCRIPTION
## Summary
- support unary and parenthesized expressions in SLT parser
- regenerate select1 cases 300-399

## Testing
- `go test ./...`
- `go run ./cmd/mochi-slt gen --cases case300-case399 --files select1.test --run`

------
https://chatgpt.com/codex/tasks/task_e_6865f2e4ca608320b4de128cbbd9df2e