### PR TITLE
Add minimal Doom renderer in pure Mochi

### DIFF
--- a/core/doom/README.md
+++ b/core/doom/README.md
@@ -1,0 +1,31 @@
+# `core/doom`
+
+This directory contains a tiny ray‑casting renderer implemented entirely in Mochi. The goal is to provide a very small, self‑contained example of how a "Doom"‑style 3D view can be produced without any FFI calls.
+
+## Architecture
+
+- **Map** – a list of strings where `#` represents a wall and `.` or space is empty.
+- **Player** – position (`x`, `y`) and viewing angle in radians.
+- **Renderer** – `render(map, player, width, height)` casts rays and returns an ASCII image as a list of lines.
+
+The implementation uses simple trigonometry approximations written in pure Mochi. Rendering is done in text only and meant for educational purposes rather than performance.
+
+## Example
+
+```mochi
+import "core/doom/doom.mochi" as doom
+
+let map = [
+  "########",
+  "#......#",
+  "#..##..#",
+  "#......#",
+  "########",
+]
+
+var p = doom.Player{ x: 3.5, y: 3.5, angle: 0.0 }
+let screen = doom.render(map, p, 40, 12)
+for line in screen { print(line) }
+```
+
+Running this program prints a simple first‑person view of the scene. Move the player by updating `p.x`, `p.y`, and `p.angle` and calling `render` again.

--- a/core/doom/doom.mochi
+++ b/core/doom/doom.mochi
@@ -1,0 +1,87 @@
+package doom
+
+// Simple ASCII ray-casting renderer written in pure Mochi.
+// No external dependencies or FFI calls are used.
+
+export type Player { x: float, y: float, angle: float }
+
+export let PI: float = 3.141592653589793
+let TWO_PI: float = 6.283185307179586
+
+fun _mod(x: float, m: float): float {
+  return x - float(int(x / m)) * m
+}
+
+fun _sin(x: float): float {
+  let y = _mod(x + PI, TWO_PI) - PI
+  let y2 = y * y
+  let y3 = y2 * y
+  let y5 = y3 * y2
+  let y7 = y5 * y2
+  return y - y3/6.0 + y5/120.0 - y7/5040.0
+}
+
+fun _cos(x: float): float {
+  let y = _mod(x + PI, TWO_PI) - PI
+  let y2 = y * y
+  let y4 = y2 * y2
+  let y6 = y4 * y2
+  return 1.0 - y2/2.0 + y4/24.0 - y6/720.0
+}
+
+fun _castRay(map: list<string>, px: float, py: float, ang: float, maxDist: float, step: float): float {
+  var dist = step
+  let rows = len(map)
+  let cols = len(map[0])
+  var hit = false
+  while dist < maxDist && !hit {
+    let rx = px + _cos(ang) * dist
+    let ry = py + _sin(ang) * dist
+    if int(ry) < 0 || int(ry) >= rows || int(rx) < 0 || int(rx) >= cols {
+      hit = true
+      dist = maxDist
+      break
+    }
+    if map[int(ry)][int(rx)] == '#' {
+      hit = true
+    } else {
+      dist = dist + step
+    }
+  }
+  return dist
+}
+
+export fun render(map: list<string>, p: Player, width: int, height: int): list<string> {
+  let fov = PI / 3.0 // 60 degrees
+  let maxDist = 20.0
+  var cols: list<int> = []
+  var i = 0
+  while i < width {
+    let ang = p.angle + (float(i)/float(width) - 0.5) * fov
+    let d = _castRay(map, p.x, p.y, ang, maxDist, 0.05)
+    var h = int(float(height) / d)
+    if h > height { h = height }
+    cols = cols + [h]
+    i = i + 1
+  }
+
+  var screen: list<string> = []
+  var y = 0
+  while y < height {
+    var line = ""
+    var x = 0
+    while x < width {
+      let h = cols[x]
+      let top = (height - h) / 2
+      let bottom = (height + h) / 2
+      var ch = ' '
+      if y >= bottom { ch = '.' }
+      if y >= top && y < bottom { ch = '#' }
+      line = line + ch
+      x = x + 1
+    }
+    screen = screen + [line]
+    y = y + 1
+  }
+  return screen
+}


### PR DESCRIPTION
## Summary
- add `core/doom` with README describing the small ray‑casting demo
- implement `core/doom/doom.mochi` – a pure Mochi text renderer for a Doom‑style view

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6867e1bb97888320bfb82295706ece0a