### PR TITLE
Update SQLLogicTest generator

### DIFF
--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -351,7 +351,7 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 		if t == "" {
 			return "any"
 		}
-		return "any"
+		return t
 	}
 
 	if t == "int" && boolLike && (seenZero || seenOne || seenNegOne) {


### PR DESCRIPTION
## Summary
- preserve column type when nulls are present during SLT generation
- regenerate select2 cases 700-799

## Testing
- `go vet ./...`
- `go run ./cmd/mochi-slt gen --cases case700-case799 --files select2.test --run`

------
https://chatgpt.com/codex/tasks/task_e_686666e9fa848320bcf74447a42126e0