### PR TITLE
Refine Go compiler min/max typing

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3597,10 +3597,30 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.use("_sum")
 		return fmt.Sprintf("_sum(%s)", argStr), nil
 	case "min":
+		if len(call.Args) == 1 {
+			at := c.inferExprType(call.Args[0])
+			if lt, ok := at.(types.ListType); ok {
+				if isInt(lt.Elem) || isInt64(lt.Elem) || isFloat(lt.Elem) || isString(lt.Elem) {
+					c.use("_minOrdered")
+					elemGo := goType(lt.Elem)
+					return fmt.Sprintf("_minOrdered[%s](%s)", elemGo, args[0]), nil
+				}
+			}
+		}
 		c.imports["mochi/runtime/data"] = true
 		c.use("_min")
 		return fmt.Sprintf("_min(%s)", argStr), nil
 	case "max":
+		if len(call.Args) == 1 {
+			at := c.inferExprType(call.Args[0])
+			if lt, ok := at.(types.ListType); ok {
+				if isInt(lt.Elem) || isInt64(lt.Elem) || isFloat(lt.Elem) || isString(lt.Elem) {
+					c.use("_maxOrdered")
+					elemGo := goType(lt.Elem)
+					return fmt.Sprintf("_maxOrdered[%s](%s)", elemGo, args[0]), nil
+				}
+			}
+		}
 		c.imports["mochi/runtime/data"] = true
 		c.use("_max")
 		return fmt.Sprintf("_max(%s)", argStr), nil

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -239,6 +239,20 @@ const (
 		"    }\n" +
 		"}\n"
 
+	helperMinOrdered = "func _minOrdered[T constraints.Ordered](s []T) T {\n" +
+		"    if len(s) == 0 { var zero T; return zero }\n" +
+		"    m := s[0]\n" +
+		"    for _, v := range s[1:] { if v < m { m = v } }\n" +
+		"    return m\n" +
+		"}\n"
+
+	helperMaxOrdered = "func _maxOrdered[T constraints.Ordered](s []T) T {\n" +
+		"    if len(s) == 0 { var zero T; return zero }\n" +
+		"    m := s[0]\n" +
+		"    for _, v := range s[1:] { if v > m { m = v } }\n" +
+		"    return m\n" +
+		"}\n"
+
 	helperFirst = "func _first(v any) any {\n" +
 		"    if g, ok := v.(*data.Group); ok {\n" +
 		"        if len(g.Items) == 0 { return nil }\n" +
@@ -767,6 +781,8 @@ var helperMap = map[string]string{
 	"_sum":           helperSum,
 	"_min":           helperMin,
 	"_max":           helperMax,
+	"_minOrdered":    helperMinOrdered,
+	"_maxOrdered":    helperMaxOrdered,
 	"_first":         helperFirst,
 	"_input":         helperInput,
 	"_genText":       helperGenText,
@@ -817,6 +833,9 @@ func (c *Compiler) use(name string) {
 		c.imports["strings"] = true
 		c.imports["reflect"] = true
 		c.helpers["_equal"] = true
+	}
+	if name == "_minOrdered" || name == "_maxOrdered" {
+		c.imports["golang.org/x/exp/constraints"] = true
 	}
 }
 

--- a/types/infer.go
+++ b/types/infer.go
@@ -377,6 +377,17 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			return IntType{}
 		case "avg":
 			return FloatType{}
+		case "min", "max":
+			if len(p.Call.Args) == 1 {
+				t := ExprType(p.Call.Args[0], env)
+				switch tt := t.(type) {
+				case ListType:
+					return tt.Elem
+				case GroupType:
+					return tt.Elem
+				}
+			}
+			return AnyType{}
 		case "first":
 			if len(p.Call.Args) == 1 {
 				t := ExprType(p.Call.Args[0], env)


### PR DESCRIPTION
## Summary
- improve static typing for `min`/`max` builtin calls
- add ordered helper functions to runtime
- generate calls to typed helpers when possible

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867c7f3681c832087e9577c2ab14a70