### PR TITLE
Improve TypeScript converter diagnostics

### DIFF
--- a/tests/any2mochi/ts/avg_builtin.ts.json
+++ b/tests/any2mochi/ts/avg_builtin.ts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "main",
+    "kind": 12,
+    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}},
+    "selectionRange": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
+  },
+  {
+    "name": "_avg",
+    "kind": 12,
+    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}},
+    "selectionRange": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
+  }
+]

--- a/tools/any2mochi/cmd/any2mochi/main.go
+++ b/tools/any2mochi/cmd/any2mochi/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/fang"
 	"github.com/spf13/cobra"
 
+	protocol "github.com/tliron/glsp/protocol_3_16"
 	"mochi/tools/any2mochi"
 )
 
@@ -47,13 +48,17 @@ func parseCmd() *cobra.Command {
 					return err
 				}
 			}
-			syms, err := any2mochi.ParseText(parts[0], parts[1:], lang, string(data))
+			syms, diags, err := any2mochi.ParseText(parts[0], parts[1:], lang, string(data))
 			if err != nil {
 				return err
 			}
+			out := struct {
+				Symbols     []protocol.DocumentSymbol `json:"symbols"`
+				Diagnostics []protocol.Diagnostic     `json:"diagnostics"`
+			}{syms, diags}
 			enc := json.NewEncoder(cmd.OutOrStdout())
 			enc.SetIndent("", "  ")
-			return enc.Encode(syms)
+			return enc.Encode(out)
 		},
 	}
 	cmd.Flags().StringVar(&server, "server", "", "language server command")

