### PR TITLE
Update expr SLT cases and improve generator

### DIFF
--- a/tests/dataset/slt/out/slt_good_0/case151.error
+++ b/tests/dataset/slt/out/slt_good_0/case151.error
@@ -1,5 +1,5 @@
 error[T008]: type mismatch: expected int, got float
-  --> :79:153
+  --> :79:157
 
 help:
   Change the value to match the expected type.

--- a/tests/dataset/slt/out/slt_good_0/case151.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case151.mochi
@@ -3,30 +3,6 @@
 skipif mysql # not compatible
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -75,8 +51,32 @@ let tab1 = [
   },
 ]
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 /* SELECT 64 * + 51 * - - 15 + 72 + - + 15 * + - 27 * + 54 * + COALESCE ( - + ( + 71 ), - 66 * + - 53 + + + 45, 4 / + 66 ) AS col2 */
-var result = [64 * 51 * 15 + 72 + (-15) * (-27) * 54 * (if -((71)) != null then -((71)) else if (-66) * (-53) + 45 != null then (-66) * (-53) + 45 else (1.0 * (4)) / 66)]
+var result = [64 * 51 * 15 + 72 + (-15) * (-27) * 54 * (if (-((71))) != null then (-((71))) else if (-66) * (-53) + 45 != null then (-66) * (-53) + 45 else (1.0 * (4)) / 66)]
 result = from x in result
   order by str(x)
   select x
@@ -85,5 +85,5 @@ for x in result {
 }
 
 test "case151" {
-  expect result == [(-1503738)]
+  expect result == [(-1503738.0)]
 }

--- a/tests/dataset/slt/out/slt_good_0/case302.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case302.mochi
@@ -2,6 +2,30 @@
 # line: 2765
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case307.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case307.mochi
@@ -2,30 +2,6 @@
 # line: 2820
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case319.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case319.mochi
@@ -2,6 +2,30 @@
 # line: 2940
 */
 
+type tab1Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab1 = [
+  tab1Row {
+    col0: 51,
+    col1: 14,
+    col2: 96,
+  },
+  tab1Row {
+    col0: 85,
+    col1: 5,
+    col2: 59,
+  },
+  tab1Row {
+    col0: 91,
+    col1: 47,
+    col2: 68,
+  },
+]
+
 type tab2Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab0 = [
     col0: 87,
     col1: 21,
     col2: 10,
-  },
-]
-
-type tab1Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab1 = [
-  tab1Row {
-    col0: 51,
-    col1: 14,
-    col2: 96,
-  },
-  tab1Row {
-    col0: 85,
-    col1: 5,
-    col2: 59,
-  },
-  tab1Row {
-    col0: 91,
-    col1: 47,
-    col2: 68,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case320.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case320.mochi
@@ -2,6 +2,30 @@
 # line: 2945
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case323.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case323.mochi
@@ -2,6 +2,30 @@
 # line: 2974
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
-  },
-]
-
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case329.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case329.mochi
@@ -2,30 +2,6 @@
 # line: 3043
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case336.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case336.mochi
@@ -2,6 +2,30 @@
 # line: 3106
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
-  },
-]
-
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case341.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case341.mochi
@@ -3,6 +3,30 @@
 skipif mysql # not compatible
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -48,30 +72,6 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
-  },
-]
-
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case343.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case343.mochi
@@ -2,30 +2,6 @@
 # line: 3155
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case344.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case344.mochi
@@ -2,6 +2,30 @@
 # line: 3160
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case348.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case348.mochi
@@ -2,30 +2,6 @@
 # line: 3209
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case369.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case369.mochi
@@ -2,6 +2,30 @@
 # line: 3430
 */
 
