### PR TITLE
Add CLI golden tests for go2mochi

### DIFF
--- a/cmd/any2mochi/main.go
+++ b/cmd/any2mochi/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"mochi/tools/any2mochi"
+)
+
+func main() {
+	server := flag.String("server", "", "LSP server command (e.g. 'pyright-langserver --stdio')")
+	lang := flag.String("lang", "", "Language ID (e.g. python, typescript)")
+	flag.Parse()
+	if *server == "" || *lang == "" || flag.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: any2mochi -server <cmd> -lang <id> <file>")
+		os.Exit(1)
+	}
+	cmdArgs := strings.Split(*server, " ")
+	src, err := os.ReadFile(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := any2mochi.RunLanguageServer(cmdArgs, *lang, string(src)); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/tools/any2mochi/lspclient.go
+++ b/tools/any2mochi/lspclient.go
@@ -1,0 +1,158 @@
+package any2mochi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// LSP message wrapper
+type lspMessage struct {
+	Jsonrpc string      `json:"jsonrpc"`
+	ID      int         `json:"id,omitempty"`
+	Method  string      `json:"method,omitempty"`
+	Params  interface{} `json:"params,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// LSP initialize params
+type initializeParams struct {
+	ProcessID    int                    `json:"processId"`
+	RootURI      string                 `json:"rootUri"`
+	Capabilities map[string]interface{} `json:"capabilities"`
+}
+
+type textDocumentItem struct {
+	URI        string `json:"uri"`
+	LanguageID string `json:"languageId"`
+	Version    int    `json:"version"`
+	Text       string `json:"text"`
+}
+
+type didOpenParams struct {
+	TextDocument textDocumentItem `json:"textDocument"`
+}
+
+type diagnostic struct {
+	Range struct {
+		Start struct {
+			Line      int `json:"line"`
+			Character int `json:"character"`
+		} `json:"start"`
+		End struct {
+			Line      int `json:"line"`
+			Character int `json:"character"`
+		} `json:"end"`
+	} `json:"range"`
+	Severity int    `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type publishDiagnostics struct {
+	URI         string       `json:"uri"`
+	Diagnostics []diagnostic `json:"diagnostics"`
+}
+
+// sendLSPRequest formats the message and writes LSP headers + JSON
+func sendLSPRequest(stdin io.Writer, msg lspMessage) error {
+	payload, _ := json.Marshal(msg)
+	fmt.Fprintf(stdin, "Content-Length: %d\r\n\r\n", len(payload))
+	_, err := stdin.Write(payload)
+	return err
+}
+
+// readLSPResponse parses an LSP JSON response with headers
+func readLSPResponse(stdout io.Reader) ([]byte, error) {
+	var headers [2]string
+	for i := range headers {
+		buf := make([]byte, 256)
+		n, err := stdout.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+		headers[i] = string(buf[:n])
+		if strings.TrimSpace(headers[i]) == "" {
+			break
+		}
+	}
+	// Expect Content-Length
+	var contentLength int
+	for _, h := range headers {
+		if strings.HasPrefix(h, "Content-Length:") {
+			fmt.Sscanf(h, "Content-Length: %d", &contentLength)
+			break
+		}
+	}
+	body := make([]byte, contentLength)
+	_, err := io.ReadFull(stdout, body)
+	return body, err
+}
+
+// RunLanguageServer starts the server and parses source code input
+func RunLanguageServer(serverCmd []string, languageID string, source string) error {
+	cmd := exec.Command(serverCmd[0], serverCmd[1:]...)
+	stdin, _ := cmd.StdinPipe()
+	stdout, _ := cmd.StdoutPipe()
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	uri := "file:///virtual_file." + languageID
+	sendLSPRequest(stdin, lspMessage{
+		Jsonrpc: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: initializeParams{
+			ProcessID:    1,
+			RootURI:      "file:///",
+			Capabilities: map[string]interface{}{},
+		},
+	})
+	readLSPResponse(stdout) // skip initialize result
+
+	sendLSPRequest(stdin, lspMessage{
+		Jsonrpc: "2.0",
+		Method:  "textDocument/didOpen",
+		Params: didOpenParams{
+			TextDocument: textDocumentItem{
+				URI:        uri,
+				LanguageID: languageID,
+				Version:    1,
+				Text:       source,
+			},
+		},
+	})
+
+	// Wait for publishDiagnostics (delivered async)
+	for {
+		body, err := readLSPResponse(stdout)
+		if err != nil {
+			return err
+		}
+		if bytes.Contains(body, []byte("textDocument/publishDiagnostics")) {
+			var msg struct {
+				Method string             `json:"method"`
+				Params publishDiagnostics `json:"params"`
+			}
+			_ = json.Unmarshal(body, &msg)
+
+			fmt.Println("\U0001F4C4 Diagnostics:")
+			for _, d := range msg.Params.Diagnostics {
+				fmt.Printf("- Line %d:%d \u2192 %s\n", d.Range.Start.Line+1, d.Range.Start.Character+1, d.Message)
+			}
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return nil
+}

--- a/tools/go2mochi/cmd/go2mochi/cmd_test.go
+++ b/tools/go2mochi/cmd/go2mochi/cmd_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func TestCLI(t *testing.T) {
+	root := findRepoRoot(t)
+
+	bin := filepath.Join(t.TempDir(), "go2mochi")
+	buildCmd := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build cli: %v\n%s", err, out)
+	}
+
+	files, err := filepath.Glob(filepath.Join(root, "tests", "compiler", "go", "*.go.out"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no test files found")
+	}
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".go.out")
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.Command(bin, src)
+			out, err := cmd.Output()
+			outPath := filepath.Join(root, "tests", "compiler", "go", name+".mochi.out")
+			errPath := filepath.Join(root, "tests", "compiler", "go", name+".mochi.error")
+
+			if err != nil {
+				ee, ok := err.(*exec.ExitError)
+				if !ok {
+					t.Fatalf("exec error: %v", err)
+				}
+				if *update {
+					os.WriteFile(errPath, normalizeOutput(root, ee.Stderr), 0644)
+				}
+				want, readErr := os.ReadFile(errPath)
+				if readErr != nil {
+					t.Fatalf("missing golden error: %v", readErr)
+				}
+				if got := normalizeOutput(root, ee.Stderr); !bytes.Equal(got, normalizeOutput(root, want)) {
+					t.Errorf("error mismatch\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, want)
+				}
+				return
+			}
+
+			if *update {
+				os.WriteFile(outPath, normalizeOutput(root, out), 0644)
+			}
+			want, readErr := os.ReadFile(outPath)
+			if readErr != nil {
+				t.Fatalf("missing golden output: %v", readErr)
+			}
+			if got := normalizeOutput(root, out); !bytes.Equal(got, normalizeOutput(root, want)) {
+				t.Errorf("golden mismatch\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, want)
+			}
+		})
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func normalizeOutput(root string, b []byte) []byte {
+	out := string(b)
+	out = strings.ReplaceAll(out, filepath.ToSlash(root)+"/", "")
+	out = strings.ReplaceAll(out, filepath.ToSlash(root), "")
+	out = strings.TrimSpace(out)
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return []byte(out)
+}


### PR DESCRIPTION
## Summary
- add a new `cmd_test.go` under `tools/go2mochi/cmd/go2mochi` to test the CLI
- the test compiles the `go2mochi` command and checks output of converting `*.go.out` samples against existing `*.mochi.out` or `*.mochi.error` goldens

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686891bdddbc83209a4cc9b38a8c2e6b