### PR TITLE
Improve type inference for C backend reduce

### DIFF
--- a/compile/x/c/compiler.go
+++ b/compile/x/c/compiler.go
@@ -2014,15 +2014,17 @@ func (c *Compiler) compilePrimary(p *parser.Primary) string {
 			list := c.compileExpr(p.Call.Args[0])
 			fn := c.compileExpr(p.Call.Args[1])
 			init := c.compileExpr(p.Call.Args[2])
-			if isListFloatExpr(p.Call.Args[0], c.env) {
+			switch listElemType(p.Call.Args[0], c.env).(type) {
+			case types.FloatType:
 				c.need(needReduceFloat)
 				return fmt.Sprintf("_reduce_float(%s, %s, %s)", list, fn, init)
-			} else if isListStringExpr(p.Call.Args[0], c.env) {
+			case types.StringType:
 				c.need(needReduceString)
 				return fmt.Sprintf("_reduce_string(%s, %s, %s)", list, fn, init)
+			default:
+				c.need(needReduceInt)
+				return fmt.Sprintf("_reduce_int(%s, %s, %s)", list, fn, init)
 			}
-			c.need(needReduceInt)
-			return fmt.Sprintf("_reduce_int(%s, %s, %s)", list, fn, init)
 		} else if p.Call.Func == "str" {
 			arg := c.compileExpr(p.Call.Args[0])
 			name := c.newTemp()

--- a/compile/x/c/helpers.go
+++ b/compile/x/c/helpers.go
@@ -158,6 +158,18 @@ func isMapStringType(t types.Type) bool {
 	return false
 }
 
+// listElemType returns the element type of e if it is a list expression with a
+// known element type in env.
+func listElemType(e *parser.Expr, env *types.Env) types.Type {
+	if env == nil || e == nil {
+		return nil
+	}
+	if lt, ok := types.ExprType(e, env).(types.ListType); ok {
+		return lt.Elem
+	}
+	return nil
+}
+
 func isListMapStringType(t types.Type) bool {
 	if lt, ok := t.(types.ListType); ok {
 		return isMapStringType(lt.Elem)


### PR DESCRIPTION
## Summary
- infer list element type with `listElemType`
- choose reduce helper based on inferred list type

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867be02ae008320ae3c675f2a958612