### PR TITLE
Update SLT runtime timeout support

### DIFF
--- a/tools/slt/logic/utils_test.go
+++ b/tools/slt/logic/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestGenerate(t *testing.T) {
@@ -39,7 +40,7 @@ func TestFindRepoRoot(t *testing.T) {
 }
 
 func TestRunMochi(t *testing.T) {
-	out, err := RunMochi("print(1 + 2)")
+	out, err := RunMochi("print(1 + 2)", time.Second)
 	if err != nil {
 		t.Fatalf("run mochi: %v", err)
 	}


### PR DESCRIPTION
## Summary
- allow RunMochi() to accept a timeout value
- use the timeout when running generated SQLLogicTest cases
- update tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866121127688320ba20935d233bf47a