### PR TITLE
Improve Python compiler first() handling

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -761,6 +761,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(args) != 1 {
 			return "", fmt.Errorf("first expects 1 arg")
 		}
+		if _, ok := c.inferExprType(call.Args[0]).(types.ListType); ok {
+			arg := args[0]
+			return fmt.Sprintf("(%s[0] if len(%s) > 0 else None)", arg, arg), nil
+		}
 		c.use("_first")
 		return fmt.Sprintf("_first(%s)", args[0]), nil
 	case "concat":

--- a/types/infer.go
+++ b/types/infer.go
@@ -344,6 +344,14 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			return IntType{}
 		case "avg":
 			return FloatType{}
+		case "first":
+			if len(p.Call.Args) == 1 {
+				t := ExprType(p.Call.Args[0], env)
+				if lt, ok := t.(ListType); ok {
+					return lt.Elem
+				}
+			}
+			return AnyType{}
 		case "reduce":
 			if len(p.Call.Args) == 3 {
 				return ExprType(p.Call.Args[2], env)


### PR DESCRIPTION
## Summary
- improve type inference for `first()` builtin
- inline simple list case when compiling `first()` to Python

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867a94b0c3c83209a7f5396bfa36d73