### PR TITLE
Support unparenthesized operations

### DIFF
--- a/tests/dataset/slt/out/select1/case1.mochi
+++ b/tests/dataset/slt/out/select1/case1.mochi
@@ -259,8 +259,8 @@ let sub0 = avg(from x in t1
   select x.c)
 
 var result = from row in t1
-  order by (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })
-  select (if row.c > sub0 { (row.a * 2) } else { (row.b * 10) })
+  order by if row.c > sub0 then row.a * 2 else row.b * 10
+  select if row.c > sub0 then row.a * 2 else row.b * 10
 for x in result {
   print(x)
 }

--- a/tests/dataset/slt/out/select1/case2.mochi
+++ b/tests/dataset/slt/out/select1/case2.mochi
@@ -225,8 +225,8 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4+e*5, (a+b+c+d+e)/5 FROM t1 ORDER BY 1,2 */
 var result = from row in t1
-  order by [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
-  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5)]
+  order by [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (row.a + row.b + row.c + row.d + row.e) / 5]
+  select [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, (row.a + row.b + row.c + row.d + row.e) / 5]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case3.mochi
+++ b/tests/dataset/slt/out/select1/case3.mochi
@@ -225,11 +225,11 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4+e*5, CASE WHEN a<b-3 THEN 111 WHEN a<=b THEN 222 WHEN a<b+3 THEN 333 ELSE 444 END, abs(b-c), (a+b+c+d+e)/5, a+b*2+c*3 FROM t1 WHERE (e>c OR e<d) AND d>e AND EXISTS(SELECT 1 FROM t1 AS x WHERE x.b<t1.b) ORDER BY 4,2,1,3,5 */
 var result = from row in t1
