### PR TITLE
Update SLT select2 case500-599

### DIFF
--- a/tests/dataset/slt/out/select2/case500.mochi
+++ b/tests/dataset/slt/out/select2/case500.mochi
@@ -232,6 +232,9 @@ var result = from row in t1
   where x.b < row.b
   select x) > 0 && (row.d < 110 || row.d > 150)) && row.b > row.c)
   select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.e, (row.c - row.d), row.b, (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case501.mochi
+++ b/tests/dataset/slt/out/select2/case501.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where row.b > row.c
   select [row.e, ((row.a + (row.b * 2)) + (row.c * 3)), (row.a + (row.b * 2)), row.a, (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case503.mochi
+++ b/tests/dataset/slt/out/select2/case503.mochi
@@ -228,6 +228,9 @@ var result = from row in t1
   select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), count(from x in t1
   where x.b < row.b
   select x)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case504.mochi
+++ b/tests/dataset/slt/out/select2/case504.mochi
@@ -231,6 +231,9 @@ var result = from row in t1
   select [count(from x in t1
   where x.b < row.b
   select x), row.a, (row.a - row.b), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case505.mochi
+++ b/tests/dataset/slt/out/select2/case505.mochi
@@ -231,6 +231,9 @@ var result = from row in t1
   select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.a]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case506.mochi
+++ b/tests/dataset/slt/out/select2/case506.mochi
@@ -228,6 +228,9 @@ var result = from row in t1
   select [row.c, count(from x in t1
   where x.b < row.b
   select x), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.a]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case507.mochi
+++ b/tests/dataset/slt/out/select2/case507.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where ((row.e > row.c || row.e < row.d))
   select [(row.a + (row.b * 2)), (row.c - row.d), row.e, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case508.mochi
+++ b/tests/dataset/slt/out/select2/case508.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), row.c, (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (row.d - row.e), (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case509.mochi
+++ b/tests/dataset/slt/out/select2/case509.mochi
@@ -228,6 +228,9 @@ var result = from row in t1
   select [row.c, ((row.a + (row.b * 2)) + (row.c * 3)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case510.mochi
+++ b/tests/dataset/slt/out/select2/case510.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where (((row.e > row.c || row.e < row.d)) && row.b > row.c)
   select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.c - row.d)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case511.mochi
+++ b/tests/dataset/slt/out/select2/case511.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(row.d - row.e), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case512.mochi
+++ b/tests/dataset/slt/out/select2/case512.mochi
@@ -229,6 +229,9 @@ let sub0 = avg(from x in t1
 
 var result = from row in t1
   select [(row.a + (row.b * 2)), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case513.mochi
+++ b/tests/dataset/slt/out/select2/case513.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (((row.d < 110 || row.d > 150) && row.a > row.b) && row.d > row.e)
   select [row.b, (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case515.mochi
+++ b/tests/dataset/slt/out/select2/case515.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130))
   select [(if row.a < 0 { -(row.a) } else { row.a }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.a]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case516.mochi
+++ b/tests/dataset/slt/out/select2/case516.mochi
@@ -229,6 +229,9 @@ let sub0 = avg(from x in t1
 
 var result = from row in t1
   select [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.b - row.c), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.a + (row.b * 2)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case517.mochi
+++ b/tests/dataset/slt/out/select2/case517.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.d > row.e || (row.d < 110 || row.d > 150)) || ((row.c <= (row.d - 2) || row.c >= (row.d + 2))))
   select [(row.a + (row.b * 2)), (row.a - row.b), row.b, row.d]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case518.mochi
+++ b/tests/dataset/slt/out/select2/case518.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)) || ((row.a > (row.b - 2) && row.a < (row.b + 2))))
   select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((row.a + (row.b * 2)) + (row.c * 3))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case519.mochi
+++ b/tests/dataset/slt/out/select2/case519.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, abs(b-c), d, e, d-e FROM t1 */
 var result = from row in t1
   select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.d, row.e, (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case520.mochi
+++ b/tests/dataset/slt/out/select2/case520.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where ((((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130)) && row.c > row.d) && row.b > row.c)
   select [(row.a + (row.b * 2)), (row.b - row.c), row.c, row.b, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case521.mochi
+++ b/tests/dataset/slt/out/select2/case521.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.a == null || ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))) || row.b > row.c)
   select [(row.c - row.d), row.a, (row.a + (row.b * 2)), (if row.a < 0 { -(row.a) } else { row.a }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), row.c]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case522.mochi
+++ b/tests/dataset/slt/out/select2/case522.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (((if row.a != null { row.a } else { (if row.b != null { row.b } else { (if row.c != null { row.c } else { (if row.d != null { row.d } else { row.e }) }) }) }) != 0 || row.a == null) || (row.d < 110 || row.d > 150))
   select [(row.b - row.c), (row.a + (row.b * 2)), ((row.a + (row.b * 2)) + (row.c * 3))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case524.mochi
+++ b/tests/dataset/slt/out/select2/case524.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.e + row.d) >= ((row.a + row.b) - 10) && (row.e + row.d) <= (row.c + 130))
   select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case525.mochi
+++ b/tests/dataset/slt/out/select2/case525.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (row.b != null && (row.d < 110 || row.d > 150))
   select [(if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case527.mochi
+++ b/tests/dataset/slt/out/select2/case527.mochi
@@ -232,6 +232,9 @@ var result = from row in t1
   where x.b < row.b
   select x) > 0 || ((row.c <= (row.d - 2) || row.c >= (row.d + 2))))
   select [(row.a - row.b), row.c, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (row.b - row.c), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case528.mochi
+++ b/tests/dataset/slt/out/select2/case528.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [count(from x in t1
   where x.b < row.b
   select x), row.c, row.d, (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.a + (row.b * 2)), (row.c - row.d), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case529.mochi
+++ b/tests/dataset/slt/out/select2/case529.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where row.a == null
   select [row.a, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.a - row.b), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case530.mochi
+++ b/tests/dataset/slt/out/select2/case530.mochi
@@ -231,6 +231,9 @@ var result = from row in t1
   select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), count(from x in t1
   where x.b < row.b
   select x), (row.d - row.e), ((row.a + (row.b * 2)) + (row.c * 3)), (row.c - row.d), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case531.mochi
+++ b/tests/dataset/slt/out/select2/case531.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   where x.b < row.b
   select x) > 0)
   select [(if row.a < 0 { -(row.a) } else { row.a }), row.c, (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.b - row.c)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case532.mochi
+++ b/tests/dataset/slt/out/select2/case532.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (((if row.a != null { row.a } else { (if row.b != null { row.b } else { (if row.c != null { row.c } else { (if row.d != null { row.d } else { row.e }) }) }) }) != 0 && row.c > row.d) && ((row.c <= (row.d - 2) || row.c >= (row.d + 2))))
   select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), row.c, (if row.a < 0 { -(row.a) } else { row.a })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case533.mochi
