### PR TITLE
Update SLT generator, regenerate cases 500-599

### DIFF
--- a/tests/dataset/slt/out/select1/case500.mochi
+++ b/tests/dataset/slt/out/select1/case500.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where ((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130))
-  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.a - row.b), row.b, (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
-  select [(if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.b, (row.a - row.b), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.a - row.b), row.b, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+  select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b, (row.a - row.b), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case504.mochi
+++ b/tests/dataset/slt/out/select1/case504.mochi
@@ -230,10 +230,10 @@ let sub0 = avg(from x in t1
 let result = from row in t1
   order by [count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (row.d - row.e), (row.a - row.b), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
+  select x), (row.d - row.e), (row.a - row.b), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
   select [count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.a - row.b), (row.d - row.e)]
+  select x), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.a - row.b), (row.d - row.e)]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case506.mochi
+++ b/tests/dataset/slt/out/select1/case506.mochi
@@ -229,10 +229,10 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where ((row.a > (row.b - 2) && row.a < (row.b + 2)))
-  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.a - row.b), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), count(from x in t1
+  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.a - row.b), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
-  select [(if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), count(from x in t1
+  select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (row.a - row.b), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case509.mochi
+++ b/tests/dataset/slt/out/select1/case509.mochi
@@ -228,8 +228,8 @@ let result = from row in t1
   where row.b > row.c
   order by [row.d, row.a, row.e, count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
-  select [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.a, (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), count(from x in t1
+  select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.a, (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), row.e, row.d]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case512.mochi
+++ b/tests/dataset/slt/out/select1/case512.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where (row.b > row.c && (row.c >= (row.b - 2) && row.c <= (row.d + 2)))
-  order by [(row.b - row.c), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < 0 { -(row.a) } else { row.a }), (row.c - row.d)]
-  select [(if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.c - row.d), (row.b - row.c), row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+  order by [(row.b - row.c), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < 0 { -(row.a) } else { row.a }), (row.c - row.d)]
+  select [(if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.c - row.d), (row.b - row.c), row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case513.mochi
+++ b/tests/dataset/slt/out/select1/case513.mochi
@@ -228,8 +228,8 @@ let result = from row in t1
   where ((((row.a > (row.b - 2) && row.a < (row.b + 2))) || row.b > row.c) || ((row.e > row.a && row.e < row.b)))
   order by [count(from x in t1
   where x.b < row.b
-  select x), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a + (row.b + row.b)), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))]
-  select [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.a + (row.b + row.b)), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), count(from x in t1
+  select x), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a + (row.b * 2)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.a + (row.b * 2)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), count(from x in t1
   where x.b < row.b
   select x)]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case516.mochi
+++ b/tests/dataset/slt/out/select1/case516.mochi
@@ -228,8 +228,8 @@ let result = from row in t1
   where ((row.b > row.c || row.a > row.b) || ((row.a > (row.b - 2) && row.a < (row.b + 2))))
   order by [row.b, count(from x in t1
   where x.b < row.b
-  select x), (row.b - row.c), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
-  select [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
+  select x), (row.b - row.c), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
   where x.b < row.b
   select x), row.b, (row.b - row.c), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case517.mochi
