### PR TITLE
Improve go2mochi converter

### DIFF
--- a/tests/compiler/go/list_concat.mochi.out
+++ b/tests/compiler/go/list_concat.mochi.out
@@ -1,1 +1,1 @@
-print(append(append([], [1, 2]), [3, 4]))
+print(concat(concat([], [1, 2]), [3, 4]))

--- a/tests/compiler/go/list_prepend.mochi.out
+++ b/tests/compiler/go/list_prepend.mochi.out
@@ -1,5 +1,5 @@
-fun prepend(level: []int, result: [][]int): [][]int {
-  result = append(append([], [level]), result)
+fun prepend(level: list<int>, result: list<list<int>>): list<list<int>> {
+  result = concat(concat([], [level]), result)
   return result
 }
 print(prepend([1, 2], [[3], [4]]))

--- a/tests/compiler/go/map_hint_literal.mochi.out
+++ b/tests/compiler/go/map_hint_literal.mochi.out
@@ -1,4 +1,4 @@
-fun foo(m: map[string]int) {
+fun foo(m: map<string, int>) {
   print(len(m))
 }
 foo({})

--- a/tests/compiler/go/string_for_loop.mochi.out
+++ b/tests/compiler/go/string_for_loop.mochi.out
@@ -1,4 +1,4 @@
 for r in "cat" {
-  let ch = string(r)
+  let ch = str(r)
   print(ch)
 }


### PR DESCRIPTION
## Summary
- enhance go2mochi converter
- add typeString helper for slices and maps
- support Go append with `...` as `concat`
- translate `string()` casts to `str()`
- update golden outputs for new behavior

## Testing
- `go test ./tools/go2mochi -run TestGo2Mochi_Golden -count=1`
- `go test ./...` *(fails: TestPy2Mochi/slice)*

------
https://chatgpt.com/codex/tasks/task_e_686883c99d488320bbf2d96609bbfb11