+type tab1Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab1 = [
+  tab1Row {
+    col0: 51,
+    col1: 14,
+    col2: 96,
+  },
+  tab1Row {
+    col0: 85,
+    col1: 5,
+    col2: 59,
+  },
+  tab1Row {
+    col0: 91,
+    col1: 47,
+    col2: 68,
+  },
+]
+
 type tab2Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab0 = [
     col0: 87,
     col1: 21,
     col2: 10,
-  },
-]
-
-type tab1Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab1 = [
-  tab1Row {
-    col0: 51,
-    col1: 14,
-    col2: 96,
-  },
-  tab1Row {
-    col0: 85,
-    col1: 5,
-    col2: 59,
-  },
-  tab1Row {
-    col0: 91,
-    col1: 47,
-    col2: 68,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case370.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case370.mochi
@@ -2,30 +2,6 @@
 # line: 3435
 */
 
-type tab1Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab1 = [
-  tab1Row {
-    col0: 51,
-    col1: 14,
-    col2: 96,
-  },
-  tab1Row {
-    col0: 85,
-    col1: 5,
-    col2: 59,
-  },
-  tab1Row {
-    col0: 91,
-    col1: 47,
-    col2: 68,
-  },
-]
-
 type tab2Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab0 = [
     col0: 87,
     col1: 21,
     col2: 10,
+  },
+]
+
+type tab1Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab1 = [
+  tab1Row {
+    col0: 51,
+    col1: 14,
+    col2: 96,
+  },
+  tab1Row {
+    col0: 85,
+    col1: 5,
+    col2: 59,
+  },
+  tab1Row {
+    col0: 91,
+    col1: 47,
+    col2: 68,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case371.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case371.mochi
@@ -2,30 +2,6 @@
 # line: 3440
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case375.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case375.mochi
@@ -2,6 +2,30 @@
 # line: 3468
 */
 
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
+  },
+]
+
 type tab1Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
-  },
-]
-
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case379.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case379.mochi
@@ -2,6 +2,30 @@
 # line: 3495
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
-  },
-]
-
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case386.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case386.mochi
@@ -2,6 +2,30 @@
 # line: 3544
 */
 
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
+  },
+]
+
 type tab0Row {
   col0: int
   col1: int
@@ -47,30 +71,6 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
-  },
-]
-
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case389.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case389.mochi
@@ -3,30 +3,6 @@
 skipif mysql # not compatible
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -72,6 +48,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case392.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case392.mochi
@@ -2,30 +2,6 @@
 # line: 3605
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case395.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case395.mochi
@@ -2,30 +2,6 @@
 # line: 3620
 */
 
-type tab2Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab2 = [
-  tab2Row {
-    col0: 64,
-    col1: 77,
-    col2: 40,
-  },
-  tab2Row {
-    col0: 75,
-    col1: 67,
-    col2: 58,
-  },
-  tab2Row {
-    col0: 46,
-    col1: 51,
-    col2: 23,
-  },
-]
-
 type tab0Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab1 = [
     col0: 91,
     col1: 47,
     col2: 68,
+  },
+]
+
+type tab2Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab2 = [
+  tab2Row {
+    col0: 64,
+    col1: 77,
+    col2: 40,
+  },
+  tab2Row {
+    col0: 75,
+    col1: 67,
+    col2: 58,
+  },
+  tab2Row {
+    col0: 46,
+    col1: 51,
+    col2: 23,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case396.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case396.mochi
@@ -2,30 +2,6 @@
 # line: 3625
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case397.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case397.mochi
@@ -2,30 +2,6 @@
 # line: 3630
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 

--- a/tests/dataset/slt/out/slt_good_0/case399.mochi
+++ b/tests/dataset/slt/out/slt_good_0/case399.mochi
@@ -2,30 +2,6 @@
 # line: 3647
 */
 
-type tab0Row {
-  col0: int
-  col1: int
-  col2: int
-}
-
-let tab0 = [
-  tab0Row {
-    col0: 97,
-    col1: 1,
-    col2: 99,
-  },
-  tab0Row {
-    col0: 15,
-    col1: 81,
-    col2: 47,
-  },
-  tab0Row {
-    col0: 87,
-    col1: 21,
-    col2: 10,
-  },
-]
-
 type tab1Row {
   col0: int
   col1: int
@@ -71,6 +47,30 @@ let tab2 = [
     col0: 46,
     col1: 51,
     col2: 23,
+  },
+]
+
+type tab0Row {
+  col0: int
+  col1: int
+  col2: int
+}
+
+let tab0 = [
+  tab0Row {
+    col0: 97,
+    col1: 1,
+    col2: 99,
+  },
+  tab0Row {
+    col0: 15,
+    col1: 81,
+    col2: 47,
+  },
+  tab0Row {
+    col0: 87,
+    col1: 21,
+    col2: 10,
   },
 ]
 


### PR DESCRIPTION
## Summary
- improve `coalesce` conversion so branch types are preserved
- keep floating‑point results in `formatExpectList`
- regenerate expr `slt_good_0` cases 300-399
- refresh failing case151 diagnostics

## Testing
- `go test ./tools/slt/logic -run Test -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6867d4ee7a508320ae13ba0abb1876da