### PR TITLE
Mark 2mochi tests as slow

### DIFF
--- a/tools/any2mochi/convert_go_test.go
+++ b/tools/any2mochi/convert_go_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/tools/any2mochi/convert_python_test.go
+++ b/tools/any2mochi/convert_python_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/tools/any2mochi/convert_test.go
+++ b/tools/any2mochi/convert_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/tools/any2mochi/convert_typescript_test.go
+++ b/tools/any2mochi/convert_typescript_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/tools/any2mochi/parse_test.go
+++ b/tools/any2mochi/parse_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/tools/go2mochi/convert_test.go
+++ b/tools/go2mochi/convert_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package go2mochi_test
 
 import (

--- a/tools/py2mochi/py2mochi_test.go
+++ b/tools/py2mochi/py2mochi_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- mark any2mochi tests with `//go:build slow`
- mark go2mochi and py2mochi tests with `//go:build slow`
- confirm `go test ./...` passes fast

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868ba4922388320bd6817f627792304