### PR TITLE
Improve Clojure type inference

### DIFF
--- a/compile/x/clj/helpers.go
+++ b/compile/x/clj/helpers.go
@@ -64,6 +64,10 @@ func isFloat(t types.Type) bool {
 	return ok
 }
 
+func isNumber(t types.Type) bool {
+	return isInt(t) || isFloat(t) || isInt64(t)
+}
+
 func isString(t types.Type) bool {
 	_, ok := t.(types.StringType)
 	return ok


### PR DESCRIPTION
## Summary
- expand helper functions with `isNumber`
- prefer native functions for membership tests
- inline numeric min/max/avg/sum in Clojure backend

## Testing
- `go test ./...`
- `go test ./compile/x/clj -tags slow` *(fails: clojure not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867d0c998b08320b04119ff3adfc601