+++ b/tests/dataset/slt/out/select1/case517.mochi
@@ -226,10 +226,10 @@ let t1 = [
 /* SELECT a+b*2+c*3, d-e, c, (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d) FROM t1 WHERE d NOT BETWEEN 110 AND 150 ORDER BY 1,2,4,3 */
 let result = from row in t1
   where (row.d < 110 || row.d > 150)
-  order by [((row.a + (row.b + row.b)) + (row.c * 3)), (row.d - row.e), count(from x in t1
+  order by [((row.a + (row.b * 2)) + (row.c * 3)), (row.d - row.e), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), row.c]
-  select [((row.a + (row.b + row.b)) + (row.c * 3)), (row.d - row.e), row.c, count(from x in t1
+  select [((row.a + (row.b * 2)) + (row.c * 3)), (row.d - row.e), row.c, count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case519.mochi
+++ b/tests/dataset/slt/out/select1/case519.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a+b*2+c*3+d*4 FROM t1 WHERE d NOT BETWEEN 110 AND 150 AND c>d AND d>e ORDER BY 1 */
 let result = from row in t1
   where (((row.d < 110 || row.d > 150) && row.c > row.d) && row.d > row.e)
-  order by (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))
-  select (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))
+  order by (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))
+  select (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case520.mochi
+++ b/tests/dataset/slt/out/select1/case520.mochi
@@ -228,12 +228,12 @@ let sub0 = avg(from x in t1
   select x.c)
 
 let result = from row in t1
-  order by [(if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.c - row.d), count(from x in t1
+  order by [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.c - row.d), count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), row.c, row.b, ((row.a + (row.b + row.b)) + (row.c * 3))]
+  select x), row.c, row.b, ((row.a + (row.b * 2)) + (row.c * 3))]
   select [count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (row.c - row.d), row.c, (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.b, ((row.a + (row.b + row.b)) + (row.c * 3))]
+  select x), (row.c - row.d), row.c, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b, ((row.a + (row.b * 2)) + (row.c * 3))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case524.mochi
+++ b/tests/dataset/slt/out/select1/case524.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a+b*2+c*3, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END FROM t1 WHERE d NOT BETWEEN 110 AND 150 AND a>b ORDER BY 1,2 */
 let result = from row in t1
   where ((row.d < 110 || row.d > 150) && row.a > row.b)
-  order by [((row.a + (row.b + row.b)) + (row.c * 3)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
-  select [((row.a + (row.b + row.b)) + (row.c * 3)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
+  order by [((row.a + (row.b * 2)) + (row.c * 3)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
+  select [((row.a + (row.b * 2)) + (row.c * 3)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case526.mochi
+++ b/tests/dataset/slt/out/select1/case526.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where (row.b > row.c || (row.d < 110 || row.d > 150))
-  order by [(row.b - row.c), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
-  select [(if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.b - row.c)]
+  order by [(row.b - row.c), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+  select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.b - row.c)]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case527.mochi
+++ b/tests/dataset/slt/out/select1/case527.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a+b*2+c*3+d*4+e*5, abs(a) FROM t1 WHERE d>e AND b>c ORDER BY 2,1 */
 let result = from row in t1
   where (row.d > row.e && row.b > row.c)
-  order by [(if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
-  select [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < 0 { -(row.a) } else { row.a })]
+  order by [(if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < 0 { -(row.a) } else { row.a })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case528.mochi
+++ b/tests/dataset/slt/out/select1/case528.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, a+b*2, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, e, a, a+b*2+c*3+d*4+e*5 FROM t1 WHERE (e>c OR e<d) AND c>d ORDER BY 1,5,2,6,3,4 */
 let result = from row in t1
   where (((row.e > row.c || row.e < row.d)) && row.c > row.d)
-  order by [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.a, (row.a + (row.b + row.b)), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.e]
-  select [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a + (row.b + row.b)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.e, row.a, ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  order by [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.a, (row.a + (row.b * 2)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.e]
+  select [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a + (row.b * 2)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.e, row.a, ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case530.mochi
+++ b/tests/dataset/slt/out/select1/case530.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a, a+b*2+c*3, a+b*2+c*3+d*4+e*5 FROM t1 WHERE e+d BETWEEN a+b-10 AND c+130 OR c>d ORDER BY 1,2,3 */
 let result = from row in t1
   where (((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)) || row.c > row.d)
-  order by [row.a, ((row.a + (row.b + row.b)) + (row.c * 3)), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
-  select [row.a, ((row.a + (row.b + row.b)) + (row.c * 3)), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  order by [row.a, ((row.a + (row.b * 2)) + (row.c * 3)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  select [row.a, ((row.a + (row.b * 2)) + (row.c * 3)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case531.mochi
+++ b/tests/dataset/slt/out/select1/case531.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a+b*2+c*3+d*4 FROM t1 WHERE d NOT BETWEEN 110 AND 150 ORDER BY 1 */
 let result = from row in t1
   where (row.d < 110 || row.d > 150)
-  order by (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))
-  select (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))
+  order by (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))
+  select (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case532.mochi
+++ b/tests/dataset/slt/out/select1/case532.mochi
@@ -228,10 +228,10 @@ let result = from row in t1
   where (row.c > row.d && ((row.e > row.c || row.e < row.d)))
   order by [count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (row.c - row.d), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), row.d, (if row.a < 0 { -(row.a) } else { row.a })]
+  select x), (row.c - row.d), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.d, (if row.a < 0 { -(row.a) } else { row.a })]
   select [(row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), row.d]
+  select x), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.d]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case533.mochi
+++ b/tests/dataset/slt/out/select1/case533.mochi
@@ -226,10 +226,10 @@ let t1 = [
 /* SELECT c-d, a+b*2+c*3+d*4+e*5, abs(b-c), d-e, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b) FROM t1 WHERE c BETWEEN b-2 AND d+2 AND (a>b-2 AND a<b+2) AND (e>c OR e<d) ORDER BY 4,1,3,2,5 */
 let result = from row in t1
   where (((row.c >= (row.b - 2) && row.c <= (row.d + 2)) && ((row.a > (row.b - 2) && row.a < (row.b + 2)))) && ((row.e > row.c || row.e < row.d)))
-  order by [(row.d - row.e), (row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
+  order by [(row.d - row.e), (row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
   where x.b < row.b
   select x)]
-  select [(row.c - row.d), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.d - row.e), count(from x in t1
+  select [(row.c - row.d), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.d - row.e), count(from x in t1
   where x.b < row.b
   select x)]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case534.mochi
+++ b/tests/dataset/slt/out/select1/case534.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT c, a+b*2+c*3, c-d, abs(b-c), d-e FROM t1 ORDER BY 3,4,1,2,5 */
 let result = from row in t1
-  order by [(row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.c, ((row.a + (row.b + row.b)) + (row.c * 3)), (row.d - row.e)]
-  select [row.c, ((row.a + (row.b + row.b)) + (row.c * 3)), (row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.d - row.e)]
+  order by [(row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.c, ((row.a + (row.b * 2)) + (row.c * 3)), (row.d - row.e)]
+  select [row.c, ((row.a + (row.b * 2)) + (row.c * 3)), (row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.d - row.e)]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case539.mochi
+++ b/tests/dataset/slt/out/select1/case539.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where ((((row.e > row.a && row.e < row.b)) || row.d > row.e) || ((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)))
-  order by [(if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.c, (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), ((row.a + (row.b + row.b)) + (row.c * 3))]
-  select [((row.a + (row.b + row.b)) + (row.c * 3)), row.c, (if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
+  order by [(if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.c, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((row.a + (row.b * 2)) + (row.c * 3))]
+  select [((row.a + (row.b * 2)) + (row.c * 3)), row.c, (if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case541.mochi
+++ b/tests/dataset/slt/out/select1/case541.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT c, a+b*2+c*3, c-d, abs(a), a+b*2+c*3+d*4+e*5 FROM t1 WHERE d>e OR (c<=d-2 OR c>=d+2) OR (e>c OR e<d) ORDER BY 1,3,5,2,4 */
 let result = from row in t1
   where ((row.d > row.e || ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))) || ((row.e > row.c || row.e < row.d)))
-  order by [row.c, (row.c - row.d), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((row.a + (row.b + row.b)) + (row.c * 3)), (if row.a < 0 { -(row.a) } else { row.a })]
-  select [row.c, ((row.a + (row.b + row.b)) + (row.c * 3)), (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  order by [row.c, (row.c - row.d), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((row.a + (row.b * 2)) + (row.c * 3)), (if row.a < 0 { -(row.a) } else { row.a })]
+  select [row.c, ((row.a + (row.b * 2)) + (row.c * 3)), (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case542.mochi
+++ b/tests/dataset/slt/out/select1/case542.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT c, a+b*2 FROM t1 WHERE (a>b-2 AND a<b+2) OR c>d OR c BETWEEN b-2 AND d+2 ORDER BY 1,2 */
 let result = from row in t1
   where ((((row.a > (row.b - 2) && row.a < (row.b + 2))) || row.c > row.d) || (row.c >= (row.b - 2) && row.c <= (row.d + 2)))
-  order by [row.c, (row.a + (row.b + row.b))]
-  select [row.c, (row.a + (row.b + row.b))]
+  order by [row.c, (row.a + (row.b * 2))]
+  select [row.c, (row.a + (row.b * 2))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case543.mochi
+++ b/tests/dataset/slt/out/select1/case543.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a+b*2+c*3+d*4, (a+b+c+d+e)/5 FROM t1 WHERE e+d BETWEEN a+b-10 AND c+130 ORDER BY 2,1 */
 let result = from row in t1
   where ((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130))
-  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))]
-  select [(((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+  select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case545.mochi
+++ b/tests/dataset/slt/out/select1/case545.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT c-d, a+b*2+c*3+d*4, d, a-b, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END FROM t1 ORDER BY 2,1,5,3,4 */
 let result = from row in t1
-  order by [(((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (row.c - row.d), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.d, (row.a - row.b)]
-  select [(row.c - row.d), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), row.d, (row.a - row.b), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
+  order by [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.c - row.d), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.d, (row.a - row.b)]
+  select [(row.c - row.d), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.d, (row.a - row.b), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case546.mochi
+++ b/tests/dataset/slt/out/select1/case546.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT abs(b-c), a, a+b*2+c*3+d*4, c-d, c, (a+b+c+d+e)/5 FROM t1 WHERE (e>c OR e<d) ORDER BY 6,3,1,4,5,2 */
 let result = from row in t1
   where ((row.e > row.c || row.e < row.d))
-  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), row.c, row.a]
-  select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.a, (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (row.c - row.d), row.c, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), row.c, row.a]
+  select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.a, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.c - row.d), row.c, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case547.mochi
+++ b/tests/dataset/slt/out/select1/case547.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4+e*5 FROM t1 ORDER BY 1 */
 let result = from row in t1
-  order by ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))
-  select ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))
+  order by ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))
+  select ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case548.mochi
+++ b/tests/dataset/slt/out/select1/case548.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where ((((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)) || row.c > row.d) || ((row.a > (row.b - 2) && row.a < (row.b + 2))))
-  order by [(row.b - row.c), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e, (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.a + (row.b + row.b))]
-  select [(row.b - row.c), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.e, (row.a + (row.b + row.b)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) })]
+  order by [(row.b - row.c), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.a + (row.b * 2))]
+  select [(row.b - row.c), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.e, (row.a + (row.b * 2)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case550.mochi
+++ b/tests/dataset/slt/out/select1/case550.mochi
@@ -228,8 +228,8 @@ let result = from row in t1
   where (count(from x in t1
   where x.b < row.b
   select x) > 0 || row.a > row.b)
-  order by [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((row.a + (row.b + row.b)) + (row.c * 3))]
-  select [((row.a + (row.b + row.b)) + (row.c * 3)), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((row.a + (row.b * 2)) + (row.c * 3))]
+  select [((row.a + (row.b * 2)) + (row.c * 3)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case553.mochi
+++ b/tests/dataset/slt/out/select1/case553.mochi
@@ -228,8 +228,8 @@ let sub0 = avg(from x in t1
   select x.c)
 
 let result = from row in t1
-  order by [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.c - row.d), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), ((row.a + (row.b + row.b)) + (row.c * 3)), (row.a + (row.b + row.b)), row.a]
-  select [((row.a + (row.b + row.b)) + (row.c * 3)), (row.c - row.d), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.a, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (row.a + (row.b + row.b)), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
+  order by [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.c - row.d), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((row.a + (row.b * 2)) + (row.c * 3)), (row.a + (row.b * 2)), row.a]
+  select [((row.a + (row.b * 2)) + (row.c * 3)), (row.c - row.d), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.a, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (row.a + (row.b * 2)), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case555.mochi
+++ b/tests/dataset/slt/out/select1/case555.mochi
@@ -226,12 +226,12 @@ let t1 = [
 /* SELECT CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, (a+b+c+d+e)/5, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), a+b*2+c*3+d*4+e*5, abs(b-c), d FROM t1 WHERE (e>a AND e<b) ORDER BY 4,2,1,6,5,3 */
 let result = from row in t1
   where ((row.e > row.a && row.e < row.b))
-  order by [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.d, (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), count(from x in t1
+  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.d, (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), count(from x in t1
   where x.b < row.b
   select x)]
   select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where x.b < row.b
-  select x), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.d]
+  select x), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.d]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case557.mochi
+++ b/tests/dataset/slt/out/select1/case557.mochi
@@ -231,8 +231,8 @@ let result = from row in t1
   where (count(from x in t1
   where x.b < row.b
   select x) > 0 && ((row.e > row.a && row.e < row.b)))
-  order by [(row.c - row.d), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.d - row.e), (if row.a < 0 { -(row.a) } else { row.a })]
-  select [(((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (row.d - row.e), (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
+  order by [(row.c - row.d), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.d - row.e), (if row.a < 0 { -(row.a) } else { row.a })]
+  select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.d - row.e), (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case558.mochi
+++ b/tests/dataset/slt/out/select1/case558.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT abs(a), c-d, abs(b-c), a+b*2+c*3 FROM t1 WHERE (a>b-2 AND a<b+2) ORDER BY 3,2,4,1 */
 let result = from row in t1
   where ((row.a > (row.b - 2) && row.a < (row.b + 2)))
-  order by [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), ((row.a + (row.b + row.b)) + (row.c * 3)), (if row.a < 0 { -(row.a) } else { row.a })]
-  select [(if row.a < 0 { -(row.a) } else { row.a }), (row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((row.a + (row.b + row.b)) + (row.c * 3))]
+  order by [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), ((row.a + (row.b * 2)) + (row.c * 3)), (if row.a < 0 { -(row.a) } else { row.a })]
+  select [(if row.a < 0 { -(row.a) } else { row.a }), (row.c - row.d), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((row.a + (row.b * 2)) + (row.c * 3))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case560.mochi
+++ b/tests/dataset/slt/out/select1/case560.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a-b, a+b*2 FROM t1 WHERE b>c OR c>d ORDER BY 2,1 */
 let result = from row in t1
   where (row.b > row.c || row.c > row.d)
-  order by [(row.a + (row.b + row.b)), (row.a - row.b)]
-  select [(row.a - row.b), (row.a + (row.b + row.b))]
+  order by [(row.a + (row.b * 2)), (row.a - row.b)]
+  select [(row.a - row.b), (row.a + (row.b * 2))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case561.mochi
+++ b/tests/dataset/slt/out/select1/case561.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4+e*5, abs(b-c) FROM t1 ORDER BY 2,1 */
 let result = from row in t1
-  order by [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
-  select [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) })]
+  order by [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case562.mochi
+++ b/tests/dataset/slt/out/select1/case562.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where ((row.d > row.e || ((row.e > row.a && row.e < row.b))) || ((row.c <= (row.d - 2) || row.c >= (row.d + 2))))
-  order by [(row.a - row.b), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (row.d - row.e), ((row.a + (row.b + row.b)) + (row.c * 3))]
-  select [(row.d - row.e), ((row.a + (row.b + row.b)) + (row.c * 3)), (row.a - row.b), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
+  order by [(row.a - row.b), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.d - row.e), ((row.a + (row.b * 2)) + (row.c * 3))]
+  select [(row.d - row.e), ((row.a + (row.b * 2)) + (row.c * 3)), (row.a - row.b), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case563.mochi
+++ b/tests/dataset/slt/out/select1/case563.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT d, d-e, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, b, c, a+b*2+c*3 FROM t1 WHERE a>b OR b>c ORDER BY 3,1,5,6,4,2 */
 let result = from row in t1
   where (row.a > row.b || row.b > row.c)
-  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.d, row.c, ((row.a + (row.b + row.b)) + (row.c * 3)), row.b, (row.d - row.e)]
-  select [row.d, (row.d - row.e), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.b, row.c, ((row.a + (row.b + row.b)) + (row.c * 3))]
+  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.d, row.c, ((row.a + (row.b * 2)) + (row.c * 3)), row.b, (row.d - row.e)]
+  select [row.d, (row.d - row.e), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.b, row.c, ((row.a + (row.b * 2)) + (row.c * 3))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case566.mochi
+++ b/tests/dataset/slt/out/select1/case566.mochi
@@ -231,8 +231,8 @@ let result = from row in t1
   where ((((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)) && row.d > row.e) && (row.c >= (row.b - 2) && row.c <= (row.d + 2)))
   order by [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), ((row.a + (row.b + row.b)) + (row.c * 3))]
-  select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), ((row.a + (row.b + row.b)) + (row.c * 3)), count(from x in t1
+  select x), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((row.a + (row.b * 2)) + (row.c * 3))]
+  select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((row.a + (row.b * 2)) + (row.c * 3)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case568.mochi
+++ b/tests/dataset/slt/out/select1/case568.mochi
@@ -228,8 +228,8 @@ let sub0 = avg(from x in t1
   select x.c)
 
 let result = from row in t1
-  order by [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.a - row.b), (row.b - row.c), row.b, (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
-  select [(row.a - row.b), (row.b - row.c), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.b]
+  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.a - row.b), (row.b - row.c), row.b, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+  select [(row.a - row.b), (row.b - row.c), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case569.mochi
+++ b/tests/dataset/slt/out/select1/case569.mochi
@@ -228,8 +228,8 @@ let result = from row in t1
   where (((row.e > row.c || row.e < row.d)) || count(from x in t1
   where x.b < row.b
   select x) > 0)
-  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.c - row.d), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (row.a + (row.b + row.b)), row.b, ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
-  select [(row.a + (row.b + row.b)), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.b, (row.c - row.d), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.c - row.d), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.a + (row.b * 2)), row.b, ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  select [(row.a + (row.b * 2)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.b, (row.c - row.d), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case570.mochi
+++ b/tests/dataset/slt/out/select1/case570.mochi
@@ -228,8 +228,8 @@ let result = from row in t1
   where (row.a > row.b || (row.d < 110 || row.d > 150))
   order by [row.e, count(from x in t1
   where x.b < row.b
-  select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.b - row.c), row.c, row.a, (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))]
-  select [row.e, (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), row.a, count(from x in t1
+  select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.b - row.c), row.c, row.a, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+  select [row.e, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.a, count(from x in t1
   where x.b < row.b
   select x), row.c, (row.b - row.c), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case571.mochi
+++ b/tests/dataset/slt/out/select1/case571.mochi
@@ -231,8 +231,8 @@ let result = from row in t1
   where ((row.c > row.d && (row.c >= (row.b - 2) && row.c <= (row.d + 2))) && ((row.e > row.c || row.e < row.d)))
   order by [count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((row.a + (row.b + row.b)) + (row.c * 3)), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
-  select [(((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((row.a + (row.b + row.b)) + (row.c * 3)), count(from x in t1
+  select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((row.a + (row.b * 2)) + (row.c * 3)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+  select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((row.a + (row.b * 2)) + (row.c * 3)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case572.mochi
+++ b/tests/dataset/slt/out/select1/case572.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where ((((row.e > row.c || row.e < row.d)) || (row.c >= (row.b - 2) && row.c <= (row.d + 2))) || row.a > row.b)
-  order by [(if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (if row.a < 0 { -(row.a) } else { row.a }), row.c, ((row.a + (row.b + row.b)) + (row.c * 3)), row.e, row.d]
-  select [((row.a + (row.b + row.b)) + (row.c * 3)), (if row.a < 0 { -(row.a) } else { row.a }), row.e, row.c, (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.d]
+  order by [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (if row.a < 0 { -(row.a) } else { row.a }), row.c, ((row.a + (row.b * 2)) + (row.c * 3)), row.e, row.d]
+  select [((row.a + (row.b * 2)) + (row.c * 3)), (if row.a < 0 { -(row.a) } else { row.a }), row.e, row.c, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.d]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case573.mochi
+++ b/tests/dataset/slt/out/select1/case573.mochi
@@ -226,10 +226,10 @@ let t1 = [
 /* SELECT a+b*2, abs(a), d, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), b-c FROM t1 WHERE b>c ORDER BY 5,1,3,2,4 */
 let result = from row in t1
   where row.b > row.c
-  order by [(row.b - row.c), (row.a + (row.b + row.b)), row.d, (if row.a < 0 { -(row.a) } else { row.a }), count(from x in t1
+  order by [(row.b - row.c), (row.a + (row.b * 2)), row.d, (if row.a < 0 { -(row.a) } else { row.a }), count(from x in t1
   where x.b < row.b
   select x)]
-  select [(row.a + (row.b + row.b)), (if row.a < 0 { -(row.a) } else { row.a }), row.d, count(from x in t1
+  select [(row.a + (row.b * 2)), (if row.a < 0 { -(row.a) } else { row.a }), row.d, count(from x in t1
   where x.b < row.b
   select x), (row.b - row.c)]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case574.mochi
+++ b/tests/dataset/slt/out/select1/case574.mochi
@@ -226,7 +226,7 @@ let t1 = [
 /* SELECT (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), (SELECT count(*) FROM t1 AS x WHERE x.c>t1.c AND x.d<t1.d), a+b*2+c*3, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, abs(b-c), CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END FROM t1 WHERE c BETWEEN b-2 AND d+2 ORDER BY 3,1,6,4,2,5 */
 let result = from row in t1
   where (row.c >= (row.b - 2) && row.c <= (row.d + 2))
-  order by [((row.a + (row.b + row.b)) + (row.c * 3)), count(from x in t1
+  order by [((row.a + (row.b * 2)) + (row.c * 3)), count(from x in t1
   where x.b < row.b
   select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
@@ -235,7 +235,7 @@ let result = from row in t1
   where x.b < row.b
   select x), count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), ((row.a + (row.b + row.b)) + (row.c * 3)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
+  select x), ((row.a + (row.b * 2)) + (row.c * 3)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case575.mochi
+++ b/tests/dataset/slt/out/select1/case575.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT b-c, a+b*2, b FROM t1 ORDER BY 2,3,1 */
 let result = from row in t1
-  order by [(row.a + (row.b + row.b)), row.b, (row.b - row.c)]
-  select [(row.b - row.c), (row.a + (row.b + row.b)), row.b]
+  order by [(row.a + (row.b * 2)), row.b, (row.b - row.c)]
+  select [(row.b - row.c), (row.a + (row.b * 2)), row.b]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case578.mochi
+++ b/tests/dataset/slt/out/select1/case578.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT abs(b-c), a+b*2+c*3+d*4, c-d, a+b*2+c*3+d*4+e*5 FROM t1 ORDER BY 4,1,3,2 */
 let result = from row in t1
-  order by [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))]
-  select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (row.c - row.d), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+  select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.c - row.d), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case581.mochi
+++ b/tests/dataset/slt/out/select1/case581.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT d, a+b*2+c*3, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END FROM t1 ORDER BY 2,1,3 */
 let result = from row in t1
-  order by [((row.a + (row.b + row.b)) + (row.c * 3)), row.d, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
-  select [row.d, ((row.a + (row.b + row.b)) + (row.c * 3)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
+  order by [((row.a + (row.b * 2)) + (row.c * 3)), row.d, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
+  select [row.d, ((row.a + (row.b * 2)) + (row.c * 3)), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case585.mochi
+++ b/tests/dataset/slt/out/select1/case585.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT c, a+b*2+c*3+d*4 FROM t1 WHERE b>c AND (a>b-2 AND a<b+2) AND (e>a AND e<b) ORDER BY 2,1 */
 let result = from row in t1
   where ((row.b > row.c && ((row.a > (row.b - 2) && row.a < (row.b + 2)))) && ((row.e > row.a && row.e < row.b)))
-  order by [(((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), row.c]
-  select [row.c, (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))]
+  order by [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.c]
+  select [row.c, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case586.mochi
+++ b/tests/dataset/slt/out/select1/case586.mochi
@@ -229,8 +229,8 @@ let sub0 = avg(from x in t1
 
 let result = from row in t1
   where (row.c > row.d && row.b > row.c)
-  order by [(if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) })]
-  select [(if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), (if row.a < 0 { -(row.a) } else { row.a })]
+  order by [(if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+  select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (if row.a < 0 { -(row.a) } else { row.a })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case587.mochi
+++ b/tests/dataset/slt/out/select1/case587.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT e, a+b*2+c*3+d*4+e*5, d-e, b-c, a+b*2+c*3+d*4, abs(b-c) FROM t1 WHERE (e>a AND e<b) ORDER BY 2,4,6,1,5,3 */
 let result = from row in t1
   where ((row.e > row.a && row.e < row.b))
-  order by [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.b - row.c), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e, (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (row.d - row.e)]
-  select [row.e, ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.d - row.e), (row.b - row.c), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) })]
+  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.b - row.c), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.d - row.e)]
+  select [row.e, ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.d - row.e), (row.b - row.c), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case589.mochi
+++ b/tests/dataset/slt/out/select1/case589.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a+b*2+c*3+d*4 FROM t1 WHERE b>c ORDER BY 1 */
 let result = from row in t1
   where row.b > row.c
-  order by (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))
-  select (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4))
+  order by (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))
+  select (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case590.mochi
+++ b/tests/dataset/slt/out/select1/case590.mochi
@@ -225,12 +225,12 @@ let t1 = [
 
 /* SELECT d-e, (SELECT count(*) FROM t1 AS x WHERE x.b<t1.b), a+b*2+c*3+d*4, abs(b-c), e FROM t1 ORDER BY 3,4,5,1,2 */
 let result = from row in t1
-  order by [(((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e, (row.d - row.e), count(from x in t1
+  order by [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e, (row.d - row.e), count(from x in t1
   where x.b < row.b
   select x)]
   select [(row.d - row.e), count(from x in t1
   where x.b < row.b
-  select x), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e]
+  select x), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.e]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case591.mochi
+++ b/tests/dataset/slt/out/select1/case591.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT e, b-c, abs(b-c), a+b*2+c*3+d*4+e*5, c-d, abs(a) FROM t1 WHERE b>c ORDER BY 3,6,2,1,5,4 */
 let result = from row in t1
   where row.b > row.c
-  order by [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if row.a < 0 { -(row.a) } else { row.a }), (row.b - row.c), row.e, (row.c - row.d), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
-  select [row.e, (row.b - row.c), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a })]
+  order by [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if row.a < 0 { -(row.a) } else { row.a }), (row.b - row.c), row.e, (row.c - row.d), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+  select [row.e, (row.b - row.c), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a })]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case593.mochi
+++ b/tests/dataset/slt/out/select1/case593.mochi
@@ -228,10 +228,10 @@ let result = from row in t1
   where row.a > row.b
   order by [count(from x in t1
   where x.b < row.b
-  select x), (if row.a < 0 { -(row.a) } else { row.a }), ((row.a + (row.b + row.b)) + (row.c * 3)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), row.c]
+  select x), (if row.a < 0 { -(row.a) } else { row.a }), ((row.a + (row.b * 2)) + (row.c * 3)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), row.c]
   select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where x.b < row.b
-  select x), (if row.a < 0 { -(row.a) } else { row.a }), row.c, ((row.a + (row.b + row.b)) + (row.c * 3))]
+  select x), (if row.a < 0 { -(row.a) } else { row.a }), row.c, ((row.a + (row.b * 2)) + (row.c * 3))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case595.mochi
+++ b/tests/dataset/slt/out/select1/case595.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, d, a+b*2+c*3+d*4, a+b*2+c*3 FROM t1 WHERE d>e OR c BETWEEN b-2 AND d+2 ORDER BY 1,4,3,2 */
 let result = from row in t1
   where (row.d > row.e || (row.c >= (row.b - 2) && row.c <= (row.d + 2)))
-  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((row.a + (row.b + row.b)) + (row.c * 3)), (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), row.d]
-  select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.d, (((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)), ((row.a + (row.b + row.b)) + (row.c * 3))]
+  order by [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((row.a + (row.b * 2)) + (row.c * 3)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.d]
+  select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.d, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((row.a + (row.b * 2)) + (row.c * 3))]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case596.mochi
+++ b/tests/dataset/slt/out/select1/case596.mochi
@@ -226,8 +226,8 @@ let t1 = [
 /* SELECT a+b*2+c*3+d*4+e*5, abs(a), b-c FROM t1 WHERE (c<=d-2 OR c>=d+2) ORDER BY 1,3,2 */
 let result = from row in t1
   where ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))
-  order by [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.b - row.c), (if row.a < 0 { -(row.a) } else { row.a })]
-  select [((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < 0 { -(row.a) } else { row.a }), (row.b - row.c)]
+  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.b - row.c), (if row.a < 0 { -(row.a) } else { row.a })]
+  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < 0 { -(row.a) } else { row.a }), (row.b - row.c)]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case598.mochi
+++ b/tests/dataset/slt/out/select1/case598.mochi
@@ -230,8 +230,8 @@ let result = from row in t1
   select x) > 0 && row.b > row.c)
   order by [count(from x in t1
   where x.b < row.b
-  select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a - row.b), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.c, (row.a + (row.b + row.b)), row.a]
-  select [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.a, (row.a + (row.b + row.b)), row.c, (row.a - row.b), count(from x in t1
+  select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a - row.b), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.c, (row.a + (row.b * 2)), row.a]
+  select [(if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), row.a, (row.a + (row.b * 2)), row.c, (row.a - row.b), count(from x in t1
   where x.b < row.b
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
 var flatResult = []

--- a/tests/dataset/slt/out/select1/case599.mochi
+++ b/tests/dataset/slt/out/select1/case599.mochi
@@ -228,14 +228,14 @@ let sub0 = avg(from x in t1
   select x.c)
 
 let result = from row in t1
-  order by [(if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.d, count(from x in t1
+  order by [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.d, count(from x in t1
   where (x.c > row.c && x.d < row.d)
-  select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a - row.b), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
+  select x), (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), (row.a - row.b), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
   where x.b < row.b
   select x)]
   select [count(from x in t1
   where x.b < row.b
-  select x), (row.a - row.b), (if row.c > sub0 { (row.a + row.a) } else { (row.b * 10) }), row.d, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), ((((row.a + (row.b + row.b)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
+  select x), (row.a - row.b), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.d, (if (row.a + 1) == row.b { 111 } else { (if (row.a + 1) == row.c { 222 } else { (if (row.a + 1) == row.d { 333 } else { (if (row.a + 1) == row.e { 444 } else { 555 }) }) }) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
 var flatResult = []

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -166,7 +166,7 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 			sv = strings.ReplaceAll(sv, ",", "")
 			sv = strings.ReplaceAll(sv, "_", "")
 
-			if sv == "true" || sv == "t" || sv == "yes" || sv == "on" {
+			if sv == "true" || sv == "t" || sv == "yes" || sv == "y" || sv == "on" {
 				if t == "" || t == "bool" {
 					t = "bool"
 				} else {
@@ -175,7 +175,7 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 				seenOne = true
 				continue
 			}
-			if sv == "false" || sv == "f" || sv == "no" || sv == "off" {
+			if sv == "false" || sv == "f" || sv == "no" || sv == "n" || sv == "off" {
 				if t == "" || t == "bool" {
 					t = "bool"
 				} else {


### PR DESCRIPTION
## Summary
- improve boolean detection in SLT generator
- regenerate cases 500-599 from `select1.test`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865f2f0ee5c83208fefb1da63c6c8c1