### PR TITLE
Improve py2mochi converter

### DIFF
--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -16,14 +16,29 @@ import (
 // builtinPrint implements the print(...) function.
 func builtinPrint(i *Interpreter, c *parser.CallExpr) (any, error) {
 	var sb strings.Builder
+	first := true
 	for _, arg := range c.Args {
 		val, err := i.evalExpr(arg)
 		if err != nil {
 			return nil, err
 		}
-		fmt.Fprintf(&sb, "%v ", val)
+		if list, ok := val.([]any); ok {
+			for i2, v := range list {
+				if !first || i2 > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprint(&sb, v)
+			}
+			first = false
+			continue
+		}
+		if !first {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, val)
+		first = false
 	}
-	_, err := fmt.Fprintln(i.env.Writer(), strings.TrimSpace(sb.String()))
+	_, err := fmt.Fprintln(i.env.Writer(), sb.String())
 	return nil, err
 }
 

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1134,7 +1134,19 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			fr.regs[ins.A] = Value{Tag: ValueMap, Map: mp}
 		case OpPrint:
-			fmt.Fprintln(m.writer, fr.regs[ins.A].ToAny())
+			v := fr.regs[ins.A]
+			if v.Tag == ValueList {
+				var sb strings.Builder
+				for i, x := range v.List {
+					if i > 0 {
+						sb.WriteByte(' ')
+					}
+					fmt.Fprint(&sb, x.ToAny())
+				}
+				fmt.Fprintln(m.writer, sb.String())
+			} else {
+				fmt.Fprintln(m.writer, v.ToAny())
+			}
 		case OpPrint2:
 			fmt.Fprintln(m.writer, fr.regs[ins.A].ToAny(), fr.regs[ins.B].ToAny())
 		case OpPrintN:

--- a/tests/compiler/py/globals_between_tests.error
+++ b/tests/compiler/py/globals_between_tests.error
@@ -2,22 +2,18 @@ generated code does not match expected
 --- expected
 +++ generated
 @@ -1,13 +1,9 @@
-+fun test_first(): any {
-+}
-+fun test_second(): any {
-+}
- let a = 1
+-let a = 1
 -
--test "first" {
--  expect a == 1
--}
+ test "first" {
+   expect a == 1
+ }
 -
- let b = 2
+-let b = 2
 -
--test "second" {
--  expect b == 2
--}
+ test "second" {
+   expect b == 2
+ }
 -
++let a = 1
++let b = 2
  print("done")
-+test_first()
-+test_second()

--- a/tests/compiler/py/load_save_json.error
+++ b/tests/compiler/py/load_save_json.error
@@ -1,5 +1,135 @@
-py2mochi failed:
-unhandled expression at line 37:                 m = max(len(r) for r in rows)
-36:             else:
-37:                 m = max(len(r) for r in rows)
-38:                 headers = [f"c{i}" for i in range(m)]
+generated code does not match expected
+--- expected
++++ generated
+@@ -1,6 +1,125 @@
+- type Person {
+-   name: string
+-   age: int
+- }
+- let people = load as Person with { format: "json" }
+- save people with { format: "json" }
++type Person {
++  name: string
++  age: int
++}
++fun _load(path: any, opts: any): any {
++  let fmt = "csv"
++  let header = True
++  let delim = ","
++  if opts {
++    if isinstance(delim, str) and delim {
++    }
++  }
++  let f = if path ? None then sys.stdin else open(path, "r")
++  if fmt == "tsv" {
++  }
++  if fmt == "csv" {
++    let rows = list(csv.reader(f, delimiter: delim))
++    if !rows {
++      return []
++    }
++    if header {
++      let headers = rows[0]
++    } else {
++      let m = max(from r in rows
++            select len(r))
++    }
++    let out = []
++    for rec in rows {
++      let row = {}
++      for (i, h) in enumerate(headers) {
++        let val = if i < len(rec) then rec[i] else ""
++        if val.isdigit() {
++        } else {
++        }
++      }
++      out.append(row)
++    }
++    return out
++  } else {
++    if fmt == "json" {
++      let data = json.load(f)
++      if isinstance(data, list) {
++        return from d in data
++            select dict(d)
++      }
++      if isinstance(data, dict) {
++        return [dict(data)]
++      }
++      return []
++    } else {
++      if fmt == "jsonl" {
++        return from line in f
++            where line.strip()
++            select json.loads(line)
++      } else {
++        if fmt == "yaml" {
++          if isinstance(data, list) {
++            return from d in data
++            select dict(d)
++          }
++          if isinstance(data, dict) {
++            return [dict(data)]
++          }
++          return []
++        } else {
++        }
++      }
++    }
++  }
++  if path ? None {
++    f.close()
++  }
++}
++fun _save(rows: any, path: any, opts: any): any {
++  if opts {
++    if isinstance(delim, str) and delim {
++    }
++  }
++  if fmt == "tsv" {
++  }
++  if fmt == "csv" {
++    let w = csv.writer(f, delimiter: delim)
++    if header {
++      w.writerow(headers)
++    }
++    for row in rows {
++      let rec = []
++      for h in headers {
++        if isinstance(val, (dict, list)) {
++          rec.append(json.dumps(val))
++        } else {
++          if val ? None {
++            rec.append("")
++          } else {
++            rec.append(str(val))
++          }
++        }
++      }
++      w.writerow(rec)
++    }
++    return
++  } else {
++    if fmt == "json" {
++      json.dump(rows, f)
++    } else {
++      if fmt == "jsonl" {
++        for row in rows {
++          f.write(json.dumps(row))
++          f.write("\n")
++        }
++      } else {
++        if fmt == "yaml" {
++          yaml.safe_dump(if len(rows) == 1 then rows[0] else rows, f)
++        } else {
++        }
++      }
++    }
++  }
++  if path ? None {
++    f.close()
++  }
++}
++let people = from _it in _load(None, dict({"format": "json"}))
++            select Person { None: _it }
++_save(people, None, dict({"format": "json"}))

--- a/tests/compiler/py/tpch_q2.error
+++ b/tests/compiler/py/tpch_q2.error
@@ -202,7 +202,8 @@ generated code does not match expected
 +  }
 +  return k
 +}
