### PR TITLE
Improve C++ type inference

### DIFF
--- a/compile/x/cpp/compiler.go
+++ b/compile/x/cpp/compiler.go
@@ -1041,8 +1041,13 @@ func (c *Compiler) compilePrimary(p *parser.Primary) string {
 		}
 		elemType := "int"
 		if len(p.List.Elems) > 0 {
-			if t := InferCppExprType(p.List.Elems[0], c.env, c.getVar); t != "" {
-				elemType = t
+			et := ""
+			for _, e := range p.List.Elems {
+				t := InferCppExprType(e, c.env, c.getVar)
+				et = mergeCppTypes(et, t)
+			}
+			if et != "" {
+				elemType = et
 			}
 		}
 		return fmt.Sprintf("vector<%s>{%s}", elemType, strings.Join(elems, ", "))
@@ -1194,6 +1199,8 @@ func (c *Compiler) compileMapLiteral(m *parser.MapLiteral) string {
 		}
 		if i == 0 {
 			keyType = kt
+		} else {
+			keyType = mergeCppTypes(keyType, kt)
 		}
 		vt := InferCppExprType(it.Value, c.env, c.getVar)
 		if vt == "" {

--- a/compile/x/cpp/inference.go
+++ b/compile/x/cpp/inference.go
@@ -150,19 +150,14 @@ func inferCppPrimaryType(env *types.Env, lookup CppVarLookup, p *parser.Primary)
 				}
 				val = InferCppExprType(it.Value, env, lookup)
 			} else {
-				if t := InferCppExprType(it.Value, env, lookup); t != val {
-					val = "any"
-				}
+				t := InferCppExprType(it.Value, env, lookup)
+				val = mergeCppTypes(val, t)
 			}
 		}
 		if val == "" {
 			valType = "any"
 		} else {
-			if val == "any" {
-				valType = "any"
-			} else {
-				valType = val
-			}
+			valType = val
 		}
 		if valType == "" {
 			valType = "any"
@@ -285,6 +280,12 @@ func isPrimitive(t string) bool {
 // If the types are incompatible the result is "any".
 func mergeCppTypes(a, b string) string {
 	if a == b {
+		return a
+	}
+	if a == "auto" {
+		return b
+	}
+	if b == "auto" {
 		return a
 	}
 	if a == "" {


### PR DESCRIPTION
## Summary
- refine mergeCppTypes to treat `auto` specially
- merge list element and map key types
- refine map literal inference for more concrete value types

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867cd04496c8320a1455f70e3140d60