### PR TITLE
Update SLT generator for binary literals

### DIFF
--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -186,9 +186,29 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 			}
 
 			clean := strings.TrimPrefix(strings.TrimPrefix(sv, "+"), "-")
-			// Support hexadecimal integer literals.
+			// Support hexadecimal and binary integer literals.
 			if strings.HasPrefix(clean, "0x") || strings.HasPrefix(clean, "0X") {
 				if v, err := strconv.ParseInt(clean[2:], 16, 64); err == nil {
+					if v == 0 {
+						seenZero = true
+					} else if v == 1 {
+						seenOne = true
+					} else {
+						boolLike = false
+					}
+					if t == "" {
+						t = "int"
+					} else if t != "int" {
+						if t == "float" {
+							// allow ints in float column
+						} else {
+							return "any"
+						}
+					}
+					continue
+				}
+			} else if strings.HasPrefix(clean, "0b") || strings.HasPrefix(clean, "0B") {
+				if v, err := strconv.ParseInt(clean[2:], 2, 64); err == nil {
 					if v == 0 {
 						seenZero = true
 					} else if v == 1 {


### PR DESCRIPTION
## Summary
- update SLT generator to recognise `0b` binary literals

## Testing
- `go build ./cmd/mochi-slt`
- `go run ./cmd/mochi-slt gen --cases case1-case1 --files select1.test --run --out tests/dataset/slt/out`


------
https://chatgpt.com/codex/tasks/task_e_6865fa9f767483209e8481e83489245a