-  where ((((row.e > row.c || row.e < row.d)) && row.d > row.e) && count(from x in t1
+  where (row.e > row.c || row.e < row.d) && row.d > row.e && count(from x in t1
   where x.b < row.b
-  select x) > 0)
-  order by [((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), ((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((row.a + (row.b * 2)) + (row.c * 3))]
-  select [((((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)) + (row.e * 5)), (if row.a < (row.b - 3) { 111 } else { (if row.a <= row.b { 222 } else { (if row.a < (row.b + 3) { 333 } else { 444 }) }) }), (if (row.b - row.c) < 0 { -((row.b - row.c)) } else { (row.b - row.c) }), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), ((row.a + (row.b * 2)) + (row.c * 3))]
+  select x) > 0
+  order by [(row.a + row.b + row.c + row.d + row.e) / 5, if row.a < row.b - 3 then 111 else if row.a <= row.b then 222 else if row.a < row.b + 3 then 333 else 444, row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, if row.b - row.c < 0 then -(row.b - row.c) else row.b - row.c, row.a + row.b * 2 + row.c * 3]
+  select [row.a + row.b * 2 + row.c * 3 + row.d * 4 + row.e * 5, if row.a < row.b - 3 then 111 else if row.a <= row.b then 222 else if row.a < row.b + 3 then 333 else 444, if row.b - row.c < 0 then -(row.b - row.c) else row.b - row.c, (row.a + row.b + row.c + row.d + row.e) / 5, row.a + row.b * 2 + row.c * 3]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case4.mochi
+++ b/tests/dataset/slt/out/select1/case4.mochi
@@ -225,9 +225,9 @@ let t1 = [
 
 /* SELECT c, d-e, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, a+b*2+c*3+d*4, e FROM t1 WHERE d NOT BETWEEN 110 AND 150 OR c BETWEEN b-2 AND d+2 OR (e>c OR e<d) ORDER BY 1,5,3,2,4 */
 var result = from row in t1
-  where (((row.d < 110 || row.d > 150) || (row.c >= (row.b - 2) && row.c <= (row.d + 2))) || ((row.e > row.c || row.e < row.d)))
-  order by [row.c, row.e, (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (row.d - row.e), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4))]
-  select [row.c, (row.d - row.e), (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), row.e]
+  where (row.d < 110 || row.d > 150) || (row.c >= row.b - 2 && row.c <= row.d + 2) || (row.e > row.c || row.e < row.d)
+  order by [row.c, row.e, if (row.a + 1 != null && row.b != null && row.a + 1 == row.b) then 111 else if (row.a + 1 != null && row.c != null && row.a + 1 == row.c) then 222 else if (row.a + 1 != null && row.d != null && row.a + 1 == row.d) then 333 else if (row.a + 1 != null && row.e != null && row.a + 1 == row.e) then 444 else 555, row.d - row.e, row.a + row.b * 2 + row.c * 3 + row.d * 4]
+  select [row.c, row.d - row.e, if (row.a + 1 != null && row.b != null && row.a + 1 == row.b) then 111 else if (row.a + 1 != null && row.c != null && row.a + 1 == row.c) then 222 else if (row.a + 1 != null && row.d != null && row.a + 1 == row.d) then 333 else if (row.a + 1 != null && row.e != null && row.a + 1 == row.e) then 444 else 555, row.a + row.b * 2 + row.c * 3 + row.d * 4, row.e]
 var flatResult = []
 for row in result {
   for x in row {

--- a/tests/dataset/slt/out/select1/case5.mochi
+++ b/tests/dataset/slt/out/select1/case5.mochi
@@ -225,9 +225,9 @@ let t1 = [
 
 /* SELECT a+b*2+c*3+d*4, (a+b+c+d+e)/5, abs(a), e, CASE a+1 WHEN b THEN 111 WHEN c THEN 222 WHEN d THEN 333  WHEN e THEN 444 ELSE 555 END, d FROM t1 WHERE b>c AND c>d ORDER BY 3,4,5,1,2,6 */
 var result = from row in t1
-  where (row.b > row.c && row.c > row.d)
-  order by [(if row.a < 0 { -(row.a) } else { row.a }), row.e, (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), (((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), row.d]
-  select [(((row.a + (row.b * 2)) + (row.c * 3)) + (row.d * 4)), ((((((row.a + row.b) + row.c) + row.d) + row.e)) / 5), (if row.a < 0 { -(row.a) } else { row.a }), row.e, (if ((row.a + 1) != null && row.b != null && (row.a + 1) == row.b) { 111 } else { (if ((row.a + 1) != null && row.c != null && (row.a + 1) == row.c) { 222 } else { (if ((row.a + 1) != null && row.d != null && (row.a + 1) == row.d) { 333 } else { (if ((row.a + 1) != null && row.e != null && (row.a + 1) == row.e) { 444 } else { 555 }) }) }) }), row.d]
+  where row.b > row.c && row.c > row.d
+  order by [if row.a < 0 then -(row.a) else row.a, row.e, if (row.a + 1 != null && row.b != null && row.a + 1 == row.b) then 111 else if (row.a + 1 != null && row.c != null && row.a + 1 == row.c) then 222 else if (row.a + 1 != null && row.d != null && row.a + 1 == row.d) then 333 else if (row.a + 1 != null && row.e != null && row.a + 1 == row.e) then 444 else 555, row.a + row.b * 2 + row.c * 3 + row.d * 4, (row.a + row.b + row.c + row.d + row.e) / 5, row.d]
+  select [row.a + row.b * 2 + row.c * 3 + row.d * 4, (row.a + row.b + row.c + row.d + row.e) / 5, if row.a < 0 then -(row.a) else row.a, row.e, if (row.a + 1 != null && row.b != null && row.a + 1 == row.b) then 111 else if (row.a + 1 != null && row.c != null && row.a + 1 == row.c) then 222 else if (row.a + 1 != null && row.d != null && row.a + 1 == row.d) then 333 else if (row.a + 1 != null && row.e != null && row.a + 1 == row.e) then 444 else 555, row.d]
 var flatResult = []
 for row in result {
   for x in row {


### PR DESCRIPTION
## Summary
- reduce parentheses in generated Mochi expressions
- update generated SLT cases with cleaner syntax

## Testing
- `go test -tags slow ./tools/slt/logic -run TestGenerate -run TestRunMochi`
- `go run ./cmd/mochi-slt gen --cases case1-case5 --files select1.test --out tests/dataset/slt/out --run`


------
https://chatgpt.com/codex/tasks/task_e_68670c7e17188320bddf39cfb09fb67d