### PR TITLE
Add SLT golden tests for Python backend

### DIFF
--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -321,6 +321,51 @@ func TestPyCompiler_TPCDSQueries(t *testing.T) {
 	}
 }
 
+func TestPyCompiler_SLTCases(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+	root := findRepoRoot(t)
+	dir := filepath.Join(root, "tests", "dataset", "slt", "out", "select1")
+	for i := 1; i <= 5; i++ {
+		name := fmt.Sprintf("case%d", i)
+		t.Run(name, func(t *testing.T) {
+			src := filepath.Join(dir, name+".mochi")
+			outWantPath := filepath.Join(dir, name+".out")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := pycode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.py")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("python3", file)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("python run error: %v\n%s", err, out)
+			}
+			gotOut := bytes.TrimSpace(out)
+			wantOut, err := os.ReadFile(outWantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", name, gotOut, bytes.TrimSpace(wantOut))
+			}
+		})
+	}
+}
+
 func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Summary
- add Python compiler golden tests for SQLLogicTest samples

## Testing
- `go test ./compile/py -run SLTCases -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686613c04a488320bfb3ebc435d560c9