### PR TITLE
Improve py2mochi conversion and record errors

### DIFF
--- a/tests/compiler/py/dataset_negative_skip_take.error
+++ b/tests/compiler/py/dataset_negative_skip_take.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/dataset_sort_take_limit.error
+++ b/tests/compiler/py/dataset_sort_take_limit.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/fetch_builtin.error
+++ b/tests/compiler/py/fetch_builtin.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/fetch_http.error
+++ b/tests/compiler/py/fetch_http.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/fetch_stmt.error
+++ b/tests/compiler/py/fetch_stmt.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/fun_call.error
+++ b/tests/compiler/py/fun_call.error
@@ -1,0 +1,10 @@
+generated code does not match expected
+--- expected
++++ generated
+@@ -1,5 +1,4 @@
+ fun add(a: int, b: int): int {
+   return a + b
+ }
+-
+-print(add(2, 3))  // 5
++print(5)

--- a/tests/compiler/py/fun_call.mochi.out
+++ b/tests/compiler/py/fun_call.mochi.out
@@ -1,4 +1,0 @@
-fun add(a: int, b: int): int {
-  return a + b
-}
-print(5)

--- a/tests/compiler/py/fun_expr_in_let.error
+++ b/tests/compiler/py/fun_expr_in_let.error
@@ -1,0 +1,8 @@
+generated code does not match expected
+--- expected
++++ generated
+@@ -1,2 +1,2 @@
+-let square = fun(x: int): int => x * x
+-print(square(6))  // 36
++let square = fun(x) => x * x
++print(square(6))

--- a/tests/compiler/py/globals_between_tests.error
+++ b/tests/compiler/py/globals_between_tests.error
@@ -1,0 +1,23 @@
+generated code does not match expected
+--- expected
++++ generated
+@@ -1,13 +1,9 @@
++fun test_first(): any {
++}
++fun test_second(): any {
++}
+ let a = 1
+-
+-test "first" {
+-  expect a == 1
+-}
+-
+ let b = 2
+-
+-test "second" {
+-  expect b == 2
+-}
+-
+ print("done")
++test_first()
++test_second()

--- a/tests/compiler/py/input_builtin.mochi.out
+++ b/tests/compiler/py/input_builtin.mochi.out
@@ -1,0 +1,5 @@
+print("Enter first input:")
+let input1 = input()
+print("Enter second input:")
+let input2 = input()
+print("You entered:", input1, ",", input2)

--- a/tests/compiler/py/load_save_json.error
+++ b/tests/compiler/py/load_save_json.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/match_capture.error
+++ b/tests/compiler/py/match_capture.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/match_underscore.error
+++ b/tests/compiler/py/match_underscore.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/math_import_py.error
+++ b/tests/compiler/py/math_import_py.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/reserved_name.error
+++ b/tests/compiler/py/reserved_name.error
@@ -1,0 +1,9 @@
+generated code does not match expected
+--- expected
++++ generated
+@@ -1,3 +1,2 @@
+-var next = 0
+-next = next + 1
+-print(next)
++let _next = 0
++print(_next)

--- a/tests/compiler/py/slice.error
+++ b/tests/compiler/py/slice.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/string_concat_int.error
+++ b/tests/compiler/py/string_concat_int.error
@@ -1,0 +1,6 @@
+generated code does not match expected
+--- expected
++++ generated
+@@ -1 +1 @@
+-print("value: " + 7)
++print("value: " + str(7))

--- a/tests/compiler/py/tpch_q2.error
+++ b/tests/compiler/py/tpch_q2.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/tpch_q3.error
+++ b/tests/compiler/py/tpch_q3.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/type_methods.error
+++ b/tests/compiler/py/type_methods.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tests/compiler/py/typed_list_negative.error
+++ b/tests/compiler/py/typed_list_negative.error
@@ -1,0 +1,15 @@
+generated code does not match expected
+--- expected
++++ generated
+@@ -1,8 +1,5 @@
+-let xs = [(-1), 0, 1] as list<int>
+-
+-test "values" {
+-  expect xs[0] == (-1)
+-  expect xs[1] == 0
+-  expect xs[2] == 1
++fun test_values(): any {
+   print("done")
+ }
++let xs = [-1, 0, 1]
++test_values()

--- a/tests/compiler/py/union.mochi.out
+++ b/tests/compiler/py/union.mochi.out
@@ -1,0 +1,5 @@
+type Tree =
+  Leaf {} |
+  Node(left: Tree, value: int, right: Tree)
+let t = Node { left: Leaf {  }, value: 42, right: Leaf {  } }
+print(t.value)

--- a/tests/compiler/py/update_stmt.error
+++ b/tests/compiler/py/update_stmt.error
@@ -1,0 +1,1 @@
+conversion incomplete: unhandled expression

--- a/tools/py2mochi/run_all.py
+++ b/tools/py2mochi/run_all.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import difflib
+import glob
+import os
+import subprocess
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PY_DIR = os.path.join(ROOT, "tests", "compiler", "py")
+CONVERTER = os.path.join(ROOT, "tools", "py2mochi", "py2mochi.py")
+
+for py_file in sorted(glob.glob(os.path.join(PY_DIR, "*.py.out"))):
+    base = py_file[:-7]
+    mochi_file = base + ".mochi"
+    out_file = base + ".mochi.out"
+    err_file = base + ".error"
+
+    try:
+        code = subprocess.check_output(["python3", CONVERTER, py_file], text=True)
+    except subprocess.CalledProcessError as e:
+        with open(err_file, "w") as f:
+            f.write(f"py2mochi failed: {e}\n")
+        if os.path.exists(out_file):
+            os.remove(out_file)
+        continue
+
+    if "<expr>" in code:
+        with open(err_file, "w") as f:
+            f.write("conversion incomplete: unhandled expression\n")
+        if os.path.exists(out_file):
+            os.remove(out_file)
+        continue
+
+    expected = open(mochi_file, encoding="utf-8").read()
+
+    def strip_comments(s: str) -> str:
+        return "\n".join([ln.split("//")[0].rstrip() for ln in s.splitlines()])
+
+    if "".join(strip_comments(code).split()) == "".join(
+        strip_comments(expected).split()
+    ):
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(code)
+        if os.path.exists(err_file):
+            os.remove(err_file)
+    else:
+        diff = "\n".join(
+            difflib.unified_diff(
+                expected.splitlines(),
+                code.splitlines(),
+                fromfile="expected",
+                tofile="generated",
+                lineterm="",
+            )
+        )
+        with open(err_file, "w", encoding="utf-8") as f:
+            f.write("generated code does not match expected\n")
+            f.write(diff)
+        if os.path.exists(out_file):
+            os.remove(out_file)


### PR DESCRIPTION
## Summary
- enhance `py2mochi` with union dataclass support
- add `run_all.py` helper to generate `.mochi.out` or `.error`
- generate `.mochi.out` for inputs that convert correctly
- add `.error` files for conversions that fail

## Testing
- `go test ./tools/py2mochi -run TestPy2Mochi -v`


------
https://chatgpt.com/codex/tasks/task_e_6868191a73188320b94b3d461ceff115