### PR TITLE
Fix Deno tests

### DIFF
--- a/tools/libmochi/typescript/README.md
+++ b/tools/libmochi/typescript/README.md
@@ -7,7 +7,11 @@ module is missing it is built automatically using `go build` and cached next to
 `mod.ts`.
 
 If the `deno` command is missing, run `make install` from the project root to
-download it.
+download it. To run the unit tests for this library execute:
+
+```bash
+deno test --allow-read --allow-write --allow-run --allow-env mod_test.ts
+```
 
 ## Usage
 

--- a/tools/libmochi/typescript/mod_test.ts
+++ b/tools/libmochi/typescript/mod_test.ts
@@ -23,5 +23,9 @@ denoTest('run file', async () => {
 });
 
 function denoTest(name: string, fn: () => Promise<void>) {
-  Deno.test(name, fn);
+  Deno.test({
+    name,
+    permissions: { write: true, read: true, run: true, env: true },
+    fn,
+  });
 }


### PR DESCRIPTION
## Summary
- set required permissions for Deno tests
- document how to run them in the TypeScript README

## Testing
- `go test ./parser ./interpreter`
- `deno test --allow-read --allow-write --allow-run --allow-env tools/libmochi/typescript/mod_test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6868b7b8e4208320b6e9cf7a487caee5