### PR TITLE
Update JOB dataset IR outputs

### DIFF
--- a/tests/dataset/job/out/q1.ir.out
+++ b/tests/dataset/job/out/q1.ir.out
@@ -18,7 +18,15 @@ func main (regs=135)
   // (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)")) &&
   Const        r8, "note"
   Const        r9, "contains"
+  // (mc.note.contains("(co-production)") || mc.note.contains("(presents)"))
+  Const        r8, "note"
+  Const        r9, "contains"
+  Const        r8, "note"
+  Const        r9, "contains"
   // select { note: mc.note, title: t.title, year: t.production_year }
+  Const        r8, "note"
+  Const        r8, "note"
+  Const        r10, "title"
   Const        r10, "title"
   Const        r11, "year"
   Const        r12, "production_year"
@@ -27,6 +35,7 @@ func main (regs=135)
   Len          r14, r13
   Const        r16, 0
   Move         r15, r16
+L12:
   LessInt      r17, r15, r14
   JumpIfFalse  r17, L0
   Index        r18, r13, r15
@@ -43,13 +52,22 @@ func main (regs=135)
   // (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)")) &&
   Const        r8, "note"
   Const        r9, "contains"
+  // (mc.note.contains("(co-production)") || mc.note.contains("(presents)"))
+  Const        r8, "note"
+  Const        r9, "contains"
+  Const        r8, "note"
+  Const        r9, "contains"
   // select { note: mc.note, title: t.title, year: t.production_year }
+  Const        r8, "note"
+  Const        r8, "note"
+  Const        r10, "title"
   Const        r10, "title"
   Const        r11, "year"
   Const        r12, "production_year"
   // join mc in movie_companies on ct.id == mc.company_type_id
   Const        r16, 0
   Move         r24, r16
+L11:
   LessInt      r25, r24, r21
   JumpIfFalse  r25, L1
   Index        r26, r20, r24
@@ -72,13 +90,22 @@ func main (regs=135)
   // (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)")) &&
   Const        r8, "note"
   Const        r9, "contains"
+  // (mc.note.contains("(co-production)") || mc.note.contains("(presents)"))
+  Const        r8, "note"
+  Const        r9, "contains"
+  Const        r8, "note"
+  Const        r9, "contains"
   // select { note: mc.note, title: t.title, year: t.production_year }
+  Const        r8, "note"
+  Const        r8, "note"
+  Const        r10, "title"
   Const        r10, "title"
   Const        r11, "year"
   Const        r12, "production_year"
   // join t in title on t.id == mc.movie_id
   Const        r16, 0
   Move         r34, r16
+L10:
   LessInt      r35, r34, r32
   JumpIfFalse  r35, L2
   Index        r36, r31, r34
@@ -101,13 +128,22 @@ func main (regs=135)
   // (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)")) &&
   Const        r8, "note"
   Const        r9, "contains"
+  // (mc.note.contains("(co-production)") || mc.note.contains("(presents)"))
+  Const        r8, "note"
+  Const        r9, "contains"
+  Const        r8, "note"
+  Const        r9, "contains"
   // select { note: mc.note, title: t.title, year: t.production_year }
+  Const        r8, "note"
+  Const        r8, "note"
+  Const        r10, "title"
   Const        r10, "title"
   Const        r11, "year"
   Const        r12, "production_year"
   // join mi in movie_info_idx on mi.movie_id == t.id
   Const        r16, 0
   Move         r43, r16
+L9:
   LessInt      r44, r43, r42
   JumpIfFalse  r44, L3
   Index        r45, r41, r43
@@ -130,13 +166,22 @@ func main (regs=135)
   // (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)")) &&
   Const        r8, "note"
   Const        r9, "contains"
+  // (mc.note.contains("(co-production)") || mc.note.contains("(presents)"))
+  Const        r8, "note"
+  Const        r9, "contains"
+  Const        r8, "note"
+  Const        r9, "contains"
   // select { note: mc.note, title: t.title, year: t.production_year }
+  Const        r8, "note"
+  Const        r8, "note"
+  Const        r10, "title"
   Const        r10, "title"
   Const        r11, "year"
   Const        r12, "production_year"
   // join it in info_type on it.id == mi.info_type_id
   Const        r16, 0
   Move         r53, r16
+L8:
   LessInt      r54, r53, r51
   JumpIfFalse  r54, L4
   Index        r55, r50, r53
@@ -180,14 +225,15 @@ func main (regs=135)
   In           r73, r72, r71
   Move         r74, r73
   JumpIfTrue   r74, L7
-L8:
   Const        r8, "note"
   Index        r75, r27, r8
   Const        r76, "(presents)"
   In           r77, r76, r75
   Move         r74, r77
+L7:
   // (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)")) &&
   Move         r66, r74
+L6:
   // where ct.kind == "production companies" &&
   JumpIfFalse  r66, L5
   // select { note: mc.note, title: t.title, year: t.production_year }
@@ -210,22 +256,43 @@ L8:
   // from ct in company_type
   Append       r91, r5, r90
   Move         r5, r91
+L5:
   // join it in info_type on it.id == mi.info_type_id
   Const        r92, 1
   Add          r53, r53, r92
   Jump         L8
-L7:
+L4:
+  // join mi in movie_info_idx on mi.movie_id == t.id
+  Const        r92, 1
+  Add          r43, r43, r92
+  Jump         L9
+L3:
+  // join t in title on t.id == mc.movie_id
+  Const        r92, 1
+  Add          r34, r34, r92
+  Jump         L10
+L2:
+  // join mc in movie_companies on ct.id == mc.company_type_id
+  Const        r92, 1
+  Add          r24, r24, r92
+  Jump         L11
+L1:
+  // from ct in company_type
+  Const        r92, 1
+  AddInt       r15, r15, r92
+  Jump         L12
+L0:
   // production_note: min(from r in filtered select r.note),
   Const        r93, "production_note"
-L6:
   Const        r94, []
   Const        r8, "note"
   IterPrep     r95, r5
   Len          r96, r95
   Const        r16, 0
   Move         r97, r16
+L14:
   LessInt      r98, r97, r96
-  JumpIfFalse  r98, L9
+  JumpIfFalse  r98, L13
   Index        r99, r95, r97
   Move         r100, r99
   Const        r8, "note"
@@ -234,49 +301,60 @@ L6:
   Move         r94, r102
   Const        r92, 1
   AddInt       r97, r97, r92
-  Jump         L10
-L5:
+  Jump         L14
+L13:
+  Min          r103, r94
   // movie_title: min(from r in filtered select r.title),
+  Const        r104, "movie_title"
   Const        r105, []
   Const        r10, "title"
   IterPrep     r106, r5
-L4:
   Len          r107, r106
   Const        r16, 0
   Move         r108, r16
-L3:
+L16:
   LessInt      r109, r108, r107
-  JumpIfFalse  r109, L11
+  JumpIfFalse  r109, L15
   Index        r110, r106, r108
-L2:
   Move         r100, r110
   Const        r10, "title"
   Index        r111, r100, r10
-L1:
   Append       r112, r105, r111
   Move         r105, r112
   Const        r92, 1
-L0:
   AddInt       r108, r108, r92
-  Jump         L12
-L10:
+  Jump         L16
+L15:
+  Min          r113, r105
   // movie_year: min(from r in filtered select r.year)
+  Const        r114, "movie_year"
+  Const        r115, []
+  Const        r11, "year"
+  IterPrep     r116, r5
   Len          r117, r116
   Const        r16, 0
   Move         r118, r16
+L18:
   LessInt      r119, r118, r117
-  JumpIfFalse  r119, L13
+  JumpIfFalse  r119, L17
   Index        r120, r116, r118
   Move         r100, r120
   Const        r11, "year"
   Index        r121, r100, r11
   Append       r122, r115, r121
   Move         r115, r122
-L9:
   Const        r92, 1
   AddInt       r118, r118, r92
-  Jump         L14
-L12:
+  Jump         L18
+L17:
+  Min          r123, r115
+  // production_note: min(from r in filtered select r.note),
+  Move         r124, r93
+  Move         r125, r103
+  // movie_title: min(from r in filtered select r.title),
+  Move         r126, r104
+  Move         r127, r113
+  // movie_year: min(from r in filtered select r.year)
   Move         r128, r114
   Move         r129, r123
   // let result = {

--- a/tests/dataset/job/out/q10.ir.out
+++ b/tests/dataset/job/out/q10.ir.out
@@ -18,6 +18,9 @@ func main (regs=141)
   // where ci.note.contains("(voice)") &&
   Const        r8, "note"
   Const        r9, "contains"
+  // ci.note.contains("(uncredited)") &&
+  Const        r8, "note"
+  Const        r9, "contains"
   // cn.country_code == "[ru]" &&
   Const        r10, "country_code"
   // rt.role == "actor" &&
@@ -34,9 +37,9 @@ func main (regs=141)
   Len          r18, r17
   Const        r20, 0
   Move         r19, r20
+L15:
   LessInt      r21, r19, r18
   JumpIfFalse  r21, L0
-L5:
   Index        r22, r17, r19
   Move         r23, r22
   // join ci in cast_info on chn.id == ci.person_role_id
@@ -45,6 +48,9 @@ L5:
   Const        r26, "id"
   Const        r27, "person_role_id"
   // where ci.note.contains("(voice)") &&
+  Const        r8, "note"
+  Const        r9, "contains"
+  // ci.note.contains("(uncredited)") &&
   Const        r8, "note"
   Const        r9, "contains"
   // cn.country_code == "[ru]" &&
@@ -61,11 +67,11 @@ L5:
   // join ci in cast_info on chn.id == ci.person_role_id
   Const        r20, 0
   Move         r28, r20
+L14:
   LessInt      r29, r28, r25
   JumpIfFalse  r29, L1
   Index        r30, r24, r28
   Move         r31, r30
-L6:
   Const        r26, "id"
   Index        r32, r23, r26
   Const        r27, "person_role_id"
@@ -78,6 +84,9 @@ L6:
   Const        r26, "id"
   Const        r37, "role_id"
   // where ci.note.contains("(voice)") &&
+  Const        r8, "note"
+  Const        r9, "contains"
+  // ci.note.contains("(uncredited)") &&
   Const        r8, "note"
   Const        r9, "contains"
   // cn.country_code == "[ru]" &&
@@ -94,13 +103,13 @@ L6:
   // join rt in role_type on rt.id == ci.role_id
   Const        r20, 0
   Move         r38, r20
+L13:
   LessInt      r39, r38, r36
   JumpIfFalse  r39, L2
   Index        r40, r35, r38
   Move         r41, r40
   Const        r26, "id"
   Index        r42, r41, r26
-L7:
   Const        r37, "role_id"
   Index        r43, r31, r37
   Equal        r44, r42, r43
@@ -111,6 +120,9 @@ L7:
   Const        r26, "id"
   Const        r47, "movie_id"
   // where ci.note.contains("(voice)") &&
+  Const        r8, "note"
+  Const        r9, "contains"
+  // ci.note.contains("(uncredited)") &&
   Const        r8, "note"
   Const        r9, "contains"
   // cn.country_code == "[ru]" &&
@@ -127,6 +139,7 @@ L7:
   // join t in title on t.id == ci.movie_id
   Const        r20, 0
   Move         r48, r20
+L12:
   LessInt      r49, r48, r46
   JumpIfFalse  r49, L3
   Index        r50, r45, r48
@@ -145,6 +158,9 @@ L7:
   // where ci.note.contains("(voice)") &&
   Const        r8, "note"
   Const        r9, "contains"
+  // ci.note.contains("(uncredited)") &&
+  Const        r8, "note"
+  Const        r9, "contains"
   // cn.country_code == "[ru]" &&
   Const        r10, "country_code"
   // rt.role == "actor" &&
@@ -159,6 +175,7 @@ L7:
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r20, 0
   Move         r57, r20
+L11:
   LessInt      r58, r57, r56
   JumpIfFalse  r58, L4
   Index        r59, r55, r57
@@ -177,6 +194,9 @@ L7:
   // where ci.note.contains("(voice)") &&
   Const        r8, "note"
   Const        r9, "contains"
+  // ci.note.contains("(uncredited)") &&
+  Const        r8, "note"
+  Const        r9, "contains"
   // cn.country_code == "[ru]" &&
   Const        r10, "country_code"
   // rt.role == "actor" &&
@@ -191,6 +211,7 @@ L7:
   // join cn in company_name on cn.id == mc.company_id
   Const        r20, 0
   Move         r67, r20
+L10:
   LessInt      r68, r67, r65
   JumpIfFalse  r68, L5
   Index        r69, r64, r67
@@ -209,6 +230,9 @@ L7:
   // where ci.note.contains("(voice)") &&
   Const        r8, "note"
   Const        r9, "contains"
+  // ci.note.contains("(uncredited)") &&
+  Const        r8, "note"
+  Const        r9, "contains"
   // cn.country_code == "[ru]" &&
   Const        r10, "country_code"
   // rt.role == "actor" &&
@@ -223,6 +247,7 @@ L7:
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r20, 0
   Move         r77, r20
+L9:
   LessInt      r78, r77, r75
   JumpIfFalse  r78, L6
   Index        r79, r74, r77
@@ -238,7 +263,6 @@ L7:
   // where ci.note.contains("(voice)") &&
   Const        r85, "(voice)"
   In           r86, r85, r84
-L9:
   // t.production_year > 2005
   Const        r12, "production_year"
   Index        r87, r51, r12
@@ -273,6 +297,7 @@ L9:
   // rt.role == "actor" &&
   JumpIfFalse  r96, L8
   Move         r96, r89
+L8:
   // where ci.note.contains("(voice)") &&
   JumpIfFalse  r96, L7
   // select { character: chn.name, movie: t.title }
@@ -290,49 +315,90 @@ L9:
   // from chn in char_name
   Append       r109, r7, r108
   Move         r7, r109
-L8:
+L7:
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r110, 1
   Add          r77, r77, r110
   Jump         L9
+L6:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r110, 1
+  Add          r67, r67, r110
+  Jump         L10
+L5:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r110, 1
+  Add          r57, r57, r110
+  Jump         L11
 L4:
+  // join t in title on t.id == ci.movie_id
+  Const        r110, 1
+  Add          r48, r48, r110
+  Jump         L12
+L3:
+  // join rt in role_type on rt.id == ci.role_id
+  Const        r110, 1
+  Add          r38, r38, r110
+  Jump         L13
+L2:
+  // join ci in cast_info on chn.id == ci.person_role_id
+  Const        r110, 1
+  Add          r28, r28, r110
+  Jump         L14
+L1:
+  // from chn in char_name
+  Const        r110, 1
+  AddInt       r19, r19, r110
+  Jump         L15
+L0:
   // uncredited_voiced_character: min(from x in matches select x.character),
+  Const        r112, "uncredited_voiced_character"
+  Const        r113, []
   Const        r13, "character"
   IterPrep     r114, r7
   Len          r115, r114
-L3:
   Const        r20, 0
   Move         r116, r20
+L17:
   LessInt      r117, r116, r115
-L2:
-  JumpIfFalse  r117, L10
+  JumpIfFalse  r117, L16
   Index        r118, r114, r116
   Move         r119, r118
-L1:
   Const        r13, "character"
   Index        r120, r119, r13
   Append       r121, r113, r120
-L0:
   Move         r113, r121
   Const        r110, 1
   AddInt       r116, r116, r110
+  Jump         L17
+L16:
+  Min          r122, r113
   // russian_movie: min(from x in matches select x.movie)
+  Const        r123, "russian_movie"
+  Const        r124, []
   Const        r15, "movie"
   IterPrep     r125, r7
   Len          r126, r125
   Const        r20, 0
   Move         r127, r20
+L19:
   LessInt      r128, r127, r126
-  JumpIfFalse  r128, L11
+  JumpIfFalse  r128, L18
   Index        r129, r125, r127
   Move         r119, r129
   Const        r15, "movie"
   Index        r130, r119, r15
-L10:
   Append       r131, r124, r130
   Move         r124, r131
   Const        r110, 1
   AddInt       r127, r127, r110
+  Jump         L19
+L18:
+  Min          r132, r124
+  // uncredited_voiced_character: min(from x in matches select x.character),
+  Move         r133, r112
+  Move         r134, r122
+  // russian_movie: min(from x in matches select x.movie)
   Move         r135, r123
   Move         r136, r132
   // {

--- a/tests/dataset/job/out/q11.ir.out
+++ b/tests/dataset/job/out/q11.ir.out
@@ -22,26 +22,42 @@ func main (regs=190)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r10, "name"
   Const        r11, "contains"
+  Const        r10, "name"
+  Const        r11, "contains"
   // ct.kind == "production companies" &&
   Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
   // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
   Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // from cn in company_name
   IterPrep     r20, r0
   Len          r21, r20
   Const        r23, 0
   Move         r22, r23
+L18:
   LessInt      r24, r22, r21
   JumpIfFalse  r24, L0
   Index        r25, r20, r22
@@ -56,24 +72,40 @@ func main (regs=190)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r10, "name"
   Const        r11, "contains"
+  Const        r10, "name"
+  Const        r11, "contains"
   // ct.kind == "production companies" &&
   Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
   // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
   Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // join mc in movie_companies on mc.company_id == cn.id
   Const        r23, 0
   Move         r31, r23
+L17:
   LessInt      r32, r31, r28
   JumpIfFalse  r32, L1
   Index        r33, r27, r31
@@ -94,24 +126,40 @@ func main (regs=190)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r10, "name"
   Const        r11, "contains"
+  Const        r10, "name"
+  Const        r11, "contains"
   // ct.kind == "production companies" &&
   Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
   // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
   Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r23, 0
   Move         r41, r23
+L16:
   LessInt      r42, r41, r39
   JumpIfFalse  r42, L2
   Index        r43, r38, r41
@@ -132,22 +180,40 @@ func main (regs=190)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r10, "name"
   Const        r11, "contains"
+  Const        r10, "name"
+  Const        r11, "contains"
   // ct.kind == "production companies" &&
   Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // join t in title on t.id == mc.movie_id
   Const        r23, 0
   Move         r50, r23
+L15:
   LessInt      r51, r50, r49
   JumpIfFalse  r51, L3
   Index        r52, r48, r50
@@ -168,22 +234,40 @@ func main (regs=190)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r10, "name"
   Const        r11, "contains"
+  Const        r10, "name"
+  Const        r11, "contains"
   // ct.kind == "production companies" &&
   Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r23, 0
   Move         r59, r23
+L14:
   LessInt      r60, r59, r58
   JumpIfFalse  r60, L4
   Index        r61, r57, r59
@@ -204,24 +288,40 @@ func main (regs=190)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r10, "name"
   Const        r11, "contains"
+  Const        r10, "name"
+  Const        r11, "contains"
   // ct.kind == "production companies" &&
   Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
   // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
   Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r23, 0
   Move         r69, r23
+L13:
   LessInt      r70, r69, r67
   JumpIfFalse  r70, L5
   Index        r71, r66, r69
@@ -242,22 +342,40 @@ func main (regs=190)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r10, "name"
   Const        r11, "contains"
+  Const        r10, "name"
+  Const        r11, "contains"
   // ct.kind == "production companies" &&
   Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // join ml in movie_link on ml.movie_id == t.id
   Const        r23, 0
   Move         r78, r23
+L12:
   LessInt      r79, r78, r77
   JumpIfFalse  r79, L6
   Index        r80, r76, r78
@@ -273,10 +391,11 @@ func main (regs=190)
   Len          r86, r85
   Const        r30, "id"
   Const        r87, "link_type_id"
-L11:
   // where cn.country_code != "[pl]" &&
   Const        r9, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+  Const        r10, "name"
+  Const        r11, "contains"
   Const        r10, "name"
   Const        r11, "contains"
   // ct.kind == "production companies" &&
@@ -285,18 +404,32 @@ L11:
   Const        r13, "keyword"
   // lt.link.contains("follow") &&
   Const        r14, "link"
+  Const        r11, "contains"
   // mc.note == null &&
   Const        r15, "note"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r16, "production_year"
+  Const        r16, "production_year"
   // ml.movie_id == mk.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
+  Const        r17, "movie_id"
+  // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
   Const        r17, "movie_id"
   // select { company: cn.name, link: lt.link, title: t.title }
   Const        r18, "company"
+  Const        r10, "name"
+  Const        r14, "link"
+  Const        r14, "link"
+  Const        r19, "title"
   Const        r19, "title"
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r23, 0
   Move         r88, r23
+L11:
   LessInt      r89, r88, r86
   JumpIfFalse  r89, L7
   Index        r90, r85, r88
@@ -315,6 +448,7 @@ L11:
   Index        r96, r53, r16
   Const        r97, 1950
   LessEq       r98, r97, r96
+  Const        r16, "production_year"
   Index        r99, r53, r16
   Const        r100, 2000
   LessEq       r101, r99, r100
@@ -339,14 +473,19 @@ L11:
   // ml.movie_id == mk.movie_id &&
   Const        r17, "movie_id"
   Index        r113, r81, r17
+  Const        r17, "movie_id"
   Index        r114, r62, r17
   Equal        r115, r113, r114
   // ml.movie_id == mc.movie_id &&
+  Const        r17, "movie_id"
   Index        r116, r81, r17
+  Const        r17, "movie_id"
   Index        r117, r34, r17
   Equal        r118, r116, r117
   // mk.movie_id == mc.movie_id
+  Const        r17, "movie_id"
   Index        r119, r62, r17
+  Const        r17, "movie_id"
   Index        r120, r34, r17
   Equal        r121, r119, r120
   // where cn.country_code != "[pl]" &&
@@ -364,6 +503,7 @@ L11:
   Const        r128, "Warner"
   In           r129, r128, r127
   Move         r126, r129
+L10:
   // where cn.country_code != "[pl]" &&
   Move         r122, r126
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
@@ -398,6 +538,7 @@ L11:
   // ml.movie_id == mc.movie_id &&
   JumpIfFalse  r122, L9
   Move         r122, r121
+L9:
   // where cn.country_code != "[pl]" &&
   JumpIfFalse  r122, L8
   // select { company: cn.name, link: lt.link, title: t.title }
@@ -420,15 +561,102 @@ L11:
   // from cn in company_name
   Append       r146, r8, r145
   Move         r8, r146
+L8:
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r147, 1
   Add          r88, r88, r147
+  Jump         L11
+L7:
+  // join ml in movie_link on ml.movie_id == t.id
+  Const        r147, 1
+  Add          r78, r78, r147
+  Jump         L12
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r147, 1
+  Add          r69, r69, r147
+  Jump         L13
+L5:
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r147, 1
   Add          r59, r59, r147
-  Jump         L11
-L10:
+  Jump         L14
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r147, 1
+  Add          r50, r50, r147
+  Jump         L15
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r147, 1
+  Add          r41, r41, r147
+  Jump         L16
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r147, 1
+  Add          r31, r31, r147
+  Jump         L17
+L1:
+  // from cn in company_name
+  Const        r147, 1
+  AddInt       r22, r22, r147
+  Jump         L18
+L0:
+  // from_company: min(from x in matches select x.company),
+  Const        r149, "from_company"
+  Const        r150, []
+  Const        r18, "company"
+  IterPrep     r151, r8
+  Len          r152, r151
+  Const        r23, 0
+  Move         r153, r23
+L20:
+  LessInt      r154, r153, r152
+  JumpIfFalse  r154, L19
+  Index        r155, r151, r153
+  Move         r156, r155
+  Const        r18, "company"
+  Index        r157, r156, r18
+  Append       r158, r150, r157
+  Move         r150, r158
+  Const        r147, 1
+  AddInt       r153, r153, r147
+  Jump         L20
+L19:
+  Min          r159, r150
+  // movie_link_type: min(from x in matches select x.link),
+  Const        r160, "movie_link_type"
+  Const        r161, []
+  Const        r14, "link"
+  IterPrep     r162, r8
+  Len          r163, r162
+  Const        r23, 0
+  Move         r164, r23
+L22:
+  LessInt      r165, r164, r163
+  JumpIfFalse  r165, L21
+  Index        r166, r162, r164
+  Move         r156, r166
+  Const        r14, "link"
+  Index        r167, r156, r14
+  Append       r168, r161, r167
+  Move         r161, r168
+  Const        r147, 1
+  AddInt       r164, r164, r147
+  Jump         L22
+L21:
+  Min          r169, r161
   // non_polish_sequel_movie: min(from x in matches select x.title)
+  Const        r170, "non_polish_sequel_movie"
+  Const        r171, []
+  Const        r19, "title"
+  IterPrep     r172, r8
+  Len          r173, r172
+  Const        r23, 0
+  Move         r174, r23
+L24:
+  LessInt      r175, r174, r173
+  JumpIfFalse  r175, L23
   Index        r176, r172, r174
   Move         r156, r176
   Const        r19, "title"
@@ -437,6 +665,27 @@ L10:
   Move         r171, r178
   Const        r147, 1
   AddInt       r174, r174, r147
-  Jump         L12
-L9:
+  Jump         L24
+L23:
+  Min          r179, r171
+  // from_company: min(from x in matches select x.company),
+  Move         r180, r149
+  Move         r181, r159
+  // movie_link_type: min(from x in matches select x.link),
+  Move         r182, r160
+  Move         r183, r169
+  // non_polish_sequel_movie: min(from x in matches select x.title)
+  Move         r184, r170
+  Move         r185, r179
+  // {
+  MakeMap      r186, 3, r180
+  Move         r148, r186
+  // let result = [
+  MakeList     r187, 1, r148
+  // json(result)
+  JSON         r187
+  // expect result == [
+  Const        r188, [{"from_company": "Best Film Co", "movie_link_type": "follow-up", "non_polish_sequel_movie": "Alpha"}]
+  Equal        r189, r187, r188
+  Expect       r189
   Return       r0

--- a/tests/dataset/job/out/q12.ir.out
+++ b/tests/dataset/job/out/q12.ir.out
@@ -21,13 +21,23 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
@@ -36,6 +46,7 @@ func main (regs=137)
   Len          r18, r17
   Const        r20, 0
   Move         r19, r20
+L18:
   LessInt      r21, r19, r18
   JumpIfFalse  r21, L0
   Index        r22, r17, r19
@@ -51,19 +62,30 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
   // join mc in movie_companies on mc.company_id == cn.id
   Const        r20, 0
   Move         r28, r20
+L17:
   LessInt      r29, r28, r25
   JumpIfFalse  r29, L1
   Index        r30, r24, r28
@@ -85,19 +107,30 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r20, 0
   Move         r38, r20
+L16:
   LessInt      r39, r38, r36
   JumpIfFalse  r39, L2
   Index        r40, r35, r38
@@ -119,19 +152,30 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
   // join t in title on t.id == mc.movie_id
   Const        r20, 0
   Move         r48, r20
+L15:
   LessInt      r49, r48, r46
   JumpIfFalse  r49, L3
   Index        r50, r45, r48
@@ -153,19 +197,30 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r20, 0
   Move         r57, r20
+L14:
   LessInt      r58, r57, r56
   JumpIfFalse  r58, L4
   Index        r59, r55, r57
@@ -187,19 +242,30 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r20, 0
   Move         r67, r20
+L13:
   LessInt      r68, r67, r65
   JumpIfFalse  r68, L5
   Index        r69, r64, r67
@@ -221,19 +287,30 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
   // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
   Const        r20, 0
   Move         r76, r20
+L12:
   LessInt      r77, r76, r75
   JumpIfFalse  r77, L6
   Index        r78, r74, r76
@@ -255,19 +332,30 @@ func main (regs=137)
   Const        r9, "kind"
   // it1.info == "genres" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r10, "info"
+  Const        r10, "info"
+  // mi_idx.info > 8.0 &&
+  Const        r10, "info"
   // t.production_year >= 2005 &&
+  Const        r11, "production_year"
+  // t.production_year <= 2008
   Const        r11, "production_year"
   // movie_company: cn.name,
   Const        r12, "movie_company"
   Const        r13, "name"
   // rating: mi_idx.info,
   Const        r14, "rating"
+  Const        r10, "info"
   // drama_horror_movie: t.title
   Const        r15, "drama_horror_movie"
   Const        r16, "title"
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r20, 0
   Move         r85, r20
+L11:
   LessInt      r86, r85, r84
   JumpIfFalse  r86, L7
   Index        r87, r83, r85
@@ -292,6 +380,7 @@ func main (regs=137)
   Const        r97, 2005
   LessEq       r98, r97, r96
   // t.production_year <= 2008
+  Const        r11, "production_year"
   Index        r99, r51, r11
   Const        r100, 2008
   LessEq       r101, r99, r100
@@ -304,10 +393,12 @@ func main (regs=137)
   Const        r105, "production companies"
   Equal        r106, r104, r105
   // it1.info == "genres" &&
+  Const        r10, "info"
   Index        r107, r70, r10
   Const        r108, "genres"
   Equal        r109, r107, r108
   // it2.info == "rating" &&
+  Const        r10, "info"
   Index        r110, r88, r10
   Const        r14, "rating"
   Equal        r111, r110, r14
@@ -328,13 +419,14 @@ func main (regs=137)
   Index        r113, r60, r10
   Const        r114, "Drama"
   Equal        r115, r113, r114
+  Const        r10, "info"
   Index        r116, r60, r10
-L11:
   Const        r117, "Horror"
   Equal        r118, r116, r117
   Move         r119, r115
   JumpIfTrue   r119, L10
   Move         r119, r118
+L10:
   // it2.info == "rating" &&
   Move         r112, r119
   // (mi.info == "Drama" || mi.info == "Horror") &&
@@ -346,6 +438,7 @@ L11:
   // t.production_year >= 2005 &&
   JumpIfFalse  r112, L9
   Move         r112, r101
+L9:
   // cn.country_code == "[us]" &&
   JumpIfFalse  r112, L8
   // movie_company: cn.name,
@@ -374,12 +467,51 @@ L11:
   // from cn in company_name
   Append       r133, r7, r132
   Move         r7, r133
+L8:
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r134, 1
   Add          r85, r85, r134
   Jump         L11
-L10:
+L7:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r134, 1
+  Add          r76, r76, r134
+  Jump         L12
+L6:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r134, 1
+  Add          r67, r67, r134
+  Jump         L13
+L5:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r134, 1
+  Add          r57, r57, r134
+  Jump         L14
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r134, 1
+  Add          r48, r48, r134
+  Jump         L15
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r134, 1
+  Add          r38, r38, r134
+  Jump         L16
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r134, 1
+  Add          r28, r28, r134
+  Jump         L17
+L1:
+  // from cn in company_name
+  Const        r134, 1
+  AddInt       r19, r19, r134
+  Jump         L18
+L0:
+  // json(result)
+  JSON         r7
   // expect result == [
+  Const        r135, [{"drama_horror_movie": "Great Drama", "movie_company": "Best Pictures", "rating": 8.3}]
   Equal        r136, r7, r135
   Expect       r136
   Return       r0

--- a/tests/dataset/job/out/q13.ir.out
+++ b/tests/dataset/job/out/q13.ir.out
@@ -23,10 +23,16 @@ func main (regs=186)
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
@@ -35,6 +41,7 @@ func main (regs=186)
   Len          r17, r16
   Const        r19, 0
   Move         r18, r19
+L19:
   LessInt      r20, r18, r17
   JumpIfFalse  r20, L0
   Index        r21, r16, r18
@@ -50,16 +57,23 @@ func main (regs=186)
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join mc in movie_companies on mc.company_id == cn.id
   Const        r19, 0
   Move         r27, r19
+L18:
   LessInt      r28, r27, r24
   JumpIfFalse  r28, L1
   Index        r29, r23, r27
@@ -81,16 +95,23 @@ func main (regs=186)
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r19, 0
   Move         r37, r19
+L17:
   LessInt      r38, r37, r35
   JumpIfFalse  r38, L2
   Index        r39, r34, r37
@@ -104,7 +125,6 @@ func main (regs=186)
   // join t in title on t.id == mc.movie_id
   IterPrep     r44, r4
   Len          r45, r44
-L10:
   Const        r26, "id"
   Const        r46, "movie_id"
   // where cn.country_code == "[de]" &&
@@ -113,16 +133,23 @@ L10:
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join t in title on t.id == mc.movie_id
   Const        r19, 0
   Move         r47, r19
+L16:
   LessInt      r48, r47, r45
   JumpIfFalse  r48, L3
   Index        r49, r44, r47
@@ -144,16 +171,23 @@ L10:
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join kt in kind_type on kt.id == t.kind_id
   Const        r19, 0
   Move         r57, r19
+L15:
   LessInt      r58, r57, r55
   JumpIfFalse  r58, L4
   Index        r59, r54, r57
@@ -175,16 +209,23 @@ L10:
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r19, 0
   Move         r66, r19
+L14:
   LessInt      r67, r66, r65
   JumpIfFalse  r67, L5
   Index        r68, r64, r66
@@ -206,16 +247,23 @@ L10:
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join it2 in info_type on it2.id == mi.info_type_id
   Const        r19, 0
   Move         r76, r19
+L13:
   LessInt      r77, r76, r74
   JumpIfFalse  r77, L6
   Index        r78, r73, r76
@@ -237,16 +285,23 @@ L10:
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join miidx in movie_info_idx on miidx.movie_id == t.id
   Const        r19, 0
   Move         r85, r19
+L12:
   LessInt      r86, r85, r84
   JumpIfFalse  r86, L7
   Index        r87, r83, r85
@@ -268,16 +323,23 @@ L10:
   Const        r10, "kind"
   // it.info == "rating" &&
   Const        r11, "info"
+  // it2.info == "release dates" &&
+  Const        r11, "info"
+  // kt.kind == "movie"
+  Const        r10, "kind"
   // release_date: mi.info,
   Const        r12, "release_date"
+  Const        r11, "info"
   // rating: miidx.info,
   Const        r13, "rating"
+  Const        r11, "info"
   // german_movie: t.title
   Const        r14, "german_movie"
   Const        r15, "title"
   // join it in info_type on it.id == miidx.info_type_id
   Const        r19, 0
   Move         r94, r19
+L11:
   LessInt      r95, r94, r93
   JumpIfFalse  r95, L8
   Index        r96, r92, r94
@@ -304,10 +366,12 @@ L10:
   Const        r13, "rating"
   Equal        r108, r107, r13
   // it2.info == "release dates" &&
+  Const        r11, "info"
   Index        r109, r79, r11
   Const        r110, "release dates"
   Equal        r111, r109, r110
   // kt.kind == "movie"
+  Const        r10, "kind"
   Index        r112, r60, r10
   Const        r113, "movie"
   Equal        r114, r112, r113
@@ -323,8 +387,8 @@ L10:
   Move         r115, r111
   // it2.info == "release dates" &&
   JumpIfFalse  r115, L10
-L11:
   Move         r115, r114
+L10:
   // where cn.country_code == "[de]" &&
   JumpIfFalse  r115, L9
   // release_date: mi.info,
@@ -333,6 +397,7 @@ L11:
   Index        r117, r69, r11
   // rating: miidx.info,
   Const        r118, "rating"
+  Const        r11, "info"
   Index        r119, r88, r11
   // german_movie: t.title
   Const        r120, "german_movie"
@@ -352,46 +417,101 @@ L11:
   // from cn in company_name
   Append       r129, r8, r128
   Move         r8, r129
+L9:
   // join it in info_type on it.id == miidx.info_type_id
   Const        r130, 1
   Add          r94, r94, r130
   Jump         L11
-L9:
+L8:
+  // join miidx in movie_info_idx on miidx.movie_id == t.id
+  Const        r130, 1
+  Add          r85, r85, r130
+  Jump         L12
+L7:
+  // join it2 in info_type on it2.id == mi.info_type_id
+  Const        r130, 1
+  Add          r76, r76, r130
+  Jump         L13
+L6:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r130, 1
+  Add          r66, r66, r130
+  Jump         L14
+L5:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r130, 1
+  Add          r57, r57, r130
+  Jump         L15
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r130, 1
+  Add          r47, r47, r130
+  Jump         L16
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r130, 1
+  Add          r37, r37, r130
+  Jump         L17
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r130, 1
+  Add          r27, r27, r130
+  Jump         L18
+L1:
+  // from cn in company_name
+  Const        r130, 1
+  AddInt       r18, r18, r130
+  Jump         L19
+L0:
   // release_date: (from x in candidates sort by x.release_date select x.release_date)[0],
+  Const        r131, "release_date"
+  Const        r132, []
+  Const        r12, "release_date"
+  Const        r12, "release_date"
+  IterPrep     r133, r8
+  Len          r134, r133
+  Const        r19, 0
+  Move         r135, r19
+L21:
+  LessInt      r136, r135, r134
+  JumpIfFalse  r136, L20
+  Index        r137, r133, r135
+  Move         r138, r137
+  Const        r12, "release_date"
   Index        r139, r138, r12
+  Const        r12, "release_date"
   Index        r142, r138, r12
   Move         r140, r142
-L8:
   Move         r141, r139
   MakeList     r143, 2, r140
   Append       r144, r132, r143
-L7:
   Move         r132, r144
   Const        r130, 1
   AddInt       r135, r135, r130
-  Jump         L6
-L5:
+  Jump         L21
+L20:
+  Sort         r145, r132
+  Move         r132, r145
   Const        r19, 0
   Index        r146, r132, r19
   // rating: (from x in candidates sort by x.rating select x.rating)[0],
   Const        r147, "rating"
-L4:
   Const        r148, []
   Const        r13, "rating"
+  Const        r13, "rating"
   IterPrep     r149, r8
-L3:
   Len          r150, r149
+  Const        r19, 0
   Move         r151, r19
+L23:
   LessInt      r152, r151, r150
-L2:
-  JumpIfFalse  r152, L12
+  JumpIfFalse  r152, L22
   Index        r153, r149, r151
   Move         r138, r153
-L1:
   Const        r13, "rating"
   Index        r154, r138, r13
+  Const        r13, "rating"
   Index        r157, r138, r13
-L0:
   Move         r155, r157
   Move         r156, r154
   MakeList     r158, 2, r155
@@ -399,8 +519,8 @@ L0:
   Move         r148, r159
   Const        r130, 1
   AddInt       r151, r151, r130
-  Jump         L13
-L6:
+  Jump         L23
+L22:
   Sort         r160, r148
   Move         r148, r160
   Const        r19, 0
@@ -409,15 +529,19 @@ L6:
   Const        r162, "german_movie"
   Const        r163, []
   Const        r14, "german_movie"
+  Const        r14, "german_movie"
   IterPrep     r164, r8
   Len          r165, r164
+  Const        r19, 0
   Move         r166, r19
+L25:
   LessInt      r167, r166, r165
-  JumpIfFalse  r167, L14
+  JumpIfFalse  r167, L24
   Index        r168, r164, r166
   Move         r138, r168
   Const        r14, "german_movie"
   Index        r169, r138, r14
+  Const        r14, "german_movie"
   Index        r172, r138, r14
   Move         r170, r172
   Move         r171, r169
@@ -426,8 +550,11 @@ L6:
   Move         r163, r174
   Const        r130, 1
   AddInt       r166, r166, r130
-  Jump         L15
-L13:
+  Jump         L25
+L24:
+  Sort         r175, r163
+  Move         r163, r175
+  Const        r19, 0
   Index        r176, r163, r19
   // release_date: (from x in candidates sort by x.release_date select x.release_date)[0],
   Move         r177, r131

--- a/tests/dataset/job/out/q14.ir.out
+++ b/tests/dataset/job/out/q14.ir.out
@@ -21,30 +21,60 @@ func main (regs=160)
   Const        r9, []
   // it1.info == "countries" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r11, "keyword"
   // kt.kind == "movie" &&
   Const        r12, "kind"
+  // (mi.info in allowed_countries) &&
+  Const        r10, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r10, "info"
   // t.production_year > 2010 &&
   Const        r13, "production_year"
   // kt.id == t.kind_id &&
   Const        r14, "id"
   Const        r15, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r14, "id"
+  Const        r16, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r14, "id"
+  Const        r16, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r14, "id"
+  Const        r16, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
   Const        r16, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r14, "id"
   Const        r17, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r14, "id"
+  Const        r18, "info_type_id"
+  // it2.id == mi_idx.info_type_id
+  Const        r14, "id"
   Const        r18, "info_type_id"
   // rating: mi_idx.info,
   Const        r19, "rating"
+  Const        r10, "info"
   // title: t.title
+  Const        r20, "title"
   Const        r20, "title"
   // from it1 in info_type
   IterPrep     r21, r0
   Len          r22, r21
   Const        r24, 0
   Move         r23, r24
+L17:
   LessInt      r25, r23, r22
   JumpIfFalse  r25, L0
   Index        r26, r21, r23
@@ -54,6 +84,7 @@ func main (regs=160)
   Len          r29, r28
   Const        r24, 0
   Move         r30, r24
+L16:
   LessInt      r31, r30, r29
   JumpIfFalse  r31, L1
   Index        r32, r28, r30
@@ -63,16 +94,17 @@ func main (regs=160)
   Len          r35, r34
   Const        r24, 0
   Move         r36, r24
+L15:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L2
   Index        r38, r34, r36
   Move         r39, r38
-L8:
   // from kt in kind_type
   IterPrep     r40, r2
   Len          r41, r40
   Const        r24, 0
   Move         r42, r24
+L14:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L3
   Index        r44, r40, r42
@@ -82,6 +114,7 @@ L8:
   Len          r47, r46
   Const        r24, 0
   Move         r48, r24
+L13:
   LessInt      r49, r48, r47
   JumpIfFalse  r49, L4
   Index        r50, r46, r48
@@ -91,6 +124,7 @@ L8:
   Len          r53, r52
   Const        r24, 0
   Move         r54, r24
+L12:
   LessInt      r55, r54, r53
   JumpIfFalse  r55, L5
   Index        r56, r52, r54
@@ -100,6 +134,7 @@ L8:
   Len          r59, r58
   Const        r24, 0
   Move         r60, r24
+L11:
   LessInt      r61, r60, r59
   JumpIfFalse  r61, L6
   Index        r62, r58, r60
@@ -109,6 +144,7 @@ L8:
   Len          r65, r64
   Const        r24, 0
   Move         r66, r24
+L10:
   LessInt      r67, r66, r65
   JumpIfFalse  r67, L7
   Index        r68, r64, r66
@@ -117,6 +153,7 @@ L8:
   Const        r10, "info"
   Index        r70, r27, r10
   // mi_idx.info < 8.5 &&
+  Const        r10, "info"
   Index        r71, r57, r10
   Const        r72, 8.5
   LessFloat    r73, r71, r72
@@ -129,13 +166,13 @@ L8:
   Const        r77, "countries"
   Equal        r78, r70, r77
   // it2.info == "rating" &&
+  Const        r10, "info"
   Index        r79, r33, r10
   Const        r19, "rating"
   Equal        r80, r79, r19
   // kt.kind == "movie" &&
   Const        r12, "kind"
   Index        r81, r45, r12
-L10:
   Const        r82, "movie"
   Equal        r83, r81, r82
   // kt.id == t.kind_id &&
@@ -145,42 +182,57 @@ L10:
   Index        r85, r69, r15
   Equal        r86, r84, r85
   // t.id == mi.movie_id &&
+  Const        r14, "id"
   Index        r87, r69, r14
   Const        r16, "movie_id"
   Index        r88, r51, r16
   Equal        r89, r87, r88
   // t.id == mk.movie_id &&
+  Const        r14, "id"
   Index        r90, r69, r14
+  Const        r16, "movie_id"
   Index        r91, r63, r16
   Equal        r92, r90, r91
   // t.id == mi_idx.movie_id &&
+  Const        r14, "id"
   Index        r93, r69, r14
+  Const        r16, "movie_id"
   Index        r94, r57, r16
   Equal        r95, r93, r94
   // mk.movie_id == mi.movie_id &&
+  Const        r16, "movie_id"
   Index        r96, r63, r16
+  Const        r16, "movie_id"
   Index        r97, r51, r16
   Equal        r98, r96, r97
   // mk.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
   Index        r99, r63, r16
+  Const        r16, "movie_id"
   Index        r100, r57, r16
   Equal        r101, r99, r100
   // mi.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
   Index        r102, r51, r16
+  Const        r16, "movie_id"
   Index        r103, r57, r16
   Equal        r104, r102, r103
   // k.id == mk.keyword_id &&
+  Const        r14, "id"
   Index        r105, r39, r14
   Const        r17, "keyword_id"
   Index        r106, r63, r17
   Equal        r107, r105, r106
   // it1.id == mi.info_type_id &&
+  Const        r14, "id"
   Index        r108, r27, r14
   Const        r18, "info_type_id"
   Index        r109, r51, r18
   Equal        r110, r108, r109
   // it2.id == mi_idx.info_type_id
+  Const        r14, "id"
   Index        r111, r33, r14
+  Const        r18, "info_type_id"
   Index        r112, r57, r18
   Equal        r113, r111, r112
   // it1.info == "countries" &&
@@ -244,6 +296,7 @@ L10:
   // it1.id == mi.info_type_id &&
   JumpIfFalse  r114, L8
   Move         r114, r113
+L8:
   // where (
   JumpIfFalse  r114, L9
   // rating: mi_idx.info,
@@ -265,44 +318,90 @@ L10:
   // from it1 in info_type
   Append       r130, r9, r129
   Move         r9, r130
+L9:
   // from t in title
   Const        r131, 1
   AddInt       r66, r66, r131
   Jump         L10
-L9:
+L7:
+  // from mk in movie_keyword
+  Const        r131, 1
+  AddInt       r60, r60, r131
+  Jump         L11
+L6:
+  // from mi_idx in movie_info_idx
+  Const        r131, 1
+  AddInt       r54, r54, r131
+  Jump         L12
+L5:
+  // from mi in movie_info
+  Const        r131, 1
+  AddInt       r48, r48, r131
+  Jump         L13
+L4:
+  // from kt in kind_type
+  Const        r131, 1
+  AddInt       r42, r42, r131
+  Jump         L14
+L3:
+  // from k in keyword
+  Const        r131, 1
+  AddInt       r36, r36, r131
+  Jump         L15
+L2:
+  // from it2 in info_type
+  Const        r131, 1
+  AddInt       r30, r30, r131
+  Jump         L16
+L1:
+  // from it1 in info_type
+  Const        r131, 1
+  AddInt       r23, r23, r131
+  Jump         L17
+L0:
   // rating: min(from x in matches select x.rating),
+  Const        r132, "rating"
+  Const        r133, []
+  Const        r19, "rating"
+  IterPrep     r134, r9
+  Len          r135, r134
+  Const        r24, 0
+  Move         r136, r24
+L19:
+  LessInt      r137, r136, r135
+  JumpIfFalse  r137, L18
+  Index        r138, r134, r136
+  Move         r139, r138
+  Const        r19, "rating"
+  Index        r140, r139, r19
   Append       r141, r133, r140
   Move         r133, r141
   Const        r131, 1
-L7:
   AddInt       r136, r136, r131
-  Jump         L11
-L6:
+  Jump         L19
+L18:
+  Min          r142, r133
   // northern_dark_movie: min(from x in matches select x.title)
   Const        r143, "northern_dark_movie"
   Const        r144, []
   Const        r20, "title"
-L5:
   IterPrep     r145, r9
   Len          r146, r145
   Const        r24, 0
-L4:
   Move         r147, r24
+L21:
   LessInt      r148, r147, r146
-  JumpIfFalse  r148, L12
-L3:
+  JumpIfFalse  r148, L20
   Index        r149, r145, r147
   Move         r139, r149
   Const        r20, "title"
-L2:
   Index        r150, r139, r20
   Append       r151, r144, r150
   Move         r144, r151
-L1:
   Const        r131, 1
   AddInt       r147, r147, r131
-  Jump         L13
-L0:
+  Jump         L21
+L20:
   Min          r152, r144
   // rating: min(from x in matches select x.rating),
   Move         r153, r132
@@ -314,7 +413,6 @@ L0:
   MakeMap      r157, 2, r153
   // json(result)
   JSON         r157
-L11:
   // expect result == { rating: 7.0, northern_dark_movie: "A Dark Movie" }
   Const        r158, {"northern_dark_movie": "A Dark Movie", "rating": 7.0}
   Equal        r159, r157, r158

--- a/tests/dataset/job/out/q15.ir.out
+++ b/tests/dataset/job/out/q15.ir.out
@@ -26,10 +26,23 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // from t in title
@@ -37,6 +50,7 @@ func main (regs=168)
   Len          r19, r18
   Const        r21, 0
   Move         r20, r21
+L19:
   LessInt      r22, r20, r19
   JumpIfFalse  r22, L0
   Index        r23, r18, r20
@@ -53,15 +67,29 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join at in aka_title on at.movie_id == t.id
   Const        r21, 0
   Move         r29, r21
+L18:
   LessInt      r30, r29, r26
   JumpIfFalse  r30, L1
   Index        r31, r25, r29
@@ -84,15 +112,29 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r21, 0
   Move         r38, r21
+L17:
   LessInt      r39, r38, r37
   JumpIfFalse  r39, L2
   Index        r40, r36, r38
@@ -115,15 +157,29 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r21, 0
   Move         r47, r21
+L16:
   LessInt      r48, r47, r46
   JumpIfFalse  r48, L3
   Index        r49, r45, r47
@@ -146,15 +202,29 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r21, 0
   Move         r56, r21
+L15:
   LessInt      r57, r56, r55
   JumpIfFalse  r57, L4
   Index        r58, r54, r56
@@ -177,15 +247,29 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r21, 0
   Move         r66, r21
+L14:
   LessInt      r67, r66, r64
   JumpIfFalse  r67, L5
   Index        r68, r63, r66
@@ -208,15 +292,29 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r21, 0
   Move         r76, r21
+L13:
   LessInt      r77, r76, r74
   JumpIfFalse  r77, L6
   Index        r78, r73, r76
@@ -239,22 +337,35 @@ func main (regs=168)
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r21, 0
   Move         r86, r21
+L12:
   LessInt      r87, r86, r84
   JumpIfFalse  r87, L7
   Index        r88, r83, r86
   Move         r89, r88
   Const        r28, "id"
   Index        r90, r89, r28
-L11:
   Const        r85, "company_id"
   Index        r91, r59, r85
   Equal        r92, r90, r91
@@ -271,15 +382,29 @@ L11:
   // mc.note.contains("200") &&
   Const        r12, "note"
   Const        r13, "contains"
+  // mc.note.contains("worldwide") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.note.contains("internet") &&
+  Const        r12, "note"
+  Const        r13, "contains"
+  // mi.info.contains("USA:") &&
+  Const        r11, "info"
+  Const        r13, "contains"
+  // mi.info.contains("200") &&
+  Const        r11, "info"
+  Const        r13, "contains"
   // t.production_year > 2000
   Const        r14, "production_year"
   // select { release_date: mi.info, internet_movie: t.title }
   Const        r15, "release_date"
+  Const        r11, "info"
   Const        r16, "internet_movie"
   Const        r17, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r21, 0
   Move         r96, r21
+L11:
   LessInt      r97, r96, r94
   JumpIfFalse  r97, L8
   Index        r98, r93, r96
@@ -358,6 +483,7 @@ L11:
   // mi.info.contains("200") &&
   JumpIfFalse  r112, L10
   Move         r112, r106
+L10:
   // where cn.country_code == "[us]" &&
   JumpIfFalse  r112, L9
   // select { release_date: mi.info, internet_movie: t.title }
@@ -375,13 +501,99 @@ L11:
   // from t in title
   Append       r136, r9, r135
   Move         r9, r136
+L9:
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r137, 1
   Add          r96, r96, r137
-  // join k in keyword on k.id == mk.keyword_id
-  Add          r66, r66, r137
   Jump         L11
-L10:
+L8:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r137, 1
+  Add          r86, r86, r137
+  Jump         L12
+L7:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r137, 1
+  Add          r76, r76, r137
+  Jump         L13
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r137, 1
+  Add          r66, r66, r137
+  Jump         L14
+L5:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r137, 1
+  Add          r56, r56, r137
+  Jump         L15
+L4:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r137, 1
+  Add          r47, r47, r137
+  Jump         L16
+L3:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r137, 1
+  Add          r38, r38, r137
+  Jump         L17
+L2:
+  // join at in aka_title on at.movie_id == t.id
+  Const        r137, 1
+  Add          r29, r29, r137
+  Jump         L18
+L1:
+  // from t in title
+  Const        r137, 1
+  AddInt       r20, r20, r137
+  Jump         L19
+L0:
+  // release_date: min(from r in rows select r.release_date),
+  Const        r139, "release_date"
+  Const        r140, []
+  Const        r15, "release_date"
+  IterPrep     r141, r9
+  Len          r142, r141
+  Const        r21, 0
+  Move         r143, r21
+L21:
+  LessInt      r144, r143, r142
+  JumpIfFalse  r144, L20
+  Index        r145, r141, r143
+  Move         r146, r145
+  Const        r15, "release_date"
+  Index        r147, r146, r15
+  Append       r148, r140, r147
+  Move         r140, r148
+  Const        r137, 1
+  AddInt       r143, r143, r137
+  Jump         L21
+L20:
+  Min          r149, r140
+  // internet_movie: min(from r in rows select r.internet_movie)
+  Const        r150, "internet_movie"
+  Const        r151, []
+  Const        r16, "internet_movie"
+  IterPrep     r152, r9
+  Len          r153, r152
+  Const        r21, 0
+  Move         r154, r21
+L23:
+  LessInt      r155, r154, r153
+  JumpIfFalse  r155, L22
+  Index        r156, r152, r154
+  Move         r146, r156
+  Const        r16, "internet_movie"
+  Index        r157, r146, r16
+  Append       r158, r151, r157
+  Move         r151, r158
+  Const        r137, 1
+  AddInt       r154, r154, r137
+  Jump         L23
+L22:
+  Min          r159, r151
+  // release_date: min(from r in rows select r.release_date),
+  Move         r160, r139
+  Move         r161, r149
   // internet_movie: min(from r in rows select r.internet_movie)
   Move         r162, r150
   Move         r163, r159

--- a/tests/dataset/job/out/q16.ir.out
+++ b/tests/dataset/job/out/q16.ir.out
@@ -23,6 +23,8 @@ func main (regs=145)
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -33,8 +35,8 @@ func main (regs=145)
   Len          r17, r16
   Const        r19, 0
   Move         r18, r19
+L17:
   LessInt      r20, r18, r17
-L15:
   JumpIfFalse  r20, L0
   Index        r21, r16, r18
   Move         r22, r21
@@ -49,6 +51,8 @@ L15:
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -57,9 +61,9 @@ L15:
   // join n in name on n.id == an.person_id
   Const        r19, 0
   Move         r27, r19
+L16:
   LessInt      r28, r27, r24
   JumpIfFalse  r28, L1
-L14:
   Index        r29, r23, r27
   Move         r30, r29
   Const        r25, "id"
@@ -79,6 +83,8 @@ L14:
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -87,10 +93,10 @@ L14:
   // join ci in cast_info on ci.person_id == n.id
   Const        r19, 0
   Move         r36, r19
+L15:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L2
   Index        r38, r34, r36
-L13:
   Move         r39, r38
   Const        r26, "person_id"
   Index        r40, r39, r26
@@ -109,6 +115,8 @@ L13:
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -117,11 +125,11 @@ L13:
   // join t in title on t.id == ci.movie_id
   Const        r19, 0
   Move         r46, r19
+L14:
   LessInt      r47, r46, r44
   JumpIfFalse  r47, L3
   Index        r48, r43, r46
   Move         r49, r48
-L12:
   Const        r25, "id"
   Index        r50, r49, r25
   Const        r45, "movie_id"
@@ -139,6 +147,8 @@ L12:
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -147,12 +157,12 @@ L12:
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r19, 0
   Move         r55, r19
+L13:
   LessInt      r56, r55, r54
   JumpIfFalse  r56, L4
   Index        r57, r53, r55
   Move         r58, r57
   Const        r45, "movie_id"
-L11:
   Index        r59, r58, r45
   Const        r25, "id"
   Index        r60, r49, r25
@@ -169,6 +179,8 @@ L11:
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -177,6 +189,7 @@ L11:
   // join k in keyword on k.id == mk.keyword_id
   Const        r19, 0
   Move         r65, r19
+L12:
   LessInt      r66, r65, r63
   JumpIfFalse  r66, L5
   Index        r67, r62, r65
@@ -198,6 +211,8 @@ L11:
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -206,6 +221,7 @@ L11:
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r19, 0
   Move         r74, r19
+L11:
   LessInt      r75, r74, r73
   JumpIfFalse  r75, L6
   Index        r76, r72, r74
@@ -227,6 +243,8 @@ L11:
   Const        r10, "keyword"
   // t.episode_nr >= 50 &&
   Const        r11, "episode_nr"
+  // t.episode_nr < 100
+  Const        r11, "episode_nr"
   // select { pseudonym: an.name, series: t.title }
   Const        r12, "pseudonym"
   Const        r13, "name"
@@ -235,6 +253,7 @@ L11:
   // join cn in company_name on cn.id == mc.company_id
   Const        r19, 0
   Move         r84, r19
+L10:
   LessInt      r85, r84, r82
   JumpIfFalse  r85, L7
   Index        r86, r81, r84
@@ -243,7 +262,6 @@ L11:
   Index        r88, r87, r25
   Const        r83, "company_id"
   Index        r89, r77, r83
-L10:
   Equal        r90, r88, r89
   JumpIfFalse  r90, L8
   // where cn.country_code == "[us]" &&
@@ -255,6 +273,7 @@ L10:
   Const        r93, 50
   LessEq       r94, r93, r92
   // t.episode_nr < 100
+  Const        r11, "episode_nr"
   Index        r95, r49, r11
   Const        r96, 100
   Less         r97, r95, r96
@@ -276,6 +295,7 @@ L10:
   // t.episode_nr >= 50 &&
   JumpIfFalse  r103, L9
   Move         r103, r97
+L9:
   // where cn.country_code == "[us]" &&
   JumpIfFalse  r103, L8
   // select { pseudonym: an.name, series: t.title }
@@ -287,56 +307,64 @@ L10:
   Index        r107, r49, r15
   Move         r108, r104
   Move         r109, r105
-L9:
   Move         r110, r106
   Move         r111, r107
   MakeMap      r112, 2, r108
   // from an in aka_name
   Append       r113, r8, r112
   Move         r8, r113
+L8:
   // join cn in company_name on cn.id == mc.company_id
   Const        r114, 1
   Add          r84, r84, r114
   Jump         L10
-L8:
+L7:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r114, 1
+  Add          r74, r74, r114
+  Jump         L11
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r114, 1
+  Add          r65, r65, r114
+  Jump         L12
+L5:
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r114, 1
   Add          r55, r55, r114
-  Jump         L11
-L7:
+  Jump         L13
+L4:
   // join t in title on t.id == ci.movie_id
   Const        r114, 1
   Add          r46, r46, r114
-  Jump         L12
-L6:
+  Jump         L14
+L3:
   // join ci in cast_info on ci.person_id == n.id
   Const        r114, 1
   Add          r36, r36, r114
-  Jump         L13
-L5:
+  Jump         L15
+L2:
   // join n in name on n.id == an.person_id
   Const        r114, 1
   Add          r27, r27, r114
-  Jump         L14
-L4:
+  Jump         L16
+L1:
   // from an in aka_name
   Const        r114, 1
   AddInt       r18, r18, r114
-  Jump         L15
-L3:
+  Jump         L17
+L0:
   // cool_actor_pseudonym: min(from r in rows select r.pseudonym),
   Const        r116, "cool_actor_pseudonym"
   Const        r117, []
   Const        r12, "pseudonym"
-L2:
   IterPrep     r118, r8
   Len          r119, r118
   Const        r19, 0
-L1:
   Move         r120, r19
+L19:
   LessInt      r121, r120, r119
-  JumpIfFalse  r121, L16
-L0:
+  JumpIfFalse  r121, L18
   Index        r122, r118, r120
   Move         r123, r122
   Const        r12, "pseudonym"
@@ -344,12 +372,21 @@ L0:
   Append       r125, r117, r124
   Move         r117, r125
   Const        r114, 1
-L17:
   AddInt       r120, r120, r114
-  Jump         L17
-L16:
+  Jump         L19
+L18:
+  Min          r126, r117
   // series_named_after_char: min(from r in rows select r.series)
-  JumpIfFalse  r132, L18
+  Const        r127, "series_named_after_char"
+  Const        r128, []
+  Const        r14, "series"
+  IterPrep     r129, r8
+  Len          r130, r129
+  Const        r19, 0
+  Move         r131, r19
+L21:
+  LessInt      r132, r131, r130
+  JumpIfFalse  r132, L20
   Index        r133, r129, r131
   Move         r123, r133
   Const        r14, "series"
@@ -357,10 +394,23 @@ L16:
   Append       r135, r128, r134
   Move         r128, r135
   Const        r114, 1
-L19:
   AddInt       r131, r131, r114
-  Jump         L19
-L18:
+  Jump         L21
+L20:
+  Min          r136, r128
+  // cool_actor_pseudonym: min(from r in rows select r.pseudonym),
+  Move         r137, r116
+  Move         r138, r126
+  // series_named_after_char: min(from r in rows select r.series)
+  Move         r139, r127
+  Move         r140, r136
+  // {
+  MakeMap      r141, 2, r137
+  Move         r115, r141
+  // let result = [
+  MakeList     r142, 1, r115
+  // json(result)
+  JSON         r142
   // expect result == [
   Const        r143, [{"cool_actor_pseudonym": "Alpha", "series_named_after_char": "Hero Bob"}]
   Equal        r144, r142, r143

--- a/tests/dataset/job/out/q17.ir.out
+++ b/tests/dataset/job/out/q17.ir.out
@@ -24,11 +24,21 @@ func main (regs=119)
   Const        r11, "starts_with"
   // ci.movie_id == mk.movie_id &&
   Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // select n.name
+  Const        r10, "name"
   // from n in name
   IterPrep     r13, r5
   Len          r14, r13
   Const        r16, 0
   Move         r15, r16
+L17:
   LessInt      r17, r15, r14
   JumpIfFalse  r17, L0
   Index        r18, r13, r15
@@ -47,9 +57,19 @@ func main (regs=119)
   Const        r11, "starts_with"
   // ci.movie_id == mk.movie_id &&
   Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // select n.name
+  Const        r10, "name"
   // join ci in cast_info on ci.person_id == n.id
   Const        r16, 0
   Move         r24, r16
+L16:
   LessInt      r25, r24, r21
   JumpIfFalse  r25, L1
   Index        r26, r20, r24
@@ -72,9 +92,21 @@ func main (regs=119)
   // n.name.starts_with("B") &&
   Const        r10, "name"
   Const        r11, "starts_with"
+  // ci.movie_id == mk.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // select n.name
+  Const        r10, "name"
   // join t in title on t.id == ci.movie_id
   Const        r16, 0
   Move         r33, r16
+L15:
   LessInt      r34, r33, r32
   JumpIfFalse  r34, L2
   Index        r35, r31, r33
@@ -97,9 +129,21 @@ func main (regs=119)
   // n.name.starts_with("B") &&
   Const        r10, "name"
   Const        r11, "starts_with"
+  // ci.movie_id == mk.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // select n.name
+  Const        r10, "name"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r16, 0
   Move         r42, r16
+L14:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L3
   Index        r44, r40, r42
@@ -124,9 +168,19 @@ func main (regs=119)
   Const        r11, "starts_with"
   // ci.movie_id == mk.movie_id &&
   Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // select n.name
+  Const        r10, "name"
   // join k in keyword on k.id == mk.keyword_id
   Const        r16, 0
   Move         r52, r16
+L13:
   LessInt      r53, r52, r50
   JumpIfFalse  r53, L4
   Index        r54, r49, r52
@@ -149,9 +203,21 @@ func main (regs=119)
   // n.name.starts_with("B") &&
   Const        r10, "name"
   Const        r11, "starts_with"
+  // ci.movie_id == mk.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // select n.name
+  Const        r10, "name"
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r16, 0
   Move         r61, r16
+L12:
   LessInt      r62, r61, r60
   JumpIfFalse  r62, L5
   Index        r63, r59, r61
@@ -176,9 +242,19 @@ func main (regs=119)
   Const        r11, "starts_with"
   // ci.movie_id == mk.movie_id &&
   Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
+  Const        r12, "movie_id"
+  // select n.name
+  Const        r10, "name"
   // join cn in company_name on cn.id == mc.company_id
   Const        r16, 0
   Move         r71, r16
+L11:
   LessInt      r72, r71, r69
   JumpIfFalse  r72, L6
   Index        r73, r68, r71
@@ -202,14 +278,19 @@ func main (regs=119)
   // ci.movie_id == mk.movie_id &&
   Const        r12, "movie_id"
   Index        r84, r27, r12
+  Const        r12, "movie_id"
   Index        r85, r45, r12
   Equal        r86, r84, r85
   // ci.movie_id == mc.movie_id &&
+  Const        r12, "movie_id"
   Index        r87, r27, r12
+  Const        r12, "movie_id"
   Index        r88, r64, r12
   Equal        r89, r87, r88
   // mc.movie_id == mk.movie_id
+  Const        r12, "movie_id"
   Index        r90, r64, r12
+  Const        r12, "movie_id"
   Index        r91, r45, r12
   Equal        r92, r90, r91
   // where cn.country_code == "[us]" &&
@@ -223,7 +304,7 @@ func main (regs=119)
   // n.name.starts_with("B") &&
   Const        r95, "B"
   Const        r96, 0
-  Const        r97, 1
+  Len          r97, r95
   Len          r98, r94
   LessEq       r99, r97, r98
   JumpIfFalse  r99, L9
@@ -231,3 +312,86 @@ func main (regs=119)
   Equal        r102, r101, r95
   Move         r100, r102
   Jump         L10
+L9:
+  Const        r100, false
+L10:
+  // k.keyword == "character-name-in-title" &&
+  Move         r93, r100
+  // n.name.starts_with("B") &&
+  JumpIfFalse  r93, L8
+  Move         r93, r86
+  // ci.movie_id == mk.movie_id &&
+  JumpIfFalse  r93, L8
+  Move         r93, r89
+  // ci.movie_id == mc.movie_id &&
+  JumpIfFalse  r93, L8
+  Move         r93, r92
+L8:
+  // where cn.country_code == "[us]" &&
+  JumpIfFalse  r93, L7
+  // select n.name
+  Const        r10, "name"
+  Index        r103, r19, r10
+  // from n in name
+  Append       r104, r7, r103
+  Move         r7, r104
+L7:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r105, 1
+  Add          r71, r71, r105
+  Jump         L11
+L6:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r105, 1
+  Add          r61, r61, r105
+  Jump         L12
+L5:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r105, 1
+  Add          r52, r52, r105
+  Jump         L13
+L4:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r105, 1
+  Add          r42, r42, r105
+  Jump         L14
+L3:
+  // join t in title on t.id == ci.movie_id
+  Const        r105, 1
+  Add          r33, r33, r105
+  Jump         L15
+L2:
+  // join ci in cast_info on ci.person_id == n.id
+  Const        r105, 1
+  Add          r24, r24, r105
+  Jump         L16
+L1:
+  // from n in name
+  Const        r105, 1
+  AddInt       r15, r15, r105
+  Jump         L17
+L0:
+  // member_in_charnamed_american_movie: min(matches),
+  Const        r107, "member_in_charnamed_american_movie"
+  Min          r108, r7
+  // a1: min(matches)
+  Const        r109, "a1"
+  Min          r110, r7
+  // member_in_charnamed_american_movie: min(matches),
+  Move         r111, r107
+  Move         r112, r108
+  // a1: min(matches)
+  Move         r113, r109
+  Move         r114, r110
+  // {
+  MakeMap      r115, 2, r111
+  Move         r106, r115
+  // let result = [
+  MakeList     r116, 1, r106
+  // json(result)
+  JSON         r116
+  // expect result == [
+  Const        r117, [{"a1": "Bob Smith", "member_in_charnamed_american_movie": "Bob Smith"}]
+  Equal        r118, r116, r117
+  Expect       r118
+  Return       r0

--- a/tests/dataset/job/out/q18.ir.out
+++ b/tests/dataset/job/out/q18.ir.out
@@ -17,6 +17,8 @@ func main (regs=161)
   Const        r7, "note"
   // it1.info == "budget" &&
   Const        r8, "info"
+  // it2.info == "votes" &&
+  Const        r8, "info"
   // n.gender == "m" &&
   Const        r9, "gender"
   // n.name.contains("Tim") &&
@@ -25,15 +27,28 @@ func main (regs=161)
   // t.id == ci.movie_id &&
   Const        r12, "id"
   Const        r13, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
   Const        r14, "budget"
+  Const        r8, "info"
   Const        r15, "votes"
+  Const        r8, "info"
+  Const        r16, "title"
   Const        r16, "title"
   // from ci in cast_info
   IterPrep     r17, r3
   Len          r18, r17
   Const        r20, 0
   Move         r19, r20
+L15:
   LessInt      r21, r19, r18
   JumpIfFalse  r21, L0
   Index        r22, r17, r19
@@ -47,20 +62,36 @@ func main (regs=161)
   Const        r7, "note"
   // it1.info == "budget" &&
   Const        r8, "info"
+  // it2.info == "votes" &&
+  Const        r8, "info"
   // n.gender == "m" &&
   Const        r9, "gender"
   // n.name.contains("Tim") &&
   Const        r10, "name"
   Const        r11, "contains"
   // t.id == ci.movie_id &&
+  Const        r12, "id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
   Const        r13, "movie_id"
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
   Const        r14, "budget"
+  Const        r8, "info"
   Const        r15, "votes"
+  Const        r8, "info"
+  Const        r16, "title"
   Const        r16, "title"
   // join n in name on n.id == ci.person_id
   Const        r20, 0
   Move         r27, r20
+L14:
   LessInt      r28, r27, r25
   JumpIfFalse  r28, L1
   Index        r29, r24, r27
@@ -80,18 +111,36 @@ func main (regs=161)
   Const        r7, "note"
   // it1.info == "budget" &&
   Const        r8, "info"
+  // it2.info == "votes" &&
+  Const        r8, "info"
   // n.gender == "m" &&
   Const        r9, "gender"
   // n.name.contains("Tim") &&
   Const        r10, "name"
   Const        r11, "contains"
+  // t.id == ci.movie_id &&
+  Const        r12, "id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
   Const        r14, "budget"
+  Const        r8, "info"
   Const        r15, "votes"
+  Const        r8, "info"
+  Const        r16, "title"
   Const        r16, "title"
   // join t in title on t.id == ci.movie_id
   Const        r20, 0
   Move         r36, r20
+L13:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L2
   Index        r38, r34, r36
@@ -111,18 +160,36 @@ func main (regs=161)
   Const        r7, "note"
   // it1.info == "budget" &&
   Const        r8, "info"
+  // it2.info == "votes" &&
+  Const        r8, "info"
   // n.gender == "m" &&
   Const        r9, "gender"
   // n.name.contains("Tim") &&
   Const        r10, "name"
   Const        r11, "contains"
+  // t.id == ci.movie_id &&
+  Const        r12, "id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
   Const        r14, "budget"
+  Const        r8, "info"
   Const        r15, "votes"
+  Const        r8, "info"
+  Const        r16, "title"
   Const        r16, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r20, 0
   Move         r45, r20
+L12:
   LessInt      r46, r45, r44
   JumpIfFalse  r46, L3
   Index        r47, r43, r45
@@ -142,18 +209,36 @@ func main (regs=161)
   Const        r7, "note"
   // it1.info == "budget" &&
   Const        r8, "info"
+  // it2.info == "votes" &&
+  Const        r8, "info"
   // n.gender == "m" &&
   Const        r9, "gender"
   // n.name.contains("Tim") &&
   Const        r10, "name"
   Const        r11, "contains"
+  // t.id == ci.movie_id &&
+  Const        r12, "id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
   Const        r14, "budget"
+  Const        r8, "info"
   Const        r15, "votes"
+  Const        r8, "info"
+  Const        r16, "title"
   Const        r16, "title"
   // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
   Const        r20, 0
   Move         r54, r20
+L11:
   LessInt      r55, r54, r53
   JumpIfFalse  r55, L4
   Index        r56, r52, r54
@@ -173,20 +258,36 @@ func main (regs=161)
   Const        r7, "note"
   // it1.info == "budget" &&
   Const        r8, "info"
+  // it2.info == "votes" &&
+  Const        r8, "info"
   // n.gender == "m" &&
   Const        r9, "gender"
   // n.name.contains("Tim") &&
   Const        r10, "name"
   Const        r11, "contains"
   // t.id == ci.movie_id &&
+  Const        r12, "id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
   Const        r13, "movie_id"
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
   Const        r14, "budget"
+  Const        r8, "info"
   Const        r15, "votes"
+  Const        r8, "info"
+  Const        r16, "title"
   Const        r16, "title"
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r20, 0
   Move         r64, r20
+L10:
   LessInt      r65, r64, r62
   JumpIfFalse  r65, L5
   Index        r66, r61, r64
@@ -206,20 +307,36 @@ func main (regs=161)
   Const        r7, "note"
   // it1.info == "budget" &&
   Const        r8, "info"
+  // it2.info == "votes" &&
+  Const        r8, "info"
   // n.gender == "m" &&
   Const        r9, "gender"
   // n.name.contains("Tim") &&
   Const        r10, "name"
   Const        r11, "contains"
   // t.id == ci.movie_id &&
+  Const        r12, "id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
+  Const        r13, "movie_id"
+  // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
   Const        r13, "movie_id"
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
   Const        r14, "budget"
+  Const        r8, "info"
   Const        r15, "votes"
+  Const        r8, "info"
+  Const        r16, "title"
   Const        r16, "title"
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r20, 0
   Move         r73, r20
+L9:
   LessInt      r74, r73, r72
   JumpIfFalse  r74, L6
   Index        r75, r71, r73
@@ -241,6 +358,7 @@ func main (regs=161)
   Const        r14, "budget"
   Equal        r84, r83, r14
   // it2.info == "votes" &&
+  Const        r8, "info"
   Index        r85, r76, r8
   Const        r15, "votes"
   Equal        r86, r85, r15
@@ -256,15 +374,21 @@ func main (regs=161)
   Index        r91, r23, r13
   Equal        r92, r90, r91
   // ci.movie_id == mi.movie_id &&
+  Const        r13, "movie_id"
   Index        r93, r23, r13
+  Const        r13, "movie_id"
   Index        r94, r48, r13
   Equal        r95, r93, r94
   // ci.movie_id == mi_idx.movie_id &&
+  Const        r13, "movie_id"
   Index        r96, r23, r13
+  Const        r13, "movie_id"
   Index        r97, r57, r13
   Equal        r98, r96, r97
   // mi.movie_id == mi_idx.movie_id
+  Const        r13, "movie_id"
   Index        r99, r48, r13
+  Const        r13, "movie_id"
   Index        r100, r57, r13
   Equal        r101, r99, r100
   // ci.note in ["(producer)", "(executive producer)"] &&
@@ -298,6 +422,7 @@ func main (regs=161)
   // ci.movie_id == mi_idx.movie_id &&
   JumpIfFalse  r102, L8
   Move         r102, r101
+L8:
   // where (
   JumpIfFalse  r102, L7
   // select { budget: mi.info, votes: mi_idx.info, title: t.title }
@@ -305,6 +430,7 @@ func main (regs=161)
   Const        r8, "info"
   Index        r107, r48, r8
   Const        r108, "votes"
+  Const        r8, "info"
   Index        r109, r57, r8
   Const        r110, "title"
   Const        r16, "title"
@@ -319,13 +445,97 @@ func main (regs=161)
   // from ci in cast_info
   Append       r119, r6, r118
   Move         r6, r119
+L7:
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r120, 1
-L9:
   Add          r73, r73, r120
   Jump         L9
-L8:
+L6:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r120, 1
+  Add          r64, r64, r120
+  Jump         L10
+L5:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r120, 1
+  Add          r54, r54, r120
+  Jump         L11
+L4:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r120, 1
+  Add          r45, r45, r120
+  Jump         L12
+L3:
+  // join t in title on t.id == ci.movie_id
+  Const        r120, 1
+  Add          r36, r36, r120
+  Jump         L13
+L2:
+  // join n in name on n.id == ci.person_id
+  Const        r120, 1
+  Add          r27, r27, r120
+  Jump         L14
+L1:
+  // from ci in cast_info
+  Const        r120, 1
+  AddInt       r19, r19, r120
+  Jump         L15
+L0:
+  // movie_budget: min(from r in rows select r.budget),
+  Const        r121, "movie_budget"
+  Const        r122, []
+  Const        r14, "budget"
+  IterPrep     r123, r6
+  Len          r124, r123
+  Const        r20, 0
+  Move         r125, r20
+L17:
+  LessInt      r126, r125, r124
+  JumpIfFalse  r126, L16
+  Index        r127, r123, r125
+  Move         r128, r127
+  Const        r14, "budget"
+  Index        r129, r128, r14
+  Append       r130, r122, r129
+  Move         r122, r130
+  Const        r120, 1
+  AddInt       r125, r125, r120
+  Jump         L17
+L16:
+  Min          r131, r122
+  // movie_votes: min(from r in rows select r.votes),
+  Const        r132, "movie_votes"
+  Const        r133, []
+  Const        r15, "votes"
+  IterPrep     r134, r6
+  Len          r135, r134
+  Const        r20, 0
+  Move         r136, r20
+L19:
+  LessInt      r137, r136, r135
+  JumpIfFalse  r137, L18
+  Index        r138, r134, r136
+  Move         r128, r138
+  Const        r15, "votes"
+  Index        r139, r128, r15
+  Append       r140, r133, r139
+  Move         r133, r140
+  Const        r120, 1
+  AddInt       r136, r136, r120
+  Jump         L19
+L18:
+  Min          r141, r133
   // movie_title: min(from r in rows select r.title)
+  Const        r142, "movie_title"
+  Const        r143, []
+  Const        r16, "title"
+  IterPrep     r144, r6
+  Len          r145, r144
+  Const        r20, 0
+  Move         r146, r20
+L21:
+  LessInt      r147, r146, r145
+  JumpIfFalse  r147, L20
   Index        r148, r144, r146
   Move         r128, r148
   Const        r16, "title"
@@ -334,9 +544,24 @@ L8:
   Move         r143, r150
   Const        r120, 1
   AddInt       r146, r146, r120
-  Jump         L10
-L7:
+  Jump         L21
+L20:
+  Min          r151, r143
+  // movie_budget: min(from r in rows select r.budget),
+  Move         r152, r121
+  Move         r153, r131
+  // movie_votes: min(from r in rows select r.votes),
+  Move         r154, r132
+  Move         r155, r141
+  // movie_title: min(from r in rows select r.title)
+  Move         r156, r142
+  Move         r157, r151
+  // let result = {
+  MakeMap      r158, 3, r152
+  // json(result)
+  JSON         r158
   // expect result == { movie_budget: 90, movie_votes: 400, movie_title: "Alpha" }
+  Const        r159, {"movie_budget": 90, "movie_title": "Alpha", "movie_votes": 400}
   Equal        r160, r158, r159
   Expect       r160
   Return       r0

--- a/tests/dataset/job/out/q19.ir.out
+++ b/tests/dataset/job/out/q19.ir.out
@@ -27,18 +27,39 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // from an in aka_name
@@ -46,6 +67,7 @@ func main (regs=208)
   Len          r23, r22
   Const        r25, 0
   Move         r24, r25
+L25:
   LessInt      r26, r24, r23
   JumpIfFalse  r26, L0
   Index        r27, r22, r24
@@ -61,23 +83,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join n in name on n.id == an.person_id
   Const        r25, 0
   Move         r33, r25
+L24:
   LessInt      r34, r33, r30
   JumpIfFalse  r34, L1
   Index        r35, r29, r33
@@ -92,35 +136,59 @@ func main (regs=208)
   IterPrep     r40, r2
   Len          r41, r40
   Const        r32, "person_id"
+  Const        r32, "person_id"
   // where ci.note in [
   Const        r11, "note"
   // cn.country_code == "[us]" &&
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join ci in cast_info on ci.person_id == an.person_id
   Const        r25, 0
   Move         r42, r25
+L23:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L2
   Index        r44, r40, r42
   Move         r45, r44
   Const        r32, "person_id"
   Index        r46, r45, r32
+  Const        r32, "person_id"
   Index        r47, r28, r32
   Equal        r48, r46, r47
   JumpIfFalse  r48, L3
@@ -135,23 +203,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join chn in char_name on chn.id == ci.person_role_id
   Const        r25, 0
   Move         r52, r25
+L22:
   LessInt      r53, r52, r50
   JumpIfFalse  r53, L3
   Index        r54, r49, r52
@@ -173,23 +263,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join rt in role_type on rt.id == ci.role_id
   Const        r25, 0
   Move         r62, r25
+L21:
   LessInt      r63, r62, r60
   JumpIfFalse  r63, L4
   Index        r64, r59, r62
@@ -211,23 +323,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join t in title on t.id == ci.movie_id
   Const        r25, 0
   Move         r72, r25
+L20:
   LessInt      r73, r72, r70
   JumpIfFalse  r73, L5
   Index        r74, r69, r72
@@ -249,23 +383,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r25, 0
   Move         r81, r25
+L19:
   LessInt      r82, r81, r80
   JumpIfFalse  r82, L6
   Index        r83, r79, r81
@@ -287,23 +443,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r25, 0
   Move         r91, r25
+L18:
   LessInt      r92, r91, r89
   JumpIfFalse  r92, L7
   Index        r93, r88, r91
@@ -325,23 +503,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r25, 0
   Move         r100, r25
+L17:
   LessInt      r101, r100, r99
   JumpIfFalse  r101, L8
   Index        r102, r98, r100
@@ -363,23 +563,45 @@ func main (regs=208)
   Const        r12, "country_code"
   // it.info == "release dates" &&
   Const        r13, "info"
+  // mc.note != null &&
+  Const        r11, "note"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r11, "note"
+  Const        r14, "contains"
+  Const        r11, "note"
+  Const        r14, "contains"
+  // mi.info != null &&
+  Const        r13, "info"
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
+  Const        r14, "contains"
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r13, "info"
+  Const        r14, "contains"
+  Const        r13, "info"
   Const        r14, "contains"
   // n.gender == "f" &&
   Const        r15, "gender"
   // n.name.contains("Ang") &&
   Const        r16, "name"
+  Const        r14, "contains"
   // rt.role == "actress" &&
   Const        r17, "role"
   // t.production_year >= 2005 &&
   Const        r18, "production_year"
+  // t.production_year <= 2009
+  Const        r18, "production_year"
   // select { actress: n.name, movie: t.title }
   Const        r19, "actress"
+  Const        r16, "name"
   Const        r20, "movie"
   Const        r21, "title"
   // join it in info_type on it.id == mi.info_type_id
   Const        r25, 0
   Move         r110, r25
+L16:
   LessInt      r111, r110, r108
   JumpIfFalse  r111, L9
   Index        r112, r107, r110
@@ -399,6 +621,7 @@ func main (regs=208)
   Const        r119, 2005
   LessEq       r120, r119, r118
   // t.production_year <= 2009
+  Const        r18, "production_year"
   Index        r121, r75, r18
   Const        r122, 2009
   LessEq       r123, r121, r122
@@ -416,11 +639,14 @@ func main (regs=208)
   Const        r130, "release dates"
   Equal        r131, r129, r130
   // mc.note != null &&
+  Const        r11, "note"
   Index        r132, r84, r11
   Const        r133, nil
   NotEqual     r134, r132, r133
   // mi.info != null &&
+  Const        r13, "info"
   Index        r135, r103, r13
+  Const        r133, nil
   NotEqual     r136, r135, r133
   // n.gender == "f" &&
   Const        r15, "gender"
@@ -456,6 +682,7 @@ func main (regs=208)
   Const        r148, "(worldwide)"
   In           r149, r148, r147
   Move         r146, r149
+L12:
   // mc.note != null &&
   Move         r142, r146
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
@@ -475,6 +702,7 @@ func main (regs=208)
   Const        r155, "200"
   In           r156, r155, r154
   Move         r153, r156
+L13:
   Move         r157, r153
   JumpIfTrue   r157, L14
   Const        r13, "info"
@@ -489,8 +717,10 @@ func main (regs=208)
   Const        r155, "200"
   In           r163, r155, r162
   Move         r161, r163
+L15:
   // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
   Move         r157, r161
+L14:
   // mi.info != null &&
   Move         r142, r157
   // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
@@ -514,6 +744,7 @@ func main (regs=208)
   // t.production_year >= 2005 &&
   JumpIfFalse  r142, L11
   Move         r142, r123
+L11:
   // where ci.note in [
   JumpIfFalse  r142, L10
   // select { actress: n.name, movie: t.title }
@@ -531,12 +762,116 @@ func main (regs=208)
   // from an in aka_name
   Append       r176, r10, r175
   Move         r10, r176
+L10:
   // join it in info_type on it.id == mi.info_type_id
   Const        r177, 1
   Add          r110, r110, r177
+  Jump         L16
+L9:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r177, 1
+  Add          r100, r100, r177
+  Jump         L17
+L8:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r177, 1
+  Add          r91, r91, r177
+  Jump         L18
+L7:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r177, 1
+  Add          r81, r81, r177
+  Jump         L19
+L6:
+  // join t in title on t.id == ci.movie_id
+  Const        r177, 1
+  Add          r72, r72, r177
+  Jump         L20
+L5:
+  // join rt in role_type on rt.id == ci.role_id
+  Const        r177, 1
+  Add          r62, r62, r177
+  Jump         L21
+L4:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r177, 1
+  Add          r52, r52, r177
+  Jump         L22
+L3:
+  // join ci in cast_info on ci.person_id == an.person_id
+  Const        r177, 1
+  Add          r42, r42, r177
+  Jump         L23
+L2:
+  // join n in name on n.id == an.person_id
+  Const        r177, 1
+  Add          r33, r33, r177
+  Jump         L24
+L1:
+  // from an in aka_name
+  Const        r177, 1
+  AddInt       r24, r24, r177
+  Jump         L25
+L0:
   // voicing_actress: min(from r in matches select r.actress),
+  Const        r179, "voicing_actress"
+  Const        r180, []
+  Const        r19, "actress"
+  IterPrep     r181, r10
+  Len          r182, r181
+  Const        r25, 0
+  Move         r183, r25
+L27:
+  LessInt      r184, r183, r182
+  JumpIfFalse  r184, L26
+  Index        r185, r181, r183
+  Move         r186, r185
+  Const        r19, "actress"
+  Index        r187, r186, r19
   Append       r188, r180, r187
   Move         r180, r188
   Const        r177, 1
   AddInt       r183, r183, r177
-  Jump         L16
+  Jump         L27
+L26:
+  Min          r189, r180
+  // voiced_movie: min(from r in matches select r.movie)
+  Const        r190, "voiced_movie"
+  Const        r191, []
+  Const        r20, "movie"
+  IterPrep     r192, r10
+  Len          r193, r192
+  Const        r25, 0
+  Move         r194, r25
+L29:
+  LessInt      r195, r194, r193
+  JumpIfFalse  r195, L28
+  Index        r196, r192, r194
+  Move         r186, r196
+  Const        r20, "movie"
+  Index        r197, r186, r20
+  Append       r198, r191, r197
+  Move         r191, r198
+  Const        r177, 1
+  AddInt       r194, r194, r177
+  Jump         L29
+L28:
+  Min          r199, r191
+  // voicing_actress: min(from r in matches select r.actress),
+  Move         r200, r179
+  Move         r201, r189
+  // voiced_movie: min(from r in matches select r.movie)
+  Move         r202, r190
+  Move         r203, r199
+  // {
+  MakeMap      r204, 2, r200
+  Move         r178, r204
+  // let result = [
+  MakeList     r205, 1, r178
+  // json(result)
+  JSON         r205
+  // expect result == [
+  Const        r206, [{"voiced_movie": "Voiced Movie", "voicing_actress": "Angela Stone"}]
+  Equal        r207, r205, r206
+  Expect       r207
+  Return       r0

--- a/tests/dataset/job/out/q2.ir.out
+++ b/tests/dataset/job/out/q2.ir.out
@@ -17,6 +17,7 @@ func main (regs=72)
   Const        r7, "keyword"
   // mc.movie_id == mk.movie_id
   Const        r8, "movie_id"
+  Const        r8, "movie_id"
   // select t.title
   Const        r9, "title"
   // from cn in company_name
@@ -24,8 +25,8 @@ func main (regs=72)
   Len          r11, r10
   Const        r13, 0
   Move         r12, r13
+L11:
   LessInt      r14, r12, r11
-L3:
   JumpIfFalse  r14, L0
   Index        r15, r10, r12
   Move         r16, r15
@@ -40,14 +41,15 @@ L3:
   Const        r7, "keyword"
   // mc.movie_id == mk.movie_id
   Const        r8, "movie_id"
+  Const        r8, "movie_id"
   // select t.title
   Const        r9, "title"
   // join mc in movie_companies on mc.company_id == cn.id
   Const        r13, 0
   Move         r21, r13
+L10:
   LessInt      r22, r21, r18
   JumpIfFalse  r22, L1
-L4:
   Index        r23, r17, r21
   Move         r24, r23
   Const        r19, "company_id"
@@ -65,16 +67,19 @@ L4:
   Const        r6, "country_code"
   // k.keyword == "character-name-in-title" &&
   Const        r7, "keyword"
+  // mc.movie_id == mk.movie_id
+  Const        r8, "movie_id"
+  Const        r8, "movie_id"
   // select t.title
   Const        r9, "title"
   // join t in title on mc.movie_id == t.id
   Const        r13, 0
   Move         r30, r13
+L9:
   LessInt      r31, r30, r29
   JumpIfFalse  r31, L2
   Index        r32, r28, r30
   Move         r33, r32
-L5:
   Const        r8, "movie_id"
   Index        r34, r24, r8
   Const        r20, "id"
@@ -90,18 +95,21 @@ L5:
   Const        r6, "country_code"
   // k.keyword == "character-name-in-title" &&
   Const        r7, "keyword"
+  // mc.movie_id == mk.movie_id
+  Const        r8, "movie_id"
+  Const        r8, "movie_id"
   // select t.title
   Const        r9, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r13, 0
   Move         r39, r13
+L8:
   LessInt      r40, r39, r38
   JumpIfFalse  r40, L3
   Index        r41, r37, r39
   Move         r42, r41
   Const        r8, "movie_id"
   Index        r43, r42, r8
-L8:
   Const        r20, "id"
   Index        r44, r33, r20
   Equal        r45, r43, r44
@@ -117,11 +125,13 @@ L8:
   Const        r7, "keyword"
   // mc.movie_id == mk.movie_id
   Const        r8, "movie_id"
+  Const        r8, "movie_id"
   // select t.title
   Const        r9, "title"
   // join k in keyword on mk.keyword_id == k.id
   Const        r13, 0
   Move         r49, r13
+L7:
   LessInt      r50, r49, r47
   JumpIfFalse  r50, L4
   Index        r51, r46, r49
@@ -129,7 +139,6 @@ L8:
   Const        r48, "keyword_id"
   Index        r53, r42, r48
   Const        r20, "id"
-L7:
   Index        r54, r52, r20
   Equal        r55, r53, r54
   JumpIfFalse  r55, L5
@@ -146,6 +155,7 @@ L7:
   // mc.movie_id == mk.movie_id
   Const        r8, "movie_id"
   Index        r62, r24, r8
+  Const        r8, "movie_id"
   Index        r63, r42, r8
   Equal        r64, r62, r63
   // where cn.country_code == "[de]" &&
@@ -155,6 +165,7 @@ L7:
   // k.keyword == "character-name-in-title" &&
   JumpIfFalse  r65, L6
   Move         r65, r64
+L6:
   // where cn.country_code == "[de]" &&
   JumpIfFalse  r65, L5
   // select t.title
@@ -163,19 +174,38 @@ L7:
   // from cn in company_name
   Append       r67, r5, r66
   Move         r5, r67
+L5:
   // join k in keyword on mk.keyword_id == k.id
   Const        r68, 1
   Add          r49, r49, r68
   Jump         L7
-L6:
+L4:
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r68, 1
   Add          r39, r39, r68
   Jump         L8
+L3:
+  // join t in title on mc.movie_id == t.id
+  Const        r68, 1
+  Add          r30, r30, r68
+  Jump         L9
 L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r68, 1
+  Add          r21, r21, r68
+  Jump         L10
+L1:
+  // from cn in company_name
+  Const        r68, 1
+  AddInt       r12, r12, r68
+  Jump         L11
+L0:
+  // let result = min(titles)
+  Min          r69, r5
+  // json(result)
+  JSON         r69
   // expect result == "Der Film"
   Const        r70, "Der Film"
   Equal        r71, r69, r70
   Expect       r71
-L1:
   Return       r0

--- a/tests/dataset/job/out/q20.ir.out
+++ b/tests/dataset/job/out/q20.ir.out
@@ -22,11 +22,20 @@ func main (regs=151)
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -36,6 +45,7 @@ func main (regs=151)
   Len          r17, r16
   Const        r19, 0
   Move         r18, r19
+L22:
   LessInt      r20, r18, r17
   JumpIfFalse  r20, L0
   Index        r21, r16, r18
@@ -48,11 +58,20 @@ func main (regs=151)
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -60,6 +79,7 @@ func main (regs=151)
   // join cct1 in comp_cast_type on cct1.id == cc.subject_id
   Const        r19, 0
   Move         r27, r19
+L21:
   LessInt      r28, r27, r24
   JumpIfFalse  r28, L1
   Index        r29, r23, r27
@@ -78,11 +98,20 @@ func main (regs=151)
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -90,6 +119,7 @@ func main (regs=151)
   // join cct2 in comp_cast_type on cct2.id == cc.status_id
   Const        r19, 0
   Move         r37, r19
+L20:
   LessInt      r38, r37, r35
   JumpIfFalse  r38, L2
   Index        r39, r34, r37
@@ -104,14 +134,24 @@ func main (regs=151)
   IterPrep     r44, r4
   Len          r45, r44
   Const        r46, "movie_id"
+  Const        r46, "movie_id"
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -119,12 +159,14 @@ func main (regs=151)
   // join ci in cast_info on ci.movie_id == cc.movie_id
   Const        r19, 0
   Move         r47, r19
+L19:
   LessInt      r48, r47, r45
   JumpIfFalse  r48, L3
   Index        r49, r44, r47
   Move         r50, r49
   Const        r46, "movie_id"
   Index        r51, r50, r46
+  Const        r46, "movie_id"
   Index        r52, r22, r46
   Equal        r53, r51, r52
   JumpIfFalse  r53, L4
@@ -136,11 +178,20 @@ func main (regs=151)
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -148,6 +199,7 @@ func main (regs=151)
   // join chn in char_name on chn.id == ci.person_role_id
   Const        r19, 0
   Move         r57, r19
+L18:
   LessInt      r58, r57, r55
   JumpIfFalse  r58, L4
   Index        r59, r54, r57
@@ -166,11 +218,20 @@ func main (regs=151)
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -178,6 +239,7 @@ func main (regs=151)
   // join n in name on n.id == ci.person_id
   Const        r19, 0
   Move         r67, r19
+L17:
   LessInt      r68, r67, r65
   JumpIfFalse  r68, L5
   Index        r69, r64, r67
@@ -192,14 +254,24 @@ func main (regs=151)
   IterPrep     r74, r6
   Len          r75, r74
   Const        r46, "movie_id"
+  Const        r46, "movie_id"
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -207,12 +279,14 @@ func main (regs=151)
   // join mk in movie_keyword on mk.movie_id == cc.movie_id
   Const        r19, 0
   Move         r76, r19
+L16:
   LessInt      r77, r76, r75
   JumpIfFalse  r77, L6
   Index        r78, r74, r76
   Move         r79, r78
   Const        r46, "movie_id"
   Index        r80, r79, r46
+  Const        r46, "movie_id"
   Index        r81, r22, r46
   Equal        r82, r80, r81
   JumpIfFalse  r82, L7
@@ -224,11 +298,20 @@ func main (regs=151)
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -236,6 +319,7 @@ func main (regs=151)
   // join k in keyword on k.id == mk.keyword_id
   Const        r19, 0
   Move         r86, r19
+L15:
   LessInt      r87, r86, r84
   JumpIfFalse  r87, L7
   Index        r88, r83, r86
@@ -254,11 +338,20 @@ func main (regs=151)
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -266,6 +359,7 @@ func main (regs=151)
   // join t in title on t.id == cc.movie_id
   Const        r19, 0
   Move         r95, r19
+L14:
   LessInt      r96, r95, r94
   JumpIfFalse  r96, L8
   Index        r97, r93, r95
@@ -275,7 +369,6 @@ func main (regs=151)
   Const        r46, "movie_id"
   Index        r100, r22, r46
   Equal        r101, r99, r100
-L13:
   JumpIfFalse  r101, L9
   // join kt in kind_type on kt.id == t.kind_id
   IterPrep     r102, r7
@@ -285,11 +378,20 @@ L13:
   // where cct1.kind == "cast" &&
   Const        r10, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r10, "kind"
   Const        r11, "contains"
   // (!chn.name.contains("Sherlock")) &&
   Const        r12, "name"
+  Const        r11, "contains"
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r12, "name"
+  Const        r11, "contains"
+  Const        r12, "name"
+  Const        r11, "contains"
   // k.keyword in [
   Const        r13, "keyword"
+  // kt.kind == "movie" &&
+  Const        r10, "kind"
   // t.production_year > 1950
   Const        r14, "production_year"
   // select t.title
@@ -297,6 +399,7 @@ L13:
   // join kt in kind_type on kt.id == t.kind_id
   Const        r19, 0
   Move         r105, r19
+L13:
   LessInt      r106, r105, r103
   JumpIfFalse  r106, L9
   Index        r107, r102, r105
@@ -324,6 +427,7 @@ L13:
   Const        r119, ["superhero", "sequel", "second-part", "marvel-comics", "based-on-comic", "tv-special", "fight", "violence"]
   In           r120, r118, r119
   // kt.kind == "movie" &&
+  Const        r10, "kind"
   Index        r121, r108, r10
   Const        r122, "movie"
   Equal        r123, r121, r122
@@ -361,6 +465,7 @@ L13:
   Const        r137, "Iron Man"
   In           r138, r137, r136
   Move         r135, r138
+L12:
   // (!chn.name.contains("Sherlock")) &&
   Move         r124, r135
   // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
@@ -372,6 +477,7 @@ L13:
   // kt.kind == "movie" &&
   JumpIfFalse  r124, L11
   Move         r124, r115
+L11:
   // where cct1.kind == "cast" &&
   JumpIfFalse  r124, L10
   // select t.title
@@ -380,7 +486,69 @@ L13:
   // from cc in complete_cast
   Append       r140, r9, r139
   Move         r9, r140
+L10:
   // join kt in kind_type on kt.id == t.kind_id
   Const        r141, 1
   Add          r105, r105, r141
   Jump         L13
+L9:
+  // join t in title on t.id == cc.movie_id
+  Const        r141, 1
+  Add          r95, r95, r141
+  Jump         L14
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r141, 1
+  Add          r86, r86, r141
+  Jump         L15
+L7:
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  Const        r141, 1
+  Add          r76, r76, r141
+  Jump         L16
+L6:
+  // join n in name on n.id == ci.person_id
+  Const        r141, 1
+  Add          r67, r67, r141
+  Jump         L17
+L5:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r141, 1
+  Add          r57, r57, r141
+  Jump         L18
+L4:
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  Const        r141, 1
+  Add          r47, r47, r141
+  Jump         L19
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r141, 1
+  Add          r37, r37, r141
+  Jump         L20
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r141, 1
+  Add          r27, r27, r141
+  Jump         L21
+L1:
+  // from cc in complete_cast
+  Const        r141, 1
+  AddInt       r18, r18, r141
+  Jump         L22
+L0:
+  // let result = [ { complete_downey_ironman_movie: min(matches) } ]
+  Const        r143, "complete_downey_ironman_movie"
+  Min          r144, r9
+  Move         r145, r143
+  Move         r146, r144
+  MakeMap      r147, 1, r145
+  Move         r142, r147
+  MakeList     r148, 1, r142
+  // json(result)
+  JSON         r148
+  // expect result == [ { complete_downey_ironman_movie: "Iron Man" } ]
+  Const        r149, [{"complete_downey_ironman_movie": "Iron Man"}]
+  Equal        r150, r148, r149
+  Expect       r150
+  Return       r0

--- a/tests/dataset/job/out/q21.ir.out
+++ b/tests/dataset/job/out/q21.ir.out
@@ -26,22 +26,28 @@ func main (regs=198)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
@@ -50,6 +56,7 @@ func main (regs=198)
   Len          r25, r24
   Const        r27, 0
   Move         r26, r27
+L20:
   LessInt      r28, r26, r25
   JumpIfFalse  r28, L0
   Index        r29, r24, r26
@@ -64,28 +71,35 @@ func main (regs=198)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join mc in movie_companies on mc.company_id == cn.id
   Const        r27, 0
   Move         r35, r27
+L19:
   LessInt      r36, r35, r32
   JumpIfFalse  r36, L1
   Index        r37, r31, r35
@@ -106,28 +120,35 @@ func main (regs=198)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r27, 0
   Move         r45, r27
+L18:
   LessInt      r46, r45, r43
   JumpIfFalse  r46, L2
   Index        r47, r42, r45
@@ -148,28 +169,35 @@ func main (regs=198)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join t in title on t.id == mc.movie_id
   Const        r27, 0
   Move         r55, r27
+L17:
   LessInt      r56, r55, r53
   JumpIfFalse  r56, L3
   Index        r57, r52, r55
@@ -190,28 +218,35 @@ func main (regs=198)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r27, 0
   Move         r64, r27
+L16:
   LessInt      r65, r64, r63
   JumpIfFalse  r65, L4
   Index        r66, r62, r64
@@ -232,30 +267,36 @@ func main (regs=198)
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r27, 0
   Move         r74, r27
+L15:
   LessInt      r75, r74, r72
-L13:
   JumpIfFalse  r75, L5
   Index        r76, r71, r74
   Move         r77, r76
@@ -275,28 +316,35 @@ L13:
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join ml in movie_link on ml.movie_id == t.id
   Const        r27, 0
   Move         r83, r27
+L14:
   LessInt      r84, r83, r82
   JumpIfFalse  r84, L6
   Index        r85, r81, r83
@@ -317,28 +365,35 @@ L13:
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r27, 0
   Move         r93, r27
+L13:
   LessInt      r94, r93, r91
   JumpIfFalse  r94, L7
   Index        r95, r90, r93
@@ -359,28 +414,35 @@ L13:
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r12, "name"
   Const        r13, "contains"
+  Const        r12, "name"
+  Const        r13, "contains"
   // ct.kind == "production companies" &&
   Const        r14, "kind"
   // k.keyword == "sequel" &&
   Const        r15, "keyword"
   // lt.link.contains("follow") &&
   Const        r16, "link"
+  Const        r13, "contains"
   // mc.note == null &&
   Const        r17, "note"
   // (mi.info in allowed_countries) &&
   Const        r18, "info"
   // t.production_year >= 1950 && t.production_year <= 2000
   Const        r19, "production_year"
+  Const        r19, "production_year"
   // company_name: cn.name,
   Const        r20, "company_name"
+  Const        r12, "name"
   // link_type: lt.link,
   Const        r21, "link_type"
+  Const        r16, "link"
   // western_follow_up: t.title
   Const        r22, "western_follow_up"
   Const        r23, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r27, 0
   Move         r102, r27
+L12:
   LessInt      r103, r102, r101
   JumpIfFalse  r103, L8
   Index        r104, r100, r102
@@ -399,6 +461,7 @@ L13:
   Index        r110, r58, r19
   Const        r111, 1950
   LessEq       r112, r111, r110
+  Const        r19, "production_year"
   Index        r113, r58, r19
   Const        r114, 2000
   LessEq       r115, r113, r114
@@ -435,6 +498,7 @@ L13:
   Const        r133, "Warner"
   In           r134, r133, r132
   Move         r131, r134
+L11:
   // where cn.country_code != "[pl]" &&
   Move         r127, r131
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
@@ -447,7 +511,6 @@ L13:
   JumpIfFalse  r127, L10
   Const        r16, "link"
   Index        r135, r96, r16
-L12:
   // lt.link.contains("follow") &&
   Const        r136, "follow"
   In           r137, r136, r135
@@ -471,6 +534,7 @@ L12:
   // t.production_year >= 1950 && t.production_year <= 2000
   JumpIfFalse  r127, L10
   Move         r127, r115
+L10:
   // where cn.country_code != "[pl]" &&
   JumpIfFalse  r127, L9
   // company_name: cn.name,
@@ -499,16 +563,63 @@ L12:
   // from cn in company_name
   Append       r154, r10, r153
   Move         r10, r154
+L9:
   // join mi in movie_info on mi.movie_id == t.id
   Const        r155, 1
   Add          r102, r102, r155
   Jump         L12
-L11:
-  // join mk in movie_keyword on mk.movie_id == t.id
-  Add          r64, r64, r155
+L8:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r155, 1
+  Add          r93, r93, r155
   Jump         L13
-L10:
+L7:
+  // join ml in movie_link on ml.movie_id == t.id
+  Const        r155, 1
+  Add          r83, r83, r155
+  Jump         L14
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r155, 1
+  Add          r74, r74, r155
+  Jump         L15
+L5:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r155, 1
+  Add          r64, r64, r155
+  Jump         L16
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r155, 1
+  Add          r55, r55, r155
+  Jump         L17
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r155, 1
+  Add          r45, r45, r155
+  Jump         L18
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r155, 1
+  Add          r35, r35, r155
+  Jump         L19
+L1:
+  // from cn in company_name
+  Const        r155, 1
+  AddInt       r26, r26, r155
+  Jump         L20
+L0:
   // company_name: min(from r in rows select r.company_name),
+  Const        r157, "company_name"
+  Const        r158, []
+  Const        r20, "company_name"
+  IterPrep     r159, r10
+  Len          r160, r159
+  Const        r27, 0
+  Move         r161, r27
+L22:
+  LessInt      r162, r161, r160
+  JumpIfFalse  r162, L21
   Index        r163, r159, r161
   Move         r164, r163
   Const        r20, "company_name"
@@ -517,47 +628,61 @@ L10:
   Move         r158, r166
   Const        r155, 1
   AddInt       r161, r161, r155
-  Jump         L14
-L9:
+  Jump         L22
+L21:
+  Min          r167, r158
   // link_type: min(from r in rows select r.link_type),
+  Const        r168, "link_type"
+  Const        r169, []
+  Const        r21, "link_type"
+  IterPrep     r170, r10
+  Len          r171, r170
+  Const        r27, 0
+  Move         r172, r27
+L24:
+  LessInt      r173, r172, r171
+  JumpIfFalse  r173, L23
   Index        r174, r170, r172
   Move         r164, r174
   Const        r21, "link_type"
-L8:
   Index        r175, r164, r21
   Append       r176, r169, r175
   Move         r169, r176
-L7:
   Const        r155, 1
   AddInt       r172, r172, r155
-  Jump         L15
-L6:
+  Jump         L24
+L23:
   Min          r177, r169
   // western_follow_up: min(from r in rows select r.western_follow_up)
   Const        r178, "western_follow_up"
   Const        r179, []
-L5:
   Const        r22, "western_follow_up"
   IterPrep     r180, r10
   Len          r181, r180
-L4:
   Const        r27, 0
   Move         r182, r27
+L26:
   LessInt      r183, r182, r181
-L3:
-  JumpIfFalse  r183, L16
+  JumpIfFalse  r183, L25
   Index        r184, r180, r182
   Move         r164, r184
-L2:
   Const        r22, "western_follow_up"
   Index        r185, r164, r22
   Append       r186, r179, r185
-L1:
   Move         r179, r186
   Const        r155, 1
   AddInt       r182, r182, r155
-  Jump         L0
-L14:
+  Jump         L26
+L25:
+  Min          r187, r179
+  // company_name: min(from r in rows select r.company_name),
+  Move         r188, r157
+  Move         r189, r167
+  // link_type: min(from r in rows select r.link_type),
+  Move         r190, r168
+  Move         r191, r177
+  // western_follow_up: min(from r in rows select r.western_follow_up)
+  Move         r192, r178
   Move         r193, r187
   // {
   MakeMap      r194, 3, r188

--- a/tests/dataset/job/out/q22.ir.out
+++ b/tests/dataset/job/out/q22.ir.out
@@ -25,38 +25,92 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
   Const        r18, "id"
   Const        r19, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // from cn in company_name
   IterPrep     r29, r0
   Len          r30, r29
   Const        r32, 0
   Move         r31, r32
+L26:
   LessInt      r33, r31, r30
   JumpIfFalse  r33, L0
   Index        r34, r29, r31
@@ -70,33 +124,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
+  // cn.id == mc.company_id
+  Const        r18, "id"
+  Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join mc in movie_companies on cn.id == mc.company_id
   Const        r32, 0
   Move         r38, r32
+L25:
   LessInt      r39, r38, r37
   JumpIfFalse  r39, L1
   Index        r40, r36, r38
@@ -116,33 +227,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // ct.id == mc.company_type_id &&
+  Const        r18, "id"
+  Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r32, 0
   Move         r47, r32
+L24:
   LessInt      r48, r47, r46
   JumpIfFalse  r48, L2
   Index        r49, r45, r47
@@ -162,33 +330,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
+  // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join t in title on t.id == mc.movie_id
   Const        r32, 0
   Move         r56, r32
+L23:
   LessInt      r57, r56, r55
   JumpIfFalse  r57, L3
   Index        r58, r54, r56
@@ -208,33 +433,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
+  // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r32, 0
   Move         r65, r32
+L22:
   LessInt      r66, r65, r64
   JumpIfFalse  r66, L4
   Index        r67, r63, r65
@@ -254,33 +536,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r18, "id"
   Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // k.id == mk.keyword_id &&
+  Const        r18, "id"
+  Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r32, 0
   Move         r74, r32
+L21:
   LessInt      r75, r74, r73
   JumpIfFalse  r75, L5
   Index        r76, r72, r74
@@ -300,33 +639,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
+  // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r32, 0
   Move         r83, r32
+L20:
   LessInt      r84, r83, r82
   JumpIfFalse  r84, L6
   Index        r85, r81, r83
@@ -346,33 +742,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
+  // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r32, 0
   Move         r92, r32
+L19:
   LessInt      r93, r92, r91
   JumpIfFalse  r93, L7
   Index        r94, r90, r92
@@ -392,33 +845,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
+  // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
   Const        r32, 0
   Move         r101, r32
+L18:
   LessInt      r102, r101, r100
   JumpIfFalse  r102, L8
   Index        r103, r99, r101
@@ -438,33 +948,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
   // kt.id == t.kind_id &&
+  Const        r18, "id"
   Const        r19, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
+  // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r32, 0
   Move         r110, r32
+L17:
   LessInt      r111, r110, r109
   JumpIfFalse  r111, L9
   Index        r112, r108, r110
@@ -484,33 +1051,90 @@ func main (regs=287)
   Const        r11, "country_code"
   // it1.info == "countries" &&
   Const        r12, "info"
+  // it2.info == "rating" &&
+  Const        r12, "info"
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
+  Const        r13, "keyword"
   // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r14, "kind"
   Const        r14, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r15, "note"
   Const        r16, "contains"
+  // mc.note.contains("(200") &&
+  Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  Const        r12, "info"
+  // mi_idx.info < 7.0 &&
+  Const        r12, "info"
   // t.production_year > 2008 &&
   Const        r17, "production_year"
+  // kt.id == t.kind_id &&
+  Const        r18, "id"
+  Const        r19, "kind_id"
   // t.id == mi.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r18, "id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
+  Const        r20, "movie_id"
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Const        r20, "movie_id"
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Const        r21, "keyword_id"
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
+  Const        r22, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Const        r22, "info_type_id"
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Const        r23, "company_type_id"
   // cn.id == mc.company_id
+  Const        r18, "id"
   Const        r24, "company_id"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r25, "company"
   Const        r26, "name"
   Const        r27, "rating"
+  Const        r12, "info"
+  Const        r28, "title"
   Const        r28, "title"
   // join kt in kind_type on kt.id == t.kind_id
   Const        r32, 0
   Move         r119, r32
+L16:
   LessInt      r120, r119, r118
   JumpIfFalse  r120, L10
   Index        r121, r117, r119
@@ -538,10 +1162,12 @@ func main (regs=287)
   Const        r133, "[us]"
   NotEqual     r134, r126, r133
   // it1.info == "countries" &&
+  Const        r12, "info"
   Index        r135, r95, r12
   Const        r136, "countries"
   Equal        r137, r135, r136
   // it2.info == "rating" &&
+  Const        r12, "info"
   Index        r138, r113, r12
   Const        r27, "rating"
   Equal        r139, r138, r27
@@ -559,66 +1185,91 @@ func main (regs=287)
   Index        r146, r59, r19
   Equal        r147, r145, r146
   // t.id == mi.movie_id &&
+  Const        r18, "id"
   Index        r148, r59, r18
   Const        r20, "movie_id"
   Index        r149, r86, r20
   Equal        r150, r148, r149
   // t.id == mk.movie_id &&
+  Const        r18, "id"
   Index        r151, r59, r18
+  Const        r20, "movie_id"
   Index        r152, r68, r20
   Equal        r153, r151, r152
   // t.id == mi_idx.movie_id &&
+  Const        r18, "id"
   Index        r154, r59, r18
+  Const        r20, "movie_id"
   Index        r155, r104, r20
   Equal        r156, r154, r155
   // t.id == mc.movie_id &&
+  Const        r18, "id"
   Index        r157, r59, r18
+  Const        r20, "movie_id"
   Index        r158, r41, r20
   Equal        r159, r157, r158
   // mk.movie_id == mi.movie_id &&
+  Const        r20, "movie_id"
   Index        r160, r68, r20
+  Const        r20, "movie_id"
   Index        r161, r86, r20
   Equal        r162, r160, r161
   // mk.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Index        r163, r68, r20
+  Const        r20, "movie_id"
   Index        r164, r104, r20
   Equal        r165, r163, r164
   // mk.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
   Index        r166, r68, r20
+  Const        r20, "movie_id"
   Index        r167, r41, r20
   Equal        r168, r166, r167
   // mi.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Index        r169, r86, r20
+  Const        r20, "movie_id"
   Index        r170, r104, r20
   Equal        r171, r169, r170
   // mi.movie_id == mc.movie_id &&
+  Const        r20, "movie_id"
   Index        r172, r86, r20
+  Const        r20, "movie_id"
   Index        r173, r41, r20
   Equal        r174, r172, r173
   // mc.movie_id == mi_idx.movie_id &&
+  Const        r20, "movie_id"
   Index        r175, r41, r20
+  Const        r20, "movie_id"
   Index        r176, r104, r20
   Equal        r177, r175, r176
   // k.id == mk.keyword_id &&
+  Const        r18, "id"
   Index        r178, r77, r18
   Const        r21, "keyword_id"
   Index        r179, r68, r21
   Equal        r180, r178, r179
   // it1.id == mi.info_type_id &&
+  Const        r18, "id"
   Index        r181, r95, r18
   Const        r22, "info_type_id"
   Index        r182, r86, r22
   Equal        r183, r181, r182
   // it2.id == mi_idx.info_type_id &&
+  Const        r18, "id"
   Index        r184, r113, r18
+  Const        r22, "info_type_id"
   Index        r185, r104, r22
   Equal        r186, r184, r185
   // ct.id == mc.company_type_id &&
+  Const        r18, "id"
   Index        r187, r50, r18
   Const        r23, "company_type_id"
   Index        r188, r41, r23
   Equal        r189, r187, r188
   // cn.id == mc.company_id
+  Const        r18, "id"
   Index        r190, r35, r18
   Const        r24, "company_id"
   Index        r191, r41, r24
@@ -637,12 +1288,15 @@ func main (regs=287)
   Index        r194, r77, r13
   Const        r195, "murder"
   Equal        r196, r194, r195
+  Const        r13, "keyword"
   Index        r197, r77, r13
   Const        r198, "murder-in-title"
   Equal        r199, r197, r198
+  Const        r13, "keyword"
   Index        r200, r77, r13
   Const        r201, "blood"
   Equal        r202, r200, r201
+  Const        r13, "keyword"
   Index        r203, r77, r13
   Const        r204, "violence"
   Equal        r205, r203, r204
@@ -653,6 +1307,7 @@ func main (regs=287)
   Move         r206, r202
   JumpIfTrue   r206, L13
   Move         r206, r205
+L13:
   // it2.info == "rating" &&
   Move         r193, r206
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
@@ -662,12 +1317,14 @@ func main (regs=287)
   Index        r207, r122, r14
   Const        r208, "movie"
   Equal        r209, r207, r208
+  Const        r14, "kind"
   Index        r210, r122, r14
   Const        r211, "episode"
   Equal        r212, r210, r211
   Move         r213, r209
   JumpIfTrue   r213, L14
   Move         r213, r212
+L14:
   // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
   Move         r193, r213
   // (kt.kind == "movie" || kt.kind == "episode") &&
@@ -689,12 +1346,15 @@ func main (regs=287)
   Index        r217, r86, r12
   Const        r218, "Germany"
   Equal        r219, r217, r218
+  Const        r12, "info"
   Index        r220, r86, r12
   Const        r221, "German"
   Equal        r222, r220, r221
+  Const        r12, "info"
   Index        r223, r86, r12
   Const        r224, "USA"
   Equal        r225, r223, r224
+  Const        r12, "info"
   Index        r226, r86, r12
   Const        r227, "American"
   Equal        r228, r226, r227
@@ -705,6 +1365,7 @@ func main (regs=287)
   Move         r229, r225
   JumpIfTrue   r229, L15
   Move         r229, r228
+L15:
   // mc.note.contains("(200") &&
   Move         r193, r229
   // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
@@ -761,6 +1422,7 @@ func main (regs=287)
   // ct.id == mc.company_type_id &&
   JumpIfFalse  r193, L12
   Move         r193, r192
+L12:
   // where (
   JumpIfFalse  r193, L11
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
@@ -783,7 +1445,146 @@ func main (regs=287)
   // from cn in company_name
   Append       r243, r10, r242
   Move         r10, r243
+L11:
   // join kt in kind_type on kt.id == t.kind_id
   Const        r244, 1
   Add          r119, r119, r244
   Jump         L16
+L10:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r244, 1
+  Add          r110, r110, r244
+  Jump         L17
+L9:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r244, 1
+  Add          r101, r101, r244
+  Jump         L18
+L8:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r244, 1
+  Add          r92, r92, r244
+  Jump         L19
+L7:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r244, 1
+  Add          r83, r83, r244
+  Jump         L20
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r244, 1
+  Add          r74, r74, r244
+  Jump         L21
+L5:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r244, 1
+  Add          r65, r65, r244
+  Jump         L22
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r244, 1
+  Add          r56, r56, r244
+  Jump         L23
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r244, 1
+  Add          r47, r47, r244
+  Jump         L24
+L2:
+  // join mc in movie_companies on cn.id == mc.company_id
+  Const        r244, 1
+  Add          r38, r38, r244
+  Jump         L25
+L1:
+  // from cn in company_name
+  Const        r244, 1
+  AddInt       r31, r31, r244
+  Jump         L26
+L0:
+  // movie_company: min(from r in rows select r.company),
+  Const        r246, "movie_company"
+  Const        r247, []
+  Const        r25, "company"
+  IterPrep     r248, r10
+  Len          r249, r248
+  Const        r32, 0
+  Move         r250, r32
+L28:
+  LessInt      r251, r250, r249
+  JumpIfFalse  r251, L27
+  Index        r252, r248, r250
+  Move         r253, r252
+  Const        r25, "company"
+  Index        r254, r253, r25
+  Append       r255, r247, r254
+  Move         r247, r255
+  Const        r244, 1
+  AddInt       r250, r250, r244
+  Jump         L28
+L27:
+  Min          r256, r247
+  // rating: min(from r in rows select r.rating),
+  Const        r257, "rating"
+  Const        r258, []
+  Const        r27, "rating"
+  IterPrep     r259, r10
+  Len          r260, r259
+  Const        r32, 0
+  Move         r261, r32
+L30:
+  LessInt      r262, r261, r260
+  JumpIfFalse  r262, L29
+  Index        r263, r259, r261
+  Move         r253, r263
+  Const        r27, "rating"
+  Index        r264, r253, r27
+  Append       r265, r258, r264
+  Move         r258, r265
+  Const        r244, 1
+  AddInt       r261, r261, r244
+  Jump         L30
+L29:
+  Min          r266, r258
+  // western_violent_movie: min(from r in rows select r.title)
+  Const        r267, "western_violent_movie"
+  Const        r268, []
+  Const        r28, "title"
+  IterPrep     r269, r10
+  Len          r270, r269
+  Const        r32, 0
+  Move         r271, r32
+L32:
+  LessInt      r272, r271, r270
+  JumpIfFalse  r272, L31
+  Index        r273, r269, r271
+  Move         r253, r273
+  Const        r28, "title"
+  Index        r274, r253, r28
+  Append       r275, r268, r274
+  Move         r268, r275
+  Const        r244, 1
+  AddInt       r271, r271, r244
+  Jump         L32
+L31:
+  Min          r276, r268
+  // movie_company: min(from r in rows select r.company),
+  Move         r277, r246
+  Move         r278, r256
+  // rating: min(from r in rows select r.rating),
+  Move         r279, r257
+  Move         r280, r266
+  // western_violent_movie: min(from r in rows select r.title)
+  Move         r281, r267
+  Move         r282, r276
+  // {
+  MakeMap      r283, 3, r277
+  Move         r245, r283
+  // let result = [
+  MakeList     r284, 1, r245
+  // json(result)
+  JSON         r284
+  // expect result == [
+  Const        r285, [{"movie_company": "Euro Films", "rating": 6.5, "western_violent_movie": "Violent Western"}]
+  Equal        r286, r284, r285
+  Expect       r286
+  Return       r0

--- a/tests/dataset/job/out/q23.ir.out
+++ b/tests/dataset/job/out/q23.ir.out
@@ -29,13 +29,23 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // from cc in complete_cast
@@ -43,6 +53,7 @@ func main (regs=197)
   Len          r22, r21
   Const        r24, 0
   Move         r23, r24
+L25:
   LessInt      r25, r23, r22
   JumpIfFalse  r25, L0
   Index        r26, r21, r23
@@ -58,18 +69,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join cct1 in comp_cast_type on cct1.id == cc.status_id
   Const        r24, 0
   Move         r32, r24
+L24:
   LessInt      r33, r32, r29
   JumpIfFalse  r33, L1
   Index        r34, r28, r32
@@ -91,18 +113,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join t in title on t.id == cc.movie_id
   Const        r24, 0
   Move         r42, r24
+L23:
   LessInt      r43, r42, r40
   JumpIfFalse  r43, L2
   Index        r44, r39, r42
@@ -124,18 +157,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join kt in kind_type on kt.id == t.kind_id
   Const        r24, 0
   Move         r52, r24
+L22:
   LessInt      r53, r52, r50
   JumpIfFalse  r53, L3
   Index        r54, r49, r52
@@ -157,18 +201,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r24, 0
   Move         r61, r24
+L21:
   LessInt      r62, r61, r60
   JumpIfFalse  r62, L4
   Index        r63, r59, r61
@@ -190,18 +245,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r24, 0
   Move         r71, r24
+L20:
   LessInt      r72, r71, r69
   JumpIfFalse  r72, L5
   Index        r73, r68, r71
@@ -223,18 +289,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r24, 0
   Move         r80, r24
+L19:
   LessInt      r81, r80, r79
   JumpIfFalse  r81, L6
   Index        r82, r78, r80
@@ -256,18 +333,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r24, 0
   Move         r90, r24
+L18:
   LessInt      r91, r90, r88
   JumpIfFalse  r91, L7
   Index        r92, r87, r90
@@ -289,18 +377,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r24, 0
   Move         r99, r24
+L17:
   LessInt      r100, r99, r98
   JumpIfFalse  r100, L8
   Index        r101, r97, r99
@@ -322,18 +421,29 @@ func main (regs=197)
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r24, 0
   Move         r109, r24
+L16:
   LessInt      r110, r109, r107
   JumpIfFalse  r110, L9
   Index        r111, r106, r109
@@ -349,25 +459,35 @@ func main (regs=197)
   Len          r117, r116
   Const        r30, "id"
   Const        r118, "company_type_id"
-L15:
   // where cct1.kind == "complete+verified" &&
   Const        r12, "kind"
   // cn.country_code == "[us]" &&
   Const        r13, "country_code"
   // it1.info == "release dates" &&
   Const        r14, "info"
+  // kt.kind == "movie" &&
+  Const        r12, "kind"
   // mi.note.contains("internet") &&
   Const        r15, "note"
+  Const        r16, "contains"
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
+  Const        r16, "contains"
+  Const        r14, "info"
   Const        r16, "contains"
   // t.production_year > 2000
   Const        r17, "production_year"
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
   Const        r18, "movie_kind"
+  Const        r12, "kind"
   Const        r19, "complete_us_internet_movie"
   Const        r20, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r24, 0
   Move         r119, r24
+L15:
   LessInt      r120, r119, r117
   JumpIfFalse  r120, L10
   Index        r121, r116, r119
@@ -400,6 +520,7 @@ L15:
   Const        r136, "release dates"
   Equal        r137, r135, r136
   // kt.kind == "movie" &&
+  Const        r12, "kind"
   Index        r138, r55, r12
   Const        r139, "movie"
   Equal        r140, r138, r139
@@ -442,12 +563,15 @@ L15:
   Const        r154, "200"
   In           r155, r154, r153
   Move         r152, r155
+L14:
   Move         r148, r152
+L13:
   // mi.note.contains("internet") &&
   Move         r141, r148
   // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
   JumpIfFalse  r141, L12
   Move         r141, r129
+L12:
   // where cct1.kind == "complete+verified" &&
   JumpIfFalse  r141, L11
   // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
@@ -465,21 +589,112 @@ L15:
   // from cc in complete_cast
   Append       r165, r11, r164
   Move         r11, r165
+L11:
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r166, 1
   Add          r119, r119, r166
-  // join k in keyword on k.id == mk.keyword_id
-  Add          r90, r90, r166
   Jump         L15
-L14:
+L10:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r166, 1
+  Add          r109, r109, r166
+  Jump         L16
+L9:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r166, 1
+  Add          r99, r99, r166
+  Jump         L17
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r166, 1
+  Add          r90, r90, r166
+  Jump         L18
+L7:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r166, 1
+  Add          r80, r80, r166
+  Jump         L19
+L6:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r166, 1
+  Add          r71, r71, r166
+  Jump         L20
+L5:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r166, 1
+  Add          r61, r61, r166
+  Jump         L21
+L4:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r166, 1
+  Add          r52, r52, r166
+  Jump         L22
+L3:
+  // join t in title on t.id == cc.movie_id
+  Const        r166, 1
+  Add          r42, r42, r166
+  Jump         L23
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.status_id
+  Const        r166, 1
+  Add          r32, r32, r166
+  Jump         L24
+L1:
+  // from cc in complete_cast
+  Const        r166, 1
+  AddInt       r23, r23, r166
+  Jump         L25
+L0:
+  // movie_kind: min(from r in matches select r.movie_kind),
+  Const        r168, "movie_kind"
+  Const        r169, []
+  Const        r18, "movie_kind"
+  IterPrep     r170, r11
+  Len          r171, r170
+  Const        r24, 0
+  Move         r172, r24
+L27:
+  LessInt      r173, r172, r171
+  JumpIfFalse  r173, L26
+  Index        r174, r170, r172
+  Move         r175, r174
+  Const        r18, "movie_kind"
+  Index        r176, r175, r18
+  Append       r177, r169, r176
+  Move         r169, r177
+  Const        r166, 1
+  AddInt       r172, r172, r166
+  Jump         L27
+L26:
+  Min          r178, r169
+  // complete_us_internet_movie: min(from r in matches select r.complete_us_internet_movie)
+  Const        r179, "complete_us_internet_movie"
+  Const        r180, []
+  Const        r19, "complete_us_internet_movie"
+  IterPrep     r181, r11
+  Len          r182, r181
+  Const        r24, 0
+  Move         r183, r24
+L29:
+  LessInt      r184, r183, r182
+  JumpIfFalse  r184, L28
+  Index        r185, r181, r183
+  Move         r175, r185
+  Const        r19, "complete_us_internet_movie"
+  Index        r186, r175, r19
+  Append       r187, r180, r186
+  Move         r180, r187
+  Const        r166, 1
+  AddInt       r183, r183, r166
+  Jump         L29
+L28:
+  Min          r188, r180
   // movie_kind: min(from r in matches select r.movie_kind),
   Move         r189, r168
-L13:
   Move         r190, r178
   // complete_us_internet_movie: min(from r in matches select r.complete_us_internet_movie)
   Move         r191, r179
   Move         r192, r188
-L12:
   // {
   MakeMap      r193, 2, r189
   Move         r167, r193

--- a/tests/dataset/job/out/q24.ir.out
+++ b/tests/dataset/job/out/q24.ir.out
@@ -33,13 +33,23 @@ func main (regs=273)
   Const        r15, "info"
   // k.keyword in ["hero", "martial-arts", "hand-to-hand-combat"] &&
   Const        r16, "keyword"
+  // mi.info != null &&
+  Const        r15, "info"
   // (mi.info.starts_with("Japan:") && mi.info.contains("201") ||
+  Const        r15, "info"
   Const        r17, "starts_with"
+  Const        r15, "info"
+  Const        r18, "contains"
+  // mi.info.starts_with("USA:") && mi.info.contains("201")) &&
+  Const        r15, "info"
+  Const        r17, "starts_with"
+  Const        r15, "info"
   Const        r18, "contains"
   // n.gender == "f" &&
   Const        r19, "gender"
   // n.name.contains("An") &&
   Const        r20, "name"
+  Const        r18, "contains"
   // rt.role == "actress" &&
   Const        r21, "role"
   // t.production_year > 2010 &&
@@ -47,22 +57,63 @@ func main (regs=273)
   // t.id == mi.movie_id &&
   Const        r23, "id"
   Const        r24, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r23, "id"
+  Const        r24, "movie_id"
+  // t.id == ci.movie_id &&
+  Const        r23, "id"
+  Const        r24, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r23, "id"
+  Const        r24, "movie_id"
+  // mc.movie_id == ci.movie_id &&
+  Const        r24, "movie_id"
+  Const        r24, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r24, "movie_id"
+  Const        r24, "movie_id"
+  // mc.movie_id == mk.movie_id &&
+  Const        r24, "movie_id"
+  Const        r24, "movie_id"
+  // mi.movie_id == ci.movie_id &&
+  Const        r24, "movie_id"
+  Const        r24, "movie_id"
+  // mi.movie_id == mk.movie_id &&
+  Const        r24, "movie_id"
+  Const        r24, "movie_id"
+  // ci.movie_id == mk.movie_id &&
+  Const        r24, "movie_id"
+  Const        r24, "movie_id"
   // cn.id == mc.company_id &&
+  Const        r23, "id"
   Const        r25, "company_id"
   // it.id == mi.info_type_id &&
+  Const        r23, "id"
   Const        r26, "info_type_id"
   // n.id == ci.person_id &&
+  Const        r23, "id"
   Const        r27, "person_id"
   // rt.id == ci.role_id &&
+  Const        r23, "id"
   Const        r28, "role_id"
+  // n.id == an.person_id &&
+  Const        r23, "id"
+  Const        r27, "person_id"
+  // ci.person_id == an.person_id &&
+  Const        r27, "person_id"
+  Const        r27, "person_id"
   // chn.id == ci.person_role_id &&
+  Const        r23, "id"
   Const        r29, "person_role_id"
   // k.id == mk.keyword_id
+  Const        r23, "id"
   Const        r30, "keyword_id"
   // voiced_char_name: chn.name,
   Const        r31, "voiced_char_name"
+  Const        r20, "name"
   // voicing_actress_name: n.name,
   Const        r32, "voicing_actress_name"
+  Const        r20, "name"
   // voiced_action_movie_jap_eng: t.title
   Const        r33, "voiced_action_movie_jap_eng"
   Const        r34, "title"
@@ -71,6 +122,7 @@ func main (regs=273)
   Len          r36, r35
   Const        r38, 0
   Move         r37, r38
+L32:
   LessInt      r39, r37, r36
   JumpIfFalse  r39, L0
   Index        r40, r35, r37
@@ -80,6 +132,7 @@ func main (regs=273)
   Len          r43, r42
   Const        r38, 0
   Move         r44, r38
+L31:
   LessInt      r45, r44, r43
   JumpIfFalse  r45, L1
   Index        r46, r42, r44
@@ -89,6 +142,7 @@ func main (regs=273)
   Len          r49, r48
   Const        r38, 0
   Move         r50, r38
+L30:
   LessInt      r51, r50, r49
   JumpIfFalse  r51, L2
   Index        r52, r48, r50
@@ -98,6 +152,7 @@ func main (regs=273)
   Len          r55, r54
   Const        r38, 0
   Move         r56, r38
+L29:
   LessInt      r57, r56, r55
   JumpIfFalse  r57, L3
   Index        r58, r54, r56
@@ -107,6 +162,7 @@ func main (regs=273)
   Len          r61, r60
   Const        r38, 0
   Move         r62, r38
+L28:
   LessInt      r63, r62, r61
   JumpIfFalse  r63, L4
   Index        r64, r60, r62
@@ -116,6 +172,7 @@ func main (regs=273)
   Len          r67, r66
   Const        r38, 0
   Move         r68, r38
+L27:
   LessInt      r69, r68, r67
   JumpIfFalse  r69, L5
   Index        r70, r66, r68
@@ -125,6 +182,7 @@ func main (regs=273)
   Len          r73, r72
   Const        r38, 0
   Move         r74, r38
+L26:
   LessInt      r75, r74, r73
   JumpIfFalse  r75, L6
   Index        r76, r72, r74
@@ -134,6 +192,7 @@ func main (regs=273)
   Len          r79, r78
   Const        r38, 0
   Move         r80, r38
+L25:
   LessInt      r81, r80, r79
   JumpIfFalse  r81, L7
   Index        r82, r78, r80
@@ -143,6 +202,7 @@ func main (regs=273)
   Len          r85, r84
   Const        r38, 0
   Move         r86, r38
+L24:
   LessInt      r87, r86, r85
   JumpIfFalse  r87, L8
   Index        r88, r84, r86
@@ -152,6 +212,7 @@ func main (regs=273)
   Len          r91, r90
   Const        r38, 0
   Move         r92, r38
+L23:
   LessInt      r93, r92, r91
   JumpIfFalse  r93, L9
   Index        r94, r90, r92
@@ -161,6 +222,7 @@ func main (regs=273)
   Len          r97, r96
   Const        r38, 0
   Move         r98, r38
+L22:
   LessInt      r99, r98, r97
   JumpIfFalse  r99, L10
   Index        r100, r96, r98
@@ -170,6 +232,7 @@ func main (regs=273)
   Len          r103, r102
   Const        r38, 0
   Move         r104, r38
+L21:
   LessInt      r105, r104, r103
   JumpIfFalse  r105, L11
   Index        r106, r102, r104
@@ -201,6 +264,7 @@ func main (regs=273)
   Const        r121, ["hero", "martial-arts", "hand-to-hand-combat"]
   In           r122, r120, r121
   // mi.info != null &&
+  Const        r15, "info"
   Index        r123, r83, r15
   Const        r124, nil
   NotEqual     r125, r123, r124
@@ -218,79 +282,106 @@ func main (regs=273)
   Const        r23, "id"
   Index        r132, r107, r23
   Const        r24, "movie_id"
-L16:
   Index        r133, r83, r24
   Equal        r134, r132, r133
   // t.id == mc.movie_id &&
+  Const        r23, "id"
   Index        r135, r107, r23
+  Const        r24, "movie_id"
   Index        r136, r77, r24
   Equal        r137, r135, r136
   // t.id == ci.movie_id &&
+  Const        r23, "id"
   Index        r138, r107, r23
+  Const        r24, "movie_id"
   Index        r139, r53, r24
   Equal        r140, r138, r139
   // t.id == mk.movie_id &&
+  Const        r23, "id"
   Index        r141, r107, r23
+  Const        r24, "movie_id"
   Index        r142, r89, r24
   Equal        r143, r141, r142
   // mc.movie_id == ci.movie_id &&
+  Const        r24, "movie_id"
   Index        r144, r77, r24
+  Const        r24, "movie_id"
   Index        r145, r53, r24
   Equal        r146, r144, r145
   // mc.movie_id == mi.movie_id &&
+  Const        r24, "movie_id"
   Index        r147, r77, r24
+  Const        r24, "movie_id"
   Index        r148, r83, r24
   Equal        r149, r147, r148
   // mc.movie_id == mk.movie_id &&
+  Const        r24, "movie_id"
   Index        r150, r77, r24
+  Const        r24, "movie_id"
   Index        r151, r89, r24
   Equal        r152, r150, r151
   // mi.movie_id == ci.movie_id &&
+  Const        r24, "movie_id"
   Index        r153, r83, r24
+  Const        r24, "movie_id"
   Index        r154, r53, r24
   Equal        r155, r153, r154
   // mi.movie_id == mk.movie_id &&
+  Const        r24, "movie_id"
   Index        r156, r83, r24
+  Const        r24, "movie_id"
   Index        r157, r89, r24
   Equal        r158, r156, r157
   // ci.movie_id == mk.movie_id &&
+  Const        r24, "movie_id"
   Index        r159, r53, r24
+  Const        r24, "movie_id"
   Index        r160, r89, r24
   Equal        r161, r159, r160
   // cn.id == mc.company_id &&
+  Const        r23, "id"
   Index        r162, r59, r23
   Const        r25, "company_id"
   Index        r163, r77, r25
   Equal        r164, r162, r163
   // it.id == mi.info_type_id &&
+  Const        r23, "id"
   Index        r165, r65, r23
   Const        r26, "info_type_id"
   Index        r166, r83, r26
   Equal        r167, r165, r166
   // n.id == ci.person_id &&
+  Const        r23, "id"
   Index        r168, r95, r23
   Const        r27, "person_id"
   Index        r169, r53, r27
   Equal        r170, r168, r169
   // rt.id == ci.role_id &&
+  Const        r23, "id"
   Index        r171, r101, r23
   Const        r28, "role_id"
   Index        r172, r53, r28
   Equal        r173, r171, r172
   // n.id == an.person_id &&
+  Const        r23, "id"
   Index        r174, r95, r23
+  Const        r27, "person_id"
   Index        r175, r41, r27
   Equal        r176, r174, r175
   // ci.person_id == an.person_id &&
+  Const        r27, "person_id"
   Index        r177, r53, r27
+  Const        r27, "person_id"
   Index        r178, r41, r27
   Equal        r179, r177, r178
   // chn.id == ci.person_role_id &&
+  Const        r23, "id"
   Index        r180, r47, r23
   Const        r29, "person_role_id"
   Index        r181, r53, r29
   Equal        r182, r180, r181
   // k.id == mk.keyword_id
+  Const        r23, "id"
   Index        r183, r71, r23
   Const        r30, "keyword_id"
   Index        r184, r89, r30
@@ -315,7 +406,7 @@ L16:
   // (mi.info.starts_with("Japan:") && mi.info.contains("201") ||
   Const        r188, "Japan:"
   Const        r189, 0
-  Const        r190, 6
+  Len          r190, r188
   Len          r191, r187
   LessEq       r192, r190, r191
   JumpIfFalse  r192, L13
@@ -324,9 +415,103 @@ L16:
   Move         r193, r195
   Jump         L14
 L13:
+  Const        r193, false
+L14:
+  Move         r196, r193
+  JumpIfFalse  r196, L15
+  Const        r15, "info"
+  Index        r197, r83, r15
+  Const        r198, "201"
+  In           r199, r198, r197
+  Move         r196, r199
+L15:
+  Const        r15, "info"
+  Index        r200, r83, r15
+  // mi.info.starts_with("USA:") && mi.info.contains("201")) &&
+  Const        r201, "USA:"
+  Const        r202, 0
+  Len          r203, r201
+  Len          r204, r200
+  LessEq       r205, r203, r204
+  JumpIfFalse  r205, L16
+  Slice        r207, r200, r202, r203
+  Equal        r208, r207, r201
+  Move         r206, r208
+  Jump         L17
+L16:
+  Const        r206, false
+L17:
+  Move         r209, r206
+  JumpIfFalse  r209, L18
+  Const        r15, "info"
+  Index        r210, r83, r15
+  Const        r198, "201"
+  In           r211, r198, r210
+  Move         r209, r211
+L18:
+  // (mi.info.starts_with("Japan:") && mi.info.contains("201") ||
+  Move         r212, r196
+  JumpIfTrue   r212, L19
+  Move         r212, r209
+L19:
+  // mi.info != null &&
+  Move         r186, r212
+  // mi.info.starts_with("USA:") && mi.info.contains("201")) &&
+  JumpIfFalse  r186, L12
+  Move         r186, r128
+  // n.gender == "f" &&
+  JumpIfFalse  r186, L12
+  Const        r20, "name"
+  Index        r213, r95, r20
+  // n.name.contains("An") &&
+  Const        r214, "An"
+  In           r215, r214, r213
+  // n.gender == "f" &&
+  Move         r186, r215
+  // n.name.contains("An") &&
+  JumpIfFalse  r186, L12
+  Move         r186, r131
+  // rt.role == "actress" &&
+  JumpIfFalse  r186, L12
+  Move         r186, r111
+  // t.production_year > 2010 &&
+  JumpIfFalse  r186, L12
+  Move         r186, r134
+  // t.id == mi.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r137
+  // t.id == mc.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r140
+  // t.id == ci.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r143
+  // t.id == mk.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r146
+  // mc.movie_id == ci.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r149
+  // mc.movie_id == mi.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r152
+  // mc.movie_id == mk.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r155
+  // mi.movie_id == ci.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r158
+  // mi.movie_id == mk.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r161
+  // ci.movie_id == mk.movie_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r164
+  // cn.id == mc.company_id &&
+  JumpIfFalse  r186, L12
+  Move         r186, r167
   // it.id == mi.info_type_id &&
   JumpIfFalse  r186, L12
-L14:
   Move         r186, r170
   // n.id == ci.person_id &&
   JumpIfFalse  r186, L12
@@ -343,14 +528,16 @@ L14:
   // chn.id == ci.person_role_id &&
   JumpIfFalse  r186, L12
   Move         r186, r185
+L12:
   // where (
-  JumpIfFalse  r186, L15
+  JumpIfFalse  r186, L20
   // voiced_char_name: chn.name,
   Const        r216, "voiced_char_name"
   Const        r20, "name"
   Index        r217, r47, r20
   // voicing_actress_name: n.name,
   Const        r218, "voicing_actress_name"
+  Const        r20, "name"
   Index        r219, r95, r20
   // voiced_action_movie_jap_eng: t.title
   Const        r220, "voiced_action_movie_jap_eng"
@@ -370,69 +557,151 @@ L14:
   // from an in aka_name
   Append       r229, r12, r228
   Move         r12, r229
+L20:
   // from t in title
   Const        r230, 1
   AddInt       r104, r104, r230
-  Jump         L16
-L12:
+  Jump         L21
+L11:
+  // from rt in role_type
+  Const        r230, 1
+  AddInt       r98, r98, r230
+  Jump         L22
+L10:
+  // from n in name
+  Const        r230, 1
+  AddInt       r92, r92, r230
+  Jump         L23
+L9:
+  // from mk in movie_keyword
+  Const        r230, 1
+  AddInt       r86, r86, r230
+  Jump         L24
+L8:
+  // from mi in movie_info
+  Const        r230, 1
+  AddInt       r80, r80, r230
+  Jump         L25
+L7:
+  // from mc in movie_companies
+  Const        r230, 1
+  AddInt       r74, r74, r230
+  Jump         L26
+L6:
+  // from k in keyword
+  Const        r230, 1
+  AddInt       r68, r68, r230
+  Jump         L27
+L5:
+  // from it in info_type
+  Const        r230, 1
+  AddInt       r62, r62, r230
+  Jump         L28
+L4:
+  // from cn in company_name
+  Const        r230, 1
+  AddInt       r56, r56, r230
+  Jump         L29
+L3:
+  // from ci in cast_info
+  Const        r230, 1
+  AddInt       r50, r50, r230
+  Jump         L30
+L2:
+  // from chn in char_name
+  Const        r230, 1
+  AddInt       r44, r44, r230
+  Jump         L31
+L1:
+  // from an in aka_name
+  Const        r230, 1
+  AddInt       r37, r37, r230
+  Jump         L32
+L0:
   // voiced_char_name: min(from x in matches select x.voiced_char_name),
+  Const        r232, "voiced_char_name"
+  Const        r233, []
+  Const        r31, "voiced_char_name"
+  IterPrep     r234, r12
+  Len          r235, r234
+  Const        r38, 0
+  Move         r236, r38
+L34:
+  LessInt      r237, r236, r235
+  JumpIfFalse  r237, L33
+  Index        r238, r234, r236
+  Move         r239, r238
+  Const        r31, "voiced_char_name"
+  Index        r240, r239, r31
+  Append       r241, r233, r240
   Move         r233, r241
   Const        r230, 1
   AddInt       r236, r236, r230
-  Jump         L17
-L15:
+  Jump         L34
+L33:
+  Min          r242, r233
   // voicing_actress_name: min(from x in matches select x.voicing_actress_name),
+  Const        r243, "voicing_actress_name"
+  Const        r244, []
+  Const        r32, "voicing_actress_name"
+  IterPrep     r245, r12
+  Len          r246, r245
+  Const        r38, 0
+  Move         r247, r38
+L36:
+  LessInt      r248, r247, r246
+  JumpIfFalse  r248, L35
+  Index        r249, r245, r247
+  Move         r239, r249
+  Const        r32, "voicing_actress_name"
+  Index        r250, r239, r32
+  Append       r251, r244, r250
   Move         r244, r251
   Const        r230, 1
   AddInt       r247, r247, r230
-  Jump         L11
-L10:
+  Jump         L36
+L35:
+  Min          r252, r244
   // voiced_action_movie_jap_eng: min(from x in matches select x.voiced_action_movie_jap_eng)
+  Const        r253, "voiced_action_movie_jap_eng"
   Const        r254, []
   Const        r33, "voiced_action_movie_jap_eng"
   IterPrep     r255, r12
-L9:
   Len          r256, r255
   Const        r38, 0
   Move         r257, r38
-L8:
+L38:
   LessInt      r258, r257, r256
-  JumpIfFalse  r258, L18
+  JumpIfFalse  r258, L37
   Index        r259, r255, r257
-L7:
   Move         r239, r259
   Const        r33, "voiced_action_movie_jap_eng"
   Index        r260, r239, r33
-L6:
   Append       r261, r254, r260
   Move         r254, r261
   Const        r230, 1
-L5:
   AddInt       r257, r257, r230
-  Jump         L19
-L4:
+  Jump         L38
+L37:
+  Min          r262, r254
   // voiced_char_name: min(from x in matches select x.voiced_char_name),
   Move         r263, r232
   Move         r264, r242
   // voicing_actress_name: min(from x in matches select x.voicing_actress_name),
   Move         r265, r243
-L3:
   Move         r266, r252
   // voiced_action_movie_jap_eng: min(from x in matches select x.voiced_action_movie_jap_eng)
   Move         r267, r253
   Move         r268, r262
-L2:
   // {
   MakeMap      r269, 3, r263
   Move         r231, r269
   // let result = [
   MakeList     r270, 1, r231
-L1:
   // json(result)
   JSON         r270
   // expect result == [
   Const        r271, [{"voiced_action_movie_jap_eng": "Heroic Adventure", "voiced_char_name": "Hero Character", "voicing_actress_name": "Ann Actress"}]
   Equal        r272, r270, r271
-L0:
   Expect       r272
   Return       r0

--- a/tests/dataset/job/out/q25.ir.out
+++ b/tests/dataset/job/out/q25.ir.out
@@ -25,33 +25,74 @@ func main (regs=213)
   Const        r11, "note"
   // it1.info == "genres" &&
   Const        r12, "info"
+  // it2.info == "votes" &&
+  Const        r12, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r13, "keyword"
+  // mi.info == "Horror" &&
+  Const        r12, "info"
   // n.gender == "m" &&
   Const        r14, "gender"
   // t.id == mi.movie_id &&
   Const        r15, "id"
   Const        r16, "movie_id"
+  // t.id == mi_idx.movie_id &&
+  Const        r15, "id"
+  Const        r16, "movie_id"
+  // t.id == ci.movie_id &&
+  Const        r15, "id"
+  Const        r16, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r15, "id"
+  Const        r16, "movie_id"
+  // ci.movie_id == mi.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
+  // ci.movie_id == mk.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
+  // mi.movie_id == mk.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
+  // mi_idx.movie_id == mk.movie_id &&
+  Const        r16, "movie_id"
+  Const        r16, "movie_id"
   // n.id == ci.person_id &&
+  Const        r15, "id"
   Const        r17, "person_id"
   // it1.id == mi.info_type_id &&
+  Const        r15, "id"
+  Const        r18, "info_type_id"
+  // it2.id == mi_idx.info_type_id &&
+  Const        r15, "id"
   Const        r18, "info_type_id"
   // k.id == mk.keyword_id
+  Const        r15, "id"
   Const        r19, "keyword_id"
   // budget: mi.info,
   Const        r20, "budget"
+  Const        r12, "info"
   // votes: mi_idx.info,
   Const        r21, "votes"
+  Const        r12, "info"
   // writer: n.name,
   Const        r22, "writer"
   Const        r23, "name"
   // title: t.title
+  Const        r24, "title"
   Const        r24, "title"
   // from ci in cast_info
   IterPrep     r25, r0
   Len          r26, r25
   Const        r28, 0
   Move         r27, r28
+L19:
   LessInt      r29, r27, r26
   JumpIfFalse  r29, L0
   Index        r30, r25, r27
@@ -61,6 +102,7 @@ func main (regs=213)
   Len          r33, r32
   Const        r28, 0
   Move         r34, r28
+L18:
   LessInt      r35, r34, r33
   JumpIfFalse  r35, L1
   Index        r36, r32, r34
@@ -70,6 +112,7 @@ func main (regs=213)
   Len          r39, r38
   Const        r28, 0
   Move         r40, r28
+L17:
   LessInt      r41, r40, r39
   JumpIfFalse  r41, L2
   Index        r42, r38, r40
@@ -79,6 +122,7 @@ func main (regs=213)
   Len          r45, r44
   Const        r28, 0
   Move         r46, r28
+L16:
   LessInt      r47, r46, r45
   JumpIfFalse  r47, L3
   Index        r48, r44, r46
@@ -88,6 +132,7 @@ func main (regs=213)
   Len          r51, r50
   Const        r28, 0
   Move         r52, r28
+L15:
   LessInt      r53, r52, r51
   JumpIfFalse  r53, L4
   Index        r54, r50, r52
@@ -97,6 +142,7 @@ func main (regs=213)
   Len          r57, r56
   Const        r28, 0
   Move         r58, r28
+L14:
   LessInt      r59, r58, r57
   JumpIfFalse  r59, L5
   Index        r60, r56, r58
@@ -106,6 +152,7 @@ func main (regs=213)
   Len          r63, r62
   Const        r28, 0
   Move         r64, r28
+L13:
   LessInt      r65, r64, r63
   JumpIfFalse  r65, L6
   Index        r66, r62, r64
@@ -115,6 +162,7 @@ func main (regs=213)
   Len          r69, r68
   Const        r28, 0
   Move         r70, r28
+L12:
   LessInt      r71, r70, r69
   JumpIfFalse  r71, L7
   Index        r72, r68, r70
@@ -124,6 +172,7 @@ func main (regs=213)
   Len          r75, r74
   Const        r28, 0
   Move         r76, r28
+L11:
   LessInt      r77, r76, r75
   JumpIfFalse  r77, L8
   Index        r78, r74, r76
@@ -139,10 +188,12 @@ func main (regs=213)
   Const        r84, "genres"
   Equal        r85, r83, r84
   // it2.info == "votes" &&
+  Const        r12, "info"
   Index        r86, r43, r12
   Const        r21, "votes"
   Equal        r87, r86, r21
   // mi.info == "Horror" &&
+  Const        r12, "info"
   Index        r88, r55, r12
   Const        r89, "Horror"
   Equal        r90, r88, r89
@@ -158,57 +209,79 @@ func main (regs=213)
   Index        r95, r55, r16
   Equal        r96, r94, r95
   // t.id == mi_idx.movie_id &&
+  Const        r15, "id"
   Index        r97, r79, r15
-L11:
+  Const        r16, "movie_id"
   Index        r98, r61, r16
   Equal        r99, r97, r98
   // t.id == ci.movie_id &&
+  Const        r15, "id"
   Index        r100, r79, r15
+  Const        r16, "movie_id"
   Index        r101, r31, r16
   Equal        r102, r100, r101
   // t.id == mk.movie_id &&
+  Const        r15, "id"
   Index        r103, r79, r15
+  Const        r16, "movie_id"
   Index        r104, r67, r16
   Equal        r105, r103, r104
   // ci.movie_id == mi.movie_id &&
+  Const        r16, "movie_id"
   Index        r106, r31, r16
+  Const        r16, "movie_id"
   Index        r107, r55, r16
   Equal        r108, r106, r107
   // ci.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
   Index        r109, r31, r16
+  Const        r16, "movie_id"
   Index        r110, r61, r16
   Equal        r111, r109, r110
   // ci.movie_id == mk.movie_id &&
+  Const        r16, "movie_id"
   Index        r112, r31, r16
+  Const        r16, "movie_id"
   Index        r113, r67, r16
   Equal        r114, r112, r113
   // mi.movie_id == mi_idx.movie_id &&
+  Const        r16, "movie_id"
   Index        r115, r55, r16
+  Const        r16, "movie_id"
   Index        r116, r61, r16
   Equal        r117, r115, r116
   // mi.movie_id == mk.movie_id &&
+  Const        r16, "movie_id"
   Index        r118, r55, r16
+  Const        r16, "movie_id"
   Index        r119, r67, r16
   Equal        r120, r118, r119
   // mi_idx.movie_id == mk.movie_id &&
+  Const        r16, "movie_id"
   Index        r121, r61, r16
+  Const        r16, "movie_id"
   Index        r122, r67, r16
   Equal        r123, r121, r122
   // n.id == ci.person_id &&
+  Const        r15, "id"
   Index        r124, r73, r15
   Const        r17, "person_id"
   Index        r125, r31, r17
   Equal        r126, r124, r125
   // it1.id == mi.info_type_id &&
+  Const        r15, "id"
   Index        r127, r37, r15
   Const        r18, "info_type_id"
   Index        r128, r55, r18
   Equal        r129, r127, r128
   // it2.id == mi_idx.info_type_id &&
+  Const        r15, "id"
   Index        r130, r43, r15
+  Const        r18, "info_type_id"
   Index        r131, r61, r18
   Equal        r132, r130, r131
   // k.id == mk.keyword_id
+  Const        r15, "id"
   Index        r133, r49, r15
   Const        r19, "keyword_id"
   Index        r134, r67, r19
@@ -277,6 +350,7 @@ L11:
   // it2.id == mi_idx.info_type_id &&
   JumpIfFalse  r136, L9
   Move         r136, r135
+L9:
   // where (
   JumpIfFalse  r136, L10
   // budget: mi.info,
@@ -285,6 +359,7 @@ L11:
   Index        r141, r55, r12
   // votes: mi_idx.info,
   Const        r142, "votes"
+  Const        r12, "info"
   Index        r143, r61, r12
   // writer: n.name,
   Const        r144, "writer"
@@ -311,18 +386,63 @@ L11:
   // from ci in cast_info
   Append       r157, r10, r156
   Move         r10, r157
+L10:
   // from t in title
   Const        r158, 1
   AddInt       r76, r76, r158
   Jump         L11
-L9:
+L8:
+  // from n in name
+  Const        r158, 1
+  AddInt       r70, r70, r158
+  Jump         L12
+L7:
+  // from mk in movie_keyword
+  Const        r158, 1
+  AddInt       r64, r64, r158
+  Jump         L13
+L6:
+  // from mi_idx in movie_info_idx
+  Const        r158, 1
+  AddInt       r58, r58, r158
+  Jump         L14
+L5:
+  // from mi in movie_info
+  Const        r158, 1
+  AddInt       r52, r52, r158
+  Jump         L15
+L4:
+  // from k in keyword
+  Const        r158, 1
+  AddInt       r46, r46, r158
+  Jump         L16
+L3:
+  // from it2 in info_type
+  Const        r158, 1
+  AddInt       r40, r40, r158
+  Jump         L17
+L2:
+  // from it1 in info_type
+  Const        r158, 1
+  AddInt       r34, r34, r158
+  Jump         L18
+L1:
+  // from ci in cast_info
+  Const        r158, 1
+  AddInt       r27, r27, r158
+  Jump         L19
+L0:
   // movie_budget: min(from x in matches select x.budget),
+  Const        r160, "movie_budget"
+  Const        r161, []
+  Const        r20, "budget"
   IterPrep     r162, r10
   Len          r163, r162
   Const        r28, 0
   Move         r164, r28
+L21:
   LessInt      r165, r164, r163
-  JumpIfFalse  r165, L12
+  JumpIfFalse  r165, L20
   Index        r166, r162, r164
   Move         r167, r166
   Const        r20, "budget"
@@ -331,63 +451,81 @@ L9:
   Move         r161, r169
   Const        r158, 1
   AddInt       r164, r164, r158
-  Jump         L13
-L10:
+  Jump         L21
+L20:
+  Min          r170, r161
   // movie_votes: min(from x in matches select x.votes),
-  JumpIfFalse  r176, L14
+  Const        r171, "movie_votes"
+  Const        r172, []
+  Const        r21, "votes"
+  IterPrep     r173, r10
+  Len          r174, r173
+  Const        r28, 0
+  Move         r175, r28
+L23:
+  LessInt      r176, r175, r174
+  JumpIfFalse  r176, L22
   Index        r177, r173, r175
   Move         r167, r177
-L8:
   Const        r21, "votes"
   Index        r178, r167, r21
   Append       r179, r172, r178
-L7:
   Move         r172, r179
   Const        r158, 1
   AddInt       r175, r175, r158
-  Jump         L6
-L5:
+  Jump         L23
+L22:
+  Min          r180, r172
   // male_writer: min(from x in matches select x.writer),
+  Const        r181, "male_writer"
   Const        r182, []
   Const        r22, "writer"
   IterPrep     r183, r10
-L4:
   Len          r184, r183
   Const        r28, 0
   Move         r185, r28
-L3:
+L25:
   LessInt      r186, r185, r184
-  JumpIfFalse  r186, L15
+  JumpIfFalse  r186, L24
   Index        r187, r183, r185
-L2:
   Move         r167, r187
   Const        r22, "writer"
   Index        r188, r167, r22
-L1:
   Append       r189, r182, r188
   Move         r182, r189
   Const        r158, 1
-L0:
   AddInt       r185, r185, r158
-  Jump         L16
-L13:
+  Jump         L25
+L24:
+  Min          r190, r182
   // violent_movie_title: min(from x in matches select x.title)
+  Const        r191, "violent_movie_title"
+  Const        r192, []
+  Const        r24, "title"
+  IterPrep     r193, r10
   Len          r194, r193
   Const        r28, 0
   Move         r195, r28
+L27:
   LessInt      r196, r195, r194
-  JumpIfFalse  r196, L17
+  JumpIfFalse  r196, L26
   Index        r197, r193, r195
   Move         r167, r197
   Const        r24, "title"
   Index        r198, r167, r24
   Append       r199, r192, r198
   Move         r192, r199
-L12:
   Const        r158, 1
   AddInt       r195, r195, r158
-  Jump         L18
-L6:
+  Jump         L27
+L26:
+  Min          r200, r192
+  // movie_budget: min(from x in matches select x.budget),
+  Move         r201, r160
+  Move         r202, r170
+  // movie_votes: min(from x in matches select x.votes),
+  Move         r203, r171
+  Move         r204, r180
   // male_writer: min(from x in matches select x.writer),
   Move         r205, r181
   Move         r206, r190
@@ -405,5 +543,4 @@ L6:
   Const        r211, [{"male_writer": "Mike", "movie_budget": "Horror", "movie_votes": 100, "violent_movie_title": "Scary Movie"}]
   Equal        r212, r210, r211
   Expect       r212
-L14:
   Return       r0

--- a/tests/dataset/job/out/q26.ir.out
+++ b/tests/dataset/job/out/q26.ir.out
@@ -28,21 +28,34 @@ func main (regs=242)
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
@@ -51,6 +64,7 @@ func main (regs=242)
   Len          r25, r24
   Const        r27, 0
   Move         r26, r27
+L26:
   LessInt      r28, r26, r25
   JumpIfFalse  r28, L0
   Index        r29, r24, r26
@@ -63,27 +77,41 @@ func main (regs=242)
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join cct1 in comp_cast_type on cct1.id == cc.subject_id
   Const        r27, 0
   Move         r35, r27
+L25:
   LessInt      r36, r35, r32
   JumpIfFalse  r36, L1
   Index        r37, r31, r35
@@ -102,28 +130,41 @@ func main (regs=242)
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
-L15:
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join cct2 in comp_cast_type on cct2.id == cc.status_id
   Const        r27, 0
   Move         r45, r27
+L24:
   LessInt      r46, r45, r43
   JumpIfFalse  r46, L2
   Index        r47, r42, r45
@@ -138,36 +179,52 @@ L15:
   IterPrep     r52, r3
   Len          r53, r52
   Const        r54, "movie_id"
+  Const        r54, "movie_id"
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join ci in cast_info on ci.movie_id == cc.movie_id
   Const        r27, 0
   Move         r55, r27
+L23:
   LessInt      r56, r55, r53
   JumpIfFalse  r56, L3
   Index        r57, r52, r55
   Move         r58, r57
   Const        r54, "movie_id"
   Index        r59, r58, r54
+  Const        r54, "movie_id"
   Index        r60, r30, r54
   Equal        r61, r59, r60
   JumpIfFalse  r61, L4
@@ -179,27 +236,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join chn in char_name on chn.id == ci.person_role_id
   Const        r27, 0
   Move         r65, r27
+L22:
   LessInt      r66, r65, r63
   JumpIfFalse  r66, L4
   Index        r67, r62, r65
@@ -218,27 +289,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join n in name on n.id == ci.person_id
   Const        r27, 0
   Move         r75, r27
+L21:
   LessInt      r76, r75, r73
   JumpIfFalse  r76, L5
   Index        r77, r72, r75
@@ -257,27 +342,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join t in title on t.id == ci.movie_id
   Const        r27, 0
   Move         r84, r27
+L20:
   LessInt      r85, r84, r83
   JumpIfFalse  r85, L6
   Index        r86, r82, r84
@@ -296,27 +395,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join kt in kind_type on kt.id == t.kind_id
   Const        r27, 0
   Move         r94, r27
+L19:
   LessInt      r95, r94, r92
   JumpIfFalse  r95, L7
   Index        r96, r91, r94
@@ -335,27 +448,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r27, 0
   Move         r103, r27
+L18:
   LessInt      r104, r103, r102
   JumpIfFalse  r104, L8
   Index        r105, r101, r103
@@ -374,27 +501,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r27, 0
   Move         r113, r27
+L17:
   LessInt      r114, r113, r111
   JumpIfFalse  r114, L9
   Index        r115, r110, r113
@@ -413,27 +554,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
   Const        r27, 0
   Move         r122, r27
+L16:
   LessInt      r123, r122, r121
   JumpIfFalse  r123, L10
   Index        r124, r120, r122
@@ -452,27 +607,41 @@ L15:
   // where cct1.kind == "cast" &&
   Const        r13, "kind"
   // cct2.kind.contains("complete") &&
+  Const        r13, "kind"
   Const        r14, "contains"
   // chn.name != null &&
   Const        r15, "name"
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r15, "name"
+  Const        r14, "contains"
+  Const        r15, "name"
+  Const        r14, "contains"
   // it2.info == "rating" &&
   Const        r16, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r17, "keyword"
+  // kt.kind == "movie" &&
+  Const        r13, "kind"
+  // mi_idx.info > 7.0 &&
+  Const        r16, "info"
   // t.production_year > 2000
   Const        r18, "production_year"
   // character: chn.name,
   Const        r19, "character"
+  Const        r15, "name"
   // rating: mi_idx.info,
   Const        r20, "rating"
+  Const        r16, "info"
   // actor: n.name,
   Const        r21, "actor"
+  Const        r15, "name"
   // movie: t.title
   Const        r22, "movie"
   Const        r23, "title"
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r27, 0
   Move         r132, r27
+L15:
   LessInt      r133, r132, r130
   JumpIfFalse  r133, L11
   Index        r134, r129, r132
@@ -505,10 +674,12 @@ L15:
   Const        r149, nil
   NotEqual     r150, r148, r149
   // it2.info == "rating" &&
+  Const        r16, "info"
   Index        r151, r135, r16
   Const        r20, "rating"
   Equal        r152, r151, r20
   // kt.kind == "movie" &&
+  Const        r13, "kind"
   Index        r153, r97, r13
   Const        r22, "movie"
   Equal        r154, r153, r22
@@ -539,6 +710,7 @@ L15:
   Const        r164, "Man"
   In           r165, r164, r163
   Move         r162, r165
+L14:
   // chn.name != null &&
   Move         r155, r162
   // (chn.name.contains("man") || chn.name.contains("Man")) &&
@@ -562,6 +734,7 @@ L15:
   // mi_idx.info > 7.0 &&
   JumpIfFalse  r155, L13
   Move         r155, r145
+L13:
   // where cct1.kind == "cast" &&
   JumpIfFalse  r155, L12
   // character: chn.name,
@@ -574,6 +747,7 @@ L15:
   Index        r172, r125, r16
   // actor: n.name,
   Const        r173, "actor"
+  Const        r15, "name"
   Index        r174, r78, r15
   // movie: t.title
   Const        r175, "movie"
@@ -596,23 +770,144 @@ L15:
   // from cc in complete_cast
   Append       r186, r12, r185
   Move         r12, r186
+L12:
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r187, 1
   Add          r132, r132, r187
-  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
-  Add          r35, r35, r187
   Jump         L15
-L14:
+L11:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r187, 1
+  Add          r122, r122, r187
+  Jump         L16
+L10:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r187, 1
+  Add          r113, r113, r187
+  Jump         L17
+L9:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r187, 1
+  Add          r103, r103, r187
+  Jump         L18
+L8:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r187, 1
+  Add          r94, r94, r187
+  Jump         L19
+L7:
+  // join t in title on t.id == ci.movie_id
+  Const        r187, 1
+  Add          r84, r84, r187
+  Jump         L20
+L6:
+  // join n in name on n.id == ci.person_id
+  Const        r187, 1
+  Add          r75, r75, r187
+  Jump         L21
+L5:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r187, 1
+  Add          r65, r65, r187
+  Jump         L22
+L4:
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  Const        r187, 1
+  Add          r55, r55, r187
+  Jump         L23
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r187, 1
+  Add          r45, r45, r187
+  Jump         L24
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r187, 1
+  Add          r35, r35, r187
+  Jump         L25
+L1:
+  // from cc in complete_cast
+  Const        r187, 1
+  AddInt       r26, r26, r187
+  Jump         L26
+L0:
+  // character_name: min(from r in rows select r.character),
+  Const        r189, "character_name"
+  Const        r190, []
+  Const        r19, "character"
+  IterPrep     r191, r12
+  Len          r192, r191
+  Const        r27, 0
+  Move         r193, r27
+L28:
+  LessInt      r194, r193, r192
+  JumpIfFalse  r194, L27
+  Index        r195, r191, r193
+  Move         r196, r195
+  Const        r19, "character"
+  Index        r197, r196, r19
+  Append       r198, r190, r197
+  Move         r190, r198
+  Const        r187, 1
+  AddInt       r193, r193, r187
+  Jump         L28
+L27:
+  Min          r199, r190
+  // rating: min(from r in rows select r.rating),
+  Const        r200, "rating"
+  Const        r201, []
+  Const        r20, "rating"
+  IterPrep     r202, r12
+  Len          r203, r202
+  Const        r27, 0
+  Move         r204, r27
+L30:
+  LessInt      r205, r204, r203
+  JumpIfFalse  r205, L29
+  Index        r206, r202, r204
+  Move         r196, r206
+  Const        r20, "rating"
+  Index        r207, r196, r20
+  Append       r208, r201, r207
+  Move         r201, r208
+  Const        r187, 1
+  AddInt       r204, r204, r187
+  Jump         L30
+L29:
+  Min          r209, r201
   // playing_actor: min(from r in rows select r.actor),
+  Const        r210, "playing_actor"
+  Const        r211, []
+  Const        r21, "actor"
+  IterPrep     r212, r12
+  Len          r213, r212
+  Const        r27, 0
+  Move         r214, r27
+L32:
+  LessInt      r215, r214, r213
+  JumpIfFalse  r215, L31
+  Index        r216, r212, r214
+  Move         r196, r216
+  Const        r21, "actor"
   Index        r217, r196, r21
   Append       r218, r211, r217
   Move         r211, r218
   Const        r187, 1
   AddInt       r214, r214, r187
-  Jump         L16
-L13:
+  Jump         L32
+L31:
+  Min          r219, r211
   // complete_hero_movie: min(from r in rows select r.movie)
-  JumpIfFalse  r225, L17
+  Const        r220, "complete_hero_movie"
+  Const        r221, []
+  Const        r22, "movie"
+  IterPrep     r222, r12
+  Len          r223, r222
+  Const        r27, 0
+  Move         r224, r27
+L34:
+  LessInt      r225, r224, r223
+  JumpIfFalse  r225, L33
   Index        r226, r222, r224
   Move         r196, r226
   Const        r22, "movie"
@@ -621,9 +916,30 @@ L13:
   Move         r221, r228
   Const        r187, 1
   AddInt       r224, r224, r187
-  Jump         L18
-L12:
+  Jump         L34
+L33:
+  Min          r229, r221
+  // character_name: min(from r in rows select r.character),
+  Move         r230, r189
+  Move         r231, r199
+  // rating: min(from r in rows select r.rating),
+  Move         r232, r200
+  Move         r233, r209
+  // playing_actor: min(from r in rows select r.actor),
+  Move         r234, r210
+  Move         r235, r219
+  // complete_hero_movie: min(from r in rows select r.movie)
+  Move         r236, r220
+  Move         r237, r229
+  // {
+  MakeMap      r238, 4, r230
+  Move         r188, r238
+  // let result = [
+  MakeList     r239, 1, r188
+  // json(result)
+  JSON         r239
   // expect result == [
+  Const        r240, [{"character_name": "Spider-Man", "complete_hero_movie": "Hero Movie", "playing_actor": "Actor One", "rating": 8.5}]
   Equal        r241, r239, r240
   Expect       r241
   Return       r0

--- a/tests/dataset/job/out/q27.ir.out
+++ b/tests/dataset/job/out/q27.ir.out
@@ -25,32 +25,79 @@ func main (regs=274)
   Const        r11, []
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r20, "production_year"
   Const        r20, "production_year"
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // from cc in complete_cast
   IterPrep     r24, r1
   Len          r25, r24
   Const        r27, 0
   Move         r26, r27
+L28:
   LessInt      r28, r26, r25
   JumpIfFalse  r28, L0
   Index        r29, r24, r26
@@ -62,30 +109,77 @@ func main (regs=274)
   Const        r34, "subject_id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r20, "production_year"
   Const        r20, "production_year"
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join cct1 in comp_cast_type on cct1.id == cc.subject_id
   Const        r27, 0
   Move         r35, r27
+L27:
   LessInt      r36, r35, r32
   JumpIfFalse  r36, L1
   Index        r37, r31, r35
@@ -103,30 +197,77 @@ func main (regs=274)
   Const        r44, "status_id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r20, "production_year"
   Const        r20, "production_year"
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join cct2 in comp_cast_type on cct2.id == cc.status_id
   Const        r27, 0
   Move         r45, r27
+L26:
   LessInt      r46, r45, r43
   JumpIfFalse  r46, L2
   Index        r47, r42, r45
@@ -144,28 +285,77 @@ func main (regs=274)
   Const        r21, "movie_id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r20, "production_year"
+  Const        r20, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join t in title on t.id == cc.movie_id
   Const        r27, 0
   Move         r54, r27
+L25:
   LessInt      r55, r54, r53
   JumpIfFalse  r55, L3
   Index        r56, r52, r54
@@ -183,28 +373,77 @@ func main (regs=274)
   Const        r33, "id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r20, "production_year"
+  Const        r20, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join ml in movie_link on ml.movie_id == t.id
   Const        r27, 0
   Move         r63, r27
+L24:
   LessInt      r64, r63, r62
   JumpIfFalse  r64, L4
   Index        r65, r61, r63
@@ -222,30 +461,77 @@ func main (regs=274)
   Const        r72, "link_type_id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r20, "production_year"
   Const        r20, "production_year"
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r27, 0
   Move         r73, r27
+L23:
   LessInt      r74, r73, r71
   JumpIfFalse  r74, L5
   Index        r75, r70, r73
@@ -263,28 +549,77 @@ func main (regs=274)
   Const        r33, "id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r20, "production_year"
+  Const        r20, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r27, 0
   Move         r82, r27
+L22:
   LessInt      r83, r82, r81
   JumpIfFalse  r83, L6
   Index        r84, r80, r82
@@ -302,30 +637,77 @@ func main (regs=274)
   Const        r91, "keyword_id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r20, "production_year"
   Const        r20, "production_year"
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r27, 0
   Move         r92, r27
+L21:
   LessInt      r93, r92, r90
   JumpIfFalse  r93, L7
   Index        r94, r89, r92
@@ -343,28 +725,77 @@ func main (regs=274)
   Const        r33, "id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r20, "production_year"
+  Const        r20, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r27, 0
   Move         r101, r27
+L20:
   LessInt      r102, r101, r100
   JumpIfFalse  r102, L8
   Index        r103, r99, r101
@@ -382,30 +813,77 @@ func main (regs=274)
   Const        r110, "company_type_id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r20, "production_year"
   Const        r20, "production_year"
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r27, 0
   Move         r111, r27
+L19:
   LessInt      r112, r111, r109
   JumpIfFalse  r112, L9
   Index        r113, r108, r111
@@ -423,30 +901,77 @@ func main (regs=274)
   Const        r120, "company_id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r20, "production_year"
   Const        r20, "production_year"
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r27, 0
   Move         r121, r27
+L18:
   LessInt      r122, r121, r119
   JumpIfFalse  r122, L10
   Index        r123, r118, r121
@@ -464,28 +989,77 @@ func main (regs=274)
   Const        r33, "id"
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
   Const        r12, "kind"
+  Const        r12, "kind"
+  // cct2.kind == "complete" &&
+  Const        r12, "kind"
   // cn.country_code != "[pl]" &&
   Const        r13, "country_code"
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
   Const        r14, "name"
   Const        r15, "contains"
+  Const        r14, "name"
+  Const        r15, "contains"
+  // ct.kind == "production companies" &&
+  Const        r12, "kind"
   // k.keyword == "sequel" &&
   Const        r16, "keyword"
   // lt.link.contains("follow") &&
   Const        r17, "link"
+  Const        r15, "contains"
   // mc.note == null &&
   Const        r18, "note"
   // (mi.info == "Sweden" || mi.info == "Germany" ||
   Const        r19, "info"
+  Const        r19, "info"
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
+  Const        r19, "info"
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r20, "production_year"
+  Const        r20, "production_year"
+  // ml.movie_id == mk.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
+  // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
+  Const        r21, "movie_id"
   // company: cn.name,
   Const        r22, "company"
+  Const        r14, "name"
+  // link: lt.link,
+  Const        r17, "link"
+  Const        r17, "link"
   // title: t.title
+  Const        r23, "title"
   Const        r23, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r27, 0
   Move         r130, r27
+L17:
   LessInt      r131, r130, r129
   JumpIfFalse  r131, L11
   Index        r132, r128, r130
@@ -501,17 +1075,20 @@ func main (regs=274)
   Index        r137, r38, r12
   Const        r138, "cast"
   Equal        r139, r137, r138
+  Const        r12, "kind"
   Index        r140, r38, r12
   Const        r141, "crew"
   Equal        r142, r140, r141
   Move         r143, r139
   JumpIfTrue   r143, L13
   Move         r143, r142
+L13:
   // t.production_year >= 1950 && t.production_year <= 2000 &&
   Const        r20, "production_year"
   Index        r144, r57, r20
   Const        r145, 1950
   LessEq       r146, r145, r144
+  Const        r20, "production_year"
   Index        r147, r57, r20
   Const        r148, 2000
   LessEq       r149, r147, r148
@@ -526,6 +1103,7 @@ func main (regs=274)
   Const        r154, "[pl]"
   NotEqual     r155, r153, r154
   // ct.kind == "production companies" &&
+  Const        r12, "kind"
   Index        r156, r114, r12
   Const        r157, "production companies"
   Equal        r158, r156, r157
@@ -542,42 +1120,61 @@ func main (regs=274)
   // ml.movie_id == mk.movie_id &&
   Const        r21, "movie_id"
   Index        r165, r66, r21
+  Const        r21, "movie_id"
   Index        r166, r85, r21
   Equal        r167, r165, r166
   // ml.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
   Index        r168, r66, r21
+  Const        r21, "movie_id"
   Index        r169, r104, r21
   Equal        r170, r168, r169
   // mk.movie_id == mc.movie_id &&
+  Const        r21, "movie_id"
   Index        r171, r85, r21
+  Const        r21, "movie_id"
   Index        r172, r104, r21
   Equal        r173, r171, r172
   // ml.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
   Index        r174, r66, r21
+  Const        r21, "movie_id"
   Index        r175, r133, r21
   Equal        r176, r174, r175
   // mk.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
   Index        r177, r85, r21
+  Const        r21, "movie_id"
   Index        r178, r133, r21
   Equal        r179, r177, r178
   // mc.movie_id == mi.movie_id &&
+  Const        r21, "movie_id"
   Index        r180, r104, r21
+  Const        r21, "movie_id"
   Index        r181, r133, r21
   Equal        r182, r180, r181
   // ml.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
   Index        r183, r66, r21
+  Const        r21, "movie_id"
   Index        r184, r30, r21
   Equal        r185, r183, r184
   // mk.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
   Index        r186, r85, r21
+  Const        r21, "movie_id"
   Index        r187, r30, r21
   Equal        r188, r186, r187
   // mc.movie_id == cc.movie_id &&
+  Const        r21, "movie_id"
   Index        r189, r104, r21
+  Const        r21, "movie_id"
   Index        r190, r30, r21
   Equal        r191, r189, r190
   // mi.movie_id == cc.movie_id
+  Const        r21, "movie_id"
   Index        r192, r133, r21
+  Const        r21, "movie_id"
   Index        r193, r30, r21
   Equal        r194, r192, r193
   // (cct1.kind == "cast" || cct1.kind == "crew") &&
@@ -601,6 +1198,7 @@ func main (regs=274)
   Const        r201, "Warner"
   In           r202, r201, r200
   Move         r199, r202
+L15:
   // cn.country_code != "[pl]" &&
   Move         r195, r199
   // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
@@ -628,13 +1226,16 @@ func main (regs=274)
   Index        r206, r133, r19
   Const        r207, "Sweden"
   Equal        r208, r206, r207
+  Const        r19, "info"
   Index        r209, r133, r19
   Const        r210, "Germany"
   Equal        r211, r209, r210
   // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r19, "info"
   Index        r212, r133, r19
   Const        r213, "Swedish"
   Equal        r214, r212, r213
+  Const        r19, "info"
   Index        r215, r133, r19
   Const        r216, "German"
   Equal        r217, r215, r216
@@ -647,6 +1248,7 @@ func main (regs=274)
   // mi.info == "Swedish" || mi.info == "German") &&
   JumpIfTrue   r218, L16
   Move         r218, r217
+L16:
   // mc.note == null &&
   Move         r195, r218
   // mi.info == "Swedish" || mi.info == "German") &&
@@ -684,6 +1286,7 @@ func main (regs=274)
   // mc.movie_id == cc.movie_id &&
   JumpIfFalse  r195, L14
   Move         r195, r194
+L14:
   // where (
   JumpIfFalse  r195, L12
   // company: cn.name,
@@ -712,7 +1315,148 @@ func main (regs=274)
   // from cc in complete_cast
   Append       r232, r11, r231
   Move         r11, r232
+L12:
   // join mi in movie_info on mi.movie_id == t.id
   Const        r233, 1
   Add          r130, r130, r233
   Jump         L17
+L11:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r233, 1
+  Add          r121, r121, r233
+  Jump         L18
+L10:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r233, 1
+  Add          r111, r111, r233
+  Jump         L19
+L9:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r233, 1
+  Add          r101, r101, r233
+  Jump         L20
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r233, 1
+  Add          r92, r92, r233
+  Jump         L21
+L7:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r233, 1
+  Add          r82, r82, r233
+  Jump         L22
+L6:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r233, 1
+  Add          r73, r73, r233
+  Jump         L23
+L5:
+  // join ml in movie_link on ml.movie_id == t.id
+  Const        r233, 1
+  Add          r63, r63, r233
+  Jump         L24
+L4:
+  // join t in title on t.id == cc.movie_id
+  Const        r233, 1
+  Add          r54, r54, r233
+  Jump         L25
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r233, 1
+  Add          r45, r45, r233
+  Jump         L26
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r233, 1
+  Add          r35, r35, r233
+  Jump         L27
+L1:
+  // from cc in complete_cast
+  Const        r233, 1
+  AddInt       r26, r26, r233
+  Jump         L28
+L0:
+  // producing_company: min(from x in matches select x.company),
+  Const        r234, "producing_company"
+  Const        r235, []
+  Const        r22, "company"
+  IterPrep     r236, r11
+  Len          r237, r236
+  Const        r27, 0
+  Move         r238, r27
+L30:
+  LessInt      r239, r238, r237
+  JumpIfFalse  r239, L29
+  Index        r240, r236, r238
+  Move         r241, r240
+  Const        r22, "company"
+  Index        r242, r241, r22
+  Append       r243, r235, r242
+  Move         r235, r243
+  Const        r233, 1
+  AddInt       r238, r238, r233
+  Jump         L30
+L29:
+  Min          r244, r235
+  // link_type: min(from x in matches select x.link),
+  Const        r245, "link_type"
+  Const        r246, []
+  Const        r17, "link"
+  IterPrep     r247, r11
+  Len          r248, r247
+  Const        r27, 0
+  Move         r249, r27
+L32:
+  LessInt      r250, r249, r248
+  JumpIfFalse  r250, L31
+  Index        r251, r247, r249
+  Move         r241, r251
+  Const        r17, "link"
+  Index        r252, r241, r17
+  Append       r253, r246, r252
+  Move         r246, r253
+  Const        r233, 1
+  AddInt       r249, r249, r233
+  Jump         L32
+L31:
+  Min          r254, r246
+  // complete_western_sequel: min(from x in matches select x.title)
+  Const        r255, "complete_western_sequel"
+  Const        r256, []
+  Const        r23, "title"
+  IterPrep     r257, r11
+  Len          r258, r257
+  Const        r27, 0
+  Move         r259, r27
+L34:
+  LessInt      r260, r259, r258
+  JumpIfFalse  r260, L33
+  Index        r261, r257, r259
+  Move         r241, r261
+  Const        r23, "title"
+  Index        r262, r241, r23
+  Append       r263, r256, r262
+  Move         r256, r263
+  Const        r233, 1
+  AddInt       r259, r259, r233
+  Jump         L34
+L33:
+  Min          r264, r256
+  // producing_company: min(from x in matches select x.company),
+  Move         r265, r234
+  Move         r266, r244
+  // link_type: min(from x in matches select x.link),
+  Move         r267, r245
+  Move         r268, r254
+  // complete_western_sequel: min(from x in matches select x.title)
+  Move         r269, r255
+  Move         r270, r264
+  // let result = {
+  MakeMap      r271, 3, r265
+  // json(result)
+  JSON         r271
+  // expect result == {
+  Const        r272, {"complete_western_sequel": "Western Sequel", "link_type": "follows", "producing_company": "Best Film"}
+  Equal        r273, r271, r272
+  Expect       r273
+  Return       r0

--- a/tests/dataset/job/out/q28.ir.out
+++ b/tests/dataset/job/out/q28.ir.out
@@ -31,27 +31,43 @@ func main (regs=252)
   Const        r14, []
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // from cc in complete_cast
   IterPrep     r26, r1
   Len          r27, r26
   Const        r29, 0
   Move         r28, r29
+L29:
   LessInt      r30, r28, r27
   JumpIfFalse  r30, L0
   Index        r31, r26, r28
@@ -63,25 +79,41 @@ func main (regs=252)
   Const        r36, "subject_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join cct1 in comp_cast_type on cct1.id == cc.subject_id
   Const        r29, 0
   Move         r37, r29
+L28:
   LessInt      r38, r37, r34
   JumpIfFalse  r38, L1
   Index        r39, r33, r37
@@ -99,25 +131,41 @@ func main (regs=252)
   Const        r46, "status_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join cct2 in comp_cast_type on cct2.id == cc.status_id
   Const        r29, 0
   Move         r47, r29
+L27:
   LessInt      r48, r47, r45
   JumpIfFalse  r48, L2
   Index        r49, r44, r47
@@ -132,34 +180,51 @@ func main (regs=252)
   IterPrep     r54, r4
   Len          r55, r54
   Const        r56, "movie_id"
+  Const        r56, "movie_id"
   // cct1.kind == "crew" &&
+  Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
   Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join mc in movie_companies on mc.movie_id == cc.movie_id
   Const        r29, 0
   Move         r57, r29
+L26:
   LessInt      r58, r57, r55
-L16:
   JumpIfFalse  r58, L3
   Index        r59, r54, r57
   Move         r60, r59
   Const        r56, "movie_id"
   Index        r61, r60, r56
+  Const        r56, "movie_id"
   Index        r62, r32, r56
   Equal        r63, r61, r62
   JumpIfFalse  r63, L4
@@ -170,25 +235,41 @@ L16:
   Const        r66, "company_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r29, 0
   Move         r67, r29
+L25:
   LessInt      r68, r67, r65
   JumpIfFalse  r68, L4
   Index        r69, r64, r67
@@ -206,25 +287,41 @@ L16:
   Const        r76, "company_type_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join ct in company_type on ct.id == mc.company_type_id
   Const        r29, 0
   Move         r77, r29
+L24:
   LessInt      r78, r77, r75
   JumpIfFalse  r78, L5
   Index        r79, r74, r77
@@ -239,33 +336,51 @@ L16:
   IterPrep     r84, r10
   Len          r85, r84
   Const        r56, "movie_id"
+  Const        r56, "movie_id"
   // cct1.kind == "crew" &&
+  Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
   Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join mk in movie_keyword on mk.movie_id == cc.movie_id
   Const        r29, 0
   Move         r86, r29
+L23:
   LessInt      r87, r86, r85
   JumpIfFalse  r87, L6
   Index        r88, r84, r86
   Move         r89, r88
   Const        r56, "movie_id"
   Index        r90, r89, r56
+  Const        r56, "movie_id"
   Index        r91, r32, r56
   Equal        r92, r90, r91
   JumpIfFalse  r92, L7
@@ -276,25 +391,41 @@ L16:
   Const        r95, "keyword_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r29, 0
   Move         r96, r29
+L22:
   LessInt      r97, r96, r94
   JumpIfFalse  r97, L7
   Index        r98, r93, r96
@@ -309,33 +440,51 @@ L16:
   IterPrep     r103, r8
   Len          r104, r103
   Const        r56, "movie_id"
+  Const        r56, "movie_id"
   // cct1.kind == "crew" &&
+  Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
   Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join mi in movie_info on mi.movie_id == cc.movie_id
   Const        r29, 0
   Move         r105, r29
+L21:
   LessInt      r106, r105, r104
   JumpIfFalse  r106, L8
   Index        r107, r103, r105
   Move         r108, r107
   Const        r56, "movie_id"
   Index        r109, r108, r56
+  Const        r56, "movie_id"
   Index        r110, r32, r56
   Equal        r111, r109, r110
   JumpIfFalse  r111, L9
@@ -346,25 +495,41 @@ L16:
   Const        r114, "info_type_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r29, 0
   Move         r115, r29
+L20:
   LessInt      r116, r115, r113
   JumpIfFalse  r116, L9
   Index        r117, r112, r115
@@ -379,33 +544,51 @@ L16:
   IterPrep     r122, r9
   Len          r123, r122
   Const        r56, "movie_id"
+  Const        r56, "movie_id"
   // cct1.kind == "crew" &&
+  Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
   Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
   Const        r29, 0
   Move         r124, r29
+L19:
   LessInt      r125, r124, r123
   JumpIfFalse  r125, L10
   Index        r126, r122, r124
   Move         r127, r126
   Const        r56, "movie_id"
   Index        r128, r127, r56
+  Const        r56, "movie_id"
   Index        r129, r32, r56
   Equal        r130, r128, r129
   JumpIfFalse  r130, L11
@@ -416,25 +599,41 @@ L16:
   Const        r114, "info_type_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r29, 0
   Move         r133, r29
+L18:
   LessInt      r134, r133, r132
   JumpIfFalse  r134, L11
   Index        r135, r131, r133
@@ -452,25 +651,41 @@ L16:
   Const        r56, "movie_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join t in title on t.id == cc.movie_id
   Const        r29, 0
   Move         r142, r29
+L17:
   LessInt      r143, r142, r141
   JumpIfFalse  r143, L12
   Index        r144, r140, r142
@@ -488,25 +703,41 @@ L16:
   Const        r151, "kind_id"
   // cct1.kind == "crew" &&
   Const        r15, "kind"
+  // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   // cn.country_code != "[us]" &&
   Const        r16, "country_code"
   // it1.info == "countries" &&
   Const        r17, "info"
+  // it2.info == "rating" &&
+  Const        r17, "info"
   // (k.keyword in allowed_keywords) &&
   Const        r18, "keyword"
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r15, "kind"
   // mc.note.contains("(USA)") == false &&
   Const        r19, "note"
   Const        r20, "contains"
+  // mc.note.contains("(200") &&
+  Const        r19, "note"
+  Const        r20, "contains"
+  // (mi.info in allowed_countries) &&
+  Const        r17, "info"
+  // mi_idx.info < 8.5 &&
+  Const        r17, "info"
   // t.production_year > 2000
   Const        r21, "production_year"
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
   Const        r22, "company"
   Const        r23, "name"
   Const        r24, "rating"
+  Const        r17, "info"
+  Const        r25, "title"
   Const        r25, "title"
   // join kt in kind_type on kt.id == t.kind_id
   Const        r29, 0
   Move         r152, r29
+L16:
   LessInt      r153, r152, r150
   JumpIfFalse  r153, L13
   Index        r154, r149, r152
@@ -534,6 +765,7 @@ L16:
   Const        r166, "crew"
   Equal        r167, r159, r166
   // cct2.kind != "complete+verified" &&
+  Const        r15, "kind"
   Index        r168, r50, r15
   Const        r169, "complete+verified"
   NotEqual     r170, r168, r169
@@ -543,10 +775,12 @@ L16:
   Const        r172, "[us]"
   NotEqual     r173, r171, r172
   // it1.info == "countries" &&
+  Const        r17, "info"
   Index        r174, r118, r17
   Const        r175, "countries"
   Equal        r176, r174, r175
   // it2.info == "rating" &&
+  Const        r17, "info"
   Index        r177, r136, r17
   Const        r24, "rating"
   Equal        r178, r177, r24
@@ -615,6 +849,7 @@ L16:
   // mi_idx.info < 8.5 &&
   JumpIfFalse  r184, L15
   Move         r184, r165
+L15:
   // where (
   JumpIfFalse  r184, L14
   // select { company: cn.name, rating: mi_idx.info, title: t.title }
@@ -637,7 +872,158 @@ L16:
   // from cc in complete_cast
   Append       r210, r14, r209
   Move         r14, r210
+L14:
   // join kt in kind_type on kt.id == t.kind_id
   Const        r211, 1
   Add          r152, r152, r211
   Jump         L16
+L13:
+  // join t in title on t.id == cc.movie_id
+  Const        r211, 1
+  Add          r142, r142, r211
+  Jump         L17
+L12:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r211, 1
+  Add          r133, r133, r211
+  Jump         L18
+L11:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
+  Const        r211, 1
+  Add          r124, r124, r211
+  Jump         L19
+L10:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r211, 1
+  Add          r115, r115, r211
+  Jump         L20
+L9:
+  // join mi in movie_info on mi.movie_id == cc.movie_id
+  Const        r211, 1
+  Add          r105, r105, r211
+  Jump         L21
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r211, 1
+  Add          r96, r96, r211
+  Jump         L22
+L7:
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  Const        r211, 1
+  Add          r86, r86, r211
+  Jump         L23
+L6:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r211, 1
+  Add          r77, r77, r211
+  Jump         L24
+L5:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r211, 1
+  Add          r67, r67, r211
+  Jump         L25
+L4:
+  // join mc in movie_companies on mc.movie_id == cc.movie_id
+  Const        r211, 1
+  Add          r57, r57, r211
+  Jump         L26
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r211, 1
+  Add          r47, r47, r211
+  Jump         L27
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r211, 1
+  Add          r37, r37, r211
+  Jump         L28
+L1:
+  // from cc in complete_cast
+  Const        r211, 1
+  AddInt       r28, r28, r211
+  Jump         L29
+L0:
+  // movie_company: min(from x in matches select x.company),
+  Const        r212, "movie_company"
+  Const        r213, []
+  Const        r22, "company"
+  IterPrep     r214, r14
+  Len          r215, r214
+  Const        r29, 0
+  Move         r216, r29
+L31:
+  LessInt      r217, r216, r215
+  JumpIfFalse  r217, L30
+  Index        r218, r214, r216
+  Move         r219, r218
+  Const        r22, "company"
+  Index        r220, r219, r22
+  Append       r221, r213, r220
+  Move         r213, r221
+  Const        r211, 1
+  AddInt       r216, r216, r211
+  Jump         L31
+L30:
+  Min          r222, r213
+  // rating: min(from x in matches select x.rating),
+  Const        r223, "rating"
+  Const        r224, []
+  Const        r24, "rating"
+  IterPrep     r225, r14
+  Len          r226, r225
+  Const        r29, 0
+  Move         r227, r29
+L33:
+  LessInt      r228, r227, r226
+  JumpIfFalse  r228, L32
+  Index        r229, r225, r227
+  Move         r219, r229
+  Const        r24, "rating"
+  Index        r230, r219, r24
+  Append       r231, r224, r230
+  Move         r224, r231
+  Const        r211, 1
+  AddInt       r227, r227, r211
+  Jump         L33
+L32:
+  Min          r232, r224
+  // complete_euro_dark_movie: min(from x in matches select x.title)
+  Const        r233, "complete_euro_dark_movie"
+  Const        r234, []
+  Const        r25, "title"
+  IterPrep     r235, r14
+  Len          r236, r235
+  Const        r29, 0
+  Move         r237, r29
+L35:
+  LessInt      r238, r237, r236
+  JumpIfFalse  r238, L34
+  Index        r239, r235, r237
+  Move         r219, r239
+  Const        r25, "title"
+  Index        r240, r219, r25
+  Append       r241, r234, r240
+  Move         r234, r241
+  Const        r211, 1
+  AddInt       r237, r237, r211
+  Jump         L35
+L34:
+  Min          r242, r234
+  // movie_company: min(from x in matches select x.company),
+  Move         r243, r212
+  Move         r244, r222
+  // rating: min(from x in matches select x.rating),
+  Move         r245, r223
+  Move         r246, r232
+  // complete_euro_dark_movie: min(from x in matches select x.title)
+  Move         r247, r233
+  Move         r248, r242
+  // let result = {
+  MakeMap      r249, 3, r243
+  // json(result)
+  JSON         r249
+  // expect result == {
+  Const        r250, {"complete_euro_dark_movie": "Dark Euro Film", "movie_company": "Euro Films Ltd.", "rating": 7.2}
+  Equal        r251, r249, r250
+  Expect       r251
+  Return       r0

--- a/tests/dataset/job/out/q29.ir.out
+++ b/tests/dataset/job/out/q29.ir.out
@@ -33,21 +33,33 @@ func main (regs=354)
   Const        r15, []
   // cct1.kind == "cast" &&
   Const        r16, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r16, "kind"
   // chn.name == "Queen" &&
   Const        r17, "name"
   // (ci.note == "(voice)" ||
+  Const        r18, "note"
+  // ci.note == "(voice) (uncredited)" ||
+  Const        r18, "note"
+  // ci.note == "(voice: English version)") &&
   Const        r18, "note"
   // cn.country_code == "[us]" &&
   Const        r19, "country_code"
   // it.info == "release dates" &&
   Const        r20, "info"
+  // it3.info == "trivia" &&
+  Const        r20, "info"
   // k.keyword == "computer-animation" &&
   Const        r21, "keyword"
   // (mi.info.starts_with("Japan:200") || mi.info.starts_with("USA:200")) &&
+  Const        r20, "info"
+  Const        r22, "starts_with"
+  Const        r20, "info"
   Const        r22, "starts_with"
   // n.gender == "f" &&
   Const        r23, "gender"
   // n.name.contains("An") &&
+  Const        r17, "name"
   Const        r24, "contains"
   // rt.role == "actress" &&
   Const        r25, "role"
@@ -55,36 +67,107 @@ func main (regs=354)
   Const        r26, "title"
   // t.production_year >= 2000 &&
   Const        r27, "production_year"
+  // t.production_year <= 2010 &&
+  Const        r27, "production_year"
   // t.id == mi.movie_id &&
   Const        r28, "id"
   Const        r29, "movie_id"
+  // t.id == mc.movie_id &&
+  Const        r28, "id"
+  Const        r29, "movie_id"
+  // t.id == ci.movie_id &&
+  Const        r28, "id"
+  Const        r29, "movie_id"
+  // t.id == mk.movie_id &&
+  Const        r28, "id"
+  Const        r29, "movie_id"
+  // t.id == cc.movie_id &&
+  Const        r28, "id"
+  Const        r29, "movie_id"
+  // mc.movie_id == ci.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // mc.movie_id == mi.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // mc.movie_id == mk.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // mc.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // mi.movie_id == ci.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // mi.movie_id == mk.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // mi.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // ci.movie_id == mk.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // ci.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
+  // mk.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
+  Const        r29, "movie_id"
   // cn.id == mc.company_id &&
+  Const        r28, "id"
   Const        r30, "company_id"
   // it.id == mi.info_type_id &&
+  Const        r28, "id"
   Const        r31, "info_type_id"
   // n.id == ci.person_id &&
+  Const        r28, "id"
   Const        r32, "person_id"
   // rt.id == ci.role_id &&
+  Const        r28, "id"
   Const        r33, "role_id"
+  // n.id == an.person_id &&
+  Const        r28, "id"
+  Const        r32, "person_id"
+  // ci.person_id == an.person_id &&
+  Const        r32, "person_id"
+  Const        r32, "person_id"
   // chn.id == ci.person_role_id &&
+  Const        r28, "id"
   Const        r34, "person_role_id"
+  // n.id == pi.person_id &&
+  Const        r28, "id"
+  Const        r32, "person_id"
+  // ci.person_id == pi.person_id &&
+  Const        r32, "person_id"
+  Const        r32, "person_id"
+  // it3.id == pi.info_type_id &&
+  Const        r28, "id"
+  Const        r31, "info_type_id"
   // k.id == mk.keyword_id &&
+  Const        r28, "id"
   Const        r35, "keyword_id"
   // cct1.id == cc.subject_id &&
+  Const        r28, "id"
   Const        r36, "subject_id"
   // cct2.id == cc.status_id
+  Const        r28, "id"
   Const        r37, "status_id"
   // voiced_char: chn.name,
   Const        r38, "voiced_char"
+  Const        r17, "name"
   // voicing_actress: n.name,
   Const        r39, "voicing_actress"
+  Const        r17, "name"
   // voiced_animation: t.title
   Const        r40, "voiced_animation"
+  Const        r26, "title"
   // from an in aka_name
   IterPrep     r41, r0
   Len          r42, r41
   Const        r44, 0
   Move         r43, r44
+L41:
   LessInt      r45, r43, r42
   JumpIfFalse  r45, L0
   Index        r46, r41, r43
@@ -94,6 +177,7 @@ func main (regs=354)
   Len          r49, r48
   Const        r44, 0
   Move         r50, r44
+L40:
   LessInt      r51, r50, r49
   JumpIfFalse  r51, L1
   Index        r52, r48, r50
@@ -103,6 +187,7 @@ func main (regs=354)
   Len          r55, r54
   Const        r44, 0
   Move         r56, r44
+L39:
   LessInt      r57, r56, r55
   JumpIfFalse  r57, L2
   Index        r58, r54, r56
@@ -112,6 +197,7 @@ func main (regs=354)
   Len          r61, r60
   Const        r44, 0
   Move         r62, r44
+L38:
   LessInt      r63, r62, r61
   JumpIfFalse  r63, L3
   Index        r64, r60, r62
@@ -121,6 +207,7 @@ func main (regs=354)
   Len          r67, r66
   Const        r44, 0
   Move         r68, r44
+L37:
   LessInt      r69, r68, r67
   JumpIfFalse  r69, L4
   Index        r70, r66, r68
@@ -130,6 +217,7 @@ func main (regs=354)
   Len          r73, r72
   Const        r44, 0
   Move         r74, r44
+L36:
   LessInt      r75, r74, r73
   JumpIfFalse  r75, L5
   Index        r76, r72, r74
@@ -139,6 +227,7 @@ func main (regs=354)
   Len          r79, r78
   Const        r44, 0
   Move         r80, r44
+L35:
   LessInt      r81, r80, r79
   JumpIfFalse  r81, L6
   Index        r82, r78, r80
@@ -148,6 +237,7 @@ func main (regs=354)
   Len          r85, r84
   Const        r44, 0
   Move         r86, r44
+L34:
   LessInt      r87, r86, r85
   JumpIfFalse  r87, L7
   Index        r88, r84, r86
@@ -157,6 +247,7 @@ func main (regs=354)
   Len          r91, r90
   Const        r44, 0
   Move         r92, r44
+L33:
   LessInt      r93, r92, r91
   JumpIfFalse  r93, L8
   Index        r94, r90, r92
@@ -166,6 +257,7 @@ func main (regs=354)
   Len          r97, r96
   Const        r44, 0
   Move         r98, r44
+L32:
   LessInt      r99, r98, r97
   JumpIfFalse  r99, L9
   Index        r100, r96, r98
@@ -175,6 +267,7 @@ func main (regs=354)
   Len          r103, r102
   Const        r44, 0
   Move         r104, r44
+L31:
   LessInt      r105, r104, r103
   JumpIfFalse  r105, L10
   Index        r106, r102, r104
@@ -184,6 +277,7 @@ func main (regs=354)
   Len          r109, r108
   Const        r44, 0
   Move         r110, r44
+L30:
   LessInt      r111, r110, r109
   JumpIfFalse  r111, L11
   Index        r112, r108, r110
@@ -193,6 +287,7 @@ func main (regs=354)
   Len          r115, r114
   Const        r44, 0
   Move         r116, r44
+L29:
   LessInt      r117, r116, r115
   JumpIfFalse  r117, L12
   Index        r118, r114, r116
@@ -202,6 +297,7 @@ func main (regs=354)
   Len          r121, r120
   Const        r44, 0
   Move         r122, r44
+L28:
   LessInt      r123, r122, r121
   JumpIfFalse  r123, L13
   Index        r124, r120, r122
@@ -211,6 +307,7 @@ func main (regs=354)
   Len          r127, r126
   Const        r44, 0
   Move         r128, r44
+L27:
   LessInt      r129, r128, r127
   JumpIfFalse  r129, L14
   Index        r130, r126, r128
@@ -220,6 +317,7 @@ func main (regs=354)
   Len          r133, r132
   Const        r44, 0
   Move         r134, r44
+L26:
   LessInt      r135, r134, r133
   JumpIfFalse  r135, L15
   Index        r136, r132, r134
@@ -229,6 +327,7 @@ func main (regs=354)
   Len          r139, r138
   Const        r44, 0
   Move         r140, r44
+L25:
   LessInt      r141, r140, r139
   JumpIfFalse  r141, L16
   Index        r142, r138, r140
@@ -242,6 +341,7 @@ func main (regs=354)
   Const        r146, 2000
   LessEq       r147, r146, r145
   // t.production_year <= 2010 &&
+  Const        r27, "production_year"
   Index        r148, r143, r27
   Const        r149, 2010
   LessEq       r150, r148, r149
@@ -249,6 +349,7 @@ func main (regs=354)
   Const        r151, "cast"
   Equal        r152, r144, r151
   // cct2.kind == "complete+verified" &&
+  Const        r16, "kind"
   Index        r153, r65, r16
   Const        r154, "complete+verified"
   Equal        r155, r153, r154
@@ -268,6 +369,7 @@ func main (regs=354)
   Const        r163, "release dates"
   Equal        r164, r162, r163
   // it3.info == "trivia" &&
+  Const        r20, "info"
   Index        r165, r95, r20
   Const        r166, "trivia"
   Equal        r167, r165, r166
@@ -298,118 +400,163 @@ func main (regs=354)
   Index        r181, r113, r29
   Equal        r182, r180, r181
   // t.id == mc.movie_id &&
+  Const        r28, "id"
   Index        r183, r143, r28
+  Const        r29, "movie_id"
   Index        r184, r107, r29
   Equal        r185, r183, r184
   // t.id == ci.movie_id &&
+  Const        r28, "id"
   Index        r186, r143, r28
-L20:
+  Const        r29, "movie_id"
   Index        r187, r77, r29
   Equal        r188, r186, r187
   // t.id == mk.movie_id &&
+  Const        r28, "id"
   Index        r189, r143, r28
+  Const        r29, "movie_id"
   Index        r190, r119, r29
   Equal        r191, r189, r190
   // t.id == cc.movie_id &&
+  Const        r28, "id"
   Index        r192, r143, r28
+  Const        r29, "movie_id"
   Index        r193, r53, r29
   Equal        r194, r192, r193
   // mc.movie_id == ci.movie_id &&
+  Const        r29, "movie_id"
   Index        r195, r107, r29
+  Const        r29, "movie_id"
   Index        r196, r77, r29
   Equal        r197, r195, r196
   // mc.movie_id == mi.movie_id &&
+  Const        r29, "movie_id"
   Index        r198, r107, r29
+  Const        r29, "movie_id"
   Index        r199, r113, r29
   Equal        r200, r198, r199
   // mc.movie_id == mk.movie_id &&
+  Const        r29, "movie_id"
   Index        r201, r107, r29
+  Const        r29, "movie_id"
   Index        r202, r119, r29
   Equal        r203, r201, r202
   // mc.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
   Index        r204, r107, r29
+  Const        r29, "movie_id"
   Index        r205, r53, r29
   Equal        r206, r204, r205
   // mi.movie_id == ci.movie_id &&
+  Const        r29, "movie_id"
   Index        r207, r113, r29
+  Const        r29, "movie_id"
   Index        r208, r77, r29
   Equal        r209, r207, r208
   // mi.movie_id == mk.movie_id &&
+  Const        r29, "movie_id"
   Index        r210, r113, r29
+  Const        r29, "movie_id"
   Index        r211, r119, r29
   Equal        r212, r210, r211
   // mi.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
   Index        r213, r113, r29
+  Const        r29, "movie_id"
   Index        r214, r53, r29
   Equal        r215, r213, r214
   // ci.movie_id == mk.movie_id &&
+  Const        r29, "movie_id"
   Index        r216, r77, r29
+  Const        r29, "movie_id"
   Index        r217, r119, r29
   Equal        r218, r216, r217
   // ci.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
   Index        r219, r77, r29
+  Const        r29, "movie_id"
   Index        r220, r53, r29
   Equal        r221, r219, r220
   // mk.movie_id == cc.movie_id &&
+  Const        r29, "movie_id"
   Index        r222, r119, r29
+  Const        r29, "movie_id"
   Index        r223, r53, r29
   Equal        r224, r222, r223
   // cn.id == mc.company_id &&
+  Const        r28, "id"
   Index        r225, r83, r28
   Const        r30, "company_id"
   Index        r226, r107, r30
   Equal        r227, r225, r226
   // it.id == mi.info_type_id &&
+  Const        r28, "id"
   Index        r228, r89, r28
   Const        r31, "info_type_id"
   Index        r229, r113, r31
   Equal        r230, r228, r229
   // n.id == ci.person_id &&
+  Const        r28, "id"
   Index        r231, r125, r28
   Const        r32, "person_id"
   Index        r232, r77, r32
   Equal        r233, r231, r232
   // rt.id == ci.role_id &&
+  Const        r28, "id"
   Index        r234, r137, r28
   Const        r33, "role_id"
   Index        r235, r77, r33
   Equal        r236, r234, r235
   // n.id == an.person_id &&
+  Const        r28, "id"
   Index        r237, r125, r28
+  Const        r32, "person_id"
   Index        r238, r47, r32
   Equal        r239, r237, r238
   // ci.person_id == an.person_id &&
+  Const        r32, "person_id"
   Index        r240, r77, r32
+  Const        r32, "person_id"
   Index        r241, r47, r32
   Equal        r242, r240, r241
   // chn.id == ci.person_role_id &&
+  Const        r28, "id"
   Index        r243, r71, r28
   Const        r34, "person_role_id"
   Index        r244, r77, r34
   Equal        r245, r243, r244
   // n.id == pi.person_id &&
+  Const        r28, "id"
   Index        r246, r125, r28
+  Const        r32, "person_id"
   Index        r247, r131, r32
   Equal        r248, r246, r247
   // ci.person_id == pi.person_id &&
+  Const        r32, "person_id"
   Index        r249, r77, r32
+  Const        r32, "person_id"
   Index        r250, r131, r32
   Equal        r251, r249, r250
   // it3.id == pi.info_type_id &&
+  Const        r28, "id"
   Index        r252, r95, r28
+  Const        r31, "info_type_id"
   Index        r253, r131, r31
   Equal        r254, r252, r253
   // k.id == mk.keyword_id &&
+  Const        r28, "id"
   Index        r255, r101, r28
   Const        r35, "keyword_id"
   Index        r256, r119, r35
   Equal        r257, r255, r256
   // cct1.id == cc.subject_id &&
+  Const        r28, "id"
   Index        r258, r59, r28
   Const        r36, "subject_id"
   Index        r259, r53, r36
   Equal        r260, r258, r259
   // cct2.id == cc.status_id
+  Const        r28, "id"
   Index        r261, r65, r28
   Const        r37, "status_id"
   Index        r262, r53, r37
@@ -429,10 +576,12 @@ L20:
   Const        r266, "(voice)"
   Equal        r267, r265, r266
   // ci.note == "(voice) (uncredited)" ||
+  Const        r18, "note"
   Index        r268, r77, r18
   Const        r269, "(voice) (uncredited)"
   Equal        r270, r268, r269
   // ci.note == "(voice: English version)") &&
+  Const        r18, "note"
   Index        r271, r77, r18
   Const        r272, "(voice: English version)"
   Equal        r273, r271, r272
@@ -443,6 +592,7 @@ L20:
   // ci.note == "(voice) (uncredited)" ||
   JumpIfTrue   r274, L18
   Move         r274, r273
+L18:
   // chn.name == "Queen" &&
   Move         r264, r274
   // ci.note == "(voice: English version)") &&
@@ -464,7 +614,7 @@ L20:
   // (mi.info.starts_with("Japan:200") || mi.info.starts_with("USA:200")) &&
   Const        r276, "Japan:200"
   Const        r277, 0
-  Const        r278, 9
+  Len          r278, r276
   Len          r279, r275
   LessEq       r280, r278, r279
   JumpIfFalse  r280, L19
@@ -472,20 +622,148 @@ L20:
   Equal        r283, r282, r276
   Move         r281, r283
   Jump         L20
-L18:
+L19:
+  Const        r281, false
+L20:
+  Move         r284, r281
+  JumpIfTrue   r284, L21
+  Const        r20, "info"
+  Index        r285, r113, r20
+  Const        r286, "USA:200"
+  Const        r287, 0
+  Len          r288, r286
+  Len          r289, r285
+  LessEq       r290, r288, r289
+  JumpIfFalse  r290, L22
+  Slice        r292, r285, r287, r288
+  Equal        r293, r292, r286
+  Move         r291, r293
+  Jump         L23
+L22:
+  Const        r291, false
+L23:
+  Move         r284, r291
+L21:
+  // k.keyword == "computer-animation" &&
+  Move         r264, r284
+  // (mi.info.starts_with("Japan:200") || mi.info.starts_with("USA:200")) &&
+  JumpIfFalse  r264, L17
+  Move         r264, r173
+  // n.gender == "f" &&
+  JumpIfFalse  r264, L17
+  Const        r17, "name"
+  Index        r294, r125, r17
+  // n.name.contains("An") &&
+  Const        r295, "An"
+  In           r296, r295, r294
+  // n.gender == "f" &&
+  Move         r264, r296
+  // n.name.contains("An") &&
+  JumpIfFalse  r264, L17
+  Move         r264, r176
+  // rt.role == "actress" &&
+  JumpIfFalse  r264, L17
+  Move         r264, r179
+  // t.title == "Shrek 2" &&
+  JumpIfFalse  r264, L17
+  Move         r264, r147
+  // t.production_year >= 2000 &&
+  JumpIfFalse  r264, L17
+  Move         r264, r150
+  // t.production_year <= 2010 &&
+  JumpIfFalse  r264, L17
+  Move         r264, r182
+  // t.id == mi.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r185
+  // t.id == mc.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r188
+  // t.id == ci.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r191
+  // t.id == mk.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r194
+  // t.id == cc.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r197
+  // mc.movie_id == ci.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r200
+  // mc.movie_id == mi.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r203
+  // mc.movie_id == mk.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r206
+  // mc.movie_id == cc.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r209
+  // mi.movie_id == ci.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r212
+  // mi.movie_id == mk.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r215
+  // mi.movie_id == cc.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r218
+  // ci.movie_id == mk.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r221
+  // ci.movie_id == cc.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r224
+  // mk.movie_id == cc.movie_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r227
+  // cn.id == mc.company_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r230
+  // it.id == mi.info_type_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r233
+  // n.id == ci.person_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r236
+  // rt.id == ci.role_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r239
+  // n.id == an.person_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r242
+  // ci.person_id == an.person_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r245
+  // chn.id == ci.person_role_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r248
+  // n.id == pi.person_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r251
+  // ci.person_id == pi.person_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r254
+  // it3.id == pi.info_type_id &&
+  JumpIfFalse  r264, L17
+  Move         r264, r257
   // k.id == mk.keyword_id &&
+  JumpIfFalse  r264, L17
   Move         r264, r260
   // cct1.id == cc.subject_id &&
   JumpIfFalse  r264, L17
   Move         r264, r263
+L17:
   // where (
-  JumpIfFalse  r264, L21
+  JumpIfFalse  r264, L24
   // voiced_char: chn.name,
   Const        r297, "voiced_char"
   Const        r17, "name"
   Index        r298, r71, r17
   // voicing_actress: n.name,
   Const        r299, "voicing_actress"
+  Const        r17, "name"
   Index        r300, r125, r17
   // voiced_animation: t.title
   Const        r301, "voiced_animation"
@@ -505,20 +783,147 @@ L18:
   // from an in aka_name
   Append       r310, r15, r309
   Move         r15, r310
+L24:
   // from t in title
   Const        r311, 1
-L19:
   AddInt       r140, r140, r311
-  Jump         L20
-L17:
+  Jump         L25
+L16:
+  // from rt in role_type
+  Const        r311, 1
+  AddInt       r134, r134, r311
+  Jump         L26
+L15:
+  // from pi in person_info
+  Const        r311, 1
+  AddInt       r128, r128, r311
+  Jump         L27
+L14:
+  // from n in name
+  Const        r311, 1
+  AddInt       r122, r122, r311
+  Jump         L28
+L13:
+  // from mk in movie_keyword
+  Const        r311, 1
+  AddInt       r116, r116, r311
+  Jump         L29
+L12:
+  // from mi in movie_info
+  Const        r311, 1
+  AddInt       r110, r110, r311
+  Jump         L30
+L11:
+  // from mc in movie_companies
+  Const        r311, 1
+  AddInt       r104, r104, r311
+  Jump         L31
+L10:
+  // from k in keyword
+  Const        r311, 1
+  AddInt       r98, r98, r311
+  Jump         L32
+L9:
+  // from it3 in info_type
+  Const        r311, 1
+  AddInt       r92, r92, r311
+  Jump         L33
+L8:
+  // from it in info_type
+  Const        r311, 1
+  AddInt       r86, r86, r311
+  Jump         L34
+L7:
+  // from cn in company_name
+  Const        r311, 1
+  AddInt       r80, r80, r311
+  Jump         L35
+L6:
+  // from ci in cast_info
+  Const        r311, 1
+  AddInt       r74, r74, r311
+  Jump         L36
+L5:
+  // from chn in char_name
+  Const        r311, 1
+  AddInt       r68, r68, r311
+  Jump         L37
+L4:
+  // from cct2 in comp_cast_type
+  Const        r311, 1
+  AddInt       r62, r62, r311
+  Jump         L38
+L3:
+  // from cct1 in comp_cast_type
+  Const        r311, 1
+  AddInt       r56, r56, r311
+  Jump         L39
+L2:
+  // from cc in complete_cast
+  Const        r311, 1
+  AddInt       r50, r50, r311
+  Jump         L40
+L1:
+  // from an in aka_name
+  Const        r311, 1
+  AddInt       r43, r43, r311
+  Jump         L41
+L0:
+  // voiced_char: min(from x in matches select x.voiced_char),
+  Const        r313, "voiced_char"
+  Const        r314, []
+  Const        r38, "voiced_char"
+  IterPrep     r315, r15
+  Len          r316, r315
+  Const        r44, 0
+  Move         r317, r44
+L43:
+  LessInt      r318, r317, r316
+  JumpIfFalse  r318, L42
+  Index        r319, r315, r317
+  Move         r320, r319
+  Const        r38, "voiced_char"
+  Index        r321, r320, r38
+  Append       r322, r314, r321
+  Move         r314, r322
+  Const        r311, 1
+  AddInt       r317, r317, r311
+  Jump         L43
+L42:
+  Min          r323, r314
+  // voicing_actress: min(from x in matches select x.voicing_actress),
+  Const        r324, "voicing_actress"
+  Const        r325, []
+  Const        r39, "voicing_actress"
+  IterPrep     r326, r15
+  Len          r327, r326
+  Const        r44, 0
+  Move         r328, r44
+L45:
+  LessInt      r329, r328, r327
+  JumpIfFalse  r329, L44
+  Index        r330, r326, r328
+  Move         r320, r330
+  Const        r39, "voicing_actress"
+  Index        r331, r320, r39
+  Append       r332, r325, r331
+  Move         r325, r332
+  Const        r311, 1
+  AddInt       r328, r328, r311
+  Jump         L45
+L44:
+  Min          r333, r325
   // voiced_animation: min(from x in matches select x.voiced_animation)
+  Const        r334, "voiced_animation"
+  Const        r335, []
   Const        r40, "voiced_animation"
   IterPrep     r336, r15
   Len          r337, r336
   Const        r44, 0
   Move         r338, r44
+L47:
   LessInt      r339, r338, r337
-  JumpIfFalse  r339, L22
+  JumpIfFalse  r339, L46
   Index        r340, r336, r338
   Move         r320, r340
   Const        r40, "voiced_animation"
@@ -527,26 +932,27 @@ L17:
   Move         r335, r342
   Const        r311, 1
   AddInt       r338, r338, r311
-  Jump         L23
-L21:
+  Jump         L47
+L46:
+  Min          r343, r335
+  // voiced_char: min(from x in matches select x.voiced_char),
+  Move         r344, r313
+  Move         r345, r323
   // voicing_actress: min(from x in matches select x.voicing_actress),
   Move         r346, r324
   Move         r347, r333
   // voiced_animation: min(from x in matches select x.voiced_animation)
   Move         r348, r334
-L16:
   Move         r349, r343
   // {
   MakeMap      r350, 3, r344
   Move         r312, r350
-L15:
   // let result = [
   MakeList     r351, 1, r312
   // json(result)
   JSON         r351
   // expect result == [
   Const        r352, [{"voiced_animation": "Shrek 2", "voiced_char": "Queen", "voicing_actress": "Angela Aniston"}]
-L14:
   Equal        r353, r351, r352
   Expect       r353
   Return       r0

--- a/tests/dataset/job/out/q3.ir.out
+++ b/tests/dataset/job/out/q3.ir.out
@@ -20,6 +20,7 @@ func main (regs=73)
   Const        r9, "production_year"
   // mk.movie_id == mi.movie_id
   Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select t.title
   Const        r11, "title"
   // from k in keyword
@@ -27,8 +28,8 @@ func main (regs=73)
   Len          r13, r12
   Const        r15, 0
   Move         r14, r15
+L9:
   LessInt      r16, r14, r13
-L8:
   JumpIfFalse  r16, L0
   Index        r17, r12, r14
   Move         r18, r17
@@ -46,11 +47,13 @@ L8:
   Const        r9, "production_year"
   // mk.movie_id == mi.movie_id
   Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select t.title
   Const        r11, "title"
   // join mk in movie_keyword on mk.keyword_id == k.id
   Const        r15, 0
   Move         r23, r15
+L8:
   LessInt      r24, r23, r20
   JumpIfFalse  r24, L1
   Index        r25, r19, r23
@@ -65,6 +68,7 @@ L8:
   IterPrep     r30, r1
   Len          r31, r30
   Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // where k.keyword.contains("sequel") &&
   Const        r6, "keyword"
   Const        r7, "contains"
@@ -72,18 +76,22 @@ L8:
   Const        r8, "info"
   // t.production_year > 2005 &&
   Const        r9, "production_year"
+  // mk.movie_id == mi.movie_id
+  Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select t.title
   Const        r11, "title"
   // join mi in movie_info on mi.movie_id == mk.movie_id
   Const        r15, 0
   Move         r32, r15
+L7:
   LessInt      r33, r32, r31
   JumpIfFalse  r33, L2
   Index        r34, r30, r32
   Move         r35, r34
   Const        r10, "movie_id"
-L7:
   Index        r36, r35, r10
+  Const        r10, "movie_id"
   Index        r37, r26, r10
   Equal        r38, r36, r37
   JumpIfFalse  r38, L3
@@ -99,11 +107,15 @@ L7:
   Const        r8, "info"
   // t.production_year > 2005 &&
   Const        r9, "production_year"
+  // mk.movie_id == mi.movie_id
+  Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select t.title
   Const        r11, "title"
   // join t in title on t.id == mi.movie_id
   Const        r15, 0
   Move         r41, r15
+L6:
   LessInt      r42, r41, r40
   JumpIfFalse  r42, L3
   Index        r43, r39, r41
@@ -112,7 +124,6 @@ L7:
   Index        r45, r44, r22
   Const        r10, "movie_id"
   Index        r46, r35, r10
-L6:
   Equal        r47, r45, r46
   JumpIfFalse  r47, L4
   Const        r6, "keyword"
@@ -133,6 +144,7 @@ L6:
   // mk.movie_id == mi.movie_id
   Const        r10, "movie_id"
   Index        r57, r26, r10
+  Const        r10, "movie_id"
   Index        r58, r35, r10
   Equal        r59, r57, r58
   // where k.keyword.contains("sequel") &&
@@ -145,6 +157,7 @@ L6:
   // t.production_year > 2005 &&
   JumpIfFalse  r60, L5
   Move         r60, r59
+L5:
   // where k.keyword.contains("sequel") &&
   JumpIfFalse  r60, L4
   // select t.title
@@ -153,35 +166,39 @@ L6:
   // from k in keyword
   Append       r62, r5, r61
   Move         r5, r62
+L4:
   // join t in title on t.id == mi.movie_id
   Const        r63, 1
   Add          r41, r41, r63
   Jump         L6
-L5:
+L3:
   // join mi in movie_info on mi.movie_id == mk.movie_id
+  Const        r63, 1
   Add          r32, r32, r63
   Jump         L7
-L4:
+L2:
+  // join mk in movie_keyword on mk.keyword_id == k.id
+  Const        r63, 1
+  Add          r23, r23, r63
+  Jump         L8
+L1:
   // from k in keyword
   Const        r63, 1
   AddInt       r14, r14, r63
-  Jump         L8
-L3:
+  Jump         L9
+L0:
   // let result = [{ movie_title: min(candidate_titles) }]
   Const        r65, "movie_title"
   Min          r66, r5
   Move         r67, r65
-L2:
   Move         r68, r66
   MakeMap      r69, 1, r67
   Move         r64, r69
-L1:
   MakeList     r70, 1, r64
   // json(result)
   JSON         r70
   // expect result == [ { movie_title: "Alpha" } ]
   Const        r71, [{"movie_title": "Alpha"}]
-L0:
   Equal        r72, r70, r71
   Expect       r72
   Return       r0

--- a/tests/dataset/job/out/q30.ir.out
+++ b/tests/dataset/job/out/q30.ir.out
@@ -27,20 +27,28 @@ func main (regs=238)
   Const        r12, []
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -52,6 +60,7 @@ func main (regs=238)
   Len          r26, r25
   Const        r28, 0
   Move         r27, r28
+L25:
   LessInt      r29, r27, r26
   JumpIfFalse  r29, L0
   Index        r30, r25, r27
@@ -63,20 +72,28 @@ func main (regs=238)
   Const        r35, "subject_id"
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -86,6 +103,7 @@ func main (regs=238)
   // join cct1 in comp_cast_type on cct1.id == cc.subject_id
   Const        r28, 0
   Move         r36, r28
+L24:
   LessInt      r37, r36, r33
   JumpIfFalse  r37, L1
   Index        r38, r32, r36
@@ -103,20 +121,28 @@ func main (regs=238)
   Const        r45, "status_id"
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -126,6 +152,7 @@ func main (regs=238)
   // join cct2 in comp_cast_type on cct2.id == cc.status_id
   Const        r28, 0
   Move         r46, r28
+L23:
   LessInt      r47, r46, r44
   JumpIfFalse  r47, L2
   Index        r48, r43, r46
@@ -140,22 +167,31 @@ func main (regs=238)
   IterPrep     r53, r2
   Len          r54, r53
   Const        r55, "movie_id"
+  Const        r55, "movie_id"
   // where (cct1.kind in ["cast", "crew"]) &&
+  Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
   Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -165,12 +201,14 @@ func main (regs=238)
   // join ci in cast_info on ci.movie_id == cc.movie_id
   Const        r28, 0
   Move         r56, r28
+L22:
   LessInt      r57, r56, r54
   JumpIfFalse  r57, L3
   Index        r58, r53, r56
   Move         r59, r58
   Const        r55, "movie_id"
   Index        r60, r59, r55
+  Const        r55, "movie_id"
   Index        r61, r31, r55
   Equal        r62, r60, r61
   JumpIfFalse  r62, L4
@@ -178,22 +216,31 @@ func main (regs=238)
   IterPrep     r63, r5
   Len          r64, r63
   Const        r55, "movie_id"
+  Const        r55, "movie_id"
   // where (cct1.kind in ["cast", "crew"]) &&
+  Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
   Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -203,12 +250,14 @@ func main (regs=238)
   // join mi in movie_info on mi.movie_id == cc.movie_id
   Const        r28, 0
   Move         r65, r28
+L21:
   LessInt      r66, r65, r64
   JumpIfFalse  r66, L4
   Index        r67, r63, r65
   Move         r68, r67
   Const        r55, "movie_id"
   Index        r69, r68, r55
+  Const        r55, "movie_id"
   Index        r70, r31, r55
   Equal        r71, r69, r70
   JumpIfFalse  r71, L5
@@ -216,22 +265,31 @@ func main (regs=238)
   IterPrep     r72, r6
   Len          r73, r72
   Const        r55, "movie_id"
+  Const        r55, "movie_id"
   // where (cct1.kind in ["cast", "crew"]) &&
+  Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
   Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -241,12 +299,14 @@ func main (regs=238)
   // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
   Const        r28, 0
   Move         r74, r28
+L20:
   LessInt      r75, r74, r73
   JumpIfFalse  r75, L5
   Index        r76, r72, r74
   Move         r77, r76
   Const        r55, "movie_id"
   Index        r78, r77, r55
+  Const        r55, "movie_id"
   Index        r79, r31, r55
   Equal        r80, r78, r79
   JumpIfFalse  r80, L6
@@ -254,22 +314,31 @@ func main (regs=238)
   IterPrep     r81, r7
   Len          r82, r81
   Const        r55, "movie_id"
+  Const        r55, "movie_id"
   // where (cct1.kind in ["cast", "crew"]) &&
+  Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
   Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -279,12 +348,14 @@ func main (regs=238)
   // join mk in movie_keyword on mk.movie_id == cc.movie_id
   Const        r28, 0
   Move         r83, r28
+L19:
   LessInt      r84, r83, r82
   JumpIfFalse  r84, L6
   Index        r85, r81, r83
   Move         r86, r85
   Const        r55, "movie_id"
   Index        r87, r86, r55
+  Const        r55, "movie_id"
   Index        r88, r31, r55
   Equal        r89, r87, r88
   JumpIfFalse  r89, L7
@@ -295,20 +366,28 @@ func main (regs=238)
   Const        r92, "info_type_id"
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -318,6 +397,7 @@ func main (regs=238)
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r28, 0
   Move         r93, r28
+L18:
   LessInt      r94, r93, r91
   JumpIfFalse  r94, L7
   Index        r95, r90, r93
@@ -335,20 +415,28 @@ func main (regs=238)
   Const        r92, "info_type_id"
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -358,6 +446,7 @@ func main (regs=238)
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r28, 0
   Move         r102, r28
+L17:
   LessInt      r103, r102, r101
   JumpIfFalse  r103, L8
   Index        r104, r100, r102
@@ -375,20 +464,28 @@ func main (regs=238)
   Const        r111, "keyword_id"
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -398,6 +495,7 @@ func main (regs=238)
   // join k in keyword on k.id == mk.keyword_id
   Const        r28, 0
   Move         r112, r28
+L16:
   LessInt      r113, r112, r110
   JumpIfFalse  r113, L9
   Index        r114, r109, r112
@@ -415,20 +513,28 @@ func main (regs=238)
   Const        r121, "person_id"
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -438,6 +544,7 @@ func main (regs=238)
   // join n in name on n.id == ci.person_id
   Const        r28, 0
   Move         r122, r28
+L15:
   LessInt      r123, r122, r120
   JumpIfFalse  r123, L10
   Index        r124, r119, r122
@@ -455,20 +562,28 @@ func main (regs=238)
   Const        r55, "movie_id"
   // where (cct1.kind in ["cast", "crew"]) &&
   Const        r13, "kind"
+  // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   // (ci.note in writer_notes) &&
   Const        r14, "note"
   // it1.info == "genres" &&
   Const        r15, "info"
+  // it2.info == "votes" &&
+  Const        r15, "info"
   // (k.keyword in violent_keywords) &&
   Const        r16, "keyword"
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r15, "info"
   // n.gender == "m" &&
   Const        r17, "gender"
   // t.production_year > 2000
   Const        r18, "production_year"
   // budget: mi.info,
   Const        r19, "budget"
+  Const        r15, "info"
   // votes: mi_idx.info,
   Const        r20, "votes"
+  Const        r15, "info"
   // writer: n.name,
   Const        r21, "writer"
   Const        r22, "name"
@@ -478,6 +593,7 @@ func main (regs=238)
   // join t in title on t.id == cc.movie_id
   Const        r28, 0
   Move         r131, r28
+L14:
   LessInt      r132, r131, r130
   JumpIfFalse  r132, L11
   Index        r133, r129, r131
@@ -499,6 +615,7 @@ func main (regs=238)
   Const        r142, 2000
   Less         r143, r142, r141
   // cct2.kind == "complete+verified" &&
+  Const        r13, "kind"
   Index        r144, r49, r13
   Const        r145, "complete+verified"
   Equal        r146, r144, r145
@@ -508,6 +625,7 @@ func main (regs=238)
   Const        r148, "genres"
   Equal        r149, r147, r148
   // it2.info == "votes" &&
+  Const        r15, "info"
   Index        r150, r105, r15
   Const        r20, "votes"
   Equal        r151, r150, r20
@@ -559,6 +677,7 @@ func main (regs=238)
   // n.gender == "m" &&
   JumpIfFalse  r155, L13
   Move         r155, r143
+L13:
   // where (cct1.kind in ["cast", "crew"]) &&
   JumpIfFalse  r155, L12
   // budget: mi.info,
@@ -567,10 +686,10 @@ func main (regs=238)
   Index        r166, r68, r15
   // votes: mi_idx.info,
   Const        r167, "votes"
+  Const        r15, "info"
   Index        r168, r77, r15
   // writer: n.name,
   Const        r169, "writer"
-L14:
   Const        r22, "name"
   Index        r170, r125, r22
   // movie: t.title
@@ -594,75 +713,158 @@ L14:
   // from cc in complete_cast
   Append       r182, r12, r181
   Move         r12, r182
+L12:
   // join t in title on t.id == cc.movie_id
   Const        r183, 1
   Add          r131, r131, r183
   Jump         L14
-L13:
+L11:
+  // join n in name on n.id == ci.person_id
+  Const        r183, 1
+  Add          r122, r122, r183
+  Jump         L15
+L10:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r183, 1
+  Add          r112, r112, r183
+  Jump         L16
+L9:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r183, 1
+  Add          r102, r102, r183
+  Jump         L17
+L8:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r183, 1
+  Add          r93, r93, r183
+  Jump         L18
+L7:
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  Const        r183, 1
+  Add          r83, r83, r183
+  Jump         L19
+L6:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
+  Const        r183, 1
+  Add          r74, r74, r183
+  Jump         L20
+L5:
+  // join mi in movie_info on mi.movie_id == cc.movie_id
+  Const        r183, 1
+  Add          r65, r65, r183
+  Jump         L21
+L4:
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  Const        r183, 1
+  Add          r56, r56, r183
+  Jump         L22
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r183, 1
+  Add          r46, r46, r183
+  Jump         L23
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r183, 1
+  Add          r36, r36, r183
+  Jump         L24
+L1:
+  // from cc in complete_cast
+  Const        r183, 1
+  AddInt       r27, r27, r183
+  Jump         L25
+L0:
   // movie_budget: min(from x in matches select x.budget),
+  Const        r185, "movie_budget"
+  Const        r186, []
+  Const        r19, "budget"
+  IterPrep     r187, r12
+  Len          r188, r187
+  Const        r28, 0
+  Move         r189, r28
+L27:
+  LessInt      r190, r189, r188
+  JumpIfFalse  r190, L26
+  Index        r191, r187, r189
+  Move         r192, r191
   Const        r19, "budget"
   Index        r193, r192, r19
   Append       r194, r186, r193
   Move         r186, r194
   Const        r183, 1
   AddInt       r189, r189, r183
-  Jump         L15
-L12:
+  Jump         L27
+L26:
+  Min          r195, r186
   // movie_votes: min(from x in matches select x.votes),
+  Const        r196, "movie_votes"
+  Const        r197, []
+  Const        r20, "votes"
+  IterPrep     r198, r12
+  Len          r199, r198
+  Const        r28, 0
+  Move         r200, r28
+L29:
+  LessInt      r201, r200, r199
+  JumpIfFalse  r201, L28
+  Index        r202, r198, r200
+  Move         r192, r202
+  Const        r20, "votes"
+  Index        r203, r192, r20
+  Append       r204, r197, r203
+  Move         r197, r204
+  Const        r183, 1
   AddInt       r200, r200, r183
-  Jump         L16
-L11:
+  Jump         L29
+L28:
+  Min          r205, r197
   // writer: min(from x in matches select x.writer),
   Const        r206, "writer"
   Const        r207, []
   Const        r21, "writer"
-L10:
   IterPrep     r208, r12
   Len          r209, r208
   Const        r28, 0
-L9:
   Move         r210, r28
+L31:
   LessInt      r211, r210, r209
-  JumpIfFalse  r211, L17
-L8:
+  JumpIfFalse  r211, L30
   Index        r212, r208, r210
   Move         r192, r212
   Const        r21, "writer"
-L7:
   Index        r213, r192, r21
   Append       r214, r207, r213
   Move         r207, r214
-L6:
   Const        r183, 1
   AddInt       r210, r210, r183
-  Jump         L18
-L5:
+  Jump         L31
+L30:
   Min          r215, r207
   // complete_violent_movie: min(from x in matches select x.movie)
   Const        r216, "complete_violent_movie"
   Const        r217, []
-L4:
   Const        r23, "movie"
   IterPrep     r218, r12
   Len          r219, r218
-L3:
   Const        r28, 0
   Move         r220, r28
+L33:
   LessInt      r221, r220, r219
-L2:
-  JumpIfFalse  r221, L19
+  JumpIfFalse  r221, L32
   Index        r222, r218, r220
   Move         r192, r222
-L1:
   Const        r23, "movie"
   Index        r223, r192, r23
   Append       r224, r217, r223
-L0:
   Move         r217, r224
   Const        r183, 1
   AddInt       r220, r220, r183
-  Jump         L20
-L15:
+  Jump         L33
+L32:
+  Min          r225, r217
+  // movie_budget: min(from x in matches select x.budget),
+  Move         r226, r185
+  Move         r227, r195
   // movie_votes: min(from x in matches select x.votes),
   Move         r228, r196
   Move         r229, r205

--- a/tests/dataset/job/out/q31.ir.out
+++ b/tests/dataset/job/out/q31.ir.out
@@ -28,16 +28,23 @@ func main (regs=226)
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
@@ -46,6 +53,7 @@ func main (regs=226)
   Len          r23, r22
   Const        r25, 0
   Move         r24, r25
+L25:
   LessInt      r26, r24, r23
   JumpIfFalse  r26, L0
   Index        r27, r22, r24
@@ -62,22 +70,30 @@ func main (regs=226)
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join n in name on n.id == ci.person_id
   Const        r25, 0
   Move         r33, r25
+L24:
   LessInt      r34, r33, r30
   JumpIfFalse  r34, L1
   Index        r35, r29, r33
@@ -100,22 +116,30 @@ func main (regs=226)
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join t in title on t.id == ci.movie_id
   Const        r25, 0
   Move         r43, r25
+L23:
   LessInt      r44, r43, r41
   JumpIfFalse  r44, L2
   Index        r45, r40, r43
@@ -138,22 +162,30 @@ func main (regs=226)
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join mi in movie_info on mi.movie_id == t.id
   Const        r25, 0
   Move         r52, r25
+L22:
   LessInt      r53, r52, r51
   JumpIfFalse  r53, L3
   Index        r54, r50, r52
@@ -176,23 +208,30 @@ func main (regs=226)
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
-L14:
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
   Const        r25, 0
   Move         r61, r25
+L21:
   LessInt      r62, r61, r60
   JumpIfFalse  r62, L4
   Index        r63, r59, r61
@@ -215,22 +254,30 @@ L14:
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r25, 0
   Move         r70, r25
+L20:
   LessInt      r71, r70, r69
   JumpIfFalse  r71, L5
   Index        r72, r68, r70
@@ -253,22 +300,30 @@ L14:
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r25, 0
   Move         r80, r25
+L19:
   LessInt      r81, r80, r78
   JumpIfFalse  r81, L6
   Index        r82, r77, r80
@@ -291,22 +346,30 @@ L14:
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r25, 0
   Move         r89, r25
+L18:
   LessInt      r90, r89, r88
   JumpIfFalse  r90, L7
   Index        r91, r87, r89
@@ -329,22 +392,30 @@ L14:
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r25, 0
   Move         r99, r25
+L17:
   LessInt      r100, r99, r97
   JumpIfFalse  r100, L8
   Index        r101, r96, r99
@@ -367,22 +438,30 @@ L14:
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join it1 in info_type on it1.id == mi.info_type_id
   Const        r25, 0
   Move         r109, r25
+L16:
   LessInt      r110, r109, r107
   JumpIfFalse  r110, L9
   Index        r111, r106, r109
@@ -405,22 +484,30 @@ L14:
   Const        r13, "starts_with"
   // it1.info == "genres" &&
   Const        r14, "info"
+  // it2.info == "votes" &&
+  Const        r14, "info"
   // k.keyword in [
   Const        r15, "keyword"
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   // n.gender == "m"
   Const        r16, "gender"
   // movie_budget: mi.info,
   Const        r17, "movie_budget"
+  Const        r14, "info"
   // movie_votes: mi_idx.info,
   Const        r18, "movie_votes"
+  Const        r14, "info"
   // writer: n.name,
   Const        r19, "writer"
+  Const        r12, "name"
   // violent_liongate_movie: t.title
   Const        r20, "violent_liongate_movie"
   Const        r21, "title"
   // join it2 in info_type on it2.id == mi_idx.info_type_id
   Const        r25, 0
   Move         r118, r25
+L15:
   LessInt      r119, r118, r117
   JumpIfFalse  r119, L10
   Index        r120, r116, r118
@@ -442,6 +529,7 @@ L14:
   Const        r129, "genres"
   Equal        r130, r128, r129
   // it2.info == "votes" &&
+  Const        r14, "info"
   Index        r131, r121, r14
   Const        r132, "votes"
   Equal        r133, r131, r132
@@ -451,6 +539,7 @@ L14:
   Const        r135, ["murder", "violence", "blood", "gore", "death", "female-nudity", "hospital"]
   In           r136, r134, r135
   // mi.info in ["Horror", "Thriller"] &&
+  Const        r14, "info"
   Index        r137, r55, r14
   Const        r138, ["Horror", "Thriller"]
   In           r139, r137, r138
@@ -467,7 +556,7 @@ L14:
   // cn.name.starts_with("Lionsgate") &&
   Const        r145, "Lionsgate"
   Const        r146, 0
-  Const        r147, 9
+  Len          r147, r145
   Len          r148, r144
   LessEq       r149, r147, r148
   JumpIfFalse  r149, L13
@@ -476,19 +565,128 @@ L14:
   Move         r150, r152
   Jump         L14
 L13:
-  // join mi in movie_info on mi.movie_id == t.id
-  Add          r52, r52, r171
-  Jump         L14
+  Const        r150, false
+L14:
+  // ] &&
+  Move         r143, r150
+  // cn.name.starts_with("Lionsgate") &&
+  JumpIfFalse  r143, L12
+  Move         r143, r130
+  // it1.info == "genres" &&
+  JumpIfFalse  r143, L12
+  Move         r143, r133
+  // it2.info == "votes" &&
+  JumpIfFalse  r143, L12
+  Move         r143, r136
+  // ] &&
+  JumpIfFalse  r143, L12
+  Move         r143, r139
+  // mi.info in ["Horror", "Thriller"] &&
+  JumpIfFalse  r143, L12
+  Move         r143, r142
 L12:
+  // where ci.note in [
+  JumpIfFalse  r143, L11
+  // movie_budget: mi.info,
+  Const        r153, "movie_budget"
+  Const        r14, "info"
+  Index        r154, r55, r14
+  // movie_votes: mi_idx.info,
+  Const        r155, "movie_votes"
+  Const        r14, "info"
+  Index        r156, r64, r14
+  // writer: n.name,
+  Const        r157, "writer"
+  Const        r12, "name"
+  Index        r158, r36, r12
+  // violent_liongate_movie: t.title
+  Const        r159, "violent_liongate_movie"
+  Const        r21, "title"
+  Index        r160, r46, r21
+  // movie_budget: mi.info,
+  Move         r161, r153
+  Move         r162, r154
+  // movie_votes: mi_idx.info,
+  Move         r163, r155
+  Move         r164, r156
+  // writer: n.name,
+  Move         r165, r157
+  Move         r166, r158
+  // violent_liongate_movie: t.title
+  Move         r167, r159
+  Move         r168, r160
+  // select {
+  MakeMap      r169, 4, r161
+  // from ci in cast_info
+  Append       r170, r10, r169
+  Move         r10, r170
+L11:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r171, 1
+  Add          r118, r118, r171
+  Jump         L15
+L10:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r171, 1
+  Add          r109, r109, r171
+  Jump         L16
+L9:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r171, 1
+  Add          r99, r99, r171
+  Jump         L17
+L8:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r171, 1
+  Add          r89, r89, r171
+  Jump         L18
+L7:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r171, 1
+  Add          r80, r80, r171
+  Jump         L19
+L6:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r171, 1
+  Add          r70, r70, r171
+  Jump         L20
+L5:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r171, 1
+  Add          r61, r61, r171
+  Jump         L21
+L4:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r171, 1
+  Add          r52, r52, r171
+  Jump         L22
+L3:
+  // join t in title on t.id == ci.movie_id
+  Const        r171, 1
+  Add          r43, r43, r171
+  Jump         L23
+L2:
+  // join n in name on n.id == ci.person_id
+  Const        r171, 1
+  Add          r33, r33, r171
+  Jump         L24
+L1:
+  // from ci in cast_info
+  Const        r171, 1
+  AddInt       r24, r24, r171
+  Jump         L25
+L0:
   // movie_budget: min(from r in matches select r.movie_budget),
+  Const        r173, "movie_budget"
   Const        r174, []
   Const        r17, "movie_budget"
   IterPrep     r175, r10
   Len          r176, r175
   Const        r25, 0
   Move         r177, r25
+L27:
   LessInt      r178, r177, r176
-  JumpIfFalse  r178, L15
+  JumpIfFalse  r178, L26
   Index        r179, r175, r177
   Move         r180, r179
   Const        r17, "movie_budget"
@@ -497,61 +695,64 @@ L12:
   Move         r174, r182
   Const        r171, 1
   AddInt       r177, r177, r171
-  Jump         L16
-L11:
+  Jump         L27
+L26:
+  Min          r183, r174
   // movie_votes: min(from r in matches select r.movie_votes),
+  Const        r184, "movie_votes"
+  Const        r185, []
+  Const        r18, "movie_votes"
+  IterPrep     r186, r10
+  Len          r187, r186
+  Const        r25, 0
   Move         r188, r25
+L29:
   LessInt      r189, r188, r187
-  JumpIfFalse  r189, L17
-L10:
+  JumpIfFalse  r189, L28
   Index        r190, r186, r188
   Move         r180, r190
   Const        r18, "movie_votes"
-L9:
   Index        r191, r180, r18
   Append       r192, r185, r191
   Move         r185, r192
-L8:
   Const        r171, 1
   AddInt       r188, r188, r171
-  Jump         L18
-L7:
+  Jump         L29
+L28:
   Min          r193, r185
   // writer: min(from r in matches select r.writer),
   Const        r194, "writer"
   Const        r195, []
-L6:
   Const        r19, "writer"
   IterPrep     r196, r10
   Len          r197, r196
-L5:
   Const        r25, 0
   Move         r198, r25
+L31:
   LessInt      r199, r198, r197
-L4:
-  JumpIfFalse  r199, L19
+  JumpIfFalse  r199, L30
   Index        r200, r196, r198
   Move         r180, r200
-L3:
   Const        r19, "writer"
   Index        r201, r180, r19
   Append       r202, r195, r201
-L2:
   Move         r195, r202
   Const        r171, 1
   AddInt       r198, r198, r171
-  Jump         L1
-L0:
+  Jump         L31
+L30:
+  Min          r203, r195
   // violent_liongate_movie: min(from r in matches select r.violent_liongate_movie)
+  Const        r204, "violent_liongate_movie"
   Const        r205, []
   Const        r20, "violent_liongate_movie"
   IterPrep     r206, r10
   Len          r207, r206
   Const        r25, 0
   Move         r208, r25
+L33:
   LessInt      r209, r208, r207
-L16:
-  JumpIfFalse  r209, L20
+  JumpIfFalse  r209, L32
   Index        r210, r206, r208
   Move         r180, r210
   Const        r20, "violent_liongate_movie"
@@ -560,8 +761,9 @@ L16:
   Move         r205, r212
   Const        r171, 1
   AddInt       r208, r208, r171
-  Jump         L21
-L15:
+  Jump         L33
+L32:
+  Min          r213, r205
   // movie_budget: min(from r in matches select r.movie_budget),
   Move         r214, r173
   Move         r215, r183
@@ -574,7 +776,6 @@ L15:
   // violent_liongate_movie: min(from r in matches select r.violent_liongate_movie)
   Move         r220, r204
   Move         r221, r213
-L18:
   // {
   MakeMap      r222, 4, r214
   Move         r172, r222

--- a/tests/dataset/job/out/q32.ir.out
+++ b/tests/dataset/job/out/q32.ir.out
@@ -19,13 +19,14 @@ func main (regs=129)
   Const        r9, "first_movie"
   Const        r10, "title"
   Const        r11, "second_movie"
+  Const        r10, "title"
   // from k in keyword
   IterPrep     r12, r0
   Len          r13, r12
   Const        r15, 0
   Move         r14, r15
+L12:
   LessInt      r16, r14, r13
-L11:
   JumpIfFalse  r16, L0
   Index        r17, r12, r14
   Move         r18, r17
@@ -42,12 +43,13 @@ L11:
   Const        r9, "first_movie"
   Const        r10, "title"
   Const        r11, "second_movie"
+  Const        r10, "title"
   // join mk in movie_keyword on mk.keyword_id == k.id
   Const        r15, 0
   Move         r23, r15
+L11:
   LessInt      r24, r23, r20
   JumpIfFalse  r24, L1
-L10:
   Index        r25, r19, r23
   Move         r26, r25
   Const        r21, "keyword_id"
@@ -69,13 +71,14 @@ L10:
   Const        r9, "first_movie"
   Const        r10, "title"
   Const        r11, "second_movie"
+  Const        r10, "title"
   // join t1 in title on t1.id == mk.movie_id
   Const        r15, 0
   Move         r33, r15
+L10:
   LessInt      r34, r33, r31
   JumpIfFalse  r34, L2
   Index        r35, r30, r33
-L9:
   Move         r36, r35
   Const        r22, "id"
   Index        r37, r36, r22
@@ -96,14 +99,15 @@ L9:
   Const        r9, "first_movie"
   Const        r10, "title"
   Const        r11, "second_movie"
+  Const        r10, "title"
   // join ml in movie_link on ml.movie_id == t1.id
   Const        r15, 0
   Move         r42, r15
+L9:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L3
   Index        r44, r40, r42
   Move         r45, r44
-L8:
   Const        r32, "movie_id"
   Index        r46, r45, r32
   Const        r22, "id"
@@ -123,9 +127,11 @@ L8:
   Const        r9, "first_movie"
   Const        r10, "title"
   Const        r11, "second_movie"
+  Const        r10, "title"
   // join t2 in title on t2.id == ml.linked_movie_id
   Const        r15, 0
   Move         r52, r15
+L8:
   LessInt      r53, r52, r50
   JumpIfFalse  r53, L4
   Index        r54, r49, r52
@@ -149,16 +155,17 @@ L8:
   Const        r9, "first_movie"
   Const        r10, "title"
   Const        r11, "second_movie"
+  Const        r10, "title"
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r15, 0
   Move         r62, r15
+L7:
   LessInt      r63, r62, r60
   JumpIfFalse  r63, L5
   Index        r64, r59, r62
   Move         r65, r64
   Const        r22, "id"
   Index        r66, r65, r22
-L7:
   Const        r61, "link_type_id"
   Index        r67, r45, r61
   Equal        r68, r66, r67
@@ -177,6 +184,7 @@ L7:
   Const        r10, "title"
   Index        r75, r36, r10
   Const        r76, "second_movie"
+  Const        r10, "title"
   Index        r77, r55, r10
   Move         r78, r72
   Move         r79, r73
@@ -188,79 +196,112 @@ L7:
   // from k in keyword
   Append       r85, r5, r84
   Move         r5, r85
+L6:
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r86, 1
   Add          r62, r62, r86
   Jump         L7
-L6:
-  // join ml in movie_link on ml.movie_id == t1.id
-  Add          r42, r42, r86
-  Jump         L8
 L5:
-  // join t1 in title on t1.id == mk.movie_id
-  Add          r33, r33, r86
-  Jump         L9
+  // join t2 in title on t2.id == ml.linked_movie_id
+  Const        r86, 1
+  Add          r52, r52, r86
+  Jump         L8
 L4:
-  // join mk in movie_keyword on mk.keyword_id == k.id
-  Add          r23, r23, r86
-  Jump         L10
+  // join ml in movie_link on ml.movie_id == t1.id
+  Const        r86, 1
+  Add          r42, r42, r86
+  Jump         L9
 L3:
-  // from k in keyword
-  AddInt       r14, r14, r86
-  Jump         L11
+  // join t1 in title on t1.id == mk.movie_id
+  Const        r86, 1
+  Add          r33, r33, r86
+  Jump         L10
 L2:
+  // join mk in movie_keyword on mk.keyword_id == k.id
+  Const        r86, 1
+  Add          r23, r23, r86
+  Jump         L11
+L1:
+  // from k in keyword
+  Const        r86, 1
+  AddInt       r14, r14, r86
+  Jump         L12
+L0:
   // link_type: min(from r in joined select r.link_type),
+  Const        r87, "link_type"
   Const        r88, []
   Const        r7, "link_type"
   IterPrep     r89, r5
-L1:
   Len          r90, r89
   Const        r15, 0
   Move         r91, r15
-L0:
+L14:
   LessInt      r92, r91, r90
-  JumpIfFalse  r92, L12
+  JumpIfFalse  r92, L13
   Index        r93, r89, r91
   Move         r94, r93
   Const        r7, "link_type"
   Index        r95, r94, r7
   Append       r96, r88, r95
-L13:
   Move         r88, r96
   Const        r86, 1
   AddInt       r91, r91, r86
-  Jump         L13
-L12:
+  Jump         L14
+L13:
+  Min          r97, r88
   // first_movie: min(from r in joined select r.first_movie),
+  Const        r98, "first_movie"
+  Const        r99, []
+  Const        r9, "first_movie"
+  IterPrep     r100, r5
+  Len          r101, r100
+  Const        r15, 0
   Move         r102, r15
+L16:
   LessInt      r103, r102, r101
-  JumpIfFalse  r103, L14
+  JumpIfFalse  r103, L15
   Index        r104, r100, r102
   Move         r94, r104
   Const        r9, "first_movie"
   Index        r105, r94, r9
   Append       r106, r99, r105
-L15:
   Move         r99, r106
   Const        r86, 1
   AddInt       r102, r102, r86
-  Jump         L15
-L14:
+  Jump         L16
+L15:
+  Min          r107, r99
   // second_movie: min(from r in joined select r.second_movie)
+  Const        r108, "second_movie"
+  Const        r109, []
+  Const        r11, "second_movie"
+  IterPrep     r110, r5
+  Len          r111, r110
+  Const        r15, 0
   Move         r112, r15
+L18:
   LessInt      r113, r112, r111
-  JumpIfFalse  r113, L16
+  JumpIfFalse  r113, L17
   Index        r114, r110, r112
   Move         r94, r114
   Const        r11, "second_movie"
   Index        r115, r94, r11
   Append       r116, r109, r115
-L17:
   Move         r109, r116
   Const        r86, 1
   AddInt       r112, r112, r86
-  Jump         L17
-L16:
+  Jump         L18
+L17:
+  Min          r117, r109
+  // link_type: min(from r in joined select r.link_type),
+  Move         r118, r87
+  Move         r119, r97
+  // first_movie: min(from r in joined select r.first_movie),
+  Move         r120, r98
+  Move         r121, r107
+  // second_movie: min(from r in joined select r.second_movie)
+  Move         r122, r108
+  Move         r123, r117
   // let result = {
   MakeMap      r124, 3, r118
   // json([result])

--- a/tests/dataset/job/out/q33.ir.out
+++ b/tests/dataset/job/out/q33.ir.out
@@ -21,31 +21,45 @@ func main (regs=291)
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // from cn1 in company_name
   IterPrep     r22, r0
   Len          r23, r22
   Const        r25, 0
   Move         r24, r25
+L30:
   LessInt      r26, r24, r23
   JumpIfFalse  r26, L0
   Index        r27, r22, r24
@@ -59,30 +73,43 @@ func main (regs=291)
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
-L17:
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join mc1 in movie_companies on cn1.id == mc1.company_id
   Const        r25, 0
   Move         r33, r25
+L29:
   LessInt      r34, r33, r30
   JumpIfFalse  r34, L1
   Index        r35, r29, r33
@@ -102,29 +129,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join t1 in title on t1.id == mc1.movie_id
   Const        r25, 0
   Move         r43, r25
+L28:
   LessInt      r44, r43, r41
   JumpIfFalse  r44, L2
   Index        r45, r40, r43
@@ -144,29 +185,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join mi_idx1 in movie_info_idx on mi_idx1.movie_id == t1.id
   Const        r25, 0
   Move         r52, r25
+L27:
   LessInt      r53, r52, r51
   JumpIfFalse  r53, L3
   Index        r54, r50, r52
@@ -186,29 +241,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join it1 in info_type on it1.id == mi_idx1.info_type_id
   Const        r25, 0
   Move         r62, r25
+L26:
   LessInt      r63, r62, r60
   JumpIfFalse  r63, L4
   Index        r64, r59, r62
@@ -228,29 +297,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join kt1 in kind_type on kt1.id == t1.kind_id
   Const        r25, 0
   Move         r72, r25
+L25:
   LessInt      r73, r72, r70
   JumpIfFalse  r73, L5
   Index        r74, r69, r72
@@ -270,29 +353,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join ml in movie_link on ml.movie_id == t1.id
   Const        r25, 0
   Move         r81, r25
+L24:
   LessInt      r82, r81, r80
   JumpIfFalse  r82, L6
   Index        r83, r79, r81
@@ -312,29 +409,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join t2 in title on t2.id == ml.linked_movie_id
   Const        r25, 0
   Move         r91, r25
+L23:
   LessInt      r92, r91, r89
   JumpIfFalse  r92, L7
   Index        r93, r88, r91
@@ -354,29 +465,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join mi_idx2 in movie_info_idx on mi_idx2.movie_id == t2.id
   Const        r25, 0
   Move         r100, r25
+L22:
   LessInt      r101, r100, r99
   JumpIfFalse  r101, L8
   Index        r102, r98, r100
@@ -396,29 +521,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join it2 in info_type on it2.id == mi_idx2.info_type_id
   Const        r25, 0
   Move         r109, r25
+L21:
   LessInt      r110, r109, r108
   JumpIfFalse  r110, L9
   Index        r111, r107, r109
@@ -438,29 +577,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join kt2 in kind_type on kt2.id == t2.kind_id
   Const        r25, 0
   Move         r118, r25
+L20:
   LessInt      r119, r118, r117
   JumpIfFalse  r119, L10
   Index        r120, r116, r118
@@ -480,29 +633,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join mc2 in movie_companies on mc2.movie_id == t2.id
   Const        r25, 0
   Move         r127, r25
+L19:
   LessInt      r128, r127, r126
   JumpIfFalse  r128, L11
   Index        r129, r125, r127
@@ -522,29 +689,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join cn2 in company_name on cn2.id == mc2.company_id
   Const        r25, 0
   Move         r136, r25
+L18:
   LessInt      r137, r136, r135
   JumpIfFalse  r137, L12
   Index        r138, r134, r136
@@ -564,29 +745,43 @@ L17:
   Const        r9, "country_code"
   // it1.info == "rating" &&
   Const        r10, "info"
+  // it2.info == "rating" &&
+  Const        r10, "info"
   // kt1.kind == "tv series" &&
+  Const        r11, "kind"
+  // kt2.kind == "tv series" &&
   Const        r11, "kind"
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
   Const        r12, "link"
+  Const        r12, "link"
+  Const        r12, "link"
+  // mi_idx2.info < "3.0" &&
+  Const        r10, "info"
   // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r13, "production_year"
   Const        r13, "production_year"
   // first_company: cn1.name,
   Const        r14, "first_company"
   Const        r15, "name"
   // second_company: cn2.name,
   Const        r16, "second_company"
+  Const        r15, "name"
   // first_rating: mi_idx1.info,
   Const        r17, "first_rating"
+  Const        r10, "info"
   // second_rating: mi_idx2.info,
   Const        r18, "second_rating"
+  Const        r10, "info"
   // first_movie: t1.title,
   Const        r19, "first_movie"
   Const        r20, "title"
   // second_movie: t2.title
   Const        r21, "second_movie"
+  Const        r20, "title"
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r25, 0
   Move         r146, r25
+L17:
   LessInt      r147, r146, r144
   JumpIfFalse  r147, L13
   Index        r148, r143, r146
@@ -610,6 +805,7 @@ L17:
   Index        r157, r94, r13
   Const        r158, 2005
   LessEq       r159, r158, r157
+  Const        r13, "production_year"
   Index        r160, r94, r13
   Const        r161, 2008
   LessEq       r162, r160, r161
@@ -617,11 +813,14 @@ L17:
   Const        r163, "[us]"
   Equal        r164, r153, r163
   // it1.info == "rating" &&
+  Const        r10, "info"
   Index        r165, r65, r10
   Const        r166, "rating"
   Equal        r167, r165, r166
   // it2.info == "rating" &&
+  Const        r10, "info"
   Index        r168, r112, r10
+  Const        r166, "rating"
   Equal        r169, r168, r166
   // kt1.kind == "tv series" &&
   Const        r11, "kind"
@@ -629,7 +828,9 @@ L17:
   Const        r171, "tv series"
   Equal        r172, r170, r171
   // kt2.kind == "tv series" &&
+  Const        r11, "kind"
   Index        r173, r121, r11
+  Const        r171, "tv series"
   Equal        r174, r173, r171
   // where cn1.country_code == "[us]" &&
   Move         r175, r164
@@ -651,9 +852,11 @@ L17:
   Index        r176, r149, r12
   Const        r177, "sequel"
   Equal        r178, r176, r177
+  Const        r12, "link"
   Index        r179, r149, r12
   Const        r180, "follows"
   Equal        r181, r179, r180
+  Const        r12, "link"
   Index        r182, r149, r12
   Const        r183, "followed by"
   Equal        r184, r182, r183
@@ -662,6 +865,7 @@ L17:
   Move         r185, r181
   JumpIfTrue   r185, L16
   Move         r185, r184
+L16:
   // kt2.kind == "tv series" &&
   Move         r175, r185
   // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
@@ -673,6 +877,7 @@ L17:
   // t2.production_year >= 2005 && t2.production_year <= 2008
   JumpIfFalse  r175, L15
   Move         r175, r162
+L15:
   // where cn1.country_code == "[us]" &&
   JumpIfFalse  r175, L14
   // first_company: cn1.name,
@@ -681,6 +886,7 @@ L17:
   Index        r187, r28, r15
   // second_company: cn2.name,
   Const        r188, "second_company"
+  Const        r15, "name"
   Index        r189, r139, r15
   // first_rating: mi_idx1.info,
   Const        r190, "first_rating"
@@ -688,6 +894,7 @@ L17:
   Index        r191, r55, r10
   // second_rating: mi_idx2.info,
   Const        r192, "second_rating"
+  Const        r10, "info"
   Index        r193, r103, r10
   // first_movie: t1.title,
   Const        r194, "first_movie"
@@ -695,6 +902,7 @@ L17:
   Index        r195, r46, r20
   // second_movie: t2.title
   Const        r196, "second_movie"
+  Const        r20, "title"
   Index        r197, r94, r20
   // first_company: cn1.name,
   Move         r198, r186
@@ -719,20 +927,164 @@ L17:
   // from cn1 in company_name
   Append       r211, r8, r210
   Move         r8, r211
+L14:
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r212, 1
   Add          r146, r146, r212
   Jump         L17
-L16:
+L13:
+  // join cn2 in company_name on cn2.id == mc2.company_id
+  Const        r212, 1
+  Add          r136, r136, r212
+  Jump         L18
+L12:
+  // join mc2 in movie_companies on mc2.movie_id == t2.id
+  Const        r212, 1
+  Add          r127, r127, r212
+  Jump         L19
+L11:
+  // join kt2 in kind_type on kt2.id == t2.kind_id
+  Const        r212, 1
+  Add          r118, r118, r212
+  Jump         L20
+L10:
+  // join it2 in info_type on it2.id == mi_idx2.info_type_id
+  Const        r212, 1
+  Add          r109, r109, r212
+  Jump         L21
+L9:
+  // join mi_idx2 in movie_info_idx on mi_idx2.movie_id == t2.id
+  Const        r212, 1
+  Add          r100, r100, r212
+  Jump         L22
+L8:
+  // join t2 in title on t2.id == ml.linked_movie_id
+  Const        r212, 1
+  Add          r91, r91, r212
+  Jump         L23
+L7:
+  // join ml in movie_link on ml.movie_id == t1.id
+  Const        r212, 1
+  Add          r81, r81, r212
+  Jump         L24
+L6:
+  // join kt1 in kind_type on kt1.id == t1.kind_id
+  Const        r212, 1
+  Add          r72, r72, r212
+  Jump         L25
+L5:
+  // join it1 in info_type on it1.id == mi_idx1.info_type_id
+  Const        r212, 1
+  Add          r62, r62, r212
+  Jump         L26
+L4:
+  // join mi_idx1 in movie_info_idx on mi_idx1.movie_id == t1.id
+  Const        r212, 1
+  Add          r52, r52, r212
+  Jump         L27
+L3:
+  // join t1 in title on t1.id == mc1.movie_id
+  Const        r212, 1
+  Add          r43, r43, r212
+  Jump         L28
+L2:
+  // join mc1 in movie_companies on cn1.id == mc1.company_id
+  Const        r212, 1
+  Add          r33, r33, r212
+  Jump         L29
+L1:
+  // from cn1 in company_name
+  Const        r212, 1
+  AddInt       r24, r24, r212
+  Jump         L30
+L0:
+  // first_company: min(from r in rows select r.first_company),
+  Const        r214, "first_company"
+  Const        r215, []
+  Const        r14, "first_company"
+  IterPrep     r216, r8
+  Len          r217, r216
+  Const        r25, 0
+  Move         r218, r25
+L32:
+  LessInt      r219, r218, r217
+  JumpIfFalse  r219, L31
+  Index        r220, r216, r218
+  Move         r221, r220
+  Const        r14, "first_company"
+  Index        r222, r221, r14
+  Append       r223, r215, r222
+  Move         r215, r223
+  Const        r212, 1
+  AddInt       r218, r218, r212
+  Jump         L32
+L31:
+  Min          r224, r215
+  // second_company: min(from r in rows select r.second_company),
+  Const        r225, "second_company"
+  Const        r226, []
+  Const        r16, "second_company"
+  IterPrep     r227, r8
+  Len          r228, r227
+  Const        r25, 0
+  Move         r229, r25
+L34:
+  LessInt      r230, r229, r228
+  JumpIfFalse  r230, L33
+  Index        r231, r227, r229
+  Move         r221, r231
+  Const        r16, "second_company"
+  Index        r232, r221, r16
+  Append       r233, r226, r232
+  Move         r226, r233
+  Const        r212, 1
+  AddInt       r229, r229, r212
+  Jump         L34
+L33:
+  Min          r234, r226
+  // first_rating: min(from r in rows select r.first_rating),
+  Const        r235, "first_rating"
+  Const        r236, []
+  Const        r17, "first_rating"
+  IterPrep     r237, r8
+  Len          r238, r237
+  Const        r25, 0
+  Move         r239, r25
+L36:
+  LessInt      r240, r239, r238
+  JumpIfFalse  r240, L35
+  Index        r241, r237, r239
+  Move         r221, r241
+  Const        r17, "first_rating"
+  Index        r242, r221, r17
+  Append       r243, r236, r242
+  Move         r236, r243
+  Const        r212, 1
+  AddInt       r239, r239, r212
+  Jump         L36
+L35:
+  Min          r244, r236
   // second_rating: min(from r in rows select r.second_rating),
+  Const        r245, "second_rating"
+  Const        r246, []
+  Const        r18, "second_rating"
+  IterPrep     r247, r8
+  Len          r248, r247
+  Const        r25, 0
+  Move         r249, r25
+L38:
+  LessInt      r250, r249, r248
+  JumpIfFalse  r250, L37
+  Index        r251, r247, r249
+  Move         r221, r251
   Const        r18, "second_rating"
   Index        r252, r221, r18
   Append       r253, r246, r252
   Move         r246, r253
   Const        r212, 1
   AddInt       r249, r249, r212
-  Jump         L18
-L15:
+  Jump         L38
+L37:
   Min          r254, r246
   // first_movie: min(from r in rows select r.first_movie),
   Const        r255, "first_movie"
@@ -742,8 +1094,9 @@ L15:
   Len          r258, r257
   Const        r25, 0
   Move         r259, r25
+L40:
   LessInt      r260, r259, r258
-  JumpIfFalse  r260, L19
+  JumpIfFalse  r260, L39
   Index        r261, r257, r259
   Move         r221, r261
   Const        r19, "first_movie"
@@ -752,46 +1105,58 @@ L15:
   Move         r256, r263
   Const        r212, 1
   AddInt       r259, r259, r212
-  Jump         L20
-L14:
+  Jump         L40
+L39:
+  Min          r264, r256
   // second_movie: min(from r in rows select r.second_movie)
+  Const        r265, "second_movie"
+  Const        r266, []
+  Const        r21, "second_movie"
+  IterPrep     r267, r8
+  Len          r268, r267
+  Const        r25, 0
+  Move         r269, r25
+L42:
+  LessInt      r270, r269, r268
+  JumpIfFalse  r270, L41
+  Index        r271, r267, r269
+  Move         r221, r271
+  Const        r21, "second_movie"
+  Index        r272, r221, r21
+  Append       r273, r266, r272
   Move         r266, r273
   Const        r212, 1
   AddInt       r269, r269, r212
-  Jump         L13
-L12:
+  Jump         L42
+L41:
+  Min          r274, r266
   // first_company: min(from r in rows select r.first_company),
+  Move         r275, r214
   Move         r276, r224
   // second_company: min(from r in rows select r.second_company),
   Move         r277, r225
   Move         r278, r234
-L11:
   // first_rating: min(from r in rows select r.first_rating),
   Move         r279, r235
   Move         r280, r244
   // second_rating: min(from r in rows select r.second_rating),
   Move         r281, r245
-L10:
   Move         r282, r254
   // first_movie: min(from r in rows select r.first_movie),
   Move         r283, r255
   Move         r284, r264
-L9:
   // second_movie: min(from r in rows select r.second_movie)
   Move         r285, r265
   Move         r286, r274
   // {
   MakeMap      r287, 6, r275
-L8:
   Move         r213, r287
   // let result = [
   MakeList     r288, 1, r213
   // json(result)
   JSON         r288
-L7:
   // expect result == [
   Const        r289, [{"first_company": "US Studio", "first_movie": "Series A", "first_rating": "7.0", "second_company": "GB Studio", "second_movie": "Series B", "second_rating": "2.5"}]
   Equal        r290, r288, r289
   Expect       r290
-L6:
   Return       r0

--- a/tests/dataset/job/out/q4.ir.out
+++ b/tests/dataset/job/out/q4.ir.out
@@ -16,18 +16,24 @@ func main (regs=115)
   // k.keyword.contains("sequel") &&
   Const        r7, "keyword"
   Const        r8, "contains"
+  // mi.info > "5.0" &&
+  Const        r6, "info"
   // t.production_year > 2005 &&
   Const        r9, "production_year"
   // mk.movie_id == mi.movie_id
   Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select { rating: mi.info, title: t.title }
   Const        r11, "rating"
+  Const        r6, "info"
+  Const        r12, "title"
   Const        r12, "title"
   // from it in info_type
   IterPrep     r13, r0
   Len          r14, r13
   Const        r16, 0
   Move         r15, r16
+L11:
   LessInt      r17, r15, r14
   JumpIfFalse  r17, L0
   Index        r18, r13, r15
@@ -42,16 +48,22 @@ func main (regs=115)
   // k.keyword.contains("sequel") &&
   Const        r7, "keyword"
   Const        r8, "contains"
+  // mi.info > "5.0" &&
+  Const        r6, "info"
   // t.production_year > 2005 &&
   Const        r9, "production_year"
   // mk.movie_id == mi.movie_id
   Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select { rating: mi.info, title: t.title }
   Const        r11, "rating"
+  Const        r6, "info"
+  Const        r12, "title"
   Const        r12, "title"
   // join mi in movie_info_idx on it.id == mi.info_type_id
   Const        r16, 0
   Move         r24, r16
+L10:
   LessInt      r25, r24, r21
   JumpIfFalse  r25, L1
   Index        r26, r20, r24
@@ -60,7 +72,6 @@ func main (regs=115)
   Index        r28, r19, r22
   Const        r23, "info_type_id"
   Index        r29, r27, r23
-L8:
   Equal        r30, r28, r29
   JumpIfFalse  r30, L2
   // join t in title on t.id == mi.movie_id
@@ -73,14 +84,22 @@ L8:
   // k.keyword.contains("sequel") &&
   Const        r7, "keyword"
   Const        r8, "contains"
+  // mi.info > "5.0" &&
+  Const        r6, "info"
   // t.production_year > 2005 &&
   Const        r9, "production_year"
+  // mk.movie_id == mi.movie_id
+  Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select { rating: mi.info, title: t.title }
   Const        r11, "rating"
+  Const        r6, "info"
+  Const        r12, "title"
   Const        r12, "title"
   // join t in title on t.id == mi.movie_id
   Const        r16, 0
   Move         r33, r16
+L9:
   LessInt      r34, r33, r32
   JumpIfFalse  r34, L2
   Index        r35, r31, r33
@@ -101,14 +120,22 @@ L8:
   // k.keyword.contains("sequel") &&
   Const        r7, "keyword"
   Const        r8, "contains"
+  // mi.info > "5.0" &&
+  Const        r6, "info"
   // t.production_year > 2005 &&
   Const        r9, "production_year"
+  // mk.movie_id == mi.movie_id
+  Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select { rating: mi.info, title: t.title }
   Const        r11, "rating"
+  Const        r6, "info"
+  Const        r12, "title"
   Const        r12, "title"
   // join mk in movie_keyword on mk.movie_id == t.id
   Const        r16, 0
   Move         r42, r16
+L8:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L3
   Index        r44, r40, r42
@@ -129,16 +156,22 @@ L8:
   // k.keyword.contains("sequel") &&
   Const        r7, "keyword"
   Const        r8, "contains"
+  // mi.info > "5.0" &&
+  Const        r6, "info"
   // t.production_year > 2005 &&
   Const        r9, "production_year"
   // mk.movie_id == mi.movie_id
   Const        r10, "movie_id"
+  Const        r10, "movie_id"
   // select { rating: mi.info, title: t.title }
   Const        r11, "rating"
+  Const        r6, "info"
+  Const        r12, "title"
   Const        r12, "title"
   // join k in keyword on k.id == mk.keyword_id
   Const        r16, 0
   Move         r52, r16
+L7:
   LessInt      r53, r52, r50
   JumpIfFalse  r53, L4
   Index        r54, r49, r52
@@ -153,6 +186,7 @@ L8:
   Const        r6, "info"
   Index        r59, r19, r6
   // mi.info > "5.0" &&
+  Const        r6, "info"
   Index        r60, r27, r6
   Const        r61, "5.0"
   Less         r62, r61, r60
@@ -166,8 +200,8 @@ L8:
   Equal        r66, r59, r11
   // mk.movie_id == mi.movie_id
   Const        r10, "movie_id"
-L7:
   Index        r67, r45, r10
+  Const        r10, "movie_id"
   Index        r68, r27, r10
   Equal        r69, r67, r68
   // where it.info == "rating" &&
@@ -189,6 +223,7 @@ L7:
   // t.production_year > 2005 &&
   JumpIfFalse  r70, L6
   Move         r70, r69
+L6:
   // where it.info == "rating" &&
   JumpIfFalse  r70, L5
   // select { rating: mi.info, title: t.title }
@@ -206,48 +241,91 @@ L7:
   // from it in info_type
   Append       r83, r5, r82
   Move         r5, r83
+L5:
   // join k in keyword on k.id == mk.keyword_id
   Const        r84, 1
   Add          r52, r52, r84
   Jump         L7
-L6:
-  // join mi in movie_info_idx on it.id == mi.info_type_id
-  Add          r24, r24, r84
+L4:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r84, 1
+  Add          r42, r42, r84
   Jump         L8
-L5:
+L3:
+  // join t in title on t.id == mi.movie_id
+  Const        r84, 1
+  Add          r33, r33, r84
+  Jump         L9
+L2:
+  // join mi in movie_info_idx on it.id == mi.info_type_id
+  Const        r84, 1
+  Add          r24, r24, r84
+  Jump         L10
+L1:
+  // from it in info_type
+  Const        r84, 1
+  AddInt       r15, r15, r84
+  Jump         L11
+L0:
   // rating: min(from r in rows select r.rating),
+  Const        r86, "rating"
+  Const        r87, []
+  Const        r11, "rating"
+  IterPrep     r88, r5
+  Len          r89, r88
+  Const        r16, 0
+  Move         r90, r16
+L13:
+  LessInt      r91, r90, r89
+  JumpIfFalse  r91, L12
   Index        r92, r88, r90
   Move         r93, r92
   Const        r11, "rating"
-L4:
   Index        r94, r93, r11
   Append       r95, r87, r94
   Move         r87, r95
-L3:
   Const        r84, 1
   AddInt       r90, r90, r84
-  Jump         L9
-L2:
+  Jump         L13
+L12:
   Min          r96, r87
   // movie_title: min(from r in rows select r.title)
   Const        r97, "movie_title"
   Const        r98, []
-L1:
   Const        r12, "title"
   IterPrep     r99, r5
   Len          r100, r99
-L0:
   Const        r16, 0
   Move         r101, r16
+L15:
   LessInt      r102, r101, r100
-  JumpIfFalse  r102, L10
+  JumpIfFalse  r102, L14
   Index        r103, r99, r101
   Move         r93, r103
   Const        r12, "title"
-L9:
   Index        r104, r93, r12
   Append       r105, r98, r104
   Move         r98, r105
   Const        r84, 1
   AddInt       r101, r101, r84
-  Jump         L11
+  Jump         L15
+L14:
+  Min          r106, r98
+  // rating: min(from r in rows select r.rating),
+  Move         r107, r86
+  Move         r108, r96
+  // movie_title: min(from r in rows select r.title)
+  Move         r109, r97
+  Move         r110, r106
+  // {
+  MakeMap      r111, 2, r107
+  Move         r85, r111
+  // let result = [
+  MakeList     r112, 1, r85
+  // json(result)
+  JSON         r112
+  // expect result == [ { rating: "6.2", movie_title: "Alpha Movie" } ]
+  Const        r113, [{"movie_title": "Alpha Movie", "rating": "6.2"}]
+  Equal        r114, r112, r113
+  Expect       r114
+  Return       r0

--- a/tests/dataset/job/out/q5.ir.out
+++ b/tests/dataset/job/out/q5.ir.out
@@ -15,6 +15,8 @@ func main (regs=88)
   Const        r6, "kind"
   // "(theatrical)" in mc.note &&
   Const        r7, "note"
+  // "(France)" in mc.note &&
+  Const        r7, "note"
   // t.production_year > 2005 &&
   Const        r8, "production_year"
   // (mi.info in [
@@ -26,8 +28,8 @@ func main (regs=88)
   Len          r12, r11
   Const        r14, 0
   Move         r13, r14
+L11:
   LessInt      r15, r13, r12
-L3:
   JumpIfFalse  r15, L0
   Index        r16, r11, r13
   Move         r17, r16
@@ -40,6 +42,8 @@ L3:
   Const        r6, "kind"
   // "(theatrical)" in mc.note &&
   Const        r7, "note"
+  // "(France)" in mc.note &&
+  Const        r7, "note"
   // t.production_year > 2005 &&
   Const        r8, "production_year"
   // (mi.info in [
@@ -49,9 +53,9 @@ L3:
   // join mc in movie_companies on mc.company_type_id == ct.ct_id
   Const        r14, 0
   Move         r22, r14
+L10:
   LessInt      r23, r22, r19
   JumpIfFalse  r23, L1
-L4:
   Index        r24, r18, r22
   Move         r25, r24
   Const        r20, "company_type_id"
@@ -64,9 +68,12 @@ L4:
   IterPrep     r29, r4
   Len          r30, r29
   Const        r31, "movie_id"
+  Const        r31, "movie_id"
   // where ct.kind == "production companies" &&
   Const        r6, "kind"
   // "(theatrical)" in mc.note &&
+  Const        r7, "note"
+  // "(France)" in mc.note &&
   Const        r7, "note"
   // t.production_year > 2005 &&
   Const        r8, "production_year"
@@ -77,13 +84,14 @@ L4:
   // join mi in movie_info on mi.movie_id == mc.movie_id
   Const        r14, 0
   Move         r32, r14
+L9:
   LessInt      r33, r32, r30
   JumpIfFalse  r33, L2
   Index        r34, r29, r32
   Move         r35, r34
-L5:
   Const        r31, "movie_id"
   Index        r36, r35, r31
+  Const        r31, "movie_id"
   Index        r37, r25, r31
   Equal        r38, r36, r37
   JumpIfFalse  r38, L3
@@ -96,6 +104,8 @@ L5:
   Const        r6, "kind"
   // "(theatrical)" in mc.note &&
   Const        r7, "note"
+  // "(France)" in mc.note &&
+  Const        r7, "note"
   // t.production_year > 2005 &&
   Const        r8, "production_year"
   // (mi.info in [
@@ -105,13 +115,13 @@ L5:
   // join it in info_type on it.it_id == mi.info_type_id
   Const        r14, 0
   Move         r43, r14
+L8:
   LessInt      r44, r43, r40
   JumpIfFalse  r44, L3
   Index        r45, r39, r43
   Move         r46, r45
   Const        r41, "it_id"
   Index        r47, r46, r41
-L8:
   Const        r42, "info_type_id"
   Index        r48, r35, r42
   Equal        r49, r47, r48
@@ -125,6 +135,8 @@ L8:
   Const        r6, "kind"
   // "(theatrical)" in mc.note &&
   Const        r7, "note"
+  // "(France)" in mc.note &&
+  Const        r7, "note"
   // t.production_year > 2005 &&
   Const        r8, "production_year"
   // (mi.info in [
@@ -134,6 +146,7 @@ L8:
   // join t in title on t.t_id == mc.movie_id
   Const        r14, 0
   Move         r53, r14
+L7:
   LessInt      r54, r53, r51
   JumpIfFalse  r54, L4
   Index        r55, r50, r53
@@ -141,7 +154,6 @@ L8:
   Const        r52, "t_id"
   Index        r57, r56, r52
   Const        r31, "movie_id"
-L7:
   Index        r58, r25, r31
   Equal        r59, r57, r58
   JumpIfFalse  r59, L5
@@ -163,6 +175,7 @@ L7:
   In           r68, r66, r67
   // "(France)" in mc.note &&
   Const        r69, "(France)"
+  Const        r7, "note"
   Index        r70, r25, r7
   In           r71, r69, r70
   // where ct.kind == "production companies" &&
@@ -184,6 +197,7 @@ L7:
   In           r75, r73, r74
   // t.production_year > 2005 &&
   Move         r72, r75
+L6:
   // where ct.kind == "production companies" &&
   JumpIfFalse  r72, L5
   // select t.title
@@ -192,26 +206,42 @@ L7:
   // from ct in company_type
   Append       r77, r5, r76
   Move         r5, r77
+L5:
   // join t in title on t.t_id == mc.movie_id
   Const        r78, 1
   Add          r53, r53, r78
   Jump         L7
-L6:
+L4:
   // join it in info_type on it.it_id == mi.info_type_id
   Const        r78, 1
   Add          r43, r43, r78
   Jump         L8
+L3:
+  // join mi in movie_info on mi.movie_id == mc.movie_id
+  Const        r78, 1
+  Add          r32, r32, r78
+  Jump         L9
 L2:
+  // join mc in movie_companies on mc.company_type_id == ct.ct_id
+  Const        r78, 1
+  Add          r22, r22, r78
+  Jump         L10
+L1:
+  // from ct in company_type
+  Const        r78, 1
+  AddInt       r13, r13, r78
+  Jump         L11
+L0:
   // let result = [ { typical_european_movie: min(candidate_titles) } ]
+  Const        r80, "typical_european_movie"
+  Min          r81, r5
   Move         r82, r80
   Move         r83, r81
   MakeMap      r84, 1, r82
-L1:
   Move         r79, r84
   MakeList     r85, 1, r79
   // json(result)
   JSON         r85
-L0:
   // expect result == [ { typical_european_movie: "A Film" } ]
   Const        r86, [{"typical_european_movie": "A Film"}]
   Equal        r87, r85, r86

--- a/tests/dataset/job/out/q6.ir.out
+++ b/tests/dataset/job/out/q6.ir.out
@@ -16,12 +16,17 @@ func main (regs=91)
   // n.name.contains("Downey") &&
   Const        r7, "name"
   Const        r8, "contains"
+  // n.name.contains("Robert") &&
+  Const        r7, "name"
+  Const        r8, "contains"
   // t.production_year > 2010
   Const        r9, "production_year"
   // movie_keyword: k.keyword,
   Const        r10, "movie_keyword"
+  Const        r6, "keyword"
   // actor_name: n.name,
   Const        r11, "actor_name"
+  Const        r7, "name"
   // marvel_movie: t.title
   Const        r12, "marvel_movie"
   Const        r13, "title"
@@ -30,6 +35,7 @@ func main (regs=91)
   Len          r15, r14
   Const        r17, 0
   Move         r16, r17
+L11:
   LessInt      r18, r16, r15
   JumpIfFalse  r18, L0
   Index        r19, r14, r16
@@ -38,29 +44,37 @@ func main (regs=91)
   IterPrep     r21, r2
   Len          r22, r21
   Const        r23, "movie_id"
+  Const        r23, "movie_id"
   // k.keyword == "marvel-cinematic-universe" &&
   Const        r6, "keyword"
   // n.name.contains("Downey") &&
+  Const        r7, "name"
+  Const        r8, "contains"
+  // n.name.contains("Robert") &&
   Const        r7, "name"
   Const        r8, "contains"
   // t.production_year > 2010
   Const        r9, "production_year"
   // movie_keyword: k.keyword,
   Const        r10, "movie_keyword"
+  Const        r6, "keyword"
   // actor_name: n.name,
   Const        r11, "actor_name"
+  Const        r7, "name"
   // marvel_movie: t.title
   Const        r12, "marvel_movie"
   Const        r13, "title"
   // join mk in movie_keyword on ci.movie_id == mk.movie_id
   Const        r17, 0
   Move         r24, r17
+L10:
   LessInt      r25, r24, r22
   JumpIfFalse  r25, L1
   Index        r26, r21, r24
   Move         r27, r26
   Const        r23, "movie_id"
   Index        r28, r20, r23
+  Const        r23, "movie_id"
   Index        r29, r27, r23
   Equal        r30, r28, r29
   JumpIfFalse  r30, L2
@@ -74,18 +88,24 @@ func main (regs=91)
   // n.name.contains("Downey") &&
   Const        r7, "name"
   Const        r8, "contains"
+  // n.name.contains("Robert") &&
+  Const        r7, "name"
+  Const        r8, "contains"
   // t.production_year > 2010
   Const        r9, "production_year"
   // movie_keyword: k.keyword,
   Const        r10, "movie_keyword"
+  Const        r6, "keyword"
   // actor_name: n.name,
   Const        r11, "actor_name"
+  Const        r7, "name"
   // marvel_movie: t.title
   Const        r12, "marvel_movie"
   Const        r13, "title"
   // join k in keyword on mk.keyword_id == k.id
   Const        r17, 0
   Move         r35, r17
+L9:
   LessInt      r36, r35, r32
   JumpIfFalse  r36, L2
   Index        r37, r31, r35
@@ -106,18 +126,24 @@ func main (regs=91)
   // n.name.contains("Downey") &&
   Const        r7, "name"
   Const        r8, "contains"
+  // n.name.contains("Robert") &&
+  Const        r7, "name"
+  Const        r8, "contains"
   // t.production_year > 2010
   Const        r9, "production_year"
   // movie_keyword: k.keyword,
   Const        r10, "movie_keyword"
+  Const        r6, "keyword"
   // actor_name: n.name,
   Const        r11, "actor_name"
+  Const        r7, "name"
   // marvel_movie: t.title
   Const        r12, "marvel_movie"
   Const        r13, "title"
   // join n in name on ci.person_id == n.id
   Const        r17, 0
   Move         r45, r17
+L8:
   LessInt      r46, r45, r43
   JumpIfFalse  r46, L3
   Index        r47, r42, r45
@@ -138,19 +164,24 @@ func main (regs=91)
   // n.name.contains("Downey") &&
   Const        r7, "name"
   Const        r8, "contains"
+  // n.name.contains("Robert") &&
+  Const        r7, "name"
+  Const        r8, "contains"
   // t.production_year > 2010
   Const        r9, "production_year"
-L8:
   // movie_keyword: k.keyword,
   Const        r10, "movie_keyword"
+  Const        r6, "keyword"
   // actor_name: n.name,
   Const        r11, "actor_name"
+  Const        r7, "name"
   // marvel_movie: t.title
   Const        r12, "marvel_movie"
   Const        r13, "title"
   // join t in title on ci.movie_id == t.id
   Const        r17, 0
   Move         r54, r17
+L7:
   LessInt      r55, r54, r53
   JumpIfFalse  r55, L4
   Index        r56, r52, r54
@@ -176,7 +207,6 @@ L8:
   JumpIfFalse  r67, L6
   Const        r7, "name"
   Index        r68, r48, r7
-L7:
   // n.name.contains("Downey") &&
   Const        r69, "Downey"
   In           r70, r69, r68
@@ -194,6 +224,7 @@ L7:
   // n.name.contains("Robert") &&
   JumpIfFalse  r67, L6
   Move         r67, r64
+L6:
   // k.keyword == "marvel-cinematic-universe" &&
   JumpIfFalse  r67, L5
   // movie_keyword: k.keyword,
@@ -222,12 +253,36 @@ L7:
   // from ci in cast_info
   Append       r87, r5, r86
   Move         r5, r87
+L5:
   // join t in title on ci.movie_id == t.id
   Const        r88, 1
   Add          r54, r54, r88
   Jump         L7
-L6:
+L4:
   // join n in name on ci.person_id == n.id
   Const        r88, 1
   Add          r45, r45, r88
   Jump         L8
+L3:
+  // join k in keyword on mk.keyword_id == k.id
+  Const        r88, 1
+  Add          r35, r35, r88
+  Jump         L9
+L2:
+  // join mk in movie_keyword on ci.movie_id == mk.movie_id
+  Const        r88, 1
+  Add          r24, r24, r88
+  Jump         L10
+L1:
+  // from ci in cast_info
+  Const        r88, 1
+  AddInt       r16, r16, r88
+  Jump         L11
+L0:
+  // json(result)
+  JSON         r5
+  // expect result == [
+  Const        r89, [{"actor_name": "Downey Robert Jr.", "marvel_movie": "Iron Man 3", "movie_keyword": "marvel-cinematic-universe"}]
+  Equal        r90, r5, r89
+  Expect       r90
+  Return       r0

--- a/tests/dataset/job/out/q7.ir.out
+++ b/tests/dataset/job/out/q7.ir.out
@@ -26,20 +26,32 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
   // pi.person_id == an.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
   Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
   Const        r19, "movie_id"
   Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // from an in aka_name
@@ -47,6 +59,7 @@ func main (regs=192)
   Len          r25, r24
   Const        r27, 0
   Move         r26, r27
+L21:
   LessInt      r28, r26, r25
   JumpIfFalse  r28, L0
   Index        r29, r24, r26
@@ -65,23 +78,38 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
+  // pi.person_id == an.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
   Const        r19, "movie_id"
   Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // join n in name on n.id == an.person_id
   Const        r27, 0
   Move         r34, r27
+L20:
   LessInt      r35, r34, r32
   JumpIfFalse  r35, L1
   Index        r36, r31, r34
@@ -96,6 +124,7 @@ func main (regs=192)
   IterPrep     r41, r6
   Len          r42, r41
   Const        r18, "person_id"
+  Const        r18, "person_id"
   // an.name.contains("a") &&
   Const        r9, "name"
   Const        r10, "contains"
@@ -105,29 +134,45 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
+  // pi.person_id == an.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
   Const        r19, "movie_id"
   Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // join pi in person_info on pi.person_id == an.person_id
   Const        r27, 0
   Move         r43, r27
+L19:
   LessInt      r44, r43, r42
   JumpIfFalse  r44, L2
   Index        r45, r41, r43
   Move         r46, r45
   Const        r18, "person_id"
   Index        r47, r46, r18
+  Const        r18, "person_id"
   Index        r48, r30, r18
   Equal        r49, r47, r48
   JumpIfFalse  r49, L3
@@ -145,25 +190,38 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
   // pi.person_id == an.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
   Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
   Const        r19, "movie_id"
   Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // join it in info_type on it.id == pi.info_type_id
   Const        r27, 0
   Move         r53, r27
+L18:
   LessInt      r54, r53, r51
   JumpIfFalse  r54, L3
   Index        r55, r50, r53
@@ -188,23 +246,38 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
+  // pi.person_id == an.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
   Const        r19, "movie_id"
   Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // join ci in cast_info on ci.person_id == n.id
   Const        r27, 0
   Move         r62, r27
+L17:
   LessInt      r63, r62, r61
   JumpIfFalse  r63, L4
   Index        r64, r60, r62
@@ -229,24 +302,38 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
   // pi.person_id == an.person_id &&
   Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
+  Const        r19, "movie_id"
   Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // join t in title on t.id == ci.movie_id
   Const        r27, 0
   Move         r71, r27
+L16:
   LessInt      r72, r71, r70
   JumpIfFalse  r72, L5
   Index        r73, r69, r71
@@ -271,24 +358,38 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
   // pi.person_id == an.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
   Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
   Const        r19, "movie_id"
+  Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // join ml in movie_link on ml.linked_movie_id == t.id
   Const        r27, 0
   Move         r80, r27
+L15:
   LessInt      r81, r80, r79
   JumpIfFalse  r81, L6
   Index        r82, r78, r80
@@ -313,25 +414,38 @@ func main (regs=192)
   Const        r12, "link"
   // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
   Const        r13, "name_pcode_cf"
+  Const        r13, "name_pcode_cf"
   // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
   Const        r14, "gender"
+  Const        r14, "gender"
+  Const        r9, "name"
   Const        r15, "starts_with"
   // pi.note == "Volker Boehm" &&
   Const        r16, "note"
   // t.production_year >= 1980 && t.production_year <= 1995 &&
   Const        r17, "production_year"
+  Const        r17, "production_year"
   // pi.person_id == an.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
+  Const        r18, "person_id"
+  // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
   Const        r18, "person_id"
   // ci.movie_id == ml.linked_movie_id
   Const        r19, "movie_id"
   Const        r20, "linked_movie_id"
   // select { person_name: n.name, movie_title: t.title }
   Const        r21, "person_name"
+  Const        r9, "name"
   Const        r22, "movie_title"
   Const        r23, "title"
   // join lt in link_type on lt.id == ml.link_type_id
   Const        r27, 0
   Move         r90, r27
+L14:
   LessInt      r91, r90, r88
   JumpIfFalse  r91, L7
   Index        r92, r87, r90
@@ -352,6 +466,7 @@ func main (regs=192)
   Index        r100, r37, r13
   Const        r101, "A"
   LessEq       r102, r101, r100
+  Const        r13, "name_pcode_cf"
   Index        r103, r37, r13
   Const        r104, "F"
   LessEq       r105, r103, r104
@@ -360,6 +475,7 @@ func main (regs=192)
   Index        r106, r74, r17
   Const        r107, 1980
   LessEq       r108, r107, r106
+  Const        r17, "production_year"
   Index        r109, r74, r17
   Const        r110, 1995
   LessEq       r111, r109, r110
@@ -381,14 +497,19 @@ func main (regs=192)
   // pi.person_id == an.person_id &&
   Const        r18, "person_id"
   Index        r121, r46, r18
+  Const        r18, "person_id"
   Index        r122, r30, r18
   Equal        r123, r121, r122
   // pi.person_id == ci.person_id &&
+  Const        r18, "person_id"
   Index        r124, r46, r18
+  Const        r18, "person_id"
   Index        r125, r65, r18
   Equal        r126, r124, r125
   // an.person_id == ci.person_id &&
+  Const        r18, "person_id"
   Index        r127, r30, r18
+  Const        r18, "person_id"
   Index        r128, r65, r18
   Equal        r129, r127, r128
   // ci.movie_id == ml.linked_movie_id
@@ -428,7 +549,7 @@ func main (regs=192)
   Index        r142, r37, r9
   Const        r143, "B"
   Const        r144, 0
-  Const        r145, 1
+  Len          r145, r143
   Len          r146, r142
   LessEq       r147, r145, r146
   JumpIfFalse  r147, L12
@@ -437,14 +558,142 @@ func main (regs=192)
   Move         r148, r150
   Jump         L13
 L12:
+  Const        r148, false
+L13:
+  Move         r141, r148
+L11:
+  Move         r137, r141
+L10:
+  // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
+  Move         r133, r137
+  // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
+  JumpIfFalse  r133, L9
+  Move         r133, r120
+  // pi.note == "Volker Boehm" &&
+  JumpIfFalse  r133, L9
+  Move         r133, r108
+  // t.production_year >= 1980 && t.production_year <= 1995 &&
+  JumpIfFalse  r133, L9
+  Move         r133, r111
+  JumpIfFalse  r133, L9
+  Move         r133, r123
+  // pi.person_id == an.person_id &&
+  JumpIfFalse  r133, L9
+  Move         r133, r126
+  // pi.person_id == ci.person_id &&
+  JumpIfFalse  r133, L9
+  Move         r133, r129
+  // an.person_id == ci.person_id &&
+  JumpIfFalse  r133, L9
+  Move         r133, r132
+L9:
+  // where (
+  JumpIfFalse  r133, L8
+  // select { person_name: n.name, movie_title: t.title }
+  Const        r151, "person_name"
+  Const        r9, "name"
+  Index        r152, r37, r9
+  Const        r153, "movie_title"
+  Const        r23, "title"
+  Index        r154, r74, r23
+  Move         r155, r151
+  Move         r156, r152
+  Move         r157, r153
+  Move         r158, r154
+  MakeMap      r159, 2, r155
+  // from an in aka_name
+  Append       r160, r8, r159
+  Move         r8, r160
+L8:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r161, 1
+  Add          r90, r90, r161
+  Jump         L14
+L7:
+  // join ml in movie_link on ml.linked_movie_id == t.id
+  Const        r161, 1
+  Add          r80, r80, r161
+  Jump         L15
+L6:
+  // join t in title on t.id == ci.movie_id
+  Const        r161, 1
+  Add          r71, r71, r161
+  Jump         L16
+L5:
+  // join ci in cast_info on ci.person_id == n.id
+  Const        r161, 1
+  Add          r62, r62, r161
+  Jump         L17
+L4:
+  // join it in info_type on it.id == pi.info_type_id
+  Const        r161, 1
+  Add          r53, r53, r161
+  Jump         L18
+L3:
+  // join pi in person_info on pi.person_id == an.person_id
+  Const        r161, 1
+  Add          r43, r43, r161
+  Jump         L19
+L2:
+  // join n in name on n.id == an.person_id
+  Const        r161, 1
+  Add          r34, r34, r161
+  Jump         L20
+L1:
+  // from an in aka_name
+  Const        r161, 1
+  AddInt       r26, r26, r161
+  Jump         L21
+L0:
+  // of_person: min(from r in rows select r.person_name),
+  Const        r163, "of_person"
+  Const        r164, []
+  Const        r21, "person_name"
+  IterPrep     r165, r8
+  Len          r166, r165
+  Const        r27, 0
+  Move         r167, r27
+L23:
+  LessInt      r168, r167, r166
+  JumpIfFalse  r168, L22
+  Index        r169, r165, r167
+  Move         r170, r169
+  Const        r21, "person_name"
+  Index        r171, r170, r21
+  Append       r172, r164, r171
+  Move         r164, r172
+  Const        r161, 1
+  AddInt       r167, r167, r161
+  Jump         L23
+L22:
+  Min          r173, r164
+  // biography_movie: min(from r in rows select r.movie_title)
+  Const        r174, "biography_movie"
+  Const        r175, []
+  Const        r22, "movie_title"
+  IterPrep     r176, r8
+  Len          r177, r176
+  Const        r27, 0
+  Move         r178, r27
+L25:
+  LessInt      r179, r178, r177
+  JumpIfFalse  r179, L24
+  Index        r180, r176, r178
+  Move         r170, r180
+  Const        r22, "movie_title"
+  Index        r181, r170, r22
+  Append       r182, r175, r181
+  Move         r175, r182
+  Const        r161, 1
+  AddInt       r178, r178, r161
+  Jump         L25
+L24:
+  Min          r183, r175
   // of_person: min(from r in rows select r.person_name),
   Move         r184, r163
-L13:
   Move         r185, r173
-L11:
   // biography_movie: min(from r in rows select r.movie_title)
   Move         r186, r174
-L10:
   Move         r187, r183
   // {
   MakeMap      r188, 2, r184

--- a/tests/dataset/job/out/q8.ir.out
+++ b/tests/dataset/job/out/q8.ir.out
@@ -20,13 +20,22 @@ func main (regs=147)
   // cn.country_code == "[jp]" &&
   Const        r9, "country_code"
   // mc.note.contains("(Japan)") &&
+  Const        r8, "note"
+  Const        r10, "contains"
+  // (!mc.note.contains("(USA)")) &&
+  Const        r8, "note"
   Const        r10, "contains"
   // n1.name.contains("Yo") &&
   Const        r11, "name"
+  Const        r10, "contains"
+  // (!n1.name.contains("Yu")) &&
+  Const        r11, "name"
+  Const        r10, "contains"
   // rt.role == "actress"
   Const        r12, "role"
   // select { pseudonym: an1.name, movie_title: t.title }
   Const        r13, "pseudonym"
+  Const        r11, "name"
   Const        r14, "movie_title"
   Const        r15, "title"
   // from an1 in aka_name
@@ -34,6 +43,7 @@ func main (regs=147)
   Len          r17, r16
   Const        r19, 0
   Move         r18, r19
+L15:
   LessInt      r20, r18, r17
   JumpIfFalse  r20, L0
   Index        r21, r16, r18
@@ -48,18 +58,28 @@ func main (regs=147)
   // cn.country_code == "[jp]" &&
   Const        r9, "country_code"
   // mc.note.contains("(Japan)") &&
+  Const        r8, "note"
+  Const        r10, "contains"
+  // (!mc.note.contains("(USA)")) &&
+  Const        r8, "note"
   Const        r10, "contains"
   // n1.name.contains("Yo") &&
   Const        r11, "name"
+  Const        r10, "contains"
+  // (!n1.name.contains("Yu")) &&
+  Const        r11, "name"
+  Const        r10, "contains"
   // rt.role == "actress"
   Const        r12, "role"
   // select { pseudonym: an1.name, movie_title: t.title }
   Const        r13, "pseudonym"
+  Const        r11, "name"
   Const        r14, "movie_title"
   Const        r15, "title"
   // join n1 in name on n1.id == an1.person_id
   Const        r19, 0
   Move         r27, r19
+L14:
   LessInt      r28, r27, r24
   JumpIfFalse  r28, L1
   Index        r29, r23, r27
@@ -74,29 +94,41 @@ func main (regs=147)
   IterPrep     r34, r1
   Len          r35, r34
   Const        r26, "person_id"
+  Const        r26, "person_id"
   // where ci.note == "(voice: English version)" &&
   Const        r8, "note"
   // cn.country_code == "[jp]" &&
   Const        r9, "country_code"
   // mc.note.contains("(Japan)") &&
+  Const        r8, "note"
+  Const        r10, "contains"
+  // (!mc.note.contains("(USA)")) &&
+  Const        r8, "note"
   Const        r10, "contains"
   // n1.name.contains("Yo") &&
   Const        r11, "name"
+  Const        r10, "contains"
+  // (!n1.name.contains("Yu")) &&
+  Const        r11, "name"
+  Const        r10, "contains"
   // rt.role == "actress"
   Const        r12, "role"
   // select { pseudonym: an1.name, movie_title: t.title }
   Const        r13, "pseudonym"
+  Const        r11, "name"
   Const        r14, "movie_title"
   Const        r15, "title"
   // join ci in cast_info on ci.person_id == an1.person_id
   Const        r19, 0
   Move         r36, r19
+L13:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L2
   Index        r38, r34, r36
   Move         r39, r38
   Const        r26, "person_id"
   Index        r40, r39, r26
+  Const        r26, "person_id"
   Index        r41, r22, r26
   Equal        r42, r40, r41
   JumpIfFalse  r42, L3
@@ -110,18 +142,28 @@ func main (regs=147)
   // cn.country_code == "[jp]" &&
   Const        r9, "country_code"
   // mc.note.contains("(Japan)") &&
+  Const        r8, "note"
+  Const        r10, "contains"
+  // (!mc.note.contains("(USA)")) &&
+  Const        r8, "note"
   Const        r10, "contains"
   // n1.name.contains("Yo") &&
   Const        r11, "name"
+  Const        r10, "contains"
+  // (!n1.name.contains("Yu")) &&
+  Const        r11, "name"
+  Const        r10, "contains"
   // rt.role == "actress"
   Const        r12, "role"
   // select { pseudonym: an1.name, movie_title: t.title }
   Const        r13, "pseudonym"
+  Const        r11, "name"
   Const        r14, "movie_title"
   Const        r15, "title"
   // join t in title on t.id == ci.movie_id
   Const        r19, 0
   Move         r46, r19
+L12:
   LessInt      r47, r46, r44
   JumpIfFalse  r47, L3
   Index        r48, r43, r46
@@ -136,29 +178,41 @@ func main (regs=147)
   IterPrep     r53, r3
   Len          r54, r53
   Const        r45, "movie_id"
+  Const        r45, "movie_id"
   // where ci.note == "(voice: English version)" &&
   Const        r8, "note"
   // cn.country_code == "[jp]" &&
   Const        r9, "country_code"
   // mc.note.contains("(Japan)") &&
+  Const        r8, "note"
+  Const        r10, "contains"
+  // (!mc.note.contains("(USA)")) &&
+  Const        r8, "note"
   Const        r10, "contains"
   // n1.name.contains("Yo") &&
   Const        r11, "name"
+  Const        r10, "contains"
+  // (!n1.name.contains("Yu")) &&
+  Const        r11, "name"
+  Const        r10, "contains"
   // rt.role == "actress"
   Const        r12, "role"
   // select { pseudonym: an1.name, movie_title: t.title }
   Const        r13, "pseudonym"
+  Const        r11, "name"
   Const        r14, "movie_title"
   Const        r15, "title"
   // join mc in movie_companies on mc.movie_id == ci.movie_id
   Const        r19, 0
   Move         r55, r19
+L11:
   LessInt      r56, r55, r54
   JumpIfFalse  r56, L4
   Index        r57, r53, r55
   Move         r58, r57
   Const        r45, "movie_id"
   Index        r59, r58, r45
+  Const        r45, "movie_id"
   Index        r60, r39, r45
   Equal        r61, r59, r60
   JumpIfFalse  r61, L5
@@ -172,18 +226,28 @@ func main (regs=147)
   // cn.country_code == "[jp]" &&
   Const        r9, "country_code"
   // mc.note.contains("(Japan)") &&
+  Const        r8, "note"
+  Const        r10, "contains"
+  // (!mc.note.contains("(USA)")) &&
+  Const        r8, "note"
   Const        r10, "contains"
   // n1.name.contains("Yo") &&
   Const        r11, "name"
+  Const        r10, "contains"
+  // (!n1.name.contains("Yu")) &&
+  Const        r11, "name"
+  Const        r10, "contains"
   // rt.role == "actress"
   Const        r12, "role"
   // select { pseudonym: an1.name, movie_title: t.title }
   Const        r13, "pseudonym"
+  Const        r11, "name"
   Const        r14, "movie_title"
   Const        r15, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r19, 0
   Move         r65, r19
+L10:
   LessInt      r66, r65, r63
   JumpIfFalse  r66, L5
   Index        r67, r62, r65
@@ -204,18 +268,28 @@ func main (regs=147)
   // cn.country_code == "[jp]" &&
   Const        r9, "country_code"
   // mc.note.contains("(Japan)") &&
+  Const        r8, "note"
+  Const        r10, "contains"
+  // (!mc.note.contains("(USA)")) &&
+  Const        r8, "note"
   Const        r10, "contains"
   // n1.name.contains("Yo") &&
   Const        r11, "name"
+  Const        r10, "contains"
+  // (!n1.name.contains("Yu")) &&
+  Const        r11, "name"
+  Const        r10, "contains"
   // rt.role == "actress"
   Const        r12, "role"
   // select { pseudonym: an1.name, movie_title: t.title }
   Const        r13, "pseudonym"
+  Const        r11, "name"
   Const        r14, "movie_title"
   Const        r15, "title"
   // join rt in role_type on rt.id == ci.role_id
   Const        r19, 0
   Move         r75, r19
+L9:
   LessInt      r76, r75, r73
   JumpIfFalse  r76, L6
   Index        r77, r72, r75
@@ -286,7 +360,7 @@ func main (regs=147)
   // (!n1.name.contains("Yu")) &&
   JumpIfFalse  r91, L8
   Move         r91, r90
-L9:
+L8:
   // where ci.note == "(voice: English version)" &&
   JumpIfFalse  r91, L7
   // select { pseudonym: an1.name, movie_title: t.title }
@@ -304,12 +378,63 @@ L9:
   // from an1 in aka_name
   Append       r115, r7, r114
   Move         r7, r115
+L7:
   // join rt in role_type on rt.id == ci.role_id
   Const        r116, 1
   Add          r75, r75, r116
   Jump         L9
-L8:
+L6:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r116, 1
+  Add          r65, r65, r116
+  Jump         L10
+L5:
+  // join mc in movie_companies on mc.movie_id == ci.movie_id
+  Const        r116, 1
+  Add          r55, r55, r116
+  Jump         L11
+L4:
+  // join t in title on t.id == ci.movie_id
+  Const        r116, 1
+  Add          r46, r46, r116
+  Jump         L12
+L3:
+  // join ci in cast_info on ci.person_id == an1.person_id
+  Const        r116, 1
+  Add          r36, r36, r116
+  Jump         L13
+L2:
+  // join n1 in name on n1.id == an1.person_id
+  Const        r116, 1
+  Add          r27, r27, r116
+  Jump         L14
+L1:
+  // from an1 in aka_name
+  Const        r116, 1
+  AddInt       r18, r18, r116
+  Jump         L15
+L0:
   // actress_pseudonym: min(from x in eligible select x.pseudonym),
+  Const        r118, "actress_pseudonym"
+  Const        r119, []
+  Const        r13, "pseudonym"
+  IterPrep     r120, r7
+  Len          r121, r120
+  Const        r19, 0
+  Move         r122, r19
+L17:
+  LessInt      r123, r122, r121
+  JumpIfFalse  r123, L16
+  Index        r124, r120, r122
+  Move         r125, r124
+  Const        r13, "pseudonym"
+  Index        r126, r125, r13
+  Append       r127, r119, r126
+  Move         r119, r127
+  Const        r116, 1
+  AddInt       r122, r122, r116
+  Jump         L17
+L16:
   Min          r128, r119
   // japanese_movie_dubbed: min(from x in eligible select x.movie_title)
   Const        r129, "japanese_movie_dubbed"
@@ -319,38 +444,35 @@ L8:
   Len          r132, r131
   Const        r19, 0
   Move         r133, r19
+L19:
   LessInt      r134, r133, r132
-  JumpIfFalse  r134, L10
+  JumpIfFalse  r134, L18
   Index        r135, r131, r133
   Move         r125, r135
   Const        r14, "movie_title"
   Index        r136, r125, r14
-L7:
   Append       r137, r130, r136
   Move         r130, r137
   Const        r116, 1
-L6:
   AddInt       r133, r133, r116
-  Jump         L11
-L5:
+  Jump         L19
+L18:
+  Min          r138, r130
   // actress_pseudonym: min(from x in eligible select x.pseudonym),
   Move         r139, r118
   Move         r140, r128
   // japanese_movie_dubbed: min(from x in eligible select x.movie_title)
   Move         r141, r129
-L4:
   Move         r142, r138
   // {
   MakeMap      r143, 2, r139
   Move         r117, r143
-L3:
   // let result = [
   MakeList     r144, 1, r117
   // json(result)
   JSON         r144
   // expect result == [
   Const        r145, [{"actress_pseudonym": "Y. S.", "japanese_movie_dubbed": "Dubbed Film"}]
-L2:
   Equal        r146, r144, r145
   Expect       r146
   Return       r0

--- a/tests/dataset/job/out/q9.ir.out
+++ b/tests/dataset/job/out/q9.ir.out
@@ -22,18 +22,25 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // from an in aka_name
@@ -41,6 +48,7 @@ func main (regs=182)
   Len          r21, r20
   Const        r23, 0
   Move         r22, r23
+L18:
   LessInt      r24, r22, r21
   JumpIfFalse  r24, L0
   Index        r25, r20, r22
@@ -55,23 +63,31 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // join n in name on an.person_id == n.id
   Const        r23, 0
   Move         r31, r23
+L17:
   LessInt      r32, r31, r28
   JumpIfFalse  r32, L1
   Index        r33, r27, r31
@@ -92,23 +108,31 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // join ci in cast_info on ci.person_id == n.id
   Const        r23, 0
   Move         r40, r23
+L16:
   LessInt      r41, r40, r39
   JumpIfFalse  r41, L2
   Index        r42, r38, r40
@@ -129,23 +153,31 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // join chn in char_name on chn.id == ci.person_role_id
   Const        r23, 0
   Move         r50, r23
+L15:
   LessInt      r51, r50, r48
   JumpIfFalse  r51, L3
   Index        r52, r47, r50
@@ -166,23 +198,31 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // join t in title on t.id == ci.movie_id
   Const        r23, 0
   Move         r60, r23
+L14:
   LessInt      r61, r60, r58
   JumpIfFalse  r61, L4
   Index        r62, r57, r60
@@ -203,23 +243,31 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // join mc in movie_companies on mc.movie_id == t.id
   Const        r23, 0
   Move         r69, r23
+L13:
   LessInt      r70, r69, r68
   JumpIfFalse  r70, L5
   Index        r71, r67, r69
@@ -240,23 +288,31 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // join cn in company_name on cn.id == mc.company_id
   Const        r23, 0
   Move         r79, r23
+L12:
   LessInt      r80, r79, r77
   JumpIfFalse  r80, L6
   Index        r81, r76, r79
@@ -277,23 +333,31 @@ func main (regs=182)
   // cn.country_code == "[us]" &&
   Const        r10, "country_code"
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r9, "note"
+  Const        r11, "contains"
+  Const        r9, "note"
   Const        r11, "contains"
   // n.gender == "f" &&
   Const        r12, "gender"
   // n.name.contains("Ang") &&
   Const        r13, "name"
+  Const        r11, "contains"
   // rt.role == "actress" &&
   Const        r14, "role"
   // t.production_year >= 2005 && t.production_year <= 2015
   Const        r15, "production_year"
+  Const        r15, "production_year"
   // select { alt: an.name, character: chn.name, movie: t.title }
   Const        r16, "alt"
+  Const        r13, "name"
   Const        r17, "character"
+  Const        r13, "name"
   Const        r18, "movie"
   Const        r19, "title"
   // join rt in role_type on rt.id == ci.role_id
   Const        r23, 0
   Move         r89, r23
+L11:
   LessInt      r90, r89, r87
   JumpIfFalse  r90, L7
   Index        r91, r86, r89
@@ -314,6 +378,7 @@ func main (regs=182)
   Index        r99, r63, r15
   Const        r100, 2005
   LessEq       r101, r100, r99
+  Const        r15, "production_year"
   Index        r102, r63, r15
   Const        r103, 2015
   LessEq       r104, r102, r103
@@ -350,6 +415,7 @@ func main (regs=182)
   Const        r120, "(worldwide)"
   In           r121, r120, r119
   Move         r118, r121
+L10:
   // cn.country_code == "[us]" &&
   Move         r114, r118
   // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
@@ -362,7 +428,6 @@ func main (regs=182)
   // n.name.contains("Ang") &&
   Const        r123, "Ang"
   In           r124, r123, r122
-L11:
   // n.gender == "f" &&
   Move         r114, r124
   // n.name.contains("Ang") &&
@@ -374,6 +439,7 @@ L11:
   // t.production_year >= 2005 && t.production_year <= 2015
   JumpIfFalse  r114, L9
   Move         r114, r104
+L9:
   // where (ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) &&
   JumpIfFalse  r114, L8
   // select { alt: an.name, character: chn.name, movie: t.title }
@@ -381,6 +447,7 @@ L11:
   Const        r13, "name"
   Index        r126, r26, r13
   Const        r127, "character"
+  Const        r13, "name"
   Index        r128, r53, r13
   Const        r129, "movie"
   Const        r19, "title"
@@ -395,11 +462,47 @@ L11:
   // from an in aka_name
   Append       r138, r8, r137
   Move         r8, r138
+L8:
   // join rt in role_type on rt.id == ci.role_id
   Const        r139, 1
   Add          r89, r89, r139
   Jump         L11
-L10:
+L7:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r139, 1
+  Add          r79, r79, r139
+  Jump         L12
+L6:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r139, 1
+  Add          r69, r69, r139
+  Jump         L13
+L5:
+  // join t in title on t.id == ci.movie_id
+  Const        r139, 1
+  Add          r60, r60, r139
+  Jump         L14
+L4:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r139, 1
+  Add          r50, r50, r139
+  Jump         L15
+L3:
+  // join ci in cast_info on ci.person_id == n.id
+  Const        r139, 1
+  Add          r40, r40, r139
+  Jump         L16
+L2:
+  // join n in name on an.person_id == n.id
+  Const        r139, 1
+  Add          r31, r31, r139
+  Jump         L17
+L1:
+  // from an in aka_name
+  Const        r139, 1
+  AddInt       r22, r22, r139
+  Jump         L18
+L0:
   // alternative_name: min(from x in matches select x.alt),
   Const        r141, "alternative_name"
   Const        r142, []
@@ -408,51 +511,66 @@ L10:
   Len          r144, r143
   Const        r23, 0
   Move         r145, r23
+L20:
   LessInt      r146, r145, r144
-  JumpIfFalse  r146, L12
+  JumpIfFalse  r146, L19
   Index        r147, r143, r145
   Move         r148, r147
   Const        r16, "alt"
   Index        r149, r148, r16
   Append       r150, r142, r149
   Move         r142, r150
-L9:
   Const        r139, 1
   AddInt       r145, r145, r139
-  Jump         L13
-L8:
+  Jump         L20
+L19:
+  Min          r151, r142
   // character_name: min(from x in matches select x.character),
+  Const        r152, "character_name"
+  Const        r153, []
+  Const        r17, "character"
+  IterPrep     r154, r8
+  Len          r155, r154
+  Const        r23, 0
+  Move         r156, r23
+L22:
+  LessInt      r157, r156, r155
+  JumpIfFalse  r157, L21
+  Index        r158, r154, r156
+  Move         r148, r158
+  Const        r17, "character"
+  Index        r159, r148, r17
+  Append       r160, r153, r159
+  Move         r153, r160
   Const        r139, 1
   AddInt       r156, r156, r139
-  Jump         L14
-L7:
+  Jump         L22
+L21:
   Min          r161, r153
   // movie: min(from x in matches select x.movie)
   Const        r162, "movie"
   Const        r163, []
-L6:
   Const        r18, "movie"
   IterPrep     r164, r8
   Len          r165, r164
-L5:
   Const        r23, 0
   Move         r166, r23
+L24:
   LessInt      r167, r166, r165
-L4:
-  JumpIfFalse  r167, L15
+  JumpIfFalse  r167, L23
   Index        r168, r164, r166
   Move         r148, r168
-L3:
   Const        r18, "movie"
   Index        r169, r148, r18
   Append       r170, r163, r169
-L2:
   Move         r163, r170
   Const        r139, 1
   AddInt       r166, r166, r139
-  Jump         L1
-L0:
+  Jump         L24
+L23:
+  Min          r171, r163
   // alternative_name: min(from x in matches select x.alt),
+  Move         r172, r141
   Move         r173, r151
   // character_name: min(from x in matches select x.character),
   Move         r174, r152
@@ -463,7 +581,6 @@ L0:
   // {
   MakeMap      r178, 3, r172
   Move         r140, r178
-L13:
   // let result = [
   MakeList     r179, 1, r140
   // json(result)


### PR DESCRIPTION
## Summary
- regenerate dataset/job IR outputs using `update_job`
- confirm JOB VM tests pass without optimization

## Testing
- `MOCHI_NO_OPT=1 go test ./tests/vm -run TestVM_JOB -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686615657e9c8320b147448f1e5947ca