-+fun test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part(): any {
++test "Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part" {
++  expect result == [{"s_acctbal": 1000, "s_name": "BestSupplier", "n_name": "FRANCE", "p_partkey": 1000, "p_mfgr": "M1", "s_address": "123 Rue", "s_phone": "123", "s_comment": "Fast and reliable", "ps_supplycost": 10}]
 +}
 +let region = [{"r_regionkey": 1, "r_name": "EUROPE"}, {"r_regionkey": 2, "r_name": "ASIA"}]
 +let nation = [{"n_nationkey": 10, "n_regionkey": 1, "n_name": "FRANCE"}, {"n_nationkey": 20, "n_regionkey": 2, "n_name": "CHINA"}]
@@ -223,4 +224,3 @@ generated code does not match expected
 +            select x, key: fun(x) => _sort_key(-x["s_acctbal"]))
 +            select x
 +print(json.dumps(result, default: fun(o) => vars(o)))
-+test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part()

--- a/tests/compiler/py/tpch_q3.error
+++ b/tests/compiler/py/tpch_q3.error
@@ -162,7 +162,8 @@ generated code does not match expected
 +  }
 +  return s
 +}
-+fun test_Q3_returns_revenue_per_order_with_correct_priority(): any {
++test "Q3_returns_revenue_per_order_with_correct_priority" {
++  expect order_line_join == [{"l_orderkey": 100, "revenue": 1000 * 0.95 + 500, "o_orderdate": "1995-03-14", "o_shippriority": 1}]
 +}
 +let customer = [{"c_custkey": 1, "c_mktsegment": "BUILDING"}, {"c_custkey": 2, "c_mktsegment": "AUTOMOBILE"}]
 +let orders = [{"o_orderkey": 100, "o_custkey": 1, "o_orderdate": "1995-03-14", "o_shippriority": 1}, {"o_orderkey": 200, "o_custkey": 2, "o_orderdate": "1995-03-10", "o_shippriority": 2}]
@@ -233,4 +234,3 @@ generated code does not match expected
 -    }
 -  ]
 -}
-+test_Q3_returns_revenue_per_order_with_correct_priority()

--- a/tests/compiler/py/typed_list_negative.error
+++ b/tests/compiler/py/typed_list_negative.error
@@ -1,15 +1,14 @@
 generated code does not match expected
 --- expected
 +++ generated
-@@ -1,8 +1,5 @@
+@@ -1,8 +1,7 @@
 -let xs = [(-1), 0, 1] as list<int>
 -
--test "values" {
+ test "values" {
 -  expect xs[0] == (-1)
--  expect xs[1] == 0
--  expect xs[2] == 1
-+fun test_values(): any {
++  expect xs[0] == -1
+   expect xs[1] == 0
+   expect xs[2] == 1
    print("done")
  }
 +let xs = [-1, 0, 1]
-+test_values()

--- a/tests/compiler/py/update_stmt.error
+++ b/tests/compiler/py/update_stmt.error
@@ -44,7 +44,8 @@ generated code does not match expected
 -    Person { name: "Charlie", age: 19, status: "adult" },
 -    Person { name: "Diana", age: 16, status: "minor" }
 -  ]
-+fun test_update_adult_status(): any {
++test "update_adult_status" {
++  expect people == [Person { name: "Alice", age: 17, status: "minor" }, Person { name: "Bob", age: 26, status: "adult" }, Person { name: "Charlie", age: 19, status: "adult" }, Person { name: "Diana", age: 16, status: "minor" }]
 +}
 +let people = [Person { name: "Alice", age: 17, status: "minor" }, Person { name: "Bob", age: 25, status: "unknown" }, Person { name: "Charlie", age: 18, status: "unknown" }, Person { name: "Diana", age: 16, status: "minor" }]
 +for (_i0, _it1) in enumerate(people) {
@@ -57,4 +58,3 @@ generated code does not match expected
 +  }
  }
  print("ok")
-+test_update_adult_status()


### PR DESCRIPTION
## Summary
- support generator expressions
- turn `test_*` functions into Mochi test blocks
- handle `assert` statements and skip test calls in `main`
- ignore `pass` statements and skip globals in functions
- regenerate converter error outputs
- print lists space-separated to match Python `print`

## Testing
- `go test ./tools/py2mochi -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868838186d48320b6d47ffd70b697fb