### PR TITLE
Implement any2mochi conversions

### DIFF
--- a/compile/go/tools.go
+++ b/compile/go/tools.go
@@ -89,6 +89,26 @@ func EnsureGo() error {
 	return fmt.Errorf("go not found")
 }
 
+// EnsureGopls installs gopls if it is not present in PATH.
+// It requires the Go toolchain to be available.
+func EnsureGopls() error {
+	if _, err := exec.LookPath("gopls"); err == nil {
+		return nil
+	}
+	if err := EnsureGo(); err != nil {
+		return err
+	}
+	fmt.Println("\U0001F527 Installing gopls...")
+	cmd := exec.Command("go", "install", "golang.org/x/tools/gopls@latest")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+	if _, err := exec.LookPath("gopls"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("gopls not found")
+}
+
 // FormatGo formats the provided Go source. It first uses the standard library
 // formatter and then, if available, attempts to run `goimports` or `gofmt` for
 // additional cleanup. The input is returned with a trailing newline.

--- a/compile/py/tools.go
+++ b/compile/py/tools.go
@@ -166,6 +166,36 @@ func EnsureBlack() error {
 	return fmt.Errorf("black not found")
 }
 
+// EnsurePyright installs the Pyright language server if needed. It attempts
+// installation using npm or pip.
+func EnsurePyright() error {
+	if _, err := exec.LookPath("pyright-langserver"); err == nil {
+		return nil
+	}
+	installers := []struct {
+		bin  string
+		args []string
+	}{
+		{"npm", []string{"install", "-g", "pyright"}},
+		{"pip3", []string{"install", "--user", "pyright"}},
+		{"pip", []string{"install", "--user", "pyright"}},
+	}
+	for _, inst := range installers {
+		if _, err := exec.LookPath(inst.bin); err == nil {
+			fmt.Println("\U0001F40D Installing Pyright via", inst.bin, "...")
+			cmd := exec.Command(inst.bin, inst.args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			break
+		}
+	}
+	if _, err := exec.LookPath("pyright-langserver"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("pyright-langserver not found")
+}
+
 // FormatPy formats Python source using Black if available.
 // If Black is not installed, the input is returned unchanged.
 func FormatPy(src []byte) []byte {

--- a/compile/ts/tools.go
+++ b/compile/ts/tools.go
@@ -77,3 +77,32 @@ func EnsureFormatter() error {
 // Ensure provides a simple entry point for other packages to verify
 // the TypeScript toolchain is available.
 func Ensure() error { return EnsureFormatter() }
+
+// EnsureTSLanguageServer installs the TypeScript language server if missing.
+// The implementation tries npm or pnpm.
+func EnsureTSLanguageServer() error {
+	if _, err := exec.LookPath("typescript-language-server"); err == nil {
+		return nil
+	}
+	installers := []struct {
+		bin  string
+		args []string
+	}{
+		{"npm", []string{"install", "-g", "typescript", "typescript-language-server"}},
+		{"pnpm", []string{"add", "-g", "typescript", "typescript-language-server"}},
+	}
+	for _, inst := range installers {
+		if _, err := exec.LookPath(inst.bin); err == nil {
+			fmt.Println("\U0001F985 Installing TS language server via", inst.bin, "...")
+			cmd := exec.Command(inst.bin, inst.args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			break
+		}
+	}
+	if _, err := exec.LookPath("typescript-language-server"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("typescript-language-server not found")
+}

--- a/tools/any2mochi/cmd/any2mochi/main.go
+++ b/tools/any2mochi/cmd/any2mochi/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/fang"
+	"github.com/spf13/cobra"
+
+	"mochi/tools/any2mochi"
+)
+
+var (
+	version   = "dev"
+	gitCommit = ""
+)
+
+func parseCmd() *cobra.Command {
+	var server string
+	var lang string
+	cmd := &cobra.Command{
+		Use:   "parse [file]",
+		Short: "Parse source with a language server",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if server == "" || lang == "" {
+				return fmt.Errorf("server and lang required")
+			}
+			var data []byte
+			var err error
+			if len(args) == 1 {
+				data, err = os.ReadFile(args[0])
+			} else {
+				data, err = io.ReadAll(cmd.InOrStdin())
+			}
+			if err != nil {
+				return err
+			}
+			parts := strings.Fields(server)
+			syms, err := any2mochi.ParseText(parts[0], parts[1:], lang, string(data))
+			if err != nil {
+				return err
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(syms)
+		},
+	}
+	cmd.Flags().StringVar(&server, "server", "", "language server command")
+	cmd.Flags().StringVar(&lang, "lang", "", "language id")
+	return cmd
+}
+
+func convertGoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-go <file.go>",
+		Short: "Convert Go source to Mochi",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			out, err := any2mochi.ConvertGo(string(data))
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	return cmd
+}
+
+func convertPythonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-py <file.py>",
+		Short: "Convert Python source to Mochi",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			out, err := any2mochi.ConvertPython(string(data))
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	return cmd
+}
+
+func convertTSCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-ts <file.ts>",
+		Short: "Convert TypeScript source to Mochi",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			out, err := any2mochi.ConvertTypeScript(string(data))
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	return cmd
+}
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "any2mochi",
+		Short: "Language server utilities",
+	}
+	cmd.AddCommand(
+		parseCmd(),
+		convertGoCmd(),
+		convertPythonCmd(),
+		convertTSCmd(),
+	)
+	return cmd
+}
+
+func main() {
+	root := newRootCmd()
+	if err := fang.Execute(
+		context.Background(),
+		root,
+		fang.WithVersion(version),
+		fang.WithCommit(gitCommit),
+	); err != nil {
+		os.Exit(1)
+	}
+}

--- a/tools/any2mochi/convert_go.go
+++ b/tools/any2mochi/convert_go.go
@@ -1,0 +1,36 @@
+package any2mochi
+
+import (
+	"os"
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// ConvertGo converts Go source code to a minimal Mochi representation using
+// symbols reported by gopls.
+func ConvertGo(src string) ([]byte, error) {
+	syms, err := ParseText("gopls", nil, "go", src)
+	if err != nil {
+		return nil, err
+	}
+	var out strings.Builder
+	for _, s := range syms {
+		if s.Kind != protocol.SymbolKindFunction {
+			continue
+		}
+		out.WriteString("fun ")
+		out.WriteString(s.Name)
+		out.WriteString("() {}\n")
+	}
+	return []byte(out.String()), nil
+}
+
+// ConvertGoFile reads the Go file at path and converts it to Mochi.
+func ConvertGoFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertGo(string(data))
+}

--- a/tools/any2mochi/convert_go_test.go
+++ b/tools/any2mochi/convert_go_test.go
@@ -1,0 +1,20 @@
+package any2mochi
+
+import (
+	"testing"
+
+	gocode "mochi/compile/go"
+)
+
+func TestConvertGo(t *testing.T) {
+	_ = gocode.EnsureGopls()
+	requireBinary(t, "gopls")
+	src := "package foo\nfunc Add(x int, y int) int { return x + y }"
+	out, err := ConvertGo(src)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if string(out) != "fun Add() {}\n" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}

--- a/tools/any2mochi/convert_python.go
+++ b/tools/any2mochi/convert_python.go
@@ -1,0 +1,35 @@
+package any2mochi
+
+import (
+	"os"
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// ConvertPython converts Python source code to a minimal Mochi representation using pyright.
+func ConvertPython(src string) ([]byte, error) {
+	syms, err := ParseText("pyright-langserver", []string{"--stdio"}, "python", src)
+	if err != nil {
+		return nil, err
+	}
+	var out strings.Builder
+	for _, s := range syms {
+		if s.Kind != protocol.SymbolKindFunction {
+			continue
+		}
+		out.WriteString("fun ")
+		out.WriteString(s.Name)
+		out.WriteString("() {}\n")
+	}
+	return []byte(out.String()), nil
+}
+
+// ConvertPythonFile reads the Python file at path and converts it to Mochi.
+func ConvertPythonFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertPython(string(data))
+}

--- a/tools/any2mochi/convert_python_test.go
+++ b/tools/any2mochi/convert_python_test.go
@@ -1,0 +1,20 @@
+package any2mochi
+
+import (
+	"testing"
+
+	pycode "mochi/compile/py"
+)
+
+func TestConvertPython(t *testing.T) {
+	_ = pycode.EnsurePyright()
+	requireBinary(t, "pyright-langserver")
+	src := "def add(x, y):\n    return x + y"
+	out, err := ConvertPython(src)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if string(out) != "fun add() {}\n" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}

--- a/tools/any2mochi/convert_typescript.go
+++ b/tools/any2mochi/convert_typescript.go
@@ -1,0 +1,35 @@
+package any2mochi
+
+import (
+	"os"
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// ConvertTypeScript converts TypeScript source code to a minimal Mochi representation using the language server.
+func ConvertTypeScript(src string) ([]byte, error) {
+	syms, err := ParseText("typescript-language-server", []string{"--stdio"}, "typescript", src)
+	if err != nil {
+		return nil, err
+	}
+	var out strings.Builder
+	for _, s := range syms {
+		if s.Kind != protocol.SymbolKindFunction {
+			continue
+		}
+		out.WriteString("fun ")
+		out.WriteString(s.Name)
+		out.WriteString("() {}\n")
+	}
+	return []byte(out.String()), nil
+}
+
+// ConvertTypeScriptFile reads the TS file and converts it to Mochi.
+func ConvertTypeScriptFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertTypeScript(string(data))
+}

--- a/tools/any2mochi/convert_typescript_test.go
+++ b/tools/any2mochi/convert_typescript_test.go
@@ -1,0 +1,20 @@
+package any2mochi
+
+import (
+	"testing"
+
+	tscode "mochi/compile/ts"
+)
+
+func TestConvertTypeScript(t *testing.T) {
+	_ = tscode.EnsureTSLanguageServer()
+	requireBinary(t, "typescript-language-server")
+	src := "export function add(x: number, y: number): number { return x + y }"
+	out, err := ConvertTypeScript(src)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if string(out) != "fun add() {}\n" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -1,0 +1,98 @@
+package any2mochi
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"time"
+
+	jsonrpc2 "github.com/sourcegraph/jsonrpc2"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+type client struct {
+	conn *jsonrpc2.Conn
+	cmd  *exec.Cmd
+}
+
+// ParseText starts the language server command given by cmdName and
+// parses the provided source using the Language Server Protocol.
+// It returns the document symbols reported by the server for the file.
+// The server must support the textDocument/documentSymbol request.
+func ParseText(cmdName string, args []string, langID string, src string) ([]protocol.DocumentSymbol, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, cmdName, args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	stream := jsonrpc2.NewBufferedStream(&pipe{r: stdout, w: stdin}, jsonrpc2.VSCodeObjectCodec{})
+	conn := jsonrpc2.NewConn(ctx, stream, jsonrpc2.HandlerWithError(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
+		// Discard all incoming messages and return no result.
+		return nil, nil
+	}))
+	c := &client{conn: conn, cmd: cmd}
+
+	if err := c.initialize(ctx); err != nil {
+		c.Close()
+		return nil, err
+	}
+	uri := protocol.DocumentUri("file:///input")
+	if err := c.conn.Notify(ctx, "textDocument/didOpen", protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: uri, LanguageID: langID, Version: 1, Text: src},
+	}); err != nil {
+		c.Close()
+		return nil, err
+	}
+	var syms []protocol.DocumentSymbol
+	if err := c.conn.Call(ctx, "textDocument/documentSymbol", protocol.DocumentSymbolParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+	}, &syms); err != nil {
+		c.Close()
+		return nil, err
+	}
+	c.Close()
+	return syms, nil
+}
+
+func (c *client) initialize(ctx context.Context) error {
+	var res protocol.InitializeResult
+	if err := c.conn.Call(ctx, "initialize", protocol.InitializeParams{}, &res); err != nil {
+		return err
+	}
+	if err := c.conn.Notify(ctx, "initialized", struct{}{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *client) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	c.conn.Call(ctx, "shutdown", nil, nil)
+	c.conn.Notify(ctx, "exit", nil)
+	c.conn.Close()
+	return c.cmd.Wait()
+}
+
+type pipe struct {
+	r io.ReadCloser
+	w io.WriteCloser
+}
+
+func (p *pipe) Read(b []byte) (int, error)  { return p.r.Read(b) }
+func (p *pipe) Write(b []byte) (int, error) { return p.w.Write(b) }
+func (p *pipe) Close() error {
+	p.w.Close()
+	return p.r.Close()
+}

--- a/tools/any2mochi/parse_test.go
+++ b/tools/any2mochi/parse_test.go
@@ -1,0 +1,56 @@
+package any2mochi
+
+import (
+	"os/exec"
+	"testing"
+
+	gocode "mochi/compile/go"
+	pycode "mochi/compile/py"
+	tscode "mochi/compile/ts"
+)
+
+func requireBinary(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s not found", name)
+	}
+}
+
+func TestParseGo(t *testing.T) {
+	_ = gocode.EnsureGopls()
+	requireBinary(t, "gopls")
+	src := "package foo\nfunc Add(x int, y int) int { return x + y }"
+	syms, err := ParseText("gopls", nil, "go", src)
+	if err != nil {
+		t.Fatalf("parse go: %v", err)
+	}
+	if len(syms) == 0 {
+		t.Fatalf("expected symbols")
+	}
+}
+
+func TestParsePython(t *testing.T) {
+	_ = pycode.EnsurePyright()
+	requireBinary(t, "pyright-langserver")
+	src := "def add(x,y):\n    return x + y"
+	syms, err := ParseText("pyright-langserver", []string{"--stdio"}, "python", src)
+	if err != nil {
+		t.Fatalf("parse python: %v", err)
+	}
+	if len(syms) == 0 {
+		t.Fatalf("expected symbols")
+	}
+}
+
+func TestParseTypeScript(t *testing.T) {
+	_ = tscode.EnsureTSLanguageServer()
+	requireBinary(t, "typescript-language-server")
+	src := "export function add(x: number, y: number): number { return x + y }"
+	syms, err := ParseText("typescript-language-server", []string{"--stdio"}, "typescript", src)
+	if err != nil {
+		t.Fatalf("parse ts: %v", err)
+	}
+	if len(syms) == 0 {
+		t.Fatalf("expected symbols")
+	}
+}

--- a/tools/install/main.go
+++ b/tools/install/main.go
@@ -2,11 +2,23 @@ package main
 
 import (
 	"fmt"
+
+	"mochi/compile/go"
+	"mochi/compile/py"
 	"mochi/compile/ts"
 )
 
 func main() {
 	if err := tscode.EnsureDeno(); err != nil {
 		fmt.Println("failed to install Deno:", err)
+	}
+	if err := gocode.EnsureGopls(); err != nil {
+		fmt.Println("failed to install gopls:", err)
+	}
+	if err := pycode.EnsurePyright(); err != nil {
+		fmt.Println("failed to install pyright:", err)
+	}
+	if err := tscode.EnsureTSLanguageServer(); err != nil {
+		fmt.Println("failed to install typescript-language-server:", err)
 	}
 }


### PR DESCRIPTION
## Summary
- support converting Go sources with language server symbols
- expose `convert-go` and `parse` commands using fang-based CLI
- add tests for Go conversion and update CLI implementation
- add Python and TypeScript conversion helpers and CLI commands
- tests for new converters

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68689143340c8320bd9eaefceaae5ba3