### PR TITLE
Enhance sqlite2duck

### DIFF
--- a/tools/sqlite2duck/README.md
+++ b/tools/sqlite2duck/README.md
@@ -21,6 +21,8 @@ The converter currently handles the following patterns:
 - `substr()` -> `substring()`
 - `group_concat()` -> `string_agg()`
 - `char_length()` -> `length()`
+- `printf()` -> `format()`
+- `instr()` -> `strpos()`
 - `datetime('now')` -> `now()`
 - `date('now')` -> `current_date`
 - `CURRENT_DATE` -> `current_date`

--- a/tools/sqlite2duck/converter.go
+++ b/tools/sqlite2duck/converter.go
@@ -15,6 +15,8 @@ var conversions = []struct {
 	{regexp.MustCompile(`(?i)\brandomblob\s*\(`), "random_bytes("},
 	{regexp.MustCompile(`(?i)\bcurrent_timestamp\b`), "now()"},
 	{regexp.MustCompile(`(?i)\bchar_length\s*\(`), "length("},
+	{regexp.MustCompile(`(?i)\bprintf\s*\(`), "format("},
+	{regexp.MustCompile(`(?i)\binstr\s*\(`), "strpos("},
 	{regexp.MustCompile(`(?i)\bcurrent_date\b`), "current_date"},
 	{regexp.MustCompile(`(?i)\bcurrent_time\b`), "current_time"},
 }

--- a/tools/sqlite2duck/converter_test.go
+++ b/tools/sqlite2duck/converter_test.go
@@ -17,6 +17,8 @@ func TestConvert(t *testing.T) {
 		{"SELECT total(x) FROM t;", "SELECT coalesce(sum(x),0) FROM t;"},
 		{"SELECT * FROM t NOT INDEXED;", "SELECT * FROM t;"},
 		{"SELECT char_length(name) FROM t;", "SELECT length(name) FROM t;"},
+		{"SELECT printf('%d', a) FROM t;", "SELECT format('%d', a) FROM t;"},
+		{"SELECT instr(a, b) FROM t;", "SELECT strpos(a, b) FROM t;"},
 		{"SELECT CURRENT_DATE;", "SELECT current_date;"},
 		{"SELECT CURRENT_TIME;", "SELECT current_time;"},
 	}


### PR DESCRIPTION
## Summary
- support `printf()` -> `format()` and `instr()` -> `strpos()`
- document additional conversions
- test new conversions

## Testing
- `go test ./tools/sqlite2duck -tags slow -run TestConvert -v`
- `go test ./tools/sqlite2duck -tags slow -run TestSLTConvert -v`


------
https://chatgpt.com/codex/tasks/task_e_6868084fe9c48320b291b062b0f7e2f3