### PR TITLE
Improve sqlite2duck testing

### DIFF
--- a/tools/sqlite2duck/README.md
+++ b/tools/sqlite2duck/README.md
@@ -22,6 +22,7 @@ The converter currently handles the following patterns:
 - `group_concat()` -> `string_agg()`
 - `char_length()` -> `length()`
 - `character_length()` -> `length()`
+- `octet_length()` -> `length()`
 - `printf()` -> `format()`
 - `instr()` -> `strpos()`
 - `iif()` -> `if()`

--- a/tools/sqlite2duck/cmd_test.go
+++ b/tools/sqlite2duck/cmd_test.go
@@ -1,0 +1,100 @@
+package sqlite2duck
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/tools/slt/logic"
+)
+
+// TestCLI runs the sqlite2duck command against each query and compares
+// the output to the golden files. Building the command once keeps the
+// test relatively quick.
+func TestCLI(t *testing.T) {
+	root, err := logic.FindRepoRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bin := filepath.Join(t.TempDir(), "sqlite2duck")
+	cmd := exec.Command("go", "build", "-o", bin, "../../cmd/sqlite2duck")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build cli: %v\n%s", err, out)
+	}
+
+	files, err := filepath.Glob("testdata/*.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, outPath := range files {
+		base := filepath.Base(outPath)
+		name := strings.TrimSuffix(base, ".sql")
+		var inPath string
+		switch {
+		case strings.HasPrefix(base, "select"):
+			inPath = filepath.Join(root, "tests/dataset/slt", name+".test")
+		case strings.HasPrefix(base, "slt_lang"):
+			inPath = filepath.Join(root, "tests/dataset/slt/evidence", name+".test")
+		case strings.HasPrefix(base, "aggregates_"):
+			inPath = filepath.Join(root, "tests/dataset/slt/test/random/aggregates", strings.TrimPrefix(name, "aggregates_")+".test")
+		case strings.HasPrefix(base, "expr_"):
+			inPath = filepath.Join(root, "tests/dataset/slt/test/random/expr", strings.TrimPrefix(name, "expr_")+".test")
+		case strings.HasPrefix(base, "groupby_"):
+			inPath = filepath.Join(root, "tests/dataset/slt/test/random/groupby", strings.TrimPrefix(name, "groupby_")+".test")
+		case strings.HasPrefix(base, "extra_"):
+			inPath = filepath.Join(root, "tests/dataset/slt/test/extra", strings.TrimPrefix(name, "extra_")+".test")
+		default:
+			t.Fatalf("unknown golden file %s", base)
+		}
+
+		t.Run(base, func(t *testing.T) {
+			cases, err := logic.ParseFile(inPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, err := os.Open(outPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			scanner := bufio.NewScanner(f)
+			var lines []string
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line != "" {
+					line = strings.TrimSuffix(line, ";")
+					lines = append(lines, line)
+				}
+			}
+			if err := scanner.Err(); err != nil {
+				t.Fatal(err)
+			}
+			if len(lines) != len(cases) {
+				t.Fatalf("case count mismatch: %d != %d", len(lines), len(cases))
+			}
+			for i, c := range cases {
+				if i >= 5 {
+					break
+				}
+				want := lines[i]
+				execCmd := exec.Command(bin, "-")
+				execCmd.Stdin = strings.NewReader(c.Query)
+				out, err := execCmd.Output()
+				if err != nil {
+					if ee, ok := err.(*exec.ExitError); ok {
+						t.Fatalf("cli error: %v %s", err, string(ee.Stderr))
+					}
+					t.Fatal(err)
+				}
+				got := strings.TrimSpace(string(out))
+				if got != want {
+					t.Fatalf("convert %q\nwant %q", c.Query, want)
+				}
+			}
+		})
+	}
+}

--- a/tools/sqlite2duck/converter.go
+++ b/tools/sqlite2duck/converter.go
@@ -15,6 +15,7 @@ var funcConversions = []struct{ in, out string }{
 	{"printf", "format("},
 	{"instr", "strpos("},
 	{"iif", "if("},
+	{"octet_length", "length("},
 	{"current_timestamp", "now("},
 	{"current_date", "current_date("},
 	{"current_time", "current_time("},

--- a/tools/sqlite2duck/converter_test.go
+++ b/tools/sqlite2duck/converter_test.go
@@ -37,6 +37,7 @@ func TestConvert(t *testing.T) {
 		{"SELECT TRUE;", "SELECT true;"},
 		{"SELECT FALSE;", "SELECT false;"},
 		{"SELECT iif(a>b,1,0) FROM t;", "SELECT if(a>b,1,0) FROM t;"},
+		{"SELECT octet_length(name) FROM t;", "SELECT length(name) FROM t;"},
 	}
 	for _, tt := range tests {
 		got := Convert(tt.in)


### PR DESCRIPTION
## Summary
- support converting `octet_length()` -> `length()`
- document conversion rule
- add regression test for new rule
- test the sqlite2duck CLI with a small sample of queries

## Testing
- `go test ./tools/sqlite2duck -run TestConvert -count=1`
- `go test ./tools/sqlite2duck -run TestConvertGolden -count=1`
- `go test ./tools/sqlite2duck -run TestCLI -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68688860109c83208c3355b606246455