### PR TITLE
Generate SLT expr cases 400-499

### DIFF
--- a/tests/dataset/slt/out/slt_good_0/case421.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case421.mochi
@@ -2,30 +2,6 @@
 # line: 3863
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case433.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case433.mochi
@@ -2,6 +2,30 @@
 # line: 3977
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case442.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case442.mochi
@@ -2,6 +2,30 @@
 # line: 4078
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case455.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case455.mochi
@@ -2,30 +2,6 @@
 # line: 4208
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case458.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case458.mochi
@@ -2,6 +2,30 @@
 # line: 4239
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case462.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case462.mochi
@@ -2,6 +2,30 @@
 # line: 4259
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case467.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case467.mochi
@@ -3,30 +3,6 @@
 skipif mysql # not compatible
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -72,6 +48,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case480.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case480.mochi
@@ -2,6 +2,30 @@
 # line: 4438
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case482.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case482.mochi
@@ -2,30 +2,6 @@
 # line: 4456
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case484.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case484.mochi
@@ -2,30 +2,6 @@
 # line: 4474
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case485.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case485.mochi
@@ -2,6 +2,30 @@
 # line: 4479
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tools/slt/logic/generate.go
+++ b/tools/slt/logic/generate.go
@@ -1084,7 +1084,13 @@ func Generate(c Case) string {
 		}
 	}
 
-	for name, t := range c.Tables {
+	names := make([]string, 0, len(c.Tables))
+	for n := range c.Tables {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		t := c.Tables[name]
 		kw := "let"
 		if mutated[name] {
 			kw = "var"


### PR DESCRIPTION
## Summary
- sort tables when generating Mochi code so output order is deterministic
- regenerate expr/slt_good_0 cases 400-499 with latest generator

## Testing
- `go test ./tools/slt/logic -run .`
- `go run ./cmd/mochi-slt gen --cases case400-case499 --files test/random/expr/slt_good_0.test --out tests/dataset/slt/out --run`

------
https://chatgpt.com/codex/tasks/task_e_6867d3102d848320a08cb2c0dbcb78b4