### PR TITLE
Fix golden helpers update logic

### DIFF
--- a/tools/any2mochi/golden_helpers_test.go
+++ b/tools/any2mochi/golden_helpers_test.go
@@ -74,7 +74,7 @@ func runConvertCompileGolden(t *testing.T, dir, pattern string, convert func(str
 			}
 
 			if *update {
-				os.WriteFile(errPath, nil, 0644)
+				os.Remove(errPath)
 				os.WriteFile(outPath, normalizeOutput(rootDir(t), mochiSrc), 0644)
 			}
 			want, readErr := os.ReadFile(outPath)
@@ -132,7 +132,7 @@ func runConvertGolden(t *testing.T, dir, pattern string, convert func(string) ([
 			}
 
 			if *update {
-				os.WriteFile(errPath, nil, 0644)
+				os.Remove(errPath)
 				os.WriteFile(outPath, normalizeOutput(rootDir(t), out), 0644)
 			}
 			want, readErr := os.ReadFile(outPath)


### PR DESCRIPTION
## Summary
- avoid creating empty `.error` files when updating golden data

## Testing
- `go test ./tools/any2mochi -run TestConvertGoCompile_Golden`


------
https://chatgpt.com/codex/tasks/task_e_6868d9dc96c483209038190d7a8ab3ab