### PR TITLE
Improve sqlite2duck converter

### DIFF
--- a/tools/sqlite2duck/README.md
+++ b/tools/sqlite2duck/README.md
@@ -35,6 +35,9 @@ The converter currently handles the following patterns:
 - `CURRENT_TIME` -> `current_time`
 - `CURRENT_TIMESTAMP()` -> `now()`
 - `randomblob(n)` -> `random_bytes(n)`
+- `julianday('now')` -> `julianday(now())`
+- `strftime(..., 'now')` -> `strftime(..., now())`
+- `zeroblob(n)` -> `repeat('\x00', n)`
 - `total(x)` -> `coalesce(sum(x),0)`
 - remove `NOT INDEXED` clauses
 

--- a/tools/sqlite2duck/cmd/gen.go
+++ b/tools/sqlite2duck/cmd/gen.go
@@ -23,7 +23,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "parse %s: %v\n", in, err)
 			os.Exit(1)
 		}
-		outPath := strings.TrimSuffix(filepath.Base(in), ".test") + ".sql"
+		base := strings.TrimSuffix(filepath.Base(in), ".test")
+		dir := filepath.Base(filepath.Dir(in))
+		outPath := base + ".sql"
+		if dir != "slt" && dir != "evidence" {
+			outPath = dir + "_" + base + ".sql"
+		}
 		f, err := os.Create(outPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "create %s: %v\n", outPath, err)

--- a/tools/sqlite2duck/converter_test.go
+++ b/tools/sqlite2duck/converter_test.go
@@ -30,6 +30,9 @@ func TestConvert(t *testing.T) {
 		{"SELECT CURRENT_TIMESTAMP();", "SELECT now();"},
 		{"SELECT CURRENT_DATE();", "SELECT current_date;"},
 		{"SELECT CURRENT_TIME();", "SELECT current_time;"},
+		{"SELECT julianday('now');", "SELECT julianday(now());"},
+		{"SELECT strftime('%Y', 'now');", "SELECT strftime('%Y', now());"},
+		{"SELECT zeroblob(2);", "SELECT repeat('\\x00', 2);"},
 	}
 	for _, tt := range tests {
 		got := Convert(tt.in)

--- a/tools/sqlite2duck/golden_test.go
+++ b/tools/sqlite2duck/golden_test.go
@@ -34,21 +34,30 @@ func TestConvertGolden(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cases := []struct {
-		in  string
-		out string
-	}{
-		{filepath.Join(root, "tests/dataset/slt/select1.test"), "testdata/select1.sql"},
-		{filepath.Join(root, "tests/dataset/slt/select2.test"), "testdata/select2.sql"},
-		{filepath.Join(root, "tests/dataset/slt/select3.test"), "testdata/select3.sql"},
-		{filepath.Join(root, "tests/dataset/slt/evidence/slt_lang_aggfunc.test"), "testdata/slt_lang_aggfunc.sql"},
-		{filepath.Join(root, "tests/dataset/slt/evidence/slt_lang_update.test"), "testdata/slt_lang_update.sql"},
-		{filepath.Join(root, "tests/dataset/slt/test/random/aggregates/slt_good_0.test"), "testdata/aggregates_slt_good_0.sql"},
-		{filepath.Join(root, "tests/dataset/slt/test/random/expr/slt_good_0.test"), "testdata/expr_slt_good_0.sql"},
-		{filepath.Join(root, "tests/dataset/slt/test/random/groupby/slt_good_0.test"), "testdata/groupby_slt_good_0.sql"},
+	files, err := filepath.Glob("testdata/*.sql")
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, c := range cases {
-		t.Run(filepath.Base(c.out), func(t *testing.T) {
+	for _, out := range files {
+		base := filepath.Base(out)
+		name := strings.TrimSuffix(base, ".sql")
+		var in string
+		switch {
+		case strings.HasPrefix(base, "select"):
+			in = filepath.Join(root, "tests/dataset/slt", name+".test")
+		case strings.HasPrefix(base, "slt_lang"):
+			in = filepath.Join(root, "tests/dataset/slt/evidence", name+".test")
+		case strings.HasPrefix(base, "aggregates_"):
+			in = filepath.Join(root, "tests/dataset/slt/test/random/aggregates", strings.TrimPrefix(name, "aggregates_")+".test")
+		case strings.HasPrefix(base, "expr_"):
+			in = filepath.Join(root, "tests/dataset/slt/test/random/expr", strings.TrimPrefix(name, "expr_")+".test")
+		case strings.HasPrefix(base, "groupby_"):
+			in = filepath.Join(root, "tests/dataset/slt/test/random/groupby", strings.TrimPrefix(name, "groupby_")+".test")
+		default:
+			t.Fatalf("unknown golden file %s", base)
+		}
+		c := struct{ in, out string }{in: in, out: out}
+		t.Run(base, func(t *testing.T) {
 			sltCases, err := logic.ParseFile(c.in)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
## Summary
- support julianday, strftime, and zeroblob
- generate one SQL file per input with a stable name
- test more conversion cases
- autodiscover golden files for testing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868754f6a288320b16ff2b08a81e031