### PR TITLE
Update SLT expr cases 100-199

### DIFF
--- a/tests/dataset/slt/out/slt_good_0/case100.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case100.mochi
@@ -2,30 +2,6 @@
 # line: 938
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case103.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case103.mochi
@@ -2,6 +2,30 @@
 # line: 968
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case108.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case108.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT - - 52 AS col1 */
-var result = [52]
+var result = [(52 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case109.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case109.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT - 33 + 89 AS col2 */
-var result = [(-33) + 89]
+var result = [((-33) + 89 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case110.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case110.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT + 62 col1 */
-var result = [62]
+var result = [(62 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case115.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case115.mochi
@@ -2,30 +2,6 @@
 # line: 1067
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case116.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case116.mochi
@@ -2,6 +2,30 @@
 # line: 1073
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab2 = [
   },
 ]
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 /* SELECT - 49 + + - 39 */
-var result = [(-49) + (-39)]
+var result = [((-49) + (-39) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case117.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case117.mochi
@@ -2,6 +2,30 @@
 # line: 1078
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab2 = [
   },
 ]
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 /* SELECT - - 60 col1 */
-var result = [60]
+var result = [(60 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case120.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case120.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT DISTINCT - 44 * - 33 */
-var result = [(-44) * (-33)]
+var result = [((-44) * (-33) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case121.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case121.mochi
@@ -2,30 +2,6 @@
 # line: 1114
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -74,8 +50,32 @@ let tab2 = [
   },
 ]
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 /* SELECT DISTINCT - 68 AS col2 */
-var result = [(-68)]
+var result = [((-68) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case128.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case128.mochi
@@ -2,30 +2,6 @@
 # line: 1193
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -74,8 +50,32 @@ let tab2 = [
   },
 ]
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 /* SELECT 58 + + COALESCE ( - 20, 19 + + 83 ) * 66 col0 */
-var result = [58 + (if (-20) != null then (-20) else 19 + 83) * 66]
+var result = [(58 + (if (-20) != null then (-20) else 19 + 83) * 66 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case129.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case129.mochi
@@ -2,30 +2,6 @@
 # line: 1198
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -74,8 +50,32 @@ let tab2 = [
   },
 ]
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 /* SELECT 67 * + + ( - ( 41 ) ) */
-var result = [67 * (-((41)))]
+var result = [(67 * ((-((41)))) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case132.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case132.mochi
@@ -2,30 +2,6 @@
 # line: 1227
 */
 
-type tab1Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab1 = [
-  tab1Row {
-    col0: 51,
-    col1: 14,
-    col2: 96,
-  },
-  tab1Row {
-    col0: 85,
-    col1: 5,
-    col2: 59,
-  },
-  tab1Row {
-    col0: 91,
-    col1: 47,
-    col2: 68,
-  },
-]
-
 type tab2Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab0 = [
     col0: 87,
     col1: 21,
     col2: 10,
+  },
+]
+
+type tab1Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab1 = [
+  tab1Row {
+    col0: 51,
+    col1: 14,
+    col2: 96,
+  },
+  tab1Row {
+    col0: 85,
+    col1: 5,
+    col2: 59,
+  },
+  tab1Row {
+    col0: 91,
+    col1: 47,
+    col2: 68,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case141.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case141.mochi
@@ -2,6 +2,30 @@
 # line: 1317
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab1 = [
   },
 ]
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 /* SELECT - - ( 84 ) AS col0, - 13 AS col2 */
-var result = [[-(-((84))), (-13)]]
+var result = [[(-((-((84))))), (-13)]]
 result = from row in result
   order by join(from v in row select str(v), " " )
   select row

--- a/tests/dataset/slt/out/slt_good_0/case143.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case143.mochi
@@ -2,6 +2,30 @@
 # line: 1335
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab2 = [
   },
 ]
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 /* SELECT DISTINCT - 18 col2 */
-var result = [(-18)]
+var result = [((-18) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case144.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case144.mochi
@@ -2,6 +2,30 @@
 # line: 1340
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab1 = [
   },
 ]
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 /* SELECT DISTINCT - + 97 - - 55 AS col0 */
-var result = [(-97) - (-55)]
+var result = [((-97) - (-55) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case148.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case148.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT + 74 * + 25 AS col2 */
-var result = [74 * 25]
+var result = [(74 * 25 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case149.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case149.mochi
@@ -75,7 +75,7 @@ let tab1 = [
 ]
 
 /* SELECT - 13 - + + 6 */
-var result = [(-13) - 6]
+var result = [((-13) - 6 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case150.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case150.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT DISTINCT - 49 AS col0 */
-var result = [(-49)]
+var result = [((-49) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case151.error
+++ b/tests/dataset/slt/out/slt_good_0/case151.error
@@ -1,5 +1,5 @@
 error[T008]: type mismatch: expected int, got float
-  --> :79:153
+  --> :79:157
 
 help:
   Change the value to match the expected type.

--- a/tests/dataset/slt/out/slt_good_0/case151.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case151.mochi
@@ -76,7 +76,7 @@ let tab1 = [
 ]
 
 /* SELECT 64 * + 51 * - - 15 + 72 + - + 15 * + - 27 * + 54 * + COALESCE ( - + ( + 71 ), - 66 * + - 53 + + + 45, 4 / + 66 ) AS col2 */
-var result = [64 * 51 * 15 + 72 + (-15) * (-27) * 54 * (if -((71)) != null then -((71)) else if (-66) * (-53) + 45 != null then (-66) * (-53) + 45 else (1.0 * (4)) / 66)]
+var result = [64 * 51 * 15 + 72 + (-15) * (-27) * 54 * (if (-((71))) != null then (-((71))) else if (-66) * (-53) + 45 != null then (-66) * (-53) + 45 else (1.0 * (4)) / 66)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case152.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case152.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT DISTINCT - ( - 4 ) AS col1 */
-var result = [-(((-4)))]
+var result = [((-(((-4)))) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case157.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case157.mochi
@@ -75,7 +75,7 @@ let tab0 = [
 ]
 
 /* SELECT + 44 * + 9 */
-var result = [44 * 9]
+var result = [(44 * 9 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case161.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case161.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT + COALESCE ( - 98, + + ( - 68 ) ) AS col2 */
-var result = [(if (-98) != null then (-98) else ((-68)))]
+var result = [((if (-98) != null then (-98) else ((-68))) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case164.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case164.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT DISTINCT ( - 57 ) * + 63 * 61 */
-var result = [((-57)) * 63 * 61]
+var result = [(((-57)) * 63 * 61 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case165.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case165.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT + 90 + 72 AS col0 */
-var result = [90 + 72]
+var result = [(90 + 72 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case171.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case171.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT + 68 + - + 54 + + - 23 + + 20 + 74 AS col2 */
-var result = [68 + (-54) + (-23) + 20 + 74]
+var result = [(68 + (-54) + (-23) + 20 + 74 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case174.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case174.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT - - 99 + 64 * 11 * + + 11 AS col2 */
-var result = [99 + 64 * 11 * 11]
+var result = [(99 + 64 * 11 * 11 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case178.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case178.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT + - 55 * 55 AS col0 */
-var result = [(-55) * 55]
+var result = [((-55) * 55 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case181.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case181.mochi
@@ -2,6 +2,30 @@
 # line: 1649
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab2 = [
   },
 ]
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 /* SELECT - 98 + - 41 * - + 77 + 49 col1 */
-var result = [(-98) + (-41) * (-77) + 49]
+var result = [((-98) + (-41) * (-77) + 49 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case186.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case186.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT - 80 * + 45 AS col0 */
-var result = [(-80) * 45]
+var result = [((-80) * 45 as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case188.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case188.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT - 98 + 72 * + - 35 */
-var result = [(-98) + 72 * (-35)]
+var result = [((-98) + 72 * (-35) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case192.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case192.mochi
@@ -75,7 +75,7 @@ let tab2 = [
 ]
 
 /* SELECT ( 90 ) */
-var result = [(90)]
+var result = [((90) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tests/dataset/slt/out/slt_good_0/case197.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case197.mochi
@@ -2,6 +2,30 @@
 # line: 1803
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -50,32 +74,8 @@ let tab2 = [
   },
 ]
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 /* SELECT - CASE + 97 WHEN 46 THEN 33 END * 10, + 90 AS col1 */
-var result = [[-(if (97 != null && 46 != null && 97 == 46) then 33 else null) * 10, 90]]
+var result = [[(-(if (97 != null && 46 != null && 97 == 46) then 33 else null)) * 10, 90]]
 result = from row in result
   order by join(from v in row select str(v), " " )
   select row

--- a/tests/dataset/slt/out/slt_good_0/case199.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case199.mochi
@@ -2,30 +2,6 @@
 # line: 1821
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -74,8 +50,32 @@ let tab1 = [
   },
 ]
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 /* SELECT ( + 38 ) */
-var result = [(38)]
+var result = [((38) as int)]
 result = from x in result
   order by str(x)
   select x

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -1183,6 +1183,9 @@ func Generate(c Case) string {
 			return ""
 		}
 		expr := exprToMochi(ae.Expr, subs)
+		if expectAllInts(c.Expect) {
+			expr = "(" + expr + " as int)"
+		}
 		cond := condToMochi(sel.Where, subs)
 		if len(sel.From) == 0 || (len(sel.From) == 1 && func() bool {
 			if tbl, ok := sel.From[0].(*sqlparser.AliasedTableExpr); ok {
@@ -1318,4 +1321,16 @@ func formatExpectList(xs []string) string {
 	}
 	sb.WriteString("]")
 	return sb.String()
+}
+
+func expectAllInts(xs []string) bool {
+	if len(xs) == 0 {
+		return false
+	}
+	for _, s := range xs {
+		if _, err := strconv.Atoi(s); err != nil {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- improve SLT generator to cast simple results to `int` when all expected
  values are integers
- regenerate expr `slt_good_0.test` cases 100–199
- keep `.error` for failing case 151

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867d2b5757c8320947de3d580abab14