### PR TITLE
Improve go2mochi conversion

### DIFF
--- a/tests/compiler/go/break_continue.mochi.error
+++ b/tests/compiler/go/break_continue.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/break_continue.go.out:26: unsupported Println args
->>> 25:    }
-26:>>> fmt.Println("odd number:", n)
-27:    }
-28:    }

--- a/tests/compiler/go/cast_struct.mochi.error
+++ b/tests/compiler/go/cast_struct.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/cast_struct.go.out:18: unsupported generics
->>> 17:    
-18:>>> func _cast[T any](v any) T {
-19:    if tv, ok := v.(T); ok {
-20:    return tv
+tests/compiler/go/cast_struct.go.out:23: unsupported statement *ast.TypeSwitchStmt
+>>> 22:    var out T
+23:>>> switch any(out).(type) {
+24:    case int:
+25:    switch vv := v.(type) {

--- a/tests/compiler/go/closure.mochi.error
+++ b/tests/compiler/go/closure.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/closure.go.out:8: unsupported expr *ast.FuncLit
->>> 7:    func makeAdder(n int) func(int) int {
-8:>>> return func(x int) int {
-9:    return (x + n)
-10:    }

--- a/tests/compiler/go/closure.mochi.out
+++ b/tests/compiler/go/closure.mochi.out
@@ -1,0 +1,7 @@
+fun makeAdder(n: int): func(int) int {
+  return fun(x: int): int {
+  return (x + n)
+}
+}
+var add10 = makeAdder(10)
+print(str(add10(7)))

--- a/tests/compiler/go/cross_join.mochi.error
+++ b/tests/compiler/go/cross_join.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/cross_join.go.out:29: unsupported expr *ast.FuncLit
->>> 28:    var orders []Order = []Order{Order{Id: 100, CustomerId: 1, Total: 250}, Order{Id: 101, CustomerId: 2, Total: 125}, Order{Id: 102, CustomerId: 1, Total: 300}}
-29:>>> var result []PairInfo = func() []PairInfo {
-30:    _res := []PairInfo{}
-31:    for _, o := range orders {

--- a/tests/compiler/go/cross_join.mochi.out
+++ b/tests/compiler/go/cross_join.mochi.out
@@ -1,0 +1,31 @@
+type Customer {
+  Id: int
+  Name: string
+}
+type Order {
+  Id: int
+  CustomerId: int
+  Total: int
+}
+type PairInfo {
+  OrderId: int
+  OrderCustomerId: int
+  PairedCustomerName: string
+  OrderTotal: int
+}
+var customers = [Customer { Id: 1, Name: "Alice" }, Customer { Id: 2, Name: "Bob" }, Customer { Id: 3, Name: "Charlie" }]
+_ = customers
+var orders = [Order { Id: 100, CustomerId: 1, Total: 250 }, Order { Id: 101, CustomerId: 2, Total: 125 }, Order { Id: 102, CustomerId: 1, Total: 300 }]
+var result = (fun(): list<PairInfo> {
+  let _res = []
+  for o in orders {
+  for c in customers {
+  _res = append(_res, PairInfo { OrderId: o.Id, OrderCustomerId: o.CustomerId, PairedCustomerName: c.Name, OrderTotal: o.Total })
+}
+}
+  return _res
+})()
+print(str("--- Cross Join: All order-customer pairs ---"))
+for entry in result {
+  print(str("Order") + " " + str(entry.OrderId) + " " + str("(customerId:") + " " + str(entry.OrderCustomerId) + " " + str(", total: $") + " " + str(entry.OrderTotal) + " " + str(") paired with") + " " + str(entry.PairedCustomerName))
+}

--- a/tests/compiler/go/cross_join_triple.mochi.error
+++ b/tests/compiler/go/cross_join_triple.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/cross_join_triple.go.out:13: unsupported expr *ast.FuncLit
->>> 12:    _ = bools
-13:>>> var combos []map[string]any = func() []map[string]any {
-14:    _res := []map[string]any{}
-15:    for _, n := range nums {

--- a/tests/compiler/go/cross_join_triple.mochi.out
+++ b/tests/compiler/go/cross_join_triple.mochi.out
@@ -1,0 +1,20 @@
+var nums = [1, 2]
+var letters = ["A", "B"]
+_ = letters
+var bools = [true, false]
+_ = bools
+var combos = (fun(): list<map<string, any>> {
+  let _res = []
+  for n in nums {
+  for l in letters {
+  for b in bools {
+  _res = append(_res, {"n": n, "l": l, "b": b})
+}
+}
+}
+  return _res
+})()
+print(str("--- Cross Join of three lists ---"))
+for c in combos {
+  print(str(c["n"]) + " " + str(c["l"]) + " " + str(c["b"]))
+}

--- a/tests/compiler/go/dataset.mochi.error
+++ b/tests/compiler/go/dataset.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/dataset.go.out:14: unsupported expr *ast.FuncLit
->>> 13:    var people []Person = []Person{Person{Name: "Alice", Age: 30}, Person{Name: "Bob", Age: 15}, Person{Name: "Charlie", Age: 65}}
-14:>>> var names []string = func() []string {
-15:    _res := []string{}
-16:    for _, p := range people {

--- a/tests/compiler/go/dataset.mochi.out
+++ b/tests/compiler/go/dataset.mochi.out
@@ -1,0 +1,19 @@
+type Person {
+  Name: string
+  Age: int
+}
+var people = [Person { Name: "Alice", Age: 30 }, Person { Name: "Bob", Age: 15 }, Person { Name: "Charlie", Age: 65 }]
+var names = (fun(): list<string> {
+  let _res = []
+  for p in people {
+  if p.Age >= 18 {
+  if p.Age >= 18 {
+  _res = append(_res, p.Name)
+}
+}
+}
+  return _res
+})()
+for n in names {
+  print(str(n))
+}

--- a/tests/compiler/go/dataset_sort_take_limit.mochi.error
+++ b/tests/compiler/go/dataset_sort_take_limit.mochi.error
@@ -1,5 +1,8 @@
-tests/compiler/go/dataset_sort_take_limit.go.out:76: unsupported generics
->>> 75:    
-76:>>> func _paginate[T any](src []T, skip, take int) []T {
-77:    if skip > 0 {
-78:    if skip < len(src) {
+tests/compiler/go/dataset_sort_take_limit.go.out:32: unsupported expr *ast.ArrayType
+>>> 30:    key  any
+31:    }
+32:>>> pairs := make([]pair, len(items))
+33:    for idx, it := range items {
+34:    p := it
+35:    pairs[idx] = pair{item: it, key: -p.Price}
+exit status 1

--- a/tests/compiler/go/factorial.mochi.error
+++ b/tests/compiler/go/factorial.mochi.error
@@ -1,1 +1,0 @@
-unsupported function declaration

--- a/tests/compiler/go/fetch_builtin.mochi.error
+++ b/tests/compiler/go/fetch_builtin.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/fetch_builtin.go.out:24: unsupported generics
->>> 23:    
-24:>>> func _cast[T any](v any) T {
-25:    if tv, ok := v.(T); ok {
-26:    return tv
+tests/compiler/go/fetch_builtin.go.out:29: unsupported statement *ast.TypeSwitchStmt
+>>> 28:    var out T
+29:>>> switch any(out).(type) {
+30:    case int:
+31:    switch vv := v.(type) {

--- a/tests/compiler/go/fetch_remote.mochi.error
+++ b/tests/compiler/go/fetch_remote.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/fetch_remote.go.out:27: unsupported generics
->>> 26:    
-27:>>> func _cast[T any](v any) T {
-28:    if tv, ok := v.(T); ok {
-29:    return tv
+tests/compiler/go/fetch_remote.go.out:32: unsupported statement *ast.TypeSwitchStmt
+>>> 31:    var out T
+32:>>> switch any(out).(type) {
+33:    case int:
+34:    switch vv := v.(type) {

--- a/tests/compiler/go/fibonacci.mochi.error
+++ b/tests/compiler/go/fibonacci.mochi.error
@@ -1,1 +1,0 @@
-unsupported function declaration

--- a/tests/compiler/go/fold_pure_let.mochi.error
+++ b/tests/compiler/go/fold_pure_let.mochi.error
@@ -1,1 +1,0 @@
-unsupported function declaration

--- a/tests/compiler/go/fun_expr_in_let.mochi.error
+++ b/tests/compiler/go/fun_expr_in_let.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/fun_expr_in_let.go.out:8: unsupported expr *ast.FuncLit
->>> 7:    func main() {
-8:>>> var square func(int) int = func(x int) int {
-9:    return (x * x)
-10:    }

--- a/tests/compiler/go/fun_expr_in_let.mochi.out
+++ b/tests/compiler/go/fun_expr_in_let.mochi.out
@@ -1,0 +1,4 @@
+var square = fun(x: int): int {
+  return (x * x)
+}
+print(str(square(6)))

--- a/tests/compiler/go/generate_struct.mochi.error
+++ b/tests/compiler/go/generate_struct.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/generate_struct.go.out:21: unsupported generics
->>> 20:    
-21:>>> func _genStruct[T any](prompt string, model string, params map[string]any) T {
-22:    opts := []llm.Option{}
-23:    if model != "" {
+tests/compiler/go/generate_struct.go.out:29: unsupported assignment
+>>> 28:    }
+29:>>> resp, err := llm.Chat(context.Background(), []llm.Message{{Role: "user", Content: prompt}}, opts...)
+30:    if err != nil {
+31:    panic(err)

--- a/tests/compiler/go/higher_order_apply.mochi.error
+++ b/tests/compiler/go/higher_order_apply.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/higher_order_apply.go.out:17: unsupported expr *ast.FuncLit
->>> 16:    fmt.Println(apply(inc, 5))
-17:>>> fmt.Println(apply(func(y int) int {
-18:    return (y * 2)
-19:    }, 7))

--- a/tests/compiler/go/higher_order_apply.mochi.out
+++ b/tests/compiler/go/higher_order_apply.mochi.out
@@ -1,0 +1,10 @@
+fun inc(x: int): int {
+  return (x + 1)
+}
+fun apply(f: func(int) int, x: int): int {
+  return f(x)
+}
+print(str(apply(inc, 5)))
+print(str(apply(fun(y: int): int {
+  return (y * 2)
+}, 7)))

--- a/tests/compiler/go/if_else.mochi.error
+++ b/tests/compiler/go/if_else.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/if_else.go.out:10: unsupported else
->>> 9:    return -1
-10:>>> } else if n == 0 {
-11:    return 0
-12:    } else {

--- a/tests/compiler/go/if_else.mochi.out
+++ b/tests/compiler/go/if_else.mochi.out
@@ -1,0 +1,12 @@
+fun foo(n: int): int {
+  if n < 0 {
+  return -1
+} else if n == 0 {
+  return 0
+} else {
+  return 1
+}
+}
+print(str(foo(-2)))
+print(str(foo(0)))
+print(str(foo(3)))

--- a/tests/compiler/go/input_builtin.mochi.error
+++ b/tests/compiler/go/input_builtin.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/input_builtin.go.out:17: unsupported unary op &
->>> 16:    var s string
-17:>>> fmt.Scanln(&s)
-18:    return s
-19:    }

--- a/tests/compiler/go/join.mochi.error
+++ b/tests/compiler/go/join.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/join.go.out:33: unsupported expr *ast.FuncLit
->>> 32:    }
-33:>>> var result []PairInfo = func() []PairInfo {
-34:    _res := []PairInfo{}
-35:    for _, o := range orders {

--- a/tests/compiler/go/join.mochi.out
+++ b/tests/compiler/go/join.mochi.out
@@ -1,0 +1,33 @@
+type Customer {
+  Id: int
+  Name: string
+}
+type Order {
+  Id: int
+  CustomerId: int
+  Total: int
+}
+type PairInfo {
+  OrderId: int
+  CustomerName: string
+  Total: int
+}
+var customers = [Customer { Id: 1, Name: "Alice" }, Customer { Id: 2, Name: "Bob" }, Customer { Id: 3, Name: "Charlie" }]
+_ = customers
+var orders = [Order { Id: 100, CustomerId: 1, Total: 250 }, Order { Id: 101, CustomerId: 2, Total: 125 }, Order { Id: 102, CustomerId: 1, Total: 300 }, Order { Id: 103, CustomerId: 4, Total: 80 }]
+var result = (fun(): list<PairInfo> {
+  let _res = []
+  for o in orders {
+  for c in customers {
+  if !(o.CustomerId == c.Id) {
+  continue
+}
+  _res = append(_res, PairInfo { OrderId: o.Id, CustomerName: c.Name, Total: o.Total })
+}
+}
+  return _res
+})()
+print(str("--- Orders with customer info ---"))
+for entry in result {
+  print(str("Order") + " " + str(entry.OrderId) + " " + str("by") + " " + str(entry.CustomerName) + " " + str("- $") + " " + str(entry.Total))
+}

--- a/tests/compiler/go/join_filter.mochi.error
+++ b/tests/compiler/go/join_filter.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/join_filter.go.out:22: unsupported expr *ast.FuncLit
->>> 21:    _ = purchases
-22:>>> var result []map[string]int = func() []map[string]int {
-23:    _res := []map[string]int{}
-24:    for _, p := range people {

--- a/tests/compiler/go/join_filter.mochi.out
+++ b/tests/compiler/go/join_filter.mochi.out
@@ -1,0 +1,29 @@
+type Person {
+  Id: int
+  Name: string
+}
+type Purchase {
+  Id: int
+  PersonId: int
+  Total: int
+}
+var people = [Person { Id: 1, Name: "Alice" }, Person { Id: 2, Name: "Bob" }]
+var purchases = [Purchase { Id: 10, PersonId: 1, Total: 100 }, Purchase { Id: 11, PersonId: 2, Total: 200 }]
+_ = purchases
+var result = (fun(): list<map<string, int>> {
+  let _res = []
+  for p in people {
+  if p.Id > 1 {
+  for o in purchases {
+  if !(p.Id == o.PersonId) {
+  continue
+}
+  _res = append(_res, {"pid": p.Id, "amount": o.Total})
+}
+}
+}
+  return _res
+})()
+for r in result {
+  print(str(r["pid"]) + " " + str(r["amount"]))
+}

--- a/tests/compiler/go/list_concat.mochi.error
+++ b/tests/compiler/go/list_concat.mochi.error
@@ -1,1 +1,0 @@
-unsupported expr *ast.CallExpr

--- a/tests/compiler/go/list_prepend.mochi.error
+++ b/tests/compiler/go/list_prepend.mochi.error
@@ -1,1 +1,0 @@
-unsupported function declaration

--- a/tests/compiler/go/load_jsonl_stdin.mochi.error
+++ b/tests/compiler/go/load_jsonl_stdin.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/load_jsonl_stdin.go.out:28: unsupported generics
->>> 27:    
-28:>>> func _cast[T any](v any) T {
-29:    if tv, ok := v.(T); ok {
-30:    return tv
+tests/compiler/go/load_jsonl_stdin.go.out:33: unsupported statement *ast.TypeSwitchStmt
+>>> 32:    var out T
+33:>>> switch any(out).(type) {
+34:    case int:
+35:    switch vv := v.(type) {

--- a/tests/compiler/go/load_save_json.mochi.error
+++ b/tests/compiler/go/load_save_json.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/load_save_json.go.out:40: unsupported generics
->>> 39:    
-40:>>> func _cast[T any](v any) T {
-41:    if tv, ok := v.(T); ok {
-42:    return tv
+tests/compiler/go/load_save_json.go.out:45: unsupported statement *ast.TypeSwitchStmt
+>>> 44:    var out T
+45:>>> switch any(out).(type) {
+46:    case int:
+47:    switch vv := v.(type) {

--- a/tests/compiler/go/lower_builtin.mochi.error
+++ b/tests/compiler/go/lower_builtin.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/lower_builtin.go.out:9: unsupported expr *ast.SelectorExpr
->>> 8:    func main() {
-9:>>> fmt.Println(strings.ToLower("BAR"))
-10:    }
-11:

--- a/tests/compiler/go/map_any_hint.mochi.error
+++ b/tests/compiler/go/map_any_hint.mochi.error
@@ -1,5 +1,5 @@
-tests/compiler/go/map_any_hint.go.out:26: unsupported generics
->>> 25:    
-26:>>> func _cast[T any](v any) T {
-27:    if tv, ok := v.(T); ok {
-28:    return tv
+tests/compiler/go/map_any_hint.go.out:31: unsupported statement *ast.TypeSwitchStmt
+>>> 30:    var out T
+31:>>> switch any(out).(type) {
+32:    case int:
+33:    switch vv := v.(type) {

--- a/tests/compiler/go/map_hint_literal.mochi.error
+++ b/tests/compiler/go/map_hint_literal.mochi.error
@@ -1,1 +1,0 @@
-unsupported function declaration

--- a/tests/compiler/go/map_len.mochi.error
+++ b/tests/compiler/go/map_len.mochi.error
@@ -1,1 +1,0 @@
-unsupported expr *ast.CallExpr

--- a/tests/compiler/go/map_ops.mochi.error
+++ b/tests/compiler/go/map_ops.mochi.error
@@ -1,5 +1,8 @@
 tests/compiler/go/map_ops.go.out:13: unsupported assignment
->>> 12:    _tmp1 := m
+>>> 11:    _tmp0 := 1
+12:    _tmp1 := m
 13:>>> _, _tmp2 := _tmp1[_tmp0]
 14:    if _tmp2 {
 15:    fmt.Println(m[1])
+16:    }
+exit status 1

--- a/tests/compiler/go/math_import_py.mochi.error
+++ b/tests/compiler/go/math_import_py.mochi.error
@@ -1,4 +1,4 @@
-tests/compiler/go/math_import_py.go.out:10: unsupported expr *ast.FuncLit
+tests/compiler/go/math_import_py.go.out:10: unsupported assignment
 >>> 9:    var r float64 = 3.0
 10:>>> var area float64 = (func() float64 { v, _ := python.Attr("math", "pi"); return v.(float64) }() * func() float64 { v, _ := python.Attr("math", "pow", r, 2.0); return v.(float64) }())
 11:    fmt.Println("Area:", area)

--- a/tests/compiler/go/matrix_search.mochi.error
+++ b/tests/compiler/go/matrix_search.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/matrix_search.go.out:25: unsupported else
->>> 24:    return true
-25:>>> } else if value < target {
-26:    left = (mid + 1)
-27:    } else {

--- a/tests/compiler/go/matrix_search.mochi.out
+++ b/tests/compiler/go/matrix_search.mochi.out
@@ -1,0 +1,28 @@
+fun searchMatrix(matrix: list<list<int>>, target: int): bool {
+  var m = len(matrix)
+  if m == 0 {
+  return false
+}
+  var n = len(matrix[0])
+  var left = 0
+  var right = ((m * n) - 1)
+  while true {
+  if !(left <= right) {
+  break
+}
+  var mid = (left + ((right - left) / 2))
+  var row = (mid / n)
+  var col = (mid % n)
+  var value = matrix[row][col]
+  if value == target {
+  return true
+} else if value < target {
+  left = (mid + 1)
+} else {
+  right = (mid - 1)
+}
+}
+  return false
+}
+print(str(searchMatrix([[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], 3)))
+print(str(searchMatrix([[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], 13)))

--- a/tests/compiler/go/multi_functions.mochi.error
+++ b/tests/compiler/go/multi_functions.mochi.error
@@ -1,1 +1,0 @@
-unsupported function declaration

--- a/tests/compiler/go/nested_inner_fn.mochi.error
+++ b/tests/compiler/go/nested_inner_fn.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/nested_inner_fn.go.out:8: unsupported expr *ast.FuncLit
->>> 7:    func outer(a int) int {
-8:>>> var inner = func(b int) int {
-9:    return (a + b)
-10:    }

--- a/tests/compiler/go/nested_inner_fn.mochi.out
+++ b/tests/compiler/go/nested_inner_fn.mochi.out
@@ -1,0 +1,7 @@
+fun outer(a: int): int {
+  var inner = fun(b: int): int {
+  return (a + b)
+}
+  return inner(10)
+}
+print(str(outer(5)))

--- a/tests/compiler/go/reduce_builtin.mochi.error
+++ b/tests/compiler/go/reduce_builtin.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/reduce_builtin.go.out:15: unsupported generics
->>> 14:    
-15:>>> func _reduce[T any](src []T, fn func(T, T) T, init T) T {
-16:    acc := init
-17:    for _, v := range src {

--- a/tests/compiler/go/reduce_builtin.mochi.out
+++ b/tests/compiler/go/reduce_builtin.mochi.out
@@ -1,5 +1,5 @@
 fun add(a: int, b: int): int {
-  return a + b
+  return (a + b)
 }
 fun _reduce(src: list<T>, fn: func(T, T) T, init: T): T {
   let acc = init
@@ -8,4 +8,4 @@ fun _reduce(src: list<T>, fn: func(T, T) T, init: T): T {
 }
   return acc
 }
-print(_reduce[int]([1, 2, 3], add, 0))
+print(str(_reduce([1, 2, 3], add, 0)))

--- a/tests/compiler/go/simple_fn.mochi.error
+++ b/tests/compiler/go/simple_fn.mochi.error
@@ -1,1 +1,0 @@
-unsupported function declaration

--- a/tests/compiler/go/string_for_loop.mochi.error
+++ b/tests/compiler/go/string_for_loop.mochi.error
@@ -1,1 +1,0 @@
-unsupported statement *ast.RangeStmt

--- a/tests/compiler/go/string_negative_slice.mochi.error
+++ b/tests/compiler/go/string_negative_slice.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/string_negative_slice.go.out:11: unsupported parameter list
->>> 10:    
-11:>>> func _sliceString(s string, i, j int) string {
-12:    start := i
-13:    end := j

--- a/tests/compiler/go/string_negative_slice.mochi.out
+++ b/tests/compiler/go/string_negative_slice.mochi.out
@@ -1,0 +1,22 @@
+fun _sliceString(s: string, i: int, j: int): string {
+  let start = i
+  let end = j
+  let n = len(s)
+  if start < 0 {
+  start = start + n
+}
+  if end < 0 {
+  end = end + n
+}
+  if start < 0 {
+  start = 0
+}
+  if end > n {
+  end = n
+}
+  if end < start {
+  end = start
+}
+  return str(s[start:end])
+}
+print(str(_sliceString("hello", -4, -1)))

--- a/tests/compiler/go/string_slice.mochi.error
+++ b/tests/compiler/go/string_slice.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/string_slice.go.out:11: unsupported parameter list
->>> 10:    
-11:>>> func _sliceString(s string, i, j int) string {
-12:    start := i
-13:    end := j

--- a/tests/compiler/go/string_slice.mochi.out
+++ b/tests/compiler/go/string_slice.mochi.out
@@ -1,0 +1,22 @@
+fun _sliceString(s: string, i: int, j: int): string {
+  let start = i
+  let end = j
+  let n = len(s)
+  if start < 0 {
+  start = start + n
+}
+  if end < 0 {
+  end = end + n
+}
+  if start < 0 {
+  start = 0
+}
+  if end > n {
+  end = n
+}
+  if end < start {
+  end = start
+}
+  return str(s[start:end])
+}
+print(str(_sliceString("hello", 1, 4)))

--- a/tests/compiler/go/typed_list_negative.mochi.error
+++ b/tests/compiler/go/typed_list_negative.mochi.error
@@ -1,5 +1,8 @@
-tests/compiler/go/typed_list_negative.go.out:16: unsupported statement *ast.SwitchStmt
->>> 15:    func formatDuration(d time.Duration) string {
-16:>>> switch {
-17:    case d < time.Microsecond:
-18:    return fmt.Sprintf("%dns", d.Nanoseconds())
+tests/compiler/go/typed_list_negative.go.out:80: unsupported statement *ast.TypeSwitchStmt
+>>> 78:    }
+79:    var out T
+80:>>> switch any(out).(type) {
+81:    case int:
+82:    switch vv := v.(type) {
+83:    case int:
+exit status 1

--- a/tests/compiler/go/update_statement.mochi.error
+++ b/tests/compiler/go/update_statement.mochi.error
@@ -1,5 +1,8 @@
-tests/compiler/go/update_statement.go.out:16: unsupported statement *ast.SwitchStmt
->>> 15:    func formatDuration(d time.Duration) string {
-16:>>> switch {
-17:    case d < time.Microsecond:
-18:    return fmt.Sprintf("%dns", d.Nanoseconds())
+tests/compiler/go/update_statement.go.out:79: unsupported statement *ast.DeferStmt
+>>> 77:    var failed error
+78:    func() {
+79:>>> defer func() {
+80:    if r := recover(); r != nil {
+81:    failed = fmt.Errorf("%v", r)
+82:    }
+exit status 1

--- a/tests/compiler/go/upper_builtin.mochi.error
+++ b/tests/compiler/go/upper_builtin.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/upper_builtin.go.out:9: unsupported expr *ast.SelectorExpr
->>> 8:    func main() {
-9:>>> fmt.Println(strings.ToUpper("foo"))
-10:    }
-11:


### PR DESCRIPTION
## Summary
- expand go2mochi converter with support for function literals as values
- update failing golden error files to new failure points
- convert examples using function literals: closure, fun_expr_in_let, higher_order_apply and nested_inner_fn

## Testing
- `go test ./tools/go2mochi -run TestGo2Mochi_Golden -short` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686892d99cf483208f7cd7729a7f0cc3