### PR TITLE
Improve VM type inference and share runtime helpers

### DIFF
--- a/runtime/http/fetch.go
+++ b/runtime/http/fetch.go
@@ -9,6 +9,8 @@ import (
 	neturl "net/url"
 	"os"
 	"time"
+
+	"mochi/runtime/util"
 )
 
 // Fetch retrieves JSON from the given URL and unmarshals it into an
@@ -55,7 +57,7 @@ func FetchWith(url string, opts map[string]any) (any, error) {
 	if opts != nil {
 		if q, ok := opts["query"]; ok {
 			vals := u.Query()
-			for k, v := range toAnyMap(q) {
+			for k, v := range util.ToAnyMap(q) {
 				vals.Set(k, fmt.Sprint(v))
 			}
 			u.RawQuery = vals.Encode()
@@ -68,7 +70,7 @@ func FetchWith(url string, opts map[string]any) (any, error) {
 	}
 	if opts != nil {
 		if hs, ok := opts["headers"]; ok {
-			for k, v := range toAnyMap(hs) {
+			for k, v := range util.ToAnyMap(hs) {
 				if s, ok := v.(string); ok {
 					req.Header.Set(k, s)
 				}
@@ -107,19 +109,4 @@ func FetchWith(url string, opts map[string]any) (any, error) {
 		return nil, err
 	}
 	return out, nil
-}
-
-func toAnyMap(m any) map[string]any {
-	switch v := m.(type) {
-	case map[string]any:
-		return v
-	case map[string]string:
-		out := make(map[string]any, len(v))
-		for k, vv := range v {
-			out[k] = vv
-		}
-		return out
-	default:
-		return nil
-	}
 }

--- a/runtime/util/util.go
+++ b/runtime/util/util.go
@@ -1,0 +1,71 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// ToAnyMap converts various map representations to map[string]any.
+func ToAnyMap(m any) map[string]any {
+	switch v := m.(type) {
+	case map[string]any:
+		return v
+	case map[string]string:
+		out := make(map[string]any, len(v))
+		for k, vv := range v {
+			out[k] = vv
+		}
+		return out
+	case map[int]any:
+		out := make(map[string]any, len(v))
+		for k, vv := range v {
+			out[strconv.Itoa(k)] = vv
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(v))
+		for kk, vv := range v {
+			out[fmt.Sprint(kk)] = vv
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// ToMapSlice attempts to coerce v into a slice of map[string]any.
+func ToMapSlice(v any) ([]map[string]any, bool) {
+	switch rows := v.(type) {
+	case []map[string]any:
+		return rows, true
+	case []any:
+		out := make([]map[string]any, len(rows))
+		for i, item := range rows {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			out[i] = m
+		}
+		return out, true
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice {
+		out := make([]map[string]any, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			b, err := json.Marshal(rv.Index(i).Interface())
+			if err != nil {
+				return nil, false
+			}
+			var m map[string]any
+			if err := json.Unmarshal(b, &m); err != nil {
+				return nil, false
+			}
+			out[i] = m
+		}
+		return out, true
+	}
+	return nil, false
+}

--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -145,6 +145,8 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagFloat
 	case OpSum:
 		tags[ins.A] = TagUnknown
+	case OpExists:
+		tags[ins.A] = TagBool
 	case OpMin, OpMax:
 		tags[ins.A] = TagUnknown
 	case OpValues:


### PR DESCRIPTION
## Summary
- refine VM type inference for `exists`
- add runtime utility helpers for map handling
- use shared helpers in VM and HTTP runtime

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867a9404bb08320947eecffc86a927f