### PR TITLE
Improve Erlang set operation typing

### DIFF
--- a/compile/x/erlang/compiler.go
+++ b/compile/x/erlang/compiler.go
@@ -1010,19 +1010,19 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 				typ = types.BoolType{}
 			case "union_all":
 				expr = fmt.Sprintf("lists:append(%s, %s)", l.expr, r.expr)
-				typ = types.ListType{Elem: types.AnyType{}}
+				typ = resultType(op, l.typ, r.typ)
 			case "union":
 				c.needSetOps = true
 				expr = fmt.Sprintf("mochi_union(%s, %s)", l.expr, r.expr)
-				typ = types.ListType{Elem: types.AnyType{}}
+				typ = resultType(op, l.typ, r.typ)
 			case "except":
 				c.needSetOps = true
 				expr = fmt.Sprintf("mochi_except(%s, %s)", l.expr, r.expr)
-				typ = types.ListType{Elem: types.AnyType{}}
+				typ = resultType(op, l.typ, r.typ)
 			case "intersect":
 				c.needSetOps = true
 				expr = fmt.Sprintf("mochi_intersect(%s, %s)", l.expr, r.expr)
-				typ = types.ListType{Elem: types.AnyType{}}
+				typ = resultType(op, l.typ, r.typ)
 			default:
 				return "", fmt.Errorf("unsupported operator %s", op)
 			}

--- a/compile/x/erlang/infer.go
+++ b/compile/x/erlang/infer.go
@@ -16,26 +16,17 @@ func (c *Compiler) exprTypeHint(e *parser.Expr, hint types.Type) types.Type {
 }
 
 func (c *Compiler) unaryType(u *parser.Unary) types.Type {
-	if u == nil {
-		return types.AnyType{}
-	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
 	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
-	if p == nil {
-		return types.AnyType{}
-	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
 	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) primaryType(p *parser.Primary) types.Type {
-	if p == nil {
-		return types.AnyType{}
-	}
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}


### PR DESCRIPTION
## Summary
- enhance Erlang compiler set ops to infer list element type using `resultType`
- rely on generic type inference helpers without explicit nil checks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867ca1fc0d48320a6d96fab9dcad0ba