### PR TITLE
Improve F# compiler typing and runtime inlining

### DIFF
--- a/compile/x/fs/compiler.go
+++ b/compile/x/fs/compiler.go
@@ -1373,14 +1373,12 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 					maps[i] = false
 					strs[i] = false
 				} else if op == "union_all" {
-					c.use("_union_all")
-					operands[i] = fmt.Sprintf("_union_all %s %s", left, right)
+					operands[i] = fmt.Sprintf("Array.append %s %s", left, right)
 					lists[i] = true
 					maps[i] = false
 					strs[i] = false
 				} else if op == "union" {
-					c.use("_union")
-					operands[i] = fmt.Sprintf("_union %s %s", left, right)
+					operands[i] = fmt.Sprintf("Array.append %s %s |> Array.distinct", left, right)
 					lists[i] = true
 					maps[i] = false
 					strs[i] = false
@@ -1673,20 +1671,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if c.isGroupExpr(call.Args[0]) {
 			return fmt.Sprintf("%s.size", args[0]), nil
 		}
-		c.use("_seq_helpers")
-		return fmt.Sprintf("count %s", args[0]), nil
+		return fmt.Sprintf("Seq.length %s", args[0]), nil
 	case "sum":
 		if len(args) != 1 {
 			return "", fmt.Errorf("sum expects 1 arg")
 		}
-		c.use("_seq_helpers")
-		return fmt.Sprintf("sum %s", args[0]), nil
+		return fmt.Sprintf("Seq.sum %s", args[0]), nil
 	case "avg":
 		if len(args) != 1 {
 			return "", fmt.Errorf("avg expects 1 arg")
 		}
-		c.use("_seq_helpers")
-		return fmt.Sprintf("avg %s", args[0]), nil
+		return fmt.Sprintf("Seq.average %s", args[0]), nil
 	case "substr":
 		if len(args) != 3 {
 			return "", fmt.Errorf("substr expects 3 args")
@@ -1698,36 +1693,31 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("reverse expects 1 arg")
 		}
 		if c.isStringExpr(call.Args[0]) {
-			c.use("_reverse_string")
-			return fmt.Sprintf("_reverse_string %s", args[0]), nil
+			return fmt.Sprintf("(%s.ToCharArray() |> Array.rev |> System.String)", args[0]), nil
 		}
 		if c.isListExpr(call.Args[0]) {
-			c.use("_reverse_array")
-			return fmt.Sprintf("_reverse_array %s", args[0]), nil
+			return fmt.Sprintf("Array.rev %s", args[0]), nil
 		}
 		return "", fmt.Errorf("reverse expects string or list")
 	case "concat":
 		if len(args) < 2 {
 			return "", fmt.Errorf("concat expects at least 2 args")
 		}
-		c.use("_concat")
-		expr := fmt.Sprintf("_concat %s %s", args[0], args[1])
+		expr := fmt.Sprintf("Array.append %s %s", args[0], args[1])
 		for i := 2; i < len(args); i++ {
-			expr = fmt.Sprintf("_concat %s %s", expr, args[i])
+			expr = fmt.Sprintf("Array.append %s %s", expr, args[i])
 		}
 		return expr, nil
 	case "min":
 		if len(args) != 1 {
 			return "", fmt.Errorf("min expects 1 arg")
 		}
-		c.use("_seq_helpers")
-		return fmt.Sprintf("_min %s", args[0]), nil
+		return fmt.Sprintf("Seq.min %s", args[0]), nil
 	case "max":
 		if len(args) != 1 {
 			return "", fmt.Errorf("max expects 1 arg")
 		}
-		c.use("_seq_helpers")
-		return fmt.Sprintf("_max %s", args[0]), nil
+		return fmt.Sprintf("Seq.max %s", args[0]), nil
 	case "now":
 		if len(args) != 0 {
 			return "", fmt.Errorf("now expects no args")

--- a/compile/x/fs/runtime.go
+++ b/compile/x/fs/runtime.go
@@ -189,26 +189,26 @@ const (
   if stop < start then stop <- start
   s.Substring(start, stop - start)`
 
-	helperReverseArray = `let _reverse_array (xs: 'T[]) : 'T[] =
+	helperReverseArray = `let inline _reverse_array (xs: 'T[]) : 'T[] =
   Array.rev xs`
 
-	helperReverseString = `let _reverse_string (s: string) : string =
+	helperReverseString = `let inline _reverse_string (s: string) : string =
   s.ToCharArray() |> Array.rev |> System.String`
 
-	helperConcat = `let _concat (a: 'T[]) (b: 'T[]) : 'T[] =
+	helperConcat = `let inline _concat (a: 'T[]) (b: 'T[]) : 'T[] =
   Array.append a b`
 
-	helperUnionAll = `let _union_all (a: 'T[]) (b: 'T[]) : 'T[] =
+	helperUnionAll = `let inline _union_all (a: 'T[]) (b: 'T[]) : 'T[] =
   Array.append a b`
 
-	helperUnion = `let _union (a: 'T[]) (b: 'T[]) : 'T[] =
+	helperUnion = `let inline _union (a: 'T[]) (b: 'T[]) : 'T[] =
   Array.append a b |> Array.distinct`
 
-	helperExcept = `let _except (a: 'T[]) (b: 'T[]) : 'T[] =
+	helperExcept = `let inline _except (a: 'T[]) (b: 'T[]) : 'T[] =
   let setB = Set.ofArray b
   Array.filter (fun x -> not (Set.contains x setB)) a`
 
-	helperIntersect = `let _intersect (a: 'T[]) (b: 'T[]) : 'T[] =
+	helperIntersect = `let inline _intersect (a: 'T[]) (b: 'T[]) : 'T[] =
   let setB = Set.ofArray b
   Array.filter (fun x -> Set.contains x setB) a |> Array.distinct`
 

--- a/types/infer.go
+++ b/types/infer.go
@@ -113,23 +113,20 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 				var res Type
 				switch ops[i] {
 				case "+", "-", "*", "/", "%":
-					if isInt64(left) {
-						if isInt64(right) || isInt(right) {
-							res = Int64Type{}
-							break
-						}
+					if (isInt64(left) && (isInt64(right) || isInt(right))) ||
+						(isInt64(right) && isInt(left)) {
+						res = Int64Type{}
+						break
 					}
-					if _, ok := left.(IntType); ok {
-						if _, ok := right.(IntType); ok {
-							res = IntType{}
-							break
-						}
+					if (isFloat(left) || isFloat(right)) &&
+						(isInt(left) || isFloat(left) || isInt64(left)) &&
+						(isInt(right) || isFloat(right) || isInt64(right)) {
+						res = FloatType{}
+						break
 					}
-					if _, ok := left.(FloatType); ok {
-						if _, ok := right.(FloatType); ok {
-							res = FloatType{}
-							break
-						}
+					if isInt(left) && isInt(right) {
+						res = IntType{}
+						break
 					}
 					if ops[i] == "+" {
 						if ll, ok := left.(ListType); ok {


### PR DESCRIPTION
## Summary
- refine type inference to reduce `any` by handling numeric ops
- inline common runtime helpers in F# backend
- emit F# built‑ins instead of helper calls for several functions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867cf9356c883208ed5e2cd80371c3b