### PR TITLE
Improve ts2mochi error reporting and JSON export

### DIFF
--- a/cmd/ts2mochi/main.go
+++ b/cmd/ts2mochi/main.go
@@ -8,16 +8,23 @@ import (
 	"mochi/tools/ts2mochi"
 )
 
+var jsonOut = flag.String("json", "", "write parsed AST to file")
+
 func main() {
 	flag.Parse()
 	if flag.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "usage: ts2mochi <file.ts>")
+		fmt.Fprintln(os.Stderr, "usage: ts2mochi [--json ast.json] <file.ts>")
 		os.Exit(1)
 	}
-	out, err := ts2mochi.ConvertFile(flag.Arg(0))
+	code, ast, err := ts2mochi.ConvertFileWithJSON(flag.Arg(0))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	os.Stdout.Write(out)
+	if *jsonOut != "" {
+		if err := os.WriteFile(*jsonOut, ast, 0644); err != nil {
+			fmt.Fprintln(os.Stderr, "write json:", err)
+		}
+	}
+	os.Stdout.Write(code)
 }

--- a/tools/ts2mochi/ast.js
+++ b/tools/ts2mochi/ast.js
@@ -1,13 +1,13 @@
-const fs = require('fs');
-const ts = require('typescript');
+const fs = require("fs");
+const ts = require("typescript");
 
 const file = process.argv[2];
 if (!file) {
-  console.error('usage: ast.js <file>');
+  console.error("usage: ast.js <file>");
   process.exit(1);
 }
 
-const source = fs.readFileSync(file, 'utf8');
+const source = fs.readFileSync(file, "utf8");
 const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
 const program = { funcs: [], calls: [] };
 
@@ -15,20 +15,30 @@ for (const stmt of sf.statements) {
   if (ts.isFunctionDeclaration(stmt) && stmt.body) {
     const fn = {
       name: stmt.name.text,
-      params: stmt.parameters.map(p => p.name.getText()),
-      body: []
+      params: stmt.parameters.map((p) => p.name.getText()),
+      body: [],
     };
     for (const s of stmt.body.statements) {
       if (ts.isReturnStatement(s)) {
-        fn.body.push({ kind: 'return', expr: exprToObj(s.expression) });
-      } else if (ts.isExpressionStatement(s) && ts.isCallExpression(s.expression) && isConsoleLog(s.expression)) {
-        fn.body.push({ kind: 'print', expr: exprToObj(s.expression.arguments[0]) });
+        fn.body.push({ kind: "return", expr: exprToObj(s.expression) });
+      } else if (
+        ts.isExpressionStatement(s) &&
+        ts.isCallExpression(s.expression) &&
+        isConsoleLog(s.expression)
+      ) {
+        fn.body.push({
+          kind: "print",
+          expr: exprToObj(s.expression.arguments[0]),
+        });
       } else {
         unsupported(s);
       }
     }
     program.funcs.push(fn);
-  } else if (ts.isExpressionStatement(stmt) && ts.isCallExpression(stmt.expression)) {
+  } else if (
+    ts.isExpressionStatement(stmt) &&
+    ts.isCallExpression(stmt.expression)
+  ) {
     if (stmt.expression.arguments.length === 0) {
       program.calls.push({ name: stmt.expression.expression.getText() });
     } else {
@@ -40,30 +50,46 @@ for (const stmt of sf.statements) {
 }
 
 function isConsoleLog(call) {
-  return ts.isPropertyAccessExpression(call.expression) &&
-    call.expression.expression.getText() === 'console' &&
-    call.expression.name.getText() === 'log';
+  return (
+    ts.isPropertyAccessExpression(call.expression) &&
+    call.expression.expression.getText() === "console" &&
+    call.expression.name.getText() === "log"
+  );
 }
 
 function exprToObj(node) {
   if (!node) return null;
   if (ts.isNumericLiteral(node)) {
-    return { kind: 'number', value: node.text };
+    return { kind: "number", value: node.text };
   }
   if (ts.isIdentifier(node)) {
-    return { kind: 'ident', name: node.text };
+    return { kind: "ident", name: node.text };
   }
   if (ts.isCallExpression(node)) {
-    return { kind: 'call', name: node.expression.getText(), args: node.arguments.map(exprToObj) };
+    return {
+      kind: "call",
+      name: node.expression.getText(),
+      args: node.arguments.map(exprToObj),
+    };
   }
   if (ts.isArrayLiteralExpression(node)) {
-    return { kind: 'array', elems: node.elements.map(exprToObj) };
+    return { kind: "array", elems: node.elements.map(exprToObj) };
   }
   unsupported(node);
 }
 
 function unsupported(node) {
-  console.error('unsupported syntax: ' + ts.SyntaxKind[node.kind]);
+  const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+  const lines = source.split(/\r?\n/);
+  const start = Math.max(0, pos.line - 1);
+  const end = Math.min(lines.length, pos.line + 2);
+  const snippet = lines
+    .slice(start, end)
+    .map((l, i) => `${start + i + 1}: ${l}`)
+    .join("\n");
+  console.error(
+    `unsupported syntax: ${ts.SyntaxKind[node.kind]} at ${file}:${pos.line + 1}:${pos.character + 1}\n${snippet}`,
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- show exact position and snippet on unsupported TypeScript syntax
- expose ConvertFileWithJSON for returning parsed AST as pretty JSON
- add `--json` option to `ts2mochi` CLI

## Testing
- `go vet ./cmd/ts2mochi ./tools/ts2mochi`
- `go build ./cmd/ts2mochi`
- `go run cmd/ts2mochi/main.go /tmp/sample.ts` *(fails with detailed error)*

------
https://chatgpt.com/codex/tasks/task_e_6868d6927e5883209755f3118d79f95a