### PR TITLE
Extend go2mochi translator

### DIFF
--- a/tests/compiler/go/break_continue.mochi.error
+++ b/tests/compiler/go/break_continue.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/cross_join.mochi.error
+++ b/tests/compiler/go/cross_join.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/cross_join_triple.mochi.error
+++ b/tests/compiler/go/cross_join_triple.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/dataset.mochi.error
+++ b/tests/compiler/go/dataset.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/fun_expr_in_let.mochi.error
+++ b/tests/compiler/go/fun_expr_in_let.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.FuncLit

--- a/tests/compiler/go/join.mochi.error
+++ b/tests/compiler/go/join.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/join_filter.mochi.error
+++ b/tests/compiler/go/join_filter.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/list_index.mochi.error
+++ b/tests/compiler/go/list_index.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/list_set.mochi.error
+++ b/tests/compiler/go/list_set.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/map_index.mochi.error
+++ b/tests/compiler/go/map_index.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/map_ops.mochi.error
+++ b/tests/compiler/go/map_ops.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/map_set.mochi.error
+++ b/tests/compiler/go/map_set.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/math_import_py.mochi.error
+++ b/tests/compiler/go/math_import_py.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CallExpr

--- a/tests/compiler/go/reserved_keyword_var.mochi.error
+++ b/tests/compiler/go/reserved_keyword_var.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit

--- a/tests/compiler/go/underscore_for_loop.mochi.error
+++ b/tests/compiler/go/underscore_for_loop.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported statement *ast.ForStmt

--- a/tests/compiler/go/var_assignment.mochi.error
+++ b/tests/compiler/go/var_assignment.mochi.error
@@ -1,1 +1,0 @@
-unsupported statement *ast.DeclStmt

--- a/tests/compiler/go/var_assignment.mochi.out
+++ b/tests/compiler/go/var_assignment.mochi.out
@@ -1,0 +1,3 @@
+var x = 1
+x = 2
+print(x)

--- a/tests/compiler/go/while_loop.mochi.error
+++ b/tests/compiler/go/while_loop.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported statement *ast.ForStmt

--- a/tests/compiler/go/while_membership.mochi.error
+++ b/tests/compiler/go/while_membership.mochi.error
@@ -1,1 +1,1 @@
-unsupported statement *ast.DeclStmt
+unsupported expr *ast.CompositeLit


### PR DESCRIPTION
## Summary
- support `var` declarations in go2mochi
- output assignments with `=` instead of `let`
- update golden test expectations

## Testing
- `make test`
- `go test ./tools/go2mochi -run TestGo2Mochi_Golden -v`

------
https://chatgpt.com/codex/tasks/task_e_68686ccbbe508320b08838bef1f39123