### PR TITLE
Improve go2mochi support

### DIFF
--- a/tests/compiler/go/input_builtin.mochi.error
+++ b/tests/compiler/go/input_builtin.mochi.error
@@ -1,5 +1,0 @@
-tests/compiler/go/input_builtin.go.out:17: unsupported unary op &
->>> 16:    var s string
-17:>>> fmt.Scanln(&s)
-18:    return s
-19:    }

--- a/tests/compiler/go/input_builtin.mochi.out
+++ b/tests/compiler/go/input_builtin.mochi.out
@@ -1,6 +1,6 @@
 fun _input(): string {
   var s: string
-  fmt.Scanln(&s)
+  s = input()
   return s
 }
 print(str("Enter first input:"))


### PR DESCRIPTION
## Summary
- handle `fmt.Scanln(&x)` when converting Go to Mochi
- update golden files for `input_builtin`

## Testing
- `go test ./tools/go2mochi -tags slow -run TestGo2Mochi_Golden/input_builtin -count=1 -v`
- `go test ./tools/go2mochi -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6868d1d3c6c083209524274f32dd92d7