### PR TITLE
Add C backend golden tests for SLT dataset

### DIFF
--- a/compile/x/c/slt_golden_test.go
+++ b/compile/x/c/slt_golden_test.go
@@ -1,0 +1,69 @@
+//go:build slow
+
+package ccode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	ccode "mochi/compile/x/c"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestCCompiler_SLT_Golden(t *testing.T) {
+	cc, err := ccode.EnsureCC()
+	if err != nil {
+		t.Skipf("C compiler not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	groups := []string{"select1"}
+	for _, g := range groups {
+		for i := 1; i <= 5; i++ {
+			caseName := fmt.Sprintf("case%d", i)
+			src := filepath.Join(root, "tests", "dataset", "slt", "out", g, caseName+".mochi")
+			if _, err := os.Stat(src); err != nil {
+				continue
+			}
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := ccode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			srcFile := filepath.Join(tmp, "prog.c")
+			if err := os.WriteFile(srcFile, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			bin := filepath.Join(tmp, "prog")
+			if out, err := exec.Command(cc, srcFile, "-o", bin).CombinedOutput(); err != nil {
+				t.Skipf("cc error: %v\n%s", err, out)
+			}
+			out, err := exec.Command(bin).CombinedOutput()
+			if err != nil {
+				t.Skipf("run error: %v\n%s", err, out)
+			}
+			gotOut := bytes.TrimSpace(out)
+			wantOutPath := filepath.Join(root, "tests", "dataset", "slt", "out", g, caseName+".out")
+			wantOut, err := os.ReadFile(wantOutPath)
+			if err != nil {
+				t.Fatalf("read golden output: %v", err)
+			}
+			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s/%s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", g, caseName, gotOut, bytes.TrimSpace(wantOut))
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `slt_golden_test.go` to verify C backend builds and runs SQLLogicTest
  programs

## Testing
- `go test ./...`
- `go test ./... -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686617c3b8548320bb52ba4f7345354d