### PR TITLE
Improve count & exists generation

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3552,6 +3552,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.use("_contains")
 		return fmt.Sprintf("_contains(%s, %s)", args[0], args[1]), nil
 	case "count":
+		if len(call.Args) == 1 {
+			at := c.inferExprType(call.Args[0])
+			switch at.(type) {
+			case types.ListType, types.MapType:
+				return fmt.Sprintf("len(%s)", args[0]), nil
+			case types.StringType:
+				return fmt.Sprintf("len([]rune(%s))", args[0]), nil
+			case types.GroupType:
+				return fmt.Sprintf("len(%s.Items)", args[0]), nil
+			}
+		}
 		c.imports["mochi/runtime/data"] = true
 		c.imports["reflect"] = true
 		c.use("_count")
@@ -3564,6 +3575,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		return fmt.Sprintf("_count(%s)", argStr), nil
 	case "exists":
+		if len(call.Args) == 1 {
+			at := c.inferExprType(call.Args[0])
+			switch at.(type) {
+			case types.ListType, types.MapType:
+				return fmt.Sprintf("len(%s) > 0", args[0]), nil
+			case types.StringType:
+				return fmt.Sprintf("len([]rune(%s)) > 0", args[0]), nil
+			case types.GroupType:
+				return fmt.Sprintf("len(%s.Items) > 0", args[0]), nil
+			}
+		}
 		c.use("_exists")
 		return fmt.Sprintf("_exists(%s)", argStr), nil
 	case "avg":


### PR DESCRIPTION
## Summary
- improve Go backend count/exists to avoid runtime helper when types known

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867ad99e06083209067507b263eab3e