+++ b/tests/dataset/slt/out/select2/case533.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (row.a == null || row.b > row.c)
   select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.b, (row.a - row.b), row.a, ((row.a + (row.b * 2)) + (row.c * 3))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case534.mochi
+++ b/tests/dataset/slt/out/select2/case534.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.a - row.b), (row.b - row.c), row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where x.b < row.b
   select x)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case535.mochi
+++ b/tests/dataset/slt/out/select2/case535.mochi
@@ -230,6 +230,9 @@ var result = from row in t1
   select x), count(from x in t1
   where x.b < row.b
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.c, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case536.mochi
+++ b/tests/dataset/slt/out/select2/case536.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where (row.d < 110 || row.d > 150)
   select [(if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.c - row.d)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case538.mochi
+++ b/tests/dataset/slt/out/select2/case538.mochi
@@ -228,6 +228,9 @@ var result = from row in t1
   select [count(from x in t1
   where x.b < row.b
   select x), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case539.mochi
+++ b/tests/dataset/slt/out/select2/case539.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))
   select [(row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case540.mochi
+++ b/tests/dataset/slt/out/select2/case540.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where row.b != null
   select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case541.mochi
+++ b/tests/dataset/slt/out/select2/case541.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [row.b, row.c, row.e, (if row.a < 0 { -(row.a) } else { row.a }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case542.mochi
+++ b/tests/dataset/slt/out/select2/case542.mochi
@@ -229,6 +229,9 @@ let sub0 = avg(from x in t1
 
 var result = from row in t1
   select [(row.a - row.b), row.c, row.b, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((row.a + (row.b * 2)) + (row.c * 3))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case543.mochi
+++ b/tests/dataset/slt/out/select2/case543.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, c-d, a+b*2+c*3+d*4+e*5, d FROM t1 */
 var result = from row in t1
   select [(if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (row.c - row.d), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.d]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case544.mochi
+++ b/tests/dataset/slt/out/select2/case544.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   where x.b < row.b
   select x) > 0 && row.b != null) && ((row.a > (row.b - 2) && row.a < (row.b + 2))))
   select [(row.a - row.b), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < 0 { -(row.a) } else { row.a })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case545.mochi
+++ b/tests/dataset/slt/out/select2/case545.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case546.mochi
+++ b/tests/dataset/slt/out/select2/case546.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((row.a + (row.b * 2)) + (row.c * 3)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case547.mochi
+++ b/tests/dataset/slt/out/select2/case547.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.a > row.b && row.d > row.e) && ((row.a > (row.b - 2) && row.a < (row.b + 2))))
   select [(row.a + (row.b * 2)), (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case548.mochi
+++ b/tests/dataset/slt/out/select2/case548.mochi
@@ -232,6 +232,9 @@ var result = from row in t1
   select [count(from x in t1
   where x.b < row.b
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.c - row.d)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case549.mochi
+++ b/tests/dataset/slt/out/select2/case549.mochi
@@ -232,6 +232,9 @@ var result = from row in t1
   select [row.d, (row.c - row.d), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where x.b < row.b
   select x)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case550.mochi
+++ b/tests/dataset/slt/out/select2/case550.mochi
@@ -231,6 +231,9 @@ var result = from row in t1
   select [(row.a - row.b), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), row.c, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.e, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case551.mochi
+++ b/tests/dataset/slt/out/select2/case551.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (((row.c <= (row.d - 2) || row.c >= (row.d + 2))) || row.c > row.d)
   select [row.a, (if row.a < 0 { -(row.a) } else { row.a }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (row.a + (row.b * 2))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case552.mochi
+++ b/tests/dataset/slt/out/select2/case552.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT c, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END FROM t1 */
 var result = from row in t1
   select [row.c, (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case553.mochi
+++ b/tests/dataset/slt/out/select2/case553.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.d > row.e && row.c > row.d) && (if row.a != null { row.a } else { (if row.b != null { row.b } else { (if row.c != null { row.c } else { (if row.d != null { row.d } else { row.e }) }) }) }) != 0)
   select [(row.b - row.c), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.b, (row.c - row.d), ((row.a + (row.b * 2)) + (row.c * 3))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case554.mochi
+++ b/tests/dataset/slt/out/select2/case554.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where row.d > row.e
   select [row.b, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (row.a - row.b), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case555.mochi
+++ b/tests/dataset/slt/out/select2/case555.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [row.c, count(from x in t1
   where x.b < row.b
   select x), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), row.a, (row.a + (row.b * 2))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case557.mochi
+++ b/tests/dataset/slt/out/select2/case557.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT a+b*2, b-c, c-d FROM t1 */
 var result = from row in t1
   select [(row.a + (row.b * 2)), (row.b - row.c), (row.c - row.d)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case558.mochi
+++ b/tests/dataset/slt/out/select2/case558.mochi
@@ -228,6 +228,9 @@ var result = from row in t1
   select [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case559.mochi
+++ b/tests/dataset/slt/out/select2/case559.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.d - row.e), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case560.mochi
+++ b/tests/dataset/slt/out/select2/case560.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where row.d > row.e
   select [row.a, (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case561.mochi
+++ b/tests/dataset/slt/out/select2/case561.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT abs(b-c), a-b, c-d, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, b-c FROM t1 */
 var result = from row in t1
   select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.a - row.b), (row.c - row.d), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (row.b - row.c)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case562.mochi
+++ b/tests/dataset/slt/out/select2/case562.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), count(from x in t1
   where x.b < row.b
   select x), (row.c - row.d), (row.d - row.e), ((row.a + (row.b * 2)) + (row.c * 3))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case564.mochi
+++ b/tests/dataset/slt/out/select2/case564.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT (a+b+c+d+e)/5, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, b, c-d, d, a+b*2+c*3+d*4, a+b*2+c*3 FROM t1 */
 var result = from row in t1
   select [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.b, (row.c - row.d), row.d, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((row.a + (row.b * 2)) + (row.c * 3))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case565.mochi
+++ b/tests/dataset/slt/out/select2/case565.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where (((row.a > (row.b - 2) && row.a < (row.b + 2))) || row.c > row.d)
   select [row.a, (row.d - row.e), row.e, ((row.a + (row.b * 2)) + (row.c * 3)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), row.c, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case567.mochi
+++ b/tests/dataset/slt/out/select2/case567.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(row.c - row.d), count(from x in t1
   where x.b < row.b
   select x), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.a - row.b), (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case569.mochi
+++ b/tests/dataset/slt/out/select2/case569.mochi
@@ -228,6 +228,9 @@ var result = from row in t1
   select [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (row.b - row.c), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (row.c - row.d)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case570.mochi
+++ b/tests/dataset/slt/out/select2/case570.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case571.mochi
+++ b/tests/dataset/slt/out/select2/case571.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [row.b, (row.d - row.e), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), count(from x in t1
   where x.b < row.b
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case572.mochi
+++ b/tests/dataset/slt/out/select2/case572.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT e, a+b*2, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, a+b*2+c*3+d*4+e*5 FROM t1 */
 var result = from row in t1
   select [row.e, (row.a + (row.b * 2)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case573.mochi
+++ b/tests/dataset/slt/out/select2/case573.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where ((row.d > row.e && row.a > row.b) && (row.d < 110 || row.d > 150))
   select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b, row.e, (row.c - row.d), (row.b - row.c), row.d]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case574.mochi
+++ b/tests/dataset/slt/out/select2/case574.mochi
@@ -232,6 +232,9 @@ var result = from row in t1
   where x.b < row.b
   select x) > 0
   select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.b, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.c, ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case575.mochi
+++ b/tests/dataset/slt/out/select2/case575.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where row.a > row.b
   select [row.c, (row.a - row.b)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case576.mochi
+++ b/tests/dataset/slt/out/select2/case576.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where (row.c > row.d || (row.c >= (row.b - 2) && row.c <= (row.d + 2)))
   select [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.c - row.d), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), row.a, row.b, (if row.a < 0 { -(row.a) } else { row.a })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case577.mochi
+++ b/tests/dataset/slt/out/select2/case577.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where row.a == null
   select [(if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.b]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case578.mochi
+++ b/tests/dataset/slt/out/select2/case578.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.a]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case579.mochi
+++ b/tests/dataset/slt/out/select2/case579.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (row.a + (row.b * 2)), ((row.a + (row.b * 2)) + (row.c * 3)), (row.d - row.e), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case580.mochi
+++ b/tests/dataset/slt/out/select2/case580.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   where x.b < row.b
   select x) > 0 || row.a > row.b) || (row.c >= (row.b - 2) && row.c <= (row.d + 2)))
   select [row.d, (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), row.a, (row.c - row.d), (row.a - row.b), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case581.mochi
+++ b/tests/dataset/slt/out/select2/case581.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(row.a - row.b), (row.c - row.d), count(from x in t1
   where x.b < row.b
   select x), (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case582.mochi
+++ b/tests/dataset/slt/out/select2/case582.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where row.c > row.d
   select [(row.c - row.d), (row.a + (row.b * 2)), (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case583.mochi
+++ b/tests/dataset/slt/out/select2/case583.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT (a+b+c+d+e)/5, abs(b-c), a+b*2+c*3, a+b*2+c*3+d*4 FROM t1 */
 var result = from row in t1
   select [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((row.a + (row.b * 2)) + (row.c * 3)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case584.mochi
+++ b/tests/dataset/slt/out/select2/case584.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where row.d > row.e
   select [(row.a - row.b), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case586.mochi
+++ b/tests/dataset/slt/out/select2/case586.mochi
@@ -226,6 +226,9 @@ let t1 = [
 /* SELECT d-e, c-d FROM t1 */
 var result = from row in t1
   select [(row.d - row.e), (row.c - row.d)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case587.mochi
+++ b/tests/dataset/slt/out/select2/case587.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((if row.a != null { row.a } else { (if row.b != null { row.b } else { (if row.c != null { row.c } else { (if row.d != null { row.d } else { row.e }) }) }) }) != 0 && ((row.e > row.c || row.e < row.d)))
   select [(row.c - row.d), row.d, (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.d - row.e), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (row.b - row.c)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case588.mochi
+++ b/tests/dataset/slt/out/select2/case588.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.b != null || ((row.a > (row.b - 2) && row.a < (row.b + 2)))) || ((row.e > row.a && row.e < row.b)))
   select [(if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.b, (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if row.a < 0 { -(row.a) } else { row.a })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case589.mochi
+++ b/tests/dataset/slt/out/select2/case589.mochi
@@ -228,6 +228,9 @@ var result = from row in t1
   select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.e, row.d]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case590.mochi
+++ b/tests/dataset/slt/out/select2/case590.mochi
@@ -230,6 +230,9 @@ let sub0 = avg(from x in t1
 var result = from row in t1
   where ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))
   select [(row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a }), (row.a + (row.b * 2)), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.d - row.e), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.a]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case591.mochi
+++ b/tests/dataset/slt/out/select2/case591.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where row.b != null
   select [row.a, (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.d]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case592.mochi
+++ b/tests/dataset/slt/out/select2/case592.mochi
@@ -229,6 +229,9 @@ var result = from row in t1
   select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (row.a - row.b), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case593.mochi
+++ b/tests/dataset/slt/out/select2/case593.mochi
@@ -234,6 +234,9 @@ var result = from row in t1
   select x), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), row.a, count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case594.mochi
+++ b/tests/dataset/slt/out/select2/case594.mochi
@@ -231,6 +231,9 @@ var result = from row in t1
   select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (if row.a < 0 { -(row.a) } else { row.a }), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (row.a - row.b), row.c, row.a]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case595.mochi
+++ b/tests/dataset/slt/out/select2/case595.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where row.c > row.d
   select [(if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), (row.d - row.e), ((row.a + (row.b * 2)) + (row.c * 3)), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), row.a, row.b, (if row.a < 0 { -(row.a) } else { row.a })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case596.mochi
+++ b/tests/dataset/slt/out/select2/case596.mochi
@@ -233,6 +233,9 @@ var result = from row in t1
   select x), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), (row.d - row.e), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case597.mochi
+++ b/tests/dataset/slt/out/select2/case597.mochi
@@ -232,6 +232,9 @@ var result = from row in t1
   where x.b < row.b
   select x) > 0 && ((row.c <= (row.d - 2) || row.c >= (row.d + 2))))
   select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), (row.d - row.e), (row.c - row.d), (if row.a < 0 { -(row.a) } else { row.a }), (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case598.mochi
+++ b/tests/dataset/slt/out/select2/case598.mochi
@@ -232,6 +232,9 @@ var result = from row in t1
   select [count(from x in t1
   where (x.c > row.c && x.d < row.d)
   select x), ((row.a + (row.b * 2)) + (row.c * 3)), row.a, (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) })]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select2/case599.mochi
+++ b/tests/dataset/slt/out/select2/case599.mochi
@@ -227,6 +227,9 @@ let t1 = [
 var result = from row in t1
   where ((row.c <= (row.d - 2) || row.c >= (row.d + 2)))
   select [row.b, (row.a + (row.b * 2)), (row.b - row.c), row.a, (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (row.d - row.e)]
+result = from row in result
+  order by join(from v in row select str(v), " " )
+  select row
 var flatResult = []
 for row in result {
   for x in row {


### PR DESCRIPTION
## Summary
- regenerate select2 cases 500-599
- handle `infinity` and `nan` strings in SLT type detection

## Testing
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/mochi-slt gen --cases case500-case599 --files select2.test --run --out tests/dataset/slt/out`

------
https://chatgpt.com/codex/tasks/task_e_6866865bca9c83209d40df83f9bba871