### PR TITLE
Generate SLT expr cases 300-399

### DIFF
--- a/tests/dataset/slt/out/slt_good_0/case300.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case300.mochi
@@ -2,30 +2,6 @@
 # line: 2748
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case307.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case307.mochi
@@ -2,6 +2,30 @@
 # line: 2820
 */
 
+type tab1Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab1 = [
+  tab1Row {
+    col0: 51,
+    col1: 14,
+    col2: 96,
+  },
+  tab1Row {
+    col0: 85,
+    col1: 5,
+    col2: 59,
+  },
+  tab1Row {
+    col0: 91,
+    col1: 47,
+    col2: 68,
+  },
+]
+
 type tab2Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab0 = [
   },
 ]
 
-type tab1Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab1 = [
-  tab1Row {
-    col0: 51,
-    col1: 14,
-    col2: 96,
-  },
-  tab1Row {
-    col0: 85,
-    col1: 5,
-    col2: 59,
-  },
-  tab1Row {
-    col0: 91,
-    col1: 47,
-    col2: 68,
-  },
-]
-
 /* SELECT + - ( + + 11 ) AS col0 */
-var result = [-((11))]
+var result = [-(11)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case308.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case308.mochi
@@ -2,6 +2,30 @@
 # line: 2825
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case316.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case316.mochi
@@ -2,6 +2,30 @@
 # line: 2918
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case319.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case319.mochi
@@ -2,30 +2,6 @@
 # line: 2940
 */
 
-type tab1Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab1 = [
-  tab1Row {
-    col0: 51,
-    col1: 14,
-    col2: 96,
-  },
-  tab1Row {
-    col0: 85,
-    col1: 5,
-    col2: 59,
-  },
-  tab1Row {
-    col0: 91,
-    col1: 47,
-    col2: 68,
-  },
-]
-
 type tab2Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab0 = [
     col0: 87,
     col1: 21,
     col2: 10,
+  },
+]
+
+type tab1Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab1 = [
+  tab1Row {
+    col0: 51,
+    col1: 14,
+    col2: 96,
+  },
+  tab1Row {
+    col0: 85,
+    col1: 5,
+    col2: 59,
+  },
+  tab1Row {
+    col0: 91,
+    col1: 47,
+    col2: 68,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case320.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case320.mochi
@@ -2,6 +2,30 @@
 # line: 2945
 */
 
+type tab1Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab1 = [
+  tab1Row {
+    col0: 51,
+    col1: 14,
+    col2: 96,
+  },
+  tab1Row {
+    col0: 85,
+    col1: 5,
+    col2: 59,
+  },
+  tab1Row {
+    col0: 91,
+    col1: 47,
+    col2: 68,
+  },
+]
+
 type tab2Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab0 = [
     col0: 87,
     col1: 21,
     col2: 10,
-  },
-]
-
-type tab1Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab1 = [
-  tab1Row {
-    col0: 51,
-    col1: 14,
-    col2: 96,
-  },
-  tab1Row {
-    col0: 85,
-    col1: 5,
-    col2: 59,
-  },
-  tab1Row {
-    col0: 91,
-    col1: 47,
-    col2: 68,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case336.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case336.mochi
@@ -2,6 +2,30 @@
 # line: 3106
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
-  },
-]
-
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case338.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case338.mochi
@@ -2,6 +2,30 @@
 # line: 3116
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case341.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case341.mochi
@@ -3,30 +3,6 @@
 skipif mysql # not compatible
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -75,8 +51,32 @@ let tab1 = [
   },
 ]
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 /* SELECT 70 / + ( + 93 ) */
-var result = [(1.0 * (70)) / (93)]
+var result = [(1.0 * (70)) / ((93))]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case344.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case344.mochi
@@ -2,6 +2,30 @@
 # line: 3160
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case348.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case348.mochi
@@ -2,30 +2,6 @@
 # line: 3209
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case369.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case369.mochi
@@ -2,30 +2,6 @@
 # line: 3430
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case370.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case370.mochi
@@ -2,6 +2,30 @@
 # line: 3435
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case372.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case372.mochi
@@ -2,30 +2,6 @@
 # line: 3445
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case375.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case375.mochi
@@ -2,30 +2,6 @@
 # line: 3468
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case378.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case378.mochi
@@ -2,30 +2,6 @@
 # line: 3490
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case379.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case379.mochi
@@ -2,30 +2,6 @@
 # line: 3495
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case380.error
+++ b/tests/dataset/slt/out/slt_good_0/case380.error
@@ -1,1 +1,5 @@
-parse error: 79:20: unexpected token "-" (expected PostfixExpr)
+error[T013]: incompatible types in comparison
+  --> :88:17
+
+help:
+  Use comparable types like numbers or strings with `<`, `>`.

--- a/tests/dataset/slt/out/slt_good_0/case380.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case380.mochi
@@ -76,7 +76,7 @@ let tab2 = [
 ]
 
 /* SELECT DISTINCT 96 + + - COALESCE ( ( + 22 ), - 9 / + 33 ) */
-var result = [96 + -((if (22) != null then (22) else (1.0 * ((-9))) / 33))]
+var result = [96 + (-(if (22.0) != null then (22.0) else (1.0 * ((-9))) / 33))]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case383.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case383.mochi
@@ -2,6 +2,30 @@
 # line: 3522
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case385.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case385.mochi
@@ -2,6 +2,30 @@
 # line: 3539
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case386.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case386.mochi
@@ -2,30 +2,6 @@
 # line: 3544
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case389.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case389.mochi
@@ -3,6 +3,30 @@
 skipif mysql # not compatible
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -48,30 +72,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case393.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case393.mochi
@@ -2,6 +2,30 @@
 # line: 3610
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case395.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case395.mochi
@@ -2,30 +2,6 @@
 # line: 3620
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case396.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case396.mochi
@@ -2,6 +2,30 @@
 # line: 3625
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
-  },
-]
-
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case399.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case399.mochi
@@ -2,6 +2,30 @@
 # line: 3647
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 


### PR DESCRIPTION
## Summary
- improve unary/parentheses handling and type detection in SLT generator
- regenerate `expr/slt_good_0.test` cases 300-399 using the updated generator
- keep failing case380 with `.error` output

## Testing
- `go test ./...`
- `go run ./cmd/mochi-slt gen --files test/random/expr/slt_good_0.test --cases case300-case399 --out tests/dataset/slt/out --run`

------
https://chatgpt.com/codex/tasks/task_e_6867cdc0de788320a8f722f7c20bf244