### PR TITLE
Add max case flag for mochi-slt

### DIFF
--- a/cmd/mochi-slt/main.go
+++ b/cmd/mochi-slt/main.go
@@ -48,6 +48,7 @@ func genCmd() *cobra.Command {
 	var fileList []string
 	var start int
 	var end int
+	var max int
 	var caseRange string
 	var singleCase string
 	cmd := &cobra.Command{
@@ -82,7 +83,7 @@ func genCmd() *cobra.Command {
 					}
 				}
 			}
-			err := logic.GenerateFiles(files, outDir, run, start, end)
+			err := logic.GenerateFiles(files, outDir, run, start, end, max)
 			if err == nil && singleCase != "" && outDir != "" {
 				fmt.Fprintf(cmd.OutOrStdout(), "generated %s case %s\n", outDir, singleCase)
 			}
@@ -96,6 +97,7 @@ func genCmd() *cobra.Command {
 	cmd.Flags().IntVar(&end, "end", 0, "last case to generate (inclusive)")
 	cmd.Flags().StringVar(&caseRange, "cases", "", "case range, e.g. case5-case10")
 	cmd.Flags().StringVar(&singleCase, "case", "", "single case to generate")
+	cmd.Flags().IntVar(&max, "max", 0, "maximum number of cases to generate")
 	return cmd
 }
 

--- a/tools/slt/README.md
+++ b/tools/slt/README.md
@@ -26,6 +26,9 @@ go run ./cmd/mochi-slt fetch --files evidence/slt_lang_update.test,test/select1.
 # Convert tests to Mochi programs and execute them
 go run ./cmd/mochi-slt gen --run --out tests/dataset/slt/out
 
+# Generate at most 1000 cases from select3.test
+go run ./cmd/mochi-slt gen --files select3.test --max 1000 --run
+
 # Generate a specific range of cases
 go run ./cmd/mochi-slt gen --cases case5-case6 --files select1.test --run
 go run ./cmd/mochi-slt gen --cases case5-case6 --files select2.test --run

--- a/tools/slt/logic/utils.go
+++ b/tools/slt/logic/utils.go
@@ -255,7 +255,7 @@ func Fetch(repo string, files []string, force bool) error {
 // Generate reads SLT files and converts them into Mochi programs.
 // If run is true, the generated program is executed and the output
 // stored next to the source with a .out extension.
-func GenerateFiles(files []string, outDir string, run bool, start, end int) error {
+func GenerateFiles(files []string, outDir string, run bool, start, end, max int) error {
 	root, err := FindRepoRoot()
 	if err != nil {
 		return err
@@ -278,12 +278,16 @@ func GenerateFiles(files []string, outDir string, run bool, start, end int) erro
 		if err := os.MkdirAll(testDir, 0o755); err != nil {
 			return err
 		}
+		generated := 0
 		for i, c := range cases {
 			idx := i + 1
 			if start > 0 && idx < start {
 				continue
 			}
 			if end > 0 && idx > end {
+				break
+			}
+			if max > 0 && generated >= max {
 				break
 			}
 			exp, _, err := EvalCase(c)
@@ -327,6 +331,7 @@ func GenerateFiles(files []string, outDir string, run bool, start, end int) erro
 					fmt.Printf("ran %s\n", srcPath)
 				}
 			}
+			generated++
 		}
 	}
 	return nil

--- a/tools/slt/logic/utils_test.go
+++ b/tools/slt/logic/utils_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestGenerate(t *testing.T) {
 	outDir := t.TempDir()
-	err := GenerateFiles([]string{"evidence/slt_lang_update.test"}, outDir, true, 0, 0)
+	err := GenerateFiles([]string{"evidence/slt_lang_update.test"}, outDir, true, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("generate failed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add `--max` option to limit generated SLT cases
- implement max limit in `GenerateFiles`
- document example usage in README

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68669fc351a88320b204d470fca5f454