### PR TITLE
Add TypeScript parse golden test

### DIFF
--- a/tests/any2mochi_parse/ts/hello.ts
+++ b/tests/any2mochi_parse/ts/hello.ts
@@ -1,0 +1,3 @@
+export function main(): void {
+  console.log("hello world");
+}

--- a/tests/any2mochi_parse/ts/hello.ts.json
+++ b/tests/any2mochi_parse/ts/hello.ts.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "main",
+    "kind": 12,
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "selectionRange": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    }
+  }
+]

--- a/tools/any2mochi/parse_typescript.go
+++ b/tools/any2mochi/parse_typescript.go
@@ -1,0 +1,41 @@
+package any2mochi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// ParseTypeScript parses the given source using the TypeScript language server.
+func ParseTypeScript(src string) ([]protocol.DocumentSymbol, []protocol.Diagnostic, error) {
+	ls := Servers["typescript"]
+	return ParseAndEnsure(ls.Command, ls.Args, ls.LangID, src)
+}
+
+// ParseTypeScriptFile reads and parses the file at path using the TypeScript language server.
+func ParseTypeScriptFile(path string) ([]protocol.DocumentSymbol, []protocol.Diagnostic, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ParseTypeScript(string(data))
+}
+
+// ParseTypeScriptFileJSON parses the file and returns the document symbols encoded as pretty JSON.
+func ParseTypeScriptFileJSON(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	syms, diags, err := ParseTypeScript(string(data))
+	if err != nil {
+		return nil, err
+	}
+	if len(diags) > 0 {
+		return nil, fmt.Errorf("%s", formatDiagnostics(string(data), diags))
+	}
+	js, _ := json.MarshalIndent(syms, "", "  ")
+	return js, nil
+}

--- a/tools/any2mochi/parse_typescript_golden_test.go
+++ b/tools/any2mochi/parse_typescript_golden_test.go
@@ -1,0 +1,35 @@
+//go:build slow
+
+package any2mochi
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tscode "mochi/compile/ts"
+)
+
+func TestParseTypeScript_HelloWorld_Golden(t *testing.T) {
+	root := findRepoRoot(t)
+	_ = tscode.EnsureTSLanguageServer()
+	src := filepath.Join(root, "tests/any2mochi_parse/ts/hello.ts")
+	outPath := filepath.Join(root, "tests/any2mochi_parse/ts/hello.ts.json")
+
+	out, err := ParseTypeScriptFileJSON(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if *update {
+		os.WriteFile(outPath, out, 0644)
+	}
+	want, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("missing golden output: %v", err)
+	}
+	if !bytes.Equal(bytes.TrimSpace(out), bytes.TrimSpace(want)) {
+		t.Errorf("golden mismatch\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", out, want)
+	}
+}


### PR DESCRIPTION
## Summary
- extend `any2mochi` with helper functions for TypeScript parsing
- add golden test exercising the TypeScript language server
- provide example hello world program and expected symbol JSON

## Testing
- `go test ./tools/any2mochi -tags slow -run TestParseTypeScript_HelloWorld_Golden`
- `go test ./... -tags slow -run TestParseTypeScript_HelloWorld_Golden`

------
https://chatgpt.com/codex/tasks/task_e_6868ecb7ab6083208f85da60151933ae