### PR TITLE
Add reduce builtin to Go backend

### DIFF
--- a/compile/go/README.md
+++ b/compile/go/README.md
@@ -25,6 +25,7 @@ cover functionality such as:
 - HTTP requests using `_fetch`
 - Data loading/saving with `_load` and `_save`
 - Generic casting and conversion utilities (`_cast`, `_toAnyMap`, `_toAnySlice`)
+- List reduction with `_reduce`
 - Dataset querying through `_query`
 
 The map of available helpers is defined near the end of `runtime.go`:
@@ -33,7 +34,12 @@ The map of available helpers is defined near the end of `runtime.go`:
 var helperMap = map[string]string{
     "_indexString":   helperIndexString,
     "_count":         helperCount,
+    "_exists":        helperExists,
     "_avg":           helperAvg,
+    "_sum":           helperSum,
+    "_min":           helperMin,
+    "_max":           helperMax,
+    "_first":         helperFirst,
     "_input":         helperInput,
     "_genText":       helperGenText,
     "_genEmbed":      helperGenEmbed,
@@ -42,16 +48,28 @@ var helperMap = map[string]string{
     "_toAnyMap":      helperToAnyMap,
     "_toAnySlice":    helperToAnySlice,
     "_convSlice":     helperConvSlice,
+    "_contains":      helperContains,
+    "_union_all":     helperUnionAll,
+    "_union":         helperUnion,
+    "_concat":        helperConcat,
+    "_reduce":        helperReduce,
+    "_reverseSlice":  helperReverseSlice,
+    "_reverseString": helperReverseString,
+    "_lower":         helperLower,
+    "_upper":         helperUpper,
+    "_except":        helperExcept,
+    "_intersect":     helperIntersect,
     "_cast":          helperCast,
     "_convertMapAny": helperConvertMapAny,
     "_equal":         helperEqual,
     "_query":         helperQuery,
+    "_paginate":      helperPaginate,
     "_load":          helperLoad,
     "_save":          helperSave,
     "_toMapSlice":    helperToMapSlice,
 }
 ```
-【F:compile/go/runtime.go†L417-L435】
+【F:compile/go/runtime.go†L761-L798】
 
 ## Supported Features
 

--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3604,6 +3604,25 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.imports["mochi/runtime/data"] = true
 		c.use("_max")
 		return fmt.Sprintf("_max(%s)", argStr), nil
+	case "reduce":
+		if len(call.Args) != 3 {
+			return "", fmt.Errorf("reduce expects 3 args")
+		}
+		arg0 := args[0]
+		elemGo := "any"
+		if lt, ok := c.inferExprType(call.Args[0]).(types.ListType); ok {
+			elemGo = goType(lt.Elem)
+			if isAny(lt.Elem) {
+				c.use("_toAnySlice")
+				arg0 = fmt.Sprintf("_toAnySlice(%s)", arg0)
+				elemGo = "any"
+			}
+		} else {
+			c.use("_toAnySlice")
+			arg0 = fmt.Sprintf("_toAnySlice(%s)", arg0)
+		}
+		c.use("_reduce")
+		return fmt.Sprintf("_reduce[%s](%s, %s, %s)", elemGo, arg0, args[1], args[2]), nil
 	case "first":
 		c.imports["mochi/runtime/data"] = true
 		c.imports["reflect"] = true

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -463,6 +463,14 @@ const (
 		"    return string(r)\n" +
 		"}\n"
 
+	helperReduce = "func _reduce[T any](src []T, fn func(T, T) T, init T) T {\n" +
+		"    acc := init\n" +
+		"    for _, v := range src {\n" +
+		"        acc = fn(acc, v)\n" +
+		"    }\n" +
+		"    return acc\n" +
+		"}\n"
+
 	helperLower = "func _lower(v any) string {\n" +
 		"    if s, ok := v.(string); ok { return strings.ToLower(s) }\n" +
 		"    return strings.ToLower(fmt.Sprint(v))\n" +
@@ -772,6 +780,7 @@ var helperMap = map[string]string{
 	"_union_all":     helperUnionAll,
 	"_union":         helperUnion,
 	"_concat":        helperConcat,
+	"_reduce":        helperReduce,
 	"_reverseSlice":  helperReverseSlice,
 	"_reverseString": helperReverseString,
 	"_lower":         helperLower,

--- a/tests/compiler/go/reduce_builtin.go.out
+++ b/tests/compiler/go/reduce_builtin.go.out
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+)
+
+func add(a int, b int) int {
+	return (a + b)
+}
+
+func main() {
+	fmt.Println(_reduce[int]([]int{1, 2, 3}, add, 0))
+}
+
+func _reduce[T any](src []T, fn func(T, T) T, init T) T {
+	acc := init
+	for _, v := range src {
+		acc = fn(acc, v)
+	}
+	return acc
+}

--- a/tests/compiler/go/reduce_builtin.mochi
+++ b/tests/compiler/go/reduce_builtin.mochi
@@ -1,0 +1,4 @@
+fun add(a: int, b: int): int {
+  return a + b
+}
+print(reduce([1,2,3], add, 0))


### PR DESCRIPTION
## Summary
- implement `_reduce` generic helper in Go runtime
- support `reduce()` builtin in Go compiler
- document new helper in Go backend README
- add regression test for reduce builtin

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867c3f87aa88320b2881f1298cd25d6