### PR TITLE
Add iif conversion to sqlite2duck

### DIFF
--- a/tests/dataset/slt/test/extra/iif.test
+++ b/tests/dataset/slt/test/extra/iif.test
@@ -1,0 +1,10 @@
+statement ok
+CREATE TABLE t1(a INTEGER, b INTEGER) 
+
+statement ok
+INSERT INTO t1 VALUES(1,2) 
+
+query I rowsort
+SELECT iif(a<b,'yes','no') FROM t1 
+----
+yes

--- a/tools/sqlite2duck/README.md
+++ b/tools/sqlite2duck/README.md
@@ -24,6 +24,7 @@ The converter currently handles the following patterns:
 - `character_length()` -> `length()`
 - `printf()` -> `format()`
 - `instr()` -> `strpos()`
+- `iif()` -> `if()`
 - `datetime('now')` -> `now()`
 - `datetime('now','localtime')` -> `now()`
 - `datetime('now','utc')` -> `now()`

--- a/tools/sqlite2duck/converter.go
+++ b/tools/sqlite2duck/converter.go
@@ -14,6 +14,7 @@ var funcConversions = []struct{ in, out string }{
 	{"character_length", "length("},
 	{"printf", "format("},
 	{"instr", "strpos("},
+	{"iif", "if("},
 	{"current_timestamp", "now("},
 	{"current_date", "current_date("},
 	{"current_time", "current_time("},

--- a/tools/sqlite2duck/converter_test.go
+++ b/tools/sqlite2duck/converter_test.go
@@ -36,6 +36,7 @@ func TestConvert(t *testing.T) {
 		{"SELECT hex(randomblob(2));", "SELECT hex(random_bytes(2));"},
 		{"SELECT TRUE;", "SELECT true;"},
 		{"SELECT FALSE;", "SELECT false;"},
+		{"SELECT iif(a>b,1,0) FROM t;", "SELECT if(a>b,1,0) FROM t;"},
 	}
 	for _, tt := range tests {
 		got := Convert(tt.in)

--- a/tools/sqlite2duck/golden_test.go
+++ b/tools/sqlite2duck/golden_test.go
@@ -53,6 +53,8 @@ func TestConvertGolden(t *testing.T) {
 			in = filepath.Join(root, "tests/dataset/slt/test/random/expr", strings.TrimPrefix(name, "expr_")+".test")
 		case strings.HasPrefix(base, "groupby_"):
 			in = filepath.Join(root, "tests/dataset/slt/test/random/groupby", strings.TrimPrefix(name, "groupby_")+".test")
+		case strings.HasPrefix(base, "extra_"):
+			in = filepath.Join(root, "tests/dataset/slt/test/extra", strings.TrimPrefix(name, "extra_")+".test")
 		default:
 			t.Fatalf("unknown golden file %s", base)
 		}

--- a/tools/sqlite2duck/testdata/extra_iif.sql
+++ b/tools/sqlite2duck/testdata/extra_iif.sql
@@ -1,0 +1,1 @@
+SELECT if(a<b,'yes','no') FROM t1;


### PR DESCRIPTION
## Summary
- extend sqlite2duck to convert `iif()` to `if()`
- document new rule in README
- support `extra_*.sql` testcases in golden tests
- add a new SQLLogicTest `iif.test` and golden output `extra_iif.sql`

## Testing
- `go test ./tools/sqlite2duck -run . -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68688401bdbc8320b7697c117157fd1e