### PR TITLE
Add generic language server support to any2mochi

### DIFF
--- a/tools/any2mochi/convert_generic.go
+++ b/tools/any2mochi/convert_generic.go
@@ -1,0 +1,128 @@
+package any2mochi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// ConvertWithServer converts source code using the provided language server configuration.
+func ConvertWithServer(cmd string, args []string, langID, src string) ([]byte, error) {
+	syms, err := ParseAndEnsure(cmd, args, langID, src)
+	if err != nil {
+		return nil, err
+	}
+	var out strings.Builder
+	for _, s := range syms {
+		if s.Kind != protocol.SymbolKindFunction {
+			continue
+		}
+		out.WriteString("fun ")
+		out.WriteString(s.Name)
+		out.WriteString("() {}\n")
+	}
+	return []byte(out.String()), nil
+}
+
+// ConvertSource converts source written in the specified language to Mochi using
+// the default server from Servers.
+func ConvertSource(lang, src string) ([]byte, error) {
+	ls, ok := Servers[lang]
+	if !ok {
+		return nil, fmt.Errorf("no language server for %s", lang)
+	}
+	return ConvertWithServer(ls.Command, ls.Args, ls.LangID, src)
+}
+
+// ConvertFile attempts to detect the language from the file extension and
+// converts the file contents using ConvertSource.
+func ConvertFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lang := DetectLanguage(path, string(data))
+	if lang == "" {
+		return nil, fmt.Errorf("unable to detect language for %s", path)
+	}
+	return ConvertSource(lang, string(data))
+}
+
+// DetectLanguage returns a language key based on the filename extension or
+// simple textual heuristics if the extension is unknown.
+func DetectLanguage(name, src string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	switch ext {
+	case ".go":
+		return "go"
+	case ".py":
+		return "python"
+	case ".ts":
+		return "typescript"
+	case ".rs":
+		return "rust"
+	case ".c":
+		return "c"
+	case ".cpp", ".cc", ".cxx", ".hpp", ".h":
+		return "cpp"
+	case ".cs":
+		return "cs"
+	case ".java":
+		return "java"
+	case ".kt":
+		return "kt"
+	case ".lua":
+		return "lua"
+	case ".dart":
+		return "dart"
+	case ".php":
+		return "php"
+	case ".swift":
+		return "swift"
+	case ".rb":
+		return "rb"
+	case ".scala":
+		return "scala"
+	case ".mlir":
+		return "mlir"
+	case ".ex":
+		return "ex"
+	case ".erl":
+		return "erlang"
+	case ".fs":
+		return "fs"
+	case ".hs":
+		return "hs"
+	case ".ml", ".mli":
+		return "ocaml"
+	case ".pas":
+		return "pas"
+	case ".pl":
+		return "pl"
+	case ".rkt":
+		return "rkt"
+	case ".zig":
+		return "zig"
+	}
+	if strings.Contains(src, "package ") && strings.Contains(src, "func ") {
+		return "go"
+	}
+	if strings.Contains(src, "fn main") {
+		return "rust"
+	}
+	if strings.Contains(src, "def ") {
+		return "python"
+	}
+	return ""
+}
+
+// ParseAndEnsure runs ParseText after ensuring the language server is installed.
+func ParseAndEnsure(cmd string, args []string, langID, src string) ([]protocol.DocumentSymbol, error) {
+	if err := EnsureServer(cmd); err != nil {
+		return nil, err
+	}
+	return ParseText(cmd, args, langID, src)
+}

--- a/tools/any2mochi/convert_go.go
+++ b/tools/any2mochi/convert_go.go
@@ -1,29 +1,12 @@
 package any2mochi
 
-import (
-	"os"
-	"strings"
-
-	protocol "github.com/tliron/glsp/protocol_3_16"
-)
+import "os"
 
 // ConvertGo converts Go source code to a minimal Mochi representation using
 // symbols reported by gopls.
 func ConvertGo(src string) ([]byte, error) {
-	syms, err := ParseText("gopls", nil, "go", src)
-	if err != nil {
-		return nil, err
-	}
-	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != protocol.SymbolKindFunction {
-			continue
-		}
-		out.WriteString("fun ")
-		out.WriteString(s.Name)
-		out.WriteString("() {}\n")
-	}
-	return []byte(out.String()), nil
+	ls := Servers["go"]
+	return ConvertWithServer(ls.Command, ls.Args, ls.LangID, src)
 }
 
 // ConvertGoFile reads the Go file at path and converts it to Mochi.

--- a/tools/any2mochi/convert_python.go
+++ b/tools/any2mochi/convert_python.go
@@ -1,28 +1,11 @@
 package any2mochi
 
-import (
-	"os"
-	"strings"
-
-	protocol "github.com/tliron/glsp/protocol_3_16"
-)
+import "os"
 
 // ConvertPython converts Python source code to a minimal Mochi representation using pyright.
 func ConvertPython(src string) ([]byte, error) {
-	syms, err := ParseText("pyright-langserver", []string{"--stdio"}, "python", src)
-	if err != nil {
-		return nil, err
-	}
-	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != protocol.SymbolKindFunction {
-			continue
-		}
-		out.WriteString("fun ")
-		out.WriteString(s.Name)
-		out.WriteString("() {}\n")
-	}
-	return []byte(out.String()), nil
+	ls := Servers["python"]
+	return ConvertWithServer(ls.Command, ls.Args, ls.LangID, src)
 }
 
 // ConvertPythonFile reads the Python file at path and converts it to Mochi.

--- a/tools/any2mochi/convert_typescript.go
+++ b/tools/any2mochi/convert_typescript.go
@@ -1,28 +1,11 @@
 package any2mochi
 
