### PR TITLE
Improve Python codegen typing

### DIFF
--- a/compile/py/helpers.go
+++ b/compile/py/helpers.go
@@ -177,6 +177,8 @@ func pyType(t types.Type) string {
 		return "list[" + pyType(tt.Elem) + "]"
 	case types.MapType:
 		return "dict[" + pyType(tt.Key) + ", " + pyType(tt.Value) + "]"
+	case types.GroupType:
+		return "_Group[Any, " + pyType(tt.Elem) + "]"
 	case types.StructType:
 		return sanitizeName(tt.Name)
 	case types.UnionType:

--- a/compile/py/runtime.go
+++ b/compile/py/runtime.go
@@ -2,7 +2,7 @@ package pycode
 
 import "sort"
 
-var helperPrelude = "from typing import Any, TypeVar\nT = TypeVar('T')\n"
+var helperPrelude = "from typing import Any, TypeVar, Generic, Callable\nT = TypeVar('T')\nK = TypeVar('K')\n"
 
 // Runtime helpers emitted by the Python compiler.
 
@@ -84,16 +84,16 @@ var helperMax = "def _max(v):\n" +
 	"        return 0\n" +
 	"    return max(vals)\n"
 
-var helperGroupClass = "class _Group:\n" +
-	"    def __init__(self, key):\n" +
+var helperGroupClass = "class _Group(Generic[K, T]):\n" +
+	"    def __init__(self, key: K):\n" +
 	"        self.key = key\n" +
-	"        self.Items = []\n" +
+	"        self.Items: list[T] = []\n" +
 	"    def __iter__(self):\n" +
 	"        return iter(self.Items)\n"
 
-var helperGroupBy = "def _group_by(src, keyfn):\n" +
-	"    groups = {}\n" +
-	"    order = []\n" +
+var helperGroupBy = "def _group_by(src: list[T], keyfn: Callable[[T], K]) -> list[_Group[K, T]]:\n" +
+	"    groups: dict[str, _Group[K, T]] = {}\n" +
+	"    order: list[str] = []\n" +
 	"    for it in src:\n" +
 	"        if isinstance(it, (list, tuple)):\n" +
 	"            key = keyfn(*it)\n" +

--- a/compile/py/statements.go
+++ b/compile/py/statements.go
@@ -658,8 +658,7 @@ func (c *Compiler) compileUpdate(u *parser.UpdateStmt) error {
 	if st.Name != "" {
 		child := types.NewEnv(c.env)
 		for _, f := range st.Order {
-			c.use("_get")
-			c.writeln(fmt.Sprintf("%s = _get(%s, %q)", sanitizeName(f), itemVar, sanitizeName(f)))
+			c.writeln(fmt.Sprintf("%s = %s.%s", sanitizeName(f), itemVar, sanitizeName(f)))
 			child.SetVar(f, st.Fields[f], true)
 		}
 		orig = c.env


### PR DESCRIPTION
## Summary
- add generics for runtime `_Group` helpers
- type `GroupType` emissions in Python
- use direct field access for struct updates

## Testing
- `go test ./... -run ^$`

------
https://chatgpt.com/codex/tasks/task_e_6867cdf965d48320bbb5172378832a55