### PR TITLE
Add v0.10.12 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📦 CHANGELOG.md
 
+## [0.10.12] – 2025-07-03T10:13:46+07:00
+
+### Added
+
+* SQL Logic Test generator covers select1 cases 1–1000 with update statement support across compilers
+* Real TPC-DS queries 50–59 included with updated examples
+
+### Changed
+
+* Improved SLT parsing of boolean strings, unary and parenthesis expressions
+* Deduplicated VM constant registers and fixed sorted query allocation
+* Normalized float constants with extended runner timeout and logging
+
+### Fixed
+
+* Subquery caching issues in SLT runs
+* Sorting value overwrite bug and miscellaneous generator fixes
+
 ## [0.10.11] – 2025-07-02T08:31:19+07:00
 
 ### Added

--- a/releases/v0.10.12.md
+++ b/releases/v0.10.12.md
@@ -1,0 +1,22 @@
+# Jul 2025 (v0.10.12)
+
+Released on Thu Jul 3 10:13:46 2025 +0700.
+
+Mochi v0.10.12 expands SQL Logic Test coverage and improves dataset compilers while refining VM optimizations.
+
+## Runtime
+
+- Deduplicated constant registers for the virtual machine
+- Fixed register allocation bug when sorting queries
+
+## Datasets
+
+- Real TPC-DS queries 50–59 added with updated examples
+- Update statement support across all language compilers
+
+## Tooling
+
+- SQL Logic Test generator now handles select1 cases 1–1000
+- Parsing enhancements for boolean strings, unary and parenthesis expressions
+- Improved column type detection with float normalization and logging
+- Increased SLT runner timeout with subquery caching fixes


### PR DESCRIPTION
## Summary
- document v0.10.12 release
- update CHANGELOG with 0.10.12 entry

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865f5b7d97c83209b6e4011fd56b975