-import (
-	"os"
-	"strings"
-
-	protocol "github.com/tliron/glsp/protocol_3_16"
-)
+import "os"
 
 // ConvertTypeScript converts TypeScript source code to a minimal Mochi representation using the language server.
 func ConvertTypeScript(src string) ([]byte, error) {
-	syms, err := ParseText("typescript-language-server", []string{"--stdio"}, "typescript", src)
-	if err != nil {
-		return nil, err
-	}
-	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != protocol.SymbolKindFunction {
-			continue
-		}
-		out.WriteString("fun ")
-		out.WriteString(s.Name)
-		out.WriteString("() {}\n")
-	}
-	return []byte(out.String()), nil
+	ls := Servers["typescript"]
+	return ConvertWithServer(ls.Command, ls.Args, ls.LangID, src)
 }
 
 // ConvertTypeScriptFile reads the TS file and converts it to Mochi.

--- a/tools/any2mochi/server.go
+++ b/tools/any2mochi/server.go
@@ -1,0 +1,84 @@
+package any2mochi
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// LanguageServer describes how to invoke a language server for a given language.
+type LanguageServer struct {
+	Command string   // binary name
+	Args    []string // additional command arguments
+	LangID  string   // language id used by LSP
+}
+
+// Servers maps language names to their default language server configuration.
+var Servers = map[string]LanguageServer{
+	"go":         {Command: "gopls", Args: nil, LangID: "go"},
+	"python":     {Command: "pyright-langserver", Args: []string{"--stdio"}, LangID: "python"},
+	"typescript": {Command: "typescript-language-server", Args: []string{"--stdio"}, LangID: "typescript"},
+	"c":          {Command: "clangd", Args: nil, LangID: "c"},
+	"cpp":        {Command: "clangd", Args: nil, LangID: "cpp"},
+	"cs":         {Command: "omnisharp", Args: nil, LangID: "csharp"},
+	"dart":       {Command: "dart", Args: []string{"language-server"}, LangID: "dart"},
+	"erlang":     {Command: "erlang_ls", Args: nil, LangID: "erlang"},
+	"ex":         {Command: "elixir-ls", Args: nil, LangID: "elixir"},
+	"fortran":    {Command: "fortls", Args: nil, LangID: "fortran"},
+	"fs":         {Command: "fsautocomplete", Args: nil, LangID: "fsharp"},
+	"hs":         {Command: "haskell-language-server-wrapper", Args: nil, LangID: "haskell"},
+	"java":       {Command: "jdtls", Args: nil, LangID: "java"},
+	"kt":         {Command: "kotlin-language-server", Args: nil, LangID: "kotlin"},
+	"lua":        {Command: "lua-language-server", Args: nil, LangID: "lua"},
+	"mlir":       {Command: "mlir-lsp-server", Args: nil, LangID: "mlir"},
+	"ocaml":      {Command: "ocamllsp", Args: nil, LangID: "ocaml"},
+	"pas":        {Command: "pasls", Args: nil, LangID: "pascal"},
+	"php":        {Command: "intelephense", Args: []string{"--stdio"}, LangID: "php"},
+	"pl":         {Command: "perlls", Args: nil, LangID: "perl"},
+	"rb":         {Command: "solargraph", Args: []string{"stdio"}, LangID: "ruby"},
+	"rkt":        {Command: "racket-langserver", Args: nil, LangID: "racket"},
+	"rust":       {Command: "rust-analyzer", Args: nil, LangID: "rust"},
+	"scala":      {Command: "metals", Args: nil, LangID: "scala"},
+	"scheme":     {Command: "scheme-langserver", Args: nil, LangID: "scheme"},
+	"st":         {Command: "squeak", Args: []string{"--headless"}, LangID: "smalltalk"},
+	"swift":      {Command: "sourcekit-lsp", Args: nil, LangID: "swift"},
+	"wasm":       {Command: "", Args: nil, LangID: "wasm"},
+	"zig":        {Command: "zls", Args: nil, LangID: "zig"},
+}
+
+// EnsureServer attempts to locate the given server binary and installs it using
+// common package managers if missing. The installation step is best effort and
+// errors only if the binary still cannot be found.
+func EnsureServer(name string) error {
+	if name == "" {
+		return fmt.Errorf("no server specified")
+	}
+	if _, err := exec.LookPath(name); err == nil {
+		return nil
+	}
+	installers := []struct {
+		bin  string
+		args []string
+	}{
+		{"npm", []string{"install", "-g", name}},
+		{"pnpm", []string{"add", "-g", name}},
+		{"pip3", []string{"install", "--user", name}},
+		{"pip", []string{"install", "--user", name}},
+		{"go", []string{"install", name + "@latest"}},
+	}
+	for _, inst := range installers {
+		if _, err := exec.LookPath(inst.bin); err == nil {
+			cmd := exec.Command(inst.bin, inst.args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath(name); err == nil {
+				return nil
+			}
+		}
+	}
+	if _, err := exec.LookPath(name); err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s not found", name)
+}


### PR DESCRIPTION
## Summary
- add a `LanguageServer` registry with `EnsureServer`
- implement generic conversion helpers and language detection
- refactor Go/Python/TypeScript conversion to use the generic helpers
- extend CLI with a new `convert` subcommand and `--ensure` flag

## Testing
- `go test ./tools/any2mochi -run TestConvertGo -run TestConvertPython -run TestConvertTypeScript`

------
https://chatgpt.com/codex/tasks/task_e_6868b7119f288320a097f4323a7691e6