### PR TITLE
Add movement helpers to doom core

### DIFF
--- a/core/doom/README.md
+++ b/core/doom/README.md
@@ -28,4 +28,12 @@ let screen = doom.render(map, p, 40, 12)
 for line in screen { print(line) }
 ```
 
-Running this program prints a simple first‑person view of the scene. Move the player by updating `p.x`, `p.y`, and `p.angle` and calling `render` again.
+Running this program prints a simple first‑person view of the scene.
+You can move the player with `doom.move` and rotate with `doom.rotate`:
+
+```mochi
+p = doom.move(p, map, 1.0)
+p = doom.rotate(p, doom.PI / 2.0)
+```
+
+Both helpers perform basic collision detection and angle wrapping.

--- a/core/doom/doom.mochi
+++ b/core/doom/doom.mochi
@@ -85,3 +85,25 @@ export fun render(map: list<string>, p: Player, width: int, height: int): list<s
   }
   return screen
 }
+
+// move advances the player forward by `dist` if no wall is hit.
+// Movement stops when the next tile would be a wall or outside the map.
+export fun move(p: Player, map: list<string>, dist: float): Player {
+  let nx = p.x + _cos(p.angle) * dist
+  let ny = p.y + _sin(p.angle) * dist
+  let rows = len(map)
+  let cols = len(map[0])
+  if int(ny) < 0 || int(ny) >= rows || int(nx) < 0 || int(nx) >= cols {
+    return p
+  }
+  if map[int(ny)][int(nx)] == '#' {
+    return p
+  }
+  return Player{ x: nx, y: ny, angle: p.angle }
+}
+
+// rotate adjusts the player's viewing angle and keeps it within [0, 2π).
+export fun rotate(p: Player, delta: float): Player {
+  let ang = _mod(p.angle + delta, TWO_PI)
+  return Player{ x: p.x, y: p.y, angle: ang }
+}

--- a/tests/types/valid/doom_move.golden
+++ b/tests/types/valid/doom_move.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/doom_move.mochi
+++ b/tests/types/valid/doom_move.mochi
@@ -1,0 +1,9 @@
+import "core/doom/doom.mochi" as doom
+var p = doom.Player{ x:1.0, y:1.0, angle:0.0 }
+let map = [
+  "###",
+  "#.#",
+  "###",
+]
+p = doom.move(p, map, 1.0)
+p = doom.rotate(p, doom.PI)


### PR DESCRIPTION
## Summary
- add `move` and `rotate` helpers to `core/doom/doom.mochi`
- document player movement in `core/doom/README.md`
- add a type-check test for the new helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68680f8e93448320aeaaea8f176db676