### PR TITLE
Improve F# load type handling

### DIFF
--- a/compile/x/fs/compiler.go
+++ b/compile/x/fs/compiler.go
@@ -1821,7 +1821,13 @@ func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {
 		opts = fmt.Sprintf("Some (%s)", v)
 	}
 	c.use("_load")
-	return fmt.Sprintf("_load %s %s", path, opts), nil
+	expr := fmt.Sprintf("_load %s %s", path, opts)
+	if l.Type != nil {
+		c.use("_cast")
+		typ := fsType(l.Type)
+		expr = fmt.Sprintf("%s |> List.map (fun row -> _cast<%s>(row))", expr, typ)
+	}
+	return expr, nil
 }
 
 func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {

--- a/tests/compiler/fs/load_save_json.fs.out
+++ b/tests/compiler/fs/load_save_json.fs.out
@@ -1,5 +1,12 @@
 open System
 
+let format = "format"
+let _cast<'T> (v: obj) : 'T =
+  match v with
+  | :? 'T as t -> t
+  | _ ->
+      let json = System.Text.Json.JsonSerializer.Serialize(v)
+      System.Text.Json.JsonSerializer.Deserialize<'T>(json)
 let _load (path: string option) (opts: Map<string,obj> option) : List<Map<string,obj>> =
   let format = opts |> Option.bind (Map.tryFind "format") |> Option.map string |> Option.defaultValue "csv"
   let header = opts |> Option.bind (Map.tryFind "header") |> Option.map unbox<bool> |> Option.defaultValue true
@@ -99,5 +106,5 @@ type Person =
         name: string;
         age: int
     }
-let people = _load None Some (Map.ofList [(format, "json")])
+let people = _load None Some (Map.ofList [(format, "json")]) |> List.map (fun row -> _cast<Person>(row))
 ignore (_save people None Some (Map.ofList [(format, "json")]))


### PR DESCRIPTION
## Summary
- support typed load expressions in F# backend
- update expected output for typed load

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867cd754b88832090e23a10f57a2476