--- a/tools/any2mochi/convert_generic.go
+++ b/tools/any2mochi/convert_generic.go
@@ -1,6 +1,7 @@
 package any2mochi
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,9 +12,12 @@ import (
 
 // ConvertWithServer converts source code using the provided language server configuration.
 func ConvertWithServer(cmd string, args []string, langID, src string) ([]byte, error) {
-	syms, err := ParseAndEnsure(cmd, args, langID, src)
+	syms, diags, err := ParseAndEnsure(cmd, args, langID, src)
 	if err != nil {
 		return nil, fmt.Errorf("convert failure: %w\n\nsource snippet:\n%s", err, numberedSnippet(src))
+	}
+	if len(diags) > 0 {
+		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
 	}
 	var out strings.Builder
 	for _, s := range syms {
@@ -28,6 +32,32 @@ func ConvertWithServer(cmd string, args []string, langID, src string) ([]byte, e
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
 	return []byte(out.String()), nil
+}
+
+// ConvertWithServerJSON is like ConvertWithServer but also returns the parsed
+// symbols encoded as pretty JSON.
+func ConvertWithServerJSON(cmd string, args []string, langID, src string) ([]byte, []byte, error) {
+	syms, diags, err := ParseAndEnsure(cmd, args, langID, src)
+	if err != nil {
+		return nil, nil, fmt.Errorf("convert failure: %w\n\nsource snippet:\n%s", err, numberedSnippet(src))
+	}
+	if len(diags) > 0 {
+		return nil, nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
+	}
+	var out strings.Builder
+	for _, s := range syms {
+		if s.Kind != protocol.SymbolKindFunction {
+			continue
+		}
+		out.WriteString("fun ")
+		out.WriteString(s.Name)
+		out.WriteString("() {}\n")
+	}
+	if out.Len() == 0 {
+		return nil, nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+	}
+	js, _ := json.MarshalIndent(syms, "", "  ")
+	return []byte(out.String()), js, nil
 }
 
 // ConvertSource converts source written in the specified language to Mochi using
@@ -123,9 +153,9 @@ func DetectLanguage(name, src string) string {
 }
 
 // ParseAndEnsure runs ParseText after ensuring the language server is installed.
-func ParseAndEnsure(cmd string, args []string, langID, src string) ([]protocol.DocumentSymbol, error) {
+func ParseAndEnsure(cmd string, args []string, langID, src string) ([]protocol.DocumentSymbol, []protocol.Diagnostic, error) {
 	if err := EnsureServer(cmd); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return ParseText(cmd, args, langID, src)
 }
@@ -139,4 +169,19 @@ func numberedSnippet(src string) string {
 		lines[i] = fmt.Sprintf("%3d: %s", i+1, l)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func formatDiagnostics(src string, diags []protocol.Diagnostic) string {
+	lines := strings.Split(src, "\n")
+	var out strings.Builder
+	for _, d := range diags {
+		start := int(d.Range.Start.Line)
+		msg := d.Message
+		line := ""
+		if start < len(lines) {
+			line = strings.TrimSpace(lines[start])
+		}
+		out.WriteString(fmt.Sprintf("line %d: %s\n  %s\n", start+1, msg, line))
+	}
+	return strings.TrimSpace(out.String())
 }

--- a/tools/any2mochi/convert_typescript.go
+++ b/tools/any2mochi/convert_typescript.go
@@ -16,3 +16,20 @@ func ConvertTypeScriptFile(path string) ([]byte, error) {
 	}
 	return ConvertTypeScript(string(data))
 }
+
+// ConvertTypeScriptWithJSON converts the source and also returns the parsed
+// symbols encoded as JSON.
+func ConvertTypeScriptWithJSON(src string) ([]byte, []byte, error) {
+	ls := Servers["typescript"]
+	return ConvertWithServerJSON(ls.Command, ls.Args, ls.LangID, src)
+}
+
+// ConvertTypeScriptFileWithJSON reads the TS file and converts it to Mochi
+// while also returning the parsed symbols as JSON.
+func ConvertTypeScriptFileWithJSON(path string) ([]byte, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ConvertTypeScriptWithJSON(string(data))
+}

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -2,8 +2,10 @@ package any2mochi
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os/exec"
+	"sync"
 	"time"
 
 	jsonrpc2 "github.com/sourcegraph/jsonrpc2"
@@ -11,58 +13,74 @@ import (
 )
 
 type client struct {
-	conn *jsonrpc2.Conn
-	cmd  *exec.Cmd
+	conn  *jsonrpc2.Conn
+	cmd   *exec.Cmd
+	mu    sync.Mutex
+	diags []protocol.Diagnostic
 }
 
 // ParseText starts the language server command given by cmdName and
 // parses the provided source using the Language Server Protocol.
 // It returns the document symbols reported by the server for the file.
 // The server must support the textDocument/documentSymbol request.
-func ParseText(cmdName string, args []string, langID string, src string) ([]protocol.DocumentSymbol, error) {
+func ParseText(cmdName string, args []string, langID string, src string) ([]protocol.DocumentSymbol, []protocol.Diagnostic, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, cmdName, args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	stream := jsonrpc2.NewBufferedStream(&pipe{r: stdout, w: stdin}, jsonrpc2.VSCodeObjectCodec{})
+	c := &client{cmd: cmd}
 	conn := jsonrpc2.NewConn(ctx, stream, jsonrpc2.HandlerWithError(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
-		// Discard all incoming messages and return no result.
-		return nil, nil
+		switch req.Method {
+		case "textDocument/publishDiagnostics":
+			var params protocol.PublishDiagnosticsParams
+			if err := json.Unmarshal(*req.Params, &params); err == nil {
+				c.mu.Lock()
+				c.diags = append(c.diags, params.Diagnostics...)
+				c.mu.Unlock()
+			}
+			return nil, nil
+		default:
+			return nil, nil
+		}
 	}))
-	c := &client{conn: conn, cmd: cmd}
+	c.conn = conn
 
 	if err := c.initialize(ctx); err != nil {
 		c.Close()
-		return nil, err
+		return nil, nil, err
 	}
 	uri := protocol.DocumentUri("file:///input")
 	if err := c.conn.Notify(ctx, "textDocument/didOpen", protocol.DidOpenTextDocumentParams{
 		TextDocument: protocol.TextDocumentItem{URI: uri, LanguageID: langID, Version: 1, Text: src},
 	}); err != nil {
 		c.Close()
-		return nil, err
+		return nil, nil, err
 	}
 	var syms []protocol.DocumentSymbol
 	if err := c.conn.Call(ctx, "textDocument/documentSymbol", protocol.DocumentSymbolParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}, &syms); err != nil {
 		c.Close()
-		return nil, err
+		return nil, nil, err
 	}
 	c.Close()
-	return syms, nil
+	c.mu.Lock()
+	diags := append([]protocol.Diagnostic(nil), c.diags...)
+	c.mu.Unlock()
+	return syms, diags, nil
 }
 
 func (c *client) initialize(ctx context.Context) error {

--- a/tools/any2mochi/parse_go_test.go
+++ b/tools/any2mochi/parse_go_test.go
@@ -20,9 +20,12 @@ func TestParseGo(t *testing.T) {
 	_ = gocode.EnsureGopls()
 	requireBinary(t, "gopls")
 	src := "package foo\nfunc Add(x int, y int) int { return x + y }"
-	syms, err := ParseText("gopls", nil, "go", src)
+	syms, diags, err := ParseText("gopls", nil, "go", src)
 	if err != nil {
 		t.Fatalf("parse go: %v", err)
+	}
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
 	if len(syms) == 0 {
 		t.Fatalf("expected symbols")

--- a/tools/any2mochi/parse_python_test.go
+++ b/tools/any2mochi/parse_python_test.go
@@ -12,9 +12,12 @@ func TestParsePython(t *testing.T) {
 	_ = pycode.EnsurePyright()
 	requireBinary(t, "pyright-langserver")
 	src := "def add(x,y):\n    return x + y"
-	syms, err := ParseText("pyright-langserver", []string{"--stdio"}, "python", src)
+	syms, diags, err := ParseText("pyright-langserver", []string{"--stdio"}, "python", src)
 	if err != nil {
 		t.Fatalf("parse python: %v", err)
+	}
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
 	if len(syms) == 0 {
 		t.Fatalf("expected symbols")

--- a/tools/any2mochi/parse_typescript_test.go
+++ b/tools/any2mochi/parse_typescript_test.go
@@ -12,9 +12,12 @@ func TestParseTypeScript(t *testing.T) {
 	_ = tscode.EnsureTSLanguageServer()
 	requireBinary(t, "typescript-language-server")
 	src := "export function add(x: number, y: number): number { return x + y }"
-	syms, err := ParseText("typescript-language-server", []string{"--stdio"}, "typescript", src)
+	syms, diags, err := ParseText("typescript-language-server", []string{"--stdio"}, "typescript", src)
 	if err != nil {
 		t.Fatalf("parse ts: %v", err)
+	}
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
 	if len(syms) == 0 {
 		t.Fatalf("expected symbols")


### PR DESCRIPTION
## Summary
- extend LSP parser to capture diagnostics
- surface diagnostics in converter and CLI
- add JSON output helpers
- update tests for new API
- include example parsed symbol JSON

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868d8d9e7e48320aba45eaf68827944