### PR TITLE
Add release notes for v0.10.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # 📦 CHANGELOG.md
+## [0.10.15] – 2025-07-04T22:41:30+07:00
+
+### Added
+
+* Map update statements across Go, C, C#, C++ and TypeScript
+* `reduce` builtin for Go and C backends with optimized count and exists
+* SQL Logic Test group-by, aggregate and expression cases
+* sqlite2duck conversion tool and tests
+
+### Changed
+
+* Typed helpers and improved type inference across Go, C++, Python and Zig
+* Inline helpers and case builtin optimizations
+* Deterministic table order for SQL Logic Test generation
+
+### Fixed
+
+* Numeric operation errors in the virtual machine
+
 
 ## [0.10.14] – 2025-07-04T10:49:16+07:00
 

--- a/releases/v0.10.15.md
+++ b/releases/v0.10.15.md
@@ -1,0 +1,28 @@
+# Jul 2025 (v0.10.15)
+
+Released on Fri Jul 4 22:41:30 2025 +0700.
+
+Mochi v0.10.15 extends SQL Logic Test coverage with group-by and expression cases while improving map updates and type inference across compilers.
+
+## Runtime
+
+- `reduce` builtin added with optimized count and exists operations
+- Inline value conversions and numeric fixes in the VM
+
+## Compilers
+
+- Map update statements supported across Go, C, C#, C++ and TypeScript
+- Typed helpers and smarter inference for Go, C++, Python and Zig
+- Inline helpers reduce runtime overhead and case builtins optimized
+
+## Datasets
+
+- Generate group-by cases and aggregate function tests for SQL Logic Test
+- Random expression suites with deterministic table order
+- Updated select3 and expression outputs
+
+## Tooling
+
+- sqlite2duck conversion utility with tests
+- Minimal Doom renderer example added
+


### PR DESCRIPTION
## Summary
- document new release notes for v0.10.15
- update CHANGELOG with v0.10.15 entry

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6867f6b8e9908320b9037acf1199fc6f