### PR TITLE
Improve C backend type inference and inline string ops

### DIFF
--- a/compile/x/c/compiler.go
+++ b/compile/x/c/compiler.go
@@ -288,7 +288,7 @@ func (c *Compiler) compileProgram(prog *parser.Program) ([]byte, error) {
 
 	c.writeln("#include <stdio.h>")
 	c.writeln("#include <stdlib.h>")
-	if c.has(needStringHeader) || c.has(needConcatString) || c.has(needConcatListString) || c.has(needListString) || c.has(needUnionListString) || c.has(needExceptListString) || c.has(needIntersectListString) || c.has(needInListString) || c.has(needInString) || c.has(needIndexString) || c.has(needSliceString) {
+	if c.has(needStringHeader) || c.has(needConcatString) || c.has(needConcatListString) || c.has(needListString) || c.has(needUnionListString) || c.has(needExceptListString) || c.has(needIntersectListString) || c.has(needInListString) || c.has(needInString) {
 		c.writeln("#include <string.h>")
 	}
 	if c.has(needNow) {
@@ -1735,8 +1735,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) string {
 				idx := c.compileExpr(op.Index.Start)
 				if isStr && op.Index.End == nil {
 					name := c.newTemp()
-					c.need(needIndexString)
-					c.writeln(fmt.Sprintf("char* %s = _index_string(%s, %s);", name, expr, idx))
+					c.need(needStringHeader)
+					c.writeln(fmt.Sprintf("char* %s = ({ int _len = strlen(%s); int _i = %s; if (_i < 0) _i += _len; if (_i < 0 || _i >= _len) { fprintf(stderr, \"index out of range\\n\"); exit(1); } char* _b = (char*)malloc(2); _b[0] = %s[_i]; _b[1] = '\\0'; _b; });", name, expr, idx, expr))
 					if c.env != nil {
 						c.env.SetVar(name, types.StringType{}, true)
 					}
@@ -1763,8 +1763,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) string {
 				}
 				name := c.newTemp()
 				if isStr {
-					c.need(needSliceString)
-					c.writeln(fmt.Sprintf("char* %s = slice_string(%s, %s, %s);", name, expr, start, end))
+					c.need(needStringHeader)
+					c.writeln(fmt.Sprintf("char* %s = ({ int _len = strlen(%s); int _s = %s; int _e = %s; if (_s < 0) _s += _len; if (_e < 0) _e += _len; if (_s < 0) _s = 0; if (_e > _len) _e = _len; if (_s > _e) _s = _e; char* _b = (char*)malloc(_e - _s + 1); memcpy(_b, %s + _s, _e - _s); _b[_e - _s] = '\\0'; _b; });", name, expr, start, end, expr))
 					if c.env != nil {
 						c.env.SetVar(name, types.StringType{}, true)
 					}

--- a/compile/x/c/helpers.go
+++ b/compile/x/c/helpers.go
@@ -164,8 +164,14 @@ func listElemType(e *parser.Expr, env *types.Env) types.Type {
 	if env == nil || e == nil {
 		return nil
 	}
-	if lt, ok := types.ExprType(e, env).(types.ListType); ok {
+	// First try the stricter checker to avoid falling back to `any`.
+	if lt, ok := types.CheckExprType(e, env).(types.ListType); ok && !types.ContainsAny(lt.Elem) {
 		return lt.Elem
+	}
+	if lt, ok := types.ExprType(e, env).(types.ListType); ok {
+		if !types.ContainsAny(lt.Elem) {
+			return lt.Elem
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- improve `listElemType` inference to avoid `AnyType`
- inline string index and slice operations instead of calling runtime helpers
- drop unused helper flags when deciding string headers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6867d011c5b483208fa0bf0500371c72