### PR TITLE
Improve TypeScript runtime helpers

### DIFF
--- a/compile/ts/helpers.go
+++ b/compile/ts/helpers.go
@@ -228,7 +228,16 @@ func tsType(t types.Type) string {
 	case types.UnionType:
 		return sanitizeName(tt.Name)
 	case types.FuncType:
-		return "any"
+		var args []string
+		for i, p := range tt.Params {
+			arg := fmt.Sprintf("p%d: %s", i, tsType(p))
+			if tt.Variadic && i == len(tt.Params)-1 {
+				arg = "..." + arg
+			}
+			args = append(args, arg)
+		}
+		ret := tsType(tt.Return)
+		return fmt.Sprintf("(%s) => %s", strings.Join(args, ", "), ret)
 	case types.VoidType:
 		return "void"
 	case types.AnyType:

--- a/compile/ts/runtime.go
+++ b/compile/ts/runtime.go
@@ -22,7 +22,7 @@ const (
 		"  if (end < start) end = start;\n" +
 		"  return runes.slice(start, end).join('');\n" +
 		"}\n"
-	helperSlice = "function _slice(v: any, i: number, j: number): any[] {\n" +
+	helperSlice = "function _slice<T>(v: T[] | string, i: number, j: number): T[] | string {\n" +
 		"  if (typeof v === 'string') return _sliceString(v, i, j);\n" +
 		"  if (!Array.isArray(v)) return [];\n" +
 		"  let start = i;\n" +
@@ -153,11 +153,11 @@ const (
 		"  return v === null ? '' : v;\n" +
 		"}\n"
 
-	helperIter = "function _iter(v: any): any {\n" +
+	helperIter = "function _iter<T>(v: Iterable<T> | Record<string, T> | any): Iterable<T | string> {\n" +
 		"  if (v && typeof v === 'object' && !Array.isArray(v) && !(Symbol.iterator in v)) {\n" +
 		"    return Object.keys(v);\n" +
 		"  }\n" +
-		"  return v;\n" +
+		"  return v as Iterable<T>;\n" +
 		"}\n"
 
 	helperGenText = "function _gen_text(prompt: string, model: string | null, params: any | null): string {\n" +


### PR DESCRIPTION
## Summary
- return proper function types in the TS backend
- add generics to `_slice` helper
- make `_iter` helper return an iterable

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6867cc1216748320af6c414a1e3a3126