### PR TITLE
Extend go2mochi conversion

### DIFF
--- a/tests/compiler/go/avg_builtin.mochi.error
+++ b/tests/compiler/go/avg_builtin.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/avg_builtin.go.out:15: unsupported expr *ast.SelectorExpr
->>> 14:    if g, ok := v.(*data.Group); ok {
-15:>>> items = g.Items
-16:    } else {
-17:    switch s := v.(type) {
+tests/compiler/go/avg_builtin.go.out:17: unsupported statement *ast.TypeSwitchStmt
+>>> 16:    } else {
+17:>>> switch s := v.(type) {
+18:    case []any:
+19:    items = s

--- a/tests/compiler/go/break_continue.mochi.out
+++ b/tests/compiler/go/break_continue.mochi.out
@@ -1,0 +1,10 @@
+var numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+for n in numbers {
+  if (n % 2) == 0 {
+  continue
+}
+  if n > 7 {
+  break
+}
+  print(str("odd number:") + " " + str(n))
+}

--- a/tests/compiler/go/cast_struct.mochi.error
+++ b/tests/compiler/go/cast_struct.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/cast_struct.go.out:8: unsupported declaration
->>> 7:    
-8:>>> type Todo struct {
-9:    Title string `json:"title"`
-10:    }
+tests/compiler/go/cast_struct.go.out:18: unsupported generics
+>>> 17:    
+18:>>> func _cast[T any](v any) T {
+19:    if tv, ok := v.(T); ok {
+20:    return tv

--- a/tests/compiler/go/count_builtin.mochi.error
+++ b/tests/compiler/go/count_builtin.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/count_builtin.go.out:15: unsupported expr *ast.SelectorExpr
->>> 14:    if g, ok := v.(*data.Group); ok {
-15:>>> return len(g.Items)
-16:    }
-17:    switch s := v.(type) {
+tests/compiler/go/count_builtin.go.out:17: unsupported statement *ast.TypeSwitchStmt
+>>> 16:    }
+17:>>> switch s := v.(type) {
+18:    case []any:
+19:    return len(s)

--- a/tests/compiler/go/cross_join.mochi.error
+++ b/tests/compiler/go/cross_join.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/cross_join.go.out:7: unsupported declaration
->>> 6:    
-7:>>> type Customer struct {
-8:    Id   int    `json:"id"`
-9:    Name string `json:"name"`
+tests/compiler/go/cross_join.go.out:29: unsupported expr *ast.FuncLit
+>>> 28:    var orders []Order = []Order{Order{Id: 100, CustomerId: 1, Total: 250}, Order{Id: 101, CustomerId: 2, Total: 125}, Order{Id: 102, CustomerId: 1, Total: 300}}
+29:>>> var result []PairInfo = func() []PairInfo {
+30:    _res := []PairInfo{}
+31:    for _, o := range orders {

--- a/tests/compiler/go/dataset.mochi.error
+++ b/tests/compiler/go/dataset.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/dataset.go.out:7: unsupported declaration
->>> 6:    
-7:>>> type Person struct {
-8:    Name string `json:"name"`
-9:    Age  int    `json:"age"`
+tests/compiler/go/dataset.go.out:14: unsupported expr *ast.FuncLit
+>>> 13:    var people []Person = []Person{Person{Name: "Alice", Age: 30}, Person{Name: "Bob", Age: 15}, Person{Name: "Charlie", Age: 65}}
+14:>>> var names []string = func() []string {
+15:    _res := []string{}
+16:    for _, p := range people {

--- a/tests/compiler/go/dataset_sort_take_limit.mochi.error
+++ b/tests/compiler/go/dataset_sort_take_limit.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/dataset_sort_take_limit.go.out:8: unsupported declaration
->>> 7:    
-8:>>> type Product struct {
-9:    Name  string `json:"name"`
-10:    Price int    `json:"price"`
+tests/compiler/go/dataset_sort_take_limit.go.out:76: unsupported generics
+>>> 75:    
+76:>>> func _paginate[T any](src []T, skip, take int) []T {
+77:    if skip > 0 {
+78:    if skip < len(src) {

--- a/tests/compiler/go/fetch_builtin.mochi.error
+++ b/tests/compiler/go/fetch_builtin.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/fetch_builtin.go.out:14: unsupported declaration
->>> 13:    
-14:>>> type Msg struct {
-15:    Message string `json:"message"`
-16:    }
+tests/compiler/go/fetch_builtin.go.out:24: unsupported generics
+>>> 23:    
+24:>>> func _cast[T any](v any) T {
+25:    if tv, ok := v.(T); ok {
+26:    return tv

--- a/tests/compiler/go/fetch_remote.mochi.error
+++ b/tests/compiler/go/fetch_remote.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/fetch_remote.go.out:14: unsupported declaration
->>> 13:    
-14:>>> type Todo struct {
-15:    UserId    int    `json:"userId"`
-16:    Id        int    `json:"id"`
+tests/compiler/go/fetch_remote.go.out:27: unsupported generics
+>>> 26:    
+27:>>> func _cast[T any](v any) T {
+28:    if tv, ok := v.(T); ok {
+29:    return tv

--- a/tests/compiler/go/generate_struct.mochi.error
+++ b/tests/compiler/go/generate_struct.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/generate_struct.go.out:11: unsupported declaration
->>> 10:    
-11:>>> type Info struct {
-12:    Msg string `json:"msg"`
-13:    }
+tests/compiler/go/generate_struct.go.out:21: unsupported generics
+>>> 20:    
+21:>>> func _genStruct[T any](prompt string, model string, params map[string]any) T {
+22:    opts := []llm.Option{}
+23:    if model != "" {

--- a/tests/compiler/go/input_builtin.mochi.error
+++ b/tests/compiler/go/input_builtin.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/input_builtin.go.out:17: unsupported expr *ast.SelectorExpr
+tests/compiler/go/input_builtin.go.out:17: unsupported unary op &
 >>> 16:    var s string
 17:>>> fmt.Scanln(&s)
 18:    return s

--- a/tests/compiler/go/input_builtin.mochi.out
+++ b/tests/compiler/go/input_builtin.mochi.out
@@ -1,0 +1,10 @@
+fun _input(): string {
+  var s: string
+  fmt.Scanln(&s)
+  return s
+}
+print(str("Enter first input:"))
+var input1 = _input()
+print(str("Enter second input:"))
+var input2 = _input()
+print(str("You entered:") + " " + str(input1) + " " + str(",") + " " + str(input2))

--- a/tests/compiler/go/join.mochi.error
+++ b/tests/compiler/go/join.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/join.go.out:7: unsupported declaration
->>> 6:    
-7:>>> type Customer struct {
-8:    Id   int    `json:"id"`
-9:    Name string `json:"name"`
+tests/compiler/go/join.go.out:33: unsupported expr *ast.FuncLit
+>>> 32:    }
+33:>>> var result []PairInfo = func() []PairInfo {
+34:    _res := []PairInfo{}
+35:    for _, o := range orders {

--- a/tests/compiler/go/join_filter.mochi.error
+++ b/tests/compiler/go/join_filter.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/join_filter.go.out:7: unsupported declaration
->>> 6:    
-7:>>> type Person struct {
-8:    Id   int    `json:"id"`
-9:    Name string `json:"name"`
+tests/compiler/go/join_filter.go.out:22: unsupported expr *ast.FuncLit
+>>> 21:    _ = purchases
+22:>>> var result []map[string]int = func() []map[string]int {
+23:    _res := []map[string]int{}
+24:    for _, p := range people {

--- a/tests/compiler/go/load_jsonl_stdin.mochi.error
+++ b/tests/compiler/go/load_jsonl_stdin.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/load_jsonl_stdin.go.out:11: unsupported declaration
->>> 10:    
-11:>>> type Person struct {
-12:    Name string `json:"name"`
-13:    Age  int    `json:"age"`
+tests/compiler/go/load_jsonl_stdin.go.out:28: unsupported generics
+>>> 27:    
+28:>>> func _cast[T any](v any) T {
+29:    if tv, ok := v.(T); ok {
+30:    return tv

--- a/tests/compiler/go/load_save_json.mochi.error
+++ b/tests/compiler/go/load_save_json.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/load_save_json.go.out:11: unsupported declaration
->>> 10:    
-11:>>> type Person struct {
-12:    Name  string `json:"name"`
-13:    Age   int    `json:"age"`
+tests/compiler/go/load_save_json.go.out:40: unsupported generics
+>>> 39:    
+40:>>> func _cast[T any](v any) T {
+41:    if tv, ok := v.(T); ok {
+42:    return tv

--- a/tests/compiler/go/local_recursion.mochi.error
+++ b/tests/compiler/go/local_recursion.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/local_recursion.go.out:7: unsupported declaration
+tests/compiler/go/local_recursion.go.out:7: unsupported type spec
 >>> 6:    
 7:>>> type Tree interface{ isTree() }
 8:    type Leaf struct {

--- a/tests/compiler/go/lower_builtin.mochi.out
+++ b/tests/compiler/go/lower_builtin.mochi.out
@@ -1,0 +1,1 @@
+print(str(lower("BAR")))

--- a/tests/compiler/go/match_capture.mochi.error
+++ b/tests/compiler/go/match_capture.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/match_capture.go.out:7: unsupported declaration
+tests/compiler/go/match_capture.go.out:7: unsupported type spec
 >>> 6:    
 7:>>> type Tree interface{ isTree() }
 8:    type Leaf struct {

--- a/tests/compiler/go/match_underscore.mochi.error
+++ b/tests/compiler/go/match_underscore.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/match_underscore.go.out:8: unsupported declaration
+tests/compiler/go/match_underscore.go.out:8: unsupported type spec
 >>> 7:    
 8:>>> type Tree interface{ isTree() }
 9:    type Leaf struct {

--- a/tests/compiler/go/struct_method.mochi.error
+++ b/tests/compiler/go/struct_method.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/struct_method.go.out:7: unsupported declaration
->>> 6:    
-7:>>> type Counter struct {
-8:    Value int `json:"value"`
-9:    }
+tests/compiler/go/struct_method.go.out:11: unsupported method declaration
+>>> 10:    
+11:>>> func (s *Counter) Inc(x int) {
+12:    s.Value = (s.Value + x)
+13:    }

--- a/tests/compiler/go/union_inorder.mochi.error
+++ b/tests/compiler/go/union_inorder.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/union_inorder.go.out:8: unsupported declaration
+tests/compiler/go/union_inorder.go.out:8: unsupported type spec
 >>> 7:    
 8:>>> type Tree interface{ isTree() }
 9:    type Leaf struct {

--- a/tests/compiler/go/union_match.mochi.error
+++ b/tests/compiler/go/union_match.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/union_match.go.out:7: unsupported declaration
+tests/compiler/go/union_match.go.out:7: unsupported type spec
 >>> 6:    
 7:>>> type Tree interface{ isTree() }
 8:    type Leaf struct {

--- a/tests/compiler/go/union_slice.mochi.error
+++ b/tests/compiler/go/union_slice.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/union_slice.go.out:7: unsupported declaration
+tests/compiler/go/union_slice.go.out:7: unsupported type spec
 >>> 6:    
 7:>>> type Foo interface{ isFoo() }
 8:    type Empty struct {

--- a/tests/compiler/go/upper_builtin.mochi.out
+++ b/tests/compiler/go/upper_builtin.mochi.out
@@ -1,0 +1,1 @@
+print(str(upper("foo")))


### PR DESCRIPTION
## Summary
- support Go struct type declarations in go2mochi
- recognise fmt.Println with multiple args
- convert strings.ToLower/ToUpper calls
- reject unsupported unary ops
- regenerate golden outputs for go tests

## Testing
- `go test ./tools/go2mochi -run TestGo2Mochi_Golden -update`
- `go test ./tools/go2mochi -run TestGo2Mochi_Golden -count=1`
- `go test ./tools/go2mochi -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686890782cbc8320b9ac659c21ab540b