### PR TITLE
Update sqlite2duck converter

### DIFF
--- a/tools/sqlite2duck/README.md
+++ b/tools/sqlite2duck/README.md
@@ -20,8 +20,11 @@ The converter currently handles the following patterns:
 - `ifnull()` -> `coalesce()`
 - `substr()` -> `substring()`
 - `group_concat()` -> `string_agg()`
+- `char_length()` -> `length()`
 - `datetime('now')` -> `now()`
 - `date('now')` -> `current_date`
+- `CURRENT_DATE` -> `current_date`
+- `CURRENT_TIME` -> `current_time`
 - `randomblob(n)` -> `random_bytes(n)`
 - `total(x)` -> `coalesce(sum(x),0)`
 - remove `NOT INDEXED` clauses

--- a/tools/sqlite2duck/converter.go
+++ b/tools/sqlite2duck/converter.go
@@ -14,6 +14,9 @@ var conversions = []struct {
 	{regexp.MustCompile(`(?i)\bgroup_concat\s*\(`), "string_agg("},
 	{regexp.MustCompile(`(?i)\brandomblob\s*\(`), "random_bytes("},
 	{regexp.MustCompile(`(?i)\bcurrent_timestamp\b`), "now()"},
+	{regexp.MustCompile(`(?i)\bchar_length\s*\(`), "length("},
+	{regexp.MustCompile(`(?i)\bcurrent_date\b`), "current_date"},
+	{regexp.MustCompile(`(?i)\bcurrent_time\b`), "current_time"},
 }
 
 var (

--- a/tools/sqlite2duck/converter_test.go
+++ b/tools/sqlite2duck/converter_test.go
@@ -16,6 +16,9 @@ func TestConvert(t *testing.T) {
 		{"SELECT CURRENT_TIMESTAMP;", "SELECT now();"},
 		{"SELECT total(x) FROM t;", "SELECT coalesce(sum(x),0) FROM t;"},
 		{"SELECT * FROM t NOT INDEXED;", "SELECT * FROM t;"},
+		{"SELECT char_length(name) FROM t;", "SELECT length(name) FROM t;"},
+		{"SELECT CURRENT_DATE;", "SELECT current_date;"},
+		{"SELECT CURRENT_TIME;", "SELECT current_time;"},
 	}
 	for _, tt := range tests {
 		got := Convert(tt.in)


### PR DESCRIPTION
## Summary
- expand converter to handle `char_length`, `CURRENT_DATE` and `CURRENT_TIME`
- document new conversions
- add unit tests for the additional rules

## Testing
- `go test ./tools/sqlite2duck -tags slow -run TestConvert -count=1`
- `go test ./tools/sqlite2duck -tags slow -run TestSLTConvert -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868043480e08320a2499c7bd2d95a11