### PR TITLE
Improve sqlite2duck tests and conversions

### DIFF
--- a/tools/sqlite2duck/README.md
+++ b/tools/sqlite2duck/README.md
@@ -21,6 +21,7 @@ The converter currently handles the following patterns:
 - `substr()` -> `substring()`
 - `group_concat()` -> `string_agg()`
 - `char_length()` -> `length()`
+- `character_length()` -> `length()`
 - `printf()` -> `format()`
 - `instr()` -> `strpos()`
 - `datetime('now')` -> `now()`
@@ -32,6 +33,7 @@ The converter currently handles the following patterns:
 - `time('now')` -> `current_time`
 - `CURRENT_DATE` -> `current_date`
 - `CURRENT_TIME` -> `current_time`
+- `CURRENT_TIMESTAMP()` -> `now()`
 - `randomblob(n)` -> `random_bytes(n)`
 - `total(x)` -> `coalesce(sum(x),0)`
 - remove `NOT INDEXED` clauses

--- a/tools/sqlite2duck/converter.go
+++ b/tools/sqlite2duck/converter.go
@@ -11,8 +11,12 @@ var funcConversions = []struct{ in, out string }{
 	{"group_concat", "string_agg("},
 	{"randomblob", "random_bytes("},
 	{"char_length", "length("},
+	{"character_length", "length("},
 	{"printf", "format("},
 	{"instr", "strpos("},
+	{"current_timestamp", "now("},
+	{"current_date", "current_date("},
+	{"current_time", "current_time("},
 }
 
 var wordConversions = []struct{ in, out string }{
@@ -222,6 +226,14 @@ func replaceTotal(sql string) string {
 	return out.String()
 }
 
+func removeEmptyParens(sql string, names ...string) string {
+	out := sql
+	for _, n := range names {
+		out = strings.ReplaceAll(out, n+"()", n)
+	}
+	return out
+}
+
 // Convert rewrites common SQLite syntax to DuckDB syntax.
 func Convert(sql string) string {
 	out := sql
@@ -236,5 +248,6 @@ func Convert(sql string) string {
 	out = replaceTime(out)
 	out = removeNotIndexed(out)
 	out = replaceTotal(out)
+	out = removeEmptyParens(out, "current_date", "current_time")
 	return out
 }

--- a/tools/sqlite2duck/converter_test.go
+++ b/tools/sqlite2duck/converter_test.go
@@ -26,6 +26,10 @@ func TestConvert(t *testing.T) {
 		{"SELECT instr(a, b) FROM t;", "SELECT strpos(a, b) FROM t;"},
 		{"SELECT CURRENT_DATE;", "SELECT current_date;"},
 		{"SELECT CURRENT_TIME;", "SELECT current_time;"},
+		{"SELECT character_length(name) FROM t;", "SELECT length(name) FROM t;"},
+		{"SELECT CURRENT_TIMESTAMP();", "SELECT now();"},
+		{"SELECT CURRENT_DATE();", "SELECT current_date;"},
+		{"SELECT CURRENT_TIME();", "SELECT current_time;"},
 	}
 	for _, tt := range tests {
 		got := Convert(tt.in)

--- a/tools/sqlite2duck/golden_test.go
+++ b/tools/sqlite2duck/golden_test.go
@@ -2,6 +2,7 @@ package sqlite2duck
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,11 +61,14 @@ func TestConvertGolden(t *testing.T) {
 				t.Fatalf("case count mismatch: %d != %d", len(lines), len(sltCases))
 			}
 			for i, sc := range sltCases {
-				got := Convert(sc.Query)
-				want := lines[i]
-				if got != want {
-					t.Fatalf("case %d\nconvert %q\nwant %q\n", i+1, got, want)
-				}
+				i, sc := i, sc
+				t.Run(fmt.Sprintf("query%d", i+1), func(t *testing.T) {
+					got := Convert(sc.Query)
+					want := lines[i]
+					if got != want {
+						t.Fatalf("convert %q\nwant %q", got, want)
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- expand builtin conversions (character_length, current_timestamp)
- drop empty parentheses on CURRENT_DATE and CURRENT_TIME
- exercise each golden query as a subtest
- add tests for new conversions

## Testing
- `go test ./tools/sqlite2duck -run TestConvert$ -tags slow`
- `go test ./tools/sqlite2duck -run TestConvertGolden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6868193518f483209d52f8ea9034084d