### PR TITLE
Improve Python compiler type inference

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -749,30 +749,30 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "input":
 		return "input()", nil
 	case "count":
-               if len(args) == 1 {
-                       t := c.inferExprType(call.Args[0])
-                       switch t.(type) {
-                       case types.ListType:
-                               return fmt.Sprintf("len(%s)", args[0]), nil
-                       case types.GroupType:
-                               return fmt.Sprintf("len(%s.Items)", args[0]), nil
-                       case types.MapType, types.StringType:
-                               return fmt.Sprintf("len(%s)", args[0]), nil
-                       }
+		if len(args) == 1 {
+			t := c.inferExprType(call.Args[0])
+			switch t.(type) {
+			case types.ListType:
+				return fmt.Sprintf("len(%s)", args[0]), nil
+			case types.GroupType:
+				return fmt.Sprintf("len(%s.Items)", args[0]), nil
+			case types.MapType, types.StringType:
+				return fmt.Sprintf("len(%s)", args[0]), nil
+			}
 		}
 		c.use("_count")
 		return fmt.Sprintf("_count(%s)", argStr), nil
 	case "exists":
-               if len(args) == 1 {
-                       t := c.inferExprType(call.Args[0])
-                       switch t.(type) {
-                       case types.ListType:
-                               return fmt.Sprintf("(len(%s) > 0)", args[0]), nil
-                       case types.GroupType:
-                               return fmt.Sprintf("(len(%s.Items) > 0)", args[0]), nil
-                       case types.MapType, types.StringType:
-                               return fmt.Sprintf("(len(%s) > 0)", args[0]), nil
-                       }
+		if len(args) == 1 {
+			t := c.inferExprType(call.Args[0])
+			switch t.(type) {
+			case types.ListType:
+				return fmt.Sprintf("(len(%s) > 0)", args[0]), nil
+			case types.GroupType:
+				return fmt.Sprintf("(len(%s.Items) > 0)", args[0]), nil
+			case types.MapType, types.StringType:
+				return fmt.Sprintf("(len(%s) > 0)", args[0]), nil
+			}
 		}
 		c.use("_exists")
 		return fmt.Sprintf("_exists(%s)", argStr), nil
@@ -847,9 +847,13 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(args) != 1 {
 			return "", fmt.Errorf("first expects 1 arg")
 		}
-		if _, ok := c.inferExprType(call.Args[0]).(types.ListType); ok {
+		switch c.inferExprType(call.Args[0]).(type) {
+		case types.ListType:
 			arg := args[0]
 			return fmt.Sprintf("(%s[0] if len(%s) > 0 else None)", arg, arg), nil
+		case types.GroupType:
+			arg := args[0]
+			return fmt.Sprintf("(%s.Items[0] if len(%s.Items) > 0 else None)", arg, arg), nil
 		}
 		c.use("_first")
 		return fmt.Sprintf("_first(%s)", args[0]), nil
@@ -931,6 +935,8 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return fmt.Sprintf("(str(%s) in %s)", args[1], args[0]), nil
 		case types.MapType:
 			return fmt.Sprintf("(str(%s) in %s)", args[1], args[0]), nil
+		case types.GroupType:
+			return fmt.Sprintf("(%s in %s.Items)", args[1], args[0]), nil
 		}
 		c.use("_contains")
 		return fmt.Sprintf("_contains(%s, %s)", args[0], args[1]), nil

--- a/types/infer.go
+++ b/types/infer.go
@@ -581,21 +581,15 @@ func inferIfExprType(ie *parser.IfExpr, env *Env) Type {
 func ResultType(op string, left, right Type) Type {
 	switch op {
 	case "+", "-", "*", "/", "%":
-		if _, ok := left.(IntType); ok {
-			if _, ok := right.(IntType); ok {
-				return IntType{}
-			}
-		}
-		if _, ok := left.(FloatType); ok {
-			if _, ok := right.(FloatType); ok {
+		if isNumeric(left) && isNumeric(right) {
+			if isFloat(left) || isFloat(right) {
 				return FloatType{}
 			}
+			return IntType{}
 		}
 		if op == "+" {
-			if _, ok := left.(StringType); ok {
-				if _, ok := right.(StringType); ok {
-					return StringType{}
-				}
+			if isString(left) || isString(right) {
+				return StringType{}
 			}
 			if ll, ok := left.(ListType); ok {
 				if rl, ok := right.(ListType); ok {
@@ -608,7 +602,7 @@ func ResultType(op string, left, right Type) Type {
 			}
 		}
 		return AnyType{}
-	case "==", "!=", "<", "<=", ">", ">=":
+	case "==", "!=", "<", "<=", ">", ">=", "in", "&&", "||":
 		return BoolType{}
 	case "union", "union_all", "except", "intersect":
 		if llist, ok := left.(ListType); ok {


### PR DESCRIPTION
## Summary
- refine ResultType to infer numeric and boolean ops better
- inline `first` and `contains` for group values

## Testing
- `make test STAGE=compile/py`

------
https://chatgpt.com/codex/tasks/task_e_6867d5713d188320b50b23a718670460