### PR TITLE
Add VM SLT golden tests

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -36,6 +36,7 @@ The VM supports a small but useful subset of Mochi:
 * Test blocks with `expect` statements
 * Capable of running the full suite of simplified TPC‑DS benchmark queries
 * Able to execute the JOB dataset benchmark queries used for compiler testing
+* Golden tests cover the generated SQLLogicTest programs under `tests/dataset/slt`
 
 ## Unsupported features
 


### PR DESCRIPTION
## Summary
- add runtime/vm README note on SQLLogicTest coverage
- test SLT dataset Mochi files with the runtime VM

## Testing
- `go test ./...`
- `go test -tags slow ./...` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68661edfe210832080d543b736e5633e