### PR TITLE
Inline python helper ops

### DIFF
--- a/compile/py/helpers.go
+++ b/compile/py/helpers.go
@@ -145,6 +145,10 @@ func isFloat(t types.Type) bool {
 	return ok
 }
 
+func isNumeric(t types.Type) bool {
+	return isInt(t) || isFloat(t)
+}
+
 func isBool(t types.Type) bool {
 	_, ok := t.(types.BoolType)
 	return ok


### PR DESCRIPTION
## Summary
- add `isNumeric` helper
- inline operations in the Python backend when types are known

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6867d2d2783c8320854504a9f536b715