### PR TITLE
Improve in-operator codegen for slices

### DIFF
--- a/compile/go/README.md
+++ b/compile/go/README.md
@@ -27,6 +27,7 @@ cover functionality such as:
 - Generic casting and conversion utilities (`_cast`, `_toAnyMap`, `_toAnySlice`)
 - List reduction with `_reduce`
 - Dataset querying through `_query`
+- Membership checks on typed lists use `slices.Contains` when possible
 
 The map of available helpers is defined near the end of `runtime.go`:
 

--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -1652,8 +1652,13 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 				c.imports["encoding/json"] = true
 				itemExpr = fmt.Sprintf("_cast[%s](%s)", elemGo, left)
 			}
-			c.use("_contains")
-			expr = fmt.Sprintf("_contains(%s, %s)", right, itemExpr)
+			if !isAny(lt.Elem) && isComparableSimple(lt.Elem) {
+				c.imports["slices"] = true
+				expr = fmt.Sprintf("slices.Contains(%s, %s)", right, itemExpr)
+			} else {
+				c.use("_contains")
+				expr = fmt.Sprintf("_contains(%s, %s)", right, itemExpr)
+			}
 			next = types.BoolType{}
 		case types.StringType:
 			c.imports["strings"] = true

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -204,6 +204,10 @@ func isString(t types.Type) bool {
 	return ok
 }
 
+func isComparableSimple(t types.Type) bool {
+	return isInt(t) || isInt64(t) || isFloat(t) || isBool(t) || isString(t)
+}
+
 func isList(t types.Type) bool {
 	_, ok := t.(types.ListType)
 	return ok


### PR DESCRIPTION
## Summary
- add `isComparableSimple` helper
- inline `slices.Contains` for `in` when element type is comparable
- document new optimisation in Go backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867ce468b2c83208f2479cd7aac128c