### PR TITLE
Improve Python runtime typings

### DIFF
--- a/compile/py/README.md
+++ b/compile/py/README.md
@@ -32,6 +32,17 @@ var helperGenStruct = "def _gen_struct(cls, prompt, model=None, params=None):\n"
 ```
 【F:compile/py/runtime.go†L7-L19】
 
+Runtime helpers include type hints using `typing.TypeVar` to reduce
+`Any` usage. For example:
+
+```go
+var helperAppend = "def _append(lst: list[T] | None, v: T) -> list[T]:\n" +
+    "    out: list[T] = list(lst) if lst is not None else []\n" +
+    "    out.append(v)\n" +
+    "    return out\n"
+```
+
+
 Additional helpers cover data loading, saving and HTTP requests. They are referenced from a map used by `emitRuntime`:
 
 ```go

--- a/compile/py/helpers.go
+++ b/compile/py/helpers.go
@@ -182,7 +182,11 @@ func pyType(t types.Type) string {
 	case types.UnionType:
 		return sanitizeName(tt.Name)
 	case types.FuncType:
-		return "typing.Callable"
+		params := make([]string, len(tt.Params))
+		for i, p := range tt.Params {
+			params[i] = pyType(p)
+		}
+		return "typing.Callable[[" + strings.Join(params, ", ") + "], " + pyType(tt.Return) + "]"
 	case types.VoidType:
 		return "None"
 	case types.AnyType:


### PR DESCRIPTION
## Summary
- refine `pyType` to provide typed callable signatures
- add `helperPrelude` and annotate runtime helpers with generics
- document new type hints in Python runtime helpers

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_6867c98ba7bc8320ab0f24fc7209e7fd