### PR TITLE
Improve zig type inference

### DIFF
--- a/compile/x/zig/helpers.go
+++ b/compile/x/zig/helpers.go
@@ -2,6 +2,7 @@ package zigcode
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"mochi/parser"
@@ -159,3 +160,53 @@ func identName(e *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+func equalTypes(a, b types.Type) bool {
+	if _, ok := a.(types.AnyType); ok {
+		return true
+	}
+	if _, ok := b.(types.AnyType); ok {
+		return true
+	}
+	if la, ok := a.(types.ListType); ok {
+		if lb, ok := b.(types.ListType); ok {
+			return equalTypes(la.Elem, lb.Elem)
+		}
+	}
+	if ma, ok := a.(types.MapType); ok {
+		if mb, ok := b.(types.MapType); ok {
+			return equalTypes(ma.Key, mb.Key) && equalTypes(ma.Value, mb.Value)
+		}
+	}
+	if ua, ok := a.(types.UnionType); ok {
+		if sb, ok := b.(types.StructType); ok {
+			if _, ok := ua.Variants[sb.Name]; ok {
+				return true
+			}
+		}
+	}
+	if ub, ok := b.(types.UnionType); ok {
+		if sa, ok := a.(types.StructType); ok {
+			if _, ok := ub.Variants[sa.Name]; ok {
+				return true
+			}
+		}
+	}
+	if isInt64(a) && (isInt64(b) || isInt(b)) {
+		return true
+	}
+	if isInt64(b) && (isInt64(a) || isInt(a)) {
+		return true
+	}
+	if isInt(a) && isInt(b) {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func isInt64(t types.Type) bool  { _, ok := t.(types.Int64Type); return ok }
+func isInt(t types.Type) bool    { _, ok := t.(types.IntType); return ok }
+func isFloat(t types.Type) bool  { _, ok := t.(types.FloatType); return ok }
+func isBool(t types.Type) bool   { _, ok := t.(types.BoolType); return ok }
+func isString(t types.Type) bool { _, ok := t.(types.StringType); return ok }
+func isList(t types.Type) bool   { _, ok := t.(types.ListType); return ok }

--- a/compile/x/zig/infer.go
+++ b/compile/x/zig/infer.go
@@ -7,26 +7,75 @@ import (
 
 // inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	t := types.ExprType(e, c.env)
-	if types.ContainsAny(t) {
-		env := types.NewEnv(c.env)
-		for name, tt := range c.locals {
-			env.SetVar(name, tt, true)
-		}
-		t = types.CheckExprType(e, env)
+	if e == nil {
+		return types.AnyType{}
 	}
-	return t
+	// Handle simple literals directly for better inference.
+	if len(e.Binary.Right) == 0 {
+		u := e.Binary.Left
+		if len(u.Ops) == 0 {
+			p := u.Value
+			if len(p.Ops) == 0 {
+				if p.Target.List != nil {
+					var elem types.Type = types.AnyType{}
+					for i, el := range p.Target.List.Elems {
+						t := c.inferExprType(el)
+						if i == 0 {
+							elem = t
+						} else if !equalTypes(elem, t) {
+							elem = types.AnyType{}
+							break
+						}
+					}
+					return types.ListType{Elem: elem}
+				}
+				if p.Target.Map != nil {
+					var key types.Type = types.AnyType{}
+					var val types.Type = types.AnyType{}
+					for i, it := range p.Target.Map.Items {
+						kt := c.inferExprType(it.Key)
+						if _, ok := identName(it.Key); ok {
+							kt = types.StringType{}
+						}
+						vt := c.inferExprType(it.Value)
+						if i == 0 {
+							key = kt
+							val = vt
+						} else {
+							if !equalTypes(key, kt) {
+								key = types.AnyType{}
+							}
+							if !equalTypes(val, vt) {
+								val = types.AnyType{}
+							}
+						}
+					}
+					return types.MapType{Key: key, Value: val}
+				}
+			}
+		}
+	}
+
+	env := types.NewEnv(c.env)
+	for name, tt := range c.locals {
+		env.SetVar(name, tt, true)
+	}
+	return types.CheckExprType(e, env)
 }
 
 // inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	t := types.ExprTypeHint(e, hint, c.env)
-	if types.ContainsAny(t) {
-		env := types.NewEnv(c.env)
-		for name, tt := range c.locals {
-			env.SetVar(name, tt, true)
-		}
-		t = types.CheckExprType(e, env)
+	if e == nil {
+		return types.AnyType{}
 	}
-	return t
+	// Empty list literals can adopt element type from hint.
+	if len(e.Binary.Right) == 0 {
+		u := e.Binary.Left
+		if len(u.Ops) == 0 && u.Value.Target.List != nil && len(u.Value.Target.List.Elems) == 0 {
+			if lt, ok := hint.(types.ListType); ok {
+				return types.ListType{Elem: lt.Elem}
+			}
+		}
+	}
+	return c.inferExprType(e)
 }


### PR DESCRIPTION
## Summary
- improve Zig type inference to analyze simple literals
- always use full type checker with locals
- add helper functions for comparing types

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867be26127c83208368064dd511307b