### PR TITLE
Add sqlite2duck converter tool

### DIFF
--- a/cmd/sqlite2duck/main.go
+++ b/cmd/sqlite2duck/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"mochi/tools/sqlite2duck"
+)
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: sqlite2duck <file.sql>|-")
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		usage()
+	}
+	var data []byte
+	var err error
+	if os.Args[1] == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(os.Args[1])
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	out := sqlite2duck.Convert(string(data))
+	fmt.Print(out)
+}

--- a/tools/sqlite2duck/README.md
+++ b/tools/sqlite2duck/README.md
@@ -1,0 +1,28 @@
+# sqlite2duck
+
+`sqlite2duck` converts common SQLite SQL syntax to DuckDB equivalents. It performs a few textual rewrites so that queries written for SQLite can run on DuckDB.
+
+## Usage
+
+Run the tool with a path to a `.sql` file or pass `-` to read from standard input:
+
+```bash
+sqlite2duck query.sql
+cat query.sql | sqlite2duck -
+```
+
+The converted query is printed to standard output.
+
+## Supported conversions
+
+The converter currently handles the following patterns:
+
+- `ifnull()` -> `coalesce()`
+- `substr()` -> `substring()`
+- `group_concat()` -> `string_agg()`
+- `datetime('now')` -> `now()`
+- `date('now')` -> `current_date`
+- `randomblob(n)` -> `random_bytes(n)`
+
+These rules cover the most common differences encountered when porting simple
+SQLite queries.

--- a/tools/sqlite2duck/converter.go
+++ b/tools/sqlite2duck/converter.go
@@ -1,0 +1,28 @@
+package sqlite2duck
+
+import (
+	"regexp"
+	"strings"
+)
+
+var replacer = strings.NewReplacer(
+	"ifnull(", "coalesce(",
+	"IFNULL(", "COALESCE(",
+	"substr(", "substring(",
+	"SUBSTR(", "SUBSTRING(",
+	"group_concat(", "string_agg(",
+	"GROUP_CONCAT(", "STRING_AGG(",
+	"randomblob(", "random_bytes(",
+	"RANDOMBLOB(", "RANDOM_BYTES(",
+)
+
+var reDateTimeNow = regexp.MustCompile(`(?i)datetime\s*\(\s*'now'\s*\)`)
+var reDateNow = regexp.MustCompile(`(?i)date\s*\(\s*'now'\s*\)`)
+
+// Convert rewrites common SQLite syntax to DuckDB syntax.
+func Convert(sql string) string {
+	out := replacer.Replace(sql)
+	out = reDateTimeNow.ReplaceAllString(out, "now()")
+	out = reDateNow.ReplaceAllString(out, "current_date")
+	return out
+}

--- a/tools/sqlite2duck/converter_test.go
+++ b/tools/sqlite2duck/converter_test.go
@@ -1,0 +1,20 @@
+package sqlite2duck
+
+import "testing"
+
+func TestConvert(t *testing.T) {
+	tests := []struct{ in, out string }{
+		{"SELECT ifnull(a,0) FROM t;", "SELECT coalesce(a,0) FROM t;"},
+		{"SELECT substr(name,1,2) FROM t;", "SELECT substring(name,1,2) FROM t;"},
+		{"SELECT group_concat(x, ',') FROM t;", "SELECT string_agg(x, ',') FROM t;"},
+		{"SELECT datetime('now');", "SELECT now();"},
+		{"SELECT date('now');", "SELECT current_date;"},
+		{"SELECT randomblob(4);", "SELECT random_bytes(4);"},
+	}
+	for _, tt := range tests {
+		got := Convert(tt.in)
+		if got != tt.out {
+			t.Fatalf("convert %q => %q, want %q", tt.in, got, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `sqlite2duck` library and CLI for translating SQLite queries to DuckDB
- include unit tests for converter
- document usage and supported conversions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867df1594688320907531ba024f2b92