### PR TITLE
Improve SLT numeric parsing

### DIFF
--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -265,6 +265,12 @@ func detectColumnType(rows []map[string]any, name string, declared []string, col
 			}
 
 			clean := strings.ReplaceAll(strings.ReplaceAll(sv, ",", ""), "_", "")
+			if len(clean) > 1 {
+				last := clean[len(clean)-1]
+				if last == 'l' || last == 'L' || last == 'f' || last == 'F' {
+					clean = clean[:len(clean)-1]
+				}
+			}
 			orig := clean
 			neg := false
 			if strings.HasPrefix(clean, "+") || strings.HasPrefix(clean, "-") {


### PR DESCRIPTION
## Summary
- handle trailing numeric suffixes like `123L` or `1f` while inferring column types

## Testing
- `go vet ./tools/slt/...`
- `go build ./cmd/mochi-slt`


------
https://chatgpt.com/codex/tasks/task_e_686741bbd0b883209148faf404000d9b