### PR TITLE
Improve go translator generics

### DIFF
--- a/tests/any2mochi/go/cast_struct.go.error
+++ b/tests/any2mochi/go/cast_struct.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/cast_struct.go.out:18: unsupported generics
->>> 17:    
-18:>>> func _cast[T any](v any) T {
-19:    if tv, ok := v.(T); ok {
-20:    return tv
-
+tests/compiler/go/cast_struct.go.out:23: unsupported statement *ast.TypeSwitchStmt
+>>> 22:    var out T
+23:>>> switch any(out).(type) {
+24:    case int:
+25:    switch vv := v.(type) {

--- a/tests/any2mochi/go/dataset_sort_take_limit.go.error
+++ b/tests/any2mochi/go/dataset_sort_take_limit.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/dataset_sort_take_limit.go.out:76: unsupported generics
->>> 75:    
-76:>>> func _paginate[T any](src []T, skip, take int) []T {
-77:    if skip > 0 {
-78:    if skip < len(src) {
-
+tests/compiler/go/dataset_sort_take_limit.go.out:28: unsupported declaration
+>>> 27:    }
+28:>>> type pair struct {
+29:    item Product
+30:    key  any

--- a/tests/any2mochi/go/fetch_builtin.go.error
+++ b/tests/any2mochi/go/fetch_builtin.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/fetch_builtin.go.out:24: unsupported generics
->>> 23:    
-24:>>> func _cast[T any](v any) T {
-25:    if tv, ok := v.(T); ok {
-26:    return tv
-
+tests/compiler/go/fetch_builtin.go.out:29: unsupported statement *ast.TypeSwitchStmt
+>>> 28:    var out T
+29:>>> switch any(out).(type) {
+30:    case int:
+31:    switch vv := v.(type) {

--- a/tests/any2mochi/go/fetch_remote.go.error
+++ b/tests/any2mochi/go/fetch_remote.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/fetch_remote.go.out:27: unsupported generics
->>> 26:    
-27:>>> func _cast[T any](v any) T {
-28:    if tv, ok := v.(T); ok {
-29:    return tv
-
+tests/compiler/go/fetch_remote.go.out:32: unsupported statement *ast.TypeSwitchStmt
+>>> 31:    var out T
+32:>>> switch any(out).(type) {
+33:    case int:
+34:    switch vv := v.(type) {

--- a/tests/any2mochi/go/generate_struct.go.error
+++ b/tests/any2mochi/go/generate_struct.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/generate_struct.go.out:21: unsupported generics
->>> 20:    
-21:>>> func _genStruct[T any](prompt string, model string, params map[string]any) T {
-22:    opts := []llm.Option{}
-23:    if model != "" {
-
+tests/compiler/go/generate_struct.go.out:29: unsupported assignment
+>>> 28:    }
+29:>>> resp, err := llm.Chat(context.Background(), []llm.Message{{Role: "user", Content: prompt}}, opts...)
+30:    if err != nil {
+31:    panic(err)

--- a/tests/any2mochi/go/load_jsonl_stdin.go.error
+++ b/tests/any2mochi/go/load_jsonl_stdin.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/load_jsonl_stdin.go.out:28: unsupported generics
->>> 27:    
-28:>>> func _cast[T any](v any) T {
-29:    if tv, ok := v.(T); ok {
-30:    return tv
-
+tests/compiler/go/load_jsonl_stdin.go.out:33: unsupported statement *ast.TypeSwitchStmt
+>>> 32:    var out T
+33:>>> switch any(out).(type) {
+34:    case int:
+35:    switch vv := v.(type) {

--- a/tests/any2mochi/go/load_save_json.go.error
+++ b/tests/any2mochi/go/load_save_json.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/load_save_json.go.out:40: unsupported generics
->>> 39:    
-40:>>> func _cast[T any](v any) T {
-41:    if tv, ok := v.(T); ok {
-42:    return tv
-
+tests/compiler/go/load_save_json.go.out:45: unsupported statement *ast.TypeSwitchStmt
+>>> 44:    var out T
+45:>>> switch any(out).(type) {
+46:    case int:
+47:    switch vv := v.(type) {

--- a/tests/any2mochi/go/map_any_hint.go.error
+++ b/tests/any2mochi/go/map_any_hint.go.error
@@ -1,6 +1,5 @@
-tests/compiler/go/map_any_hint.go.out:26: unsupported generics
->>> 25:    
-26:>>> func _cast[T any](v any) T {
-27:    if tv, ok := v.(T); ok {
-28:    return tv
-
+tests/compiler/go/map_any_hint.go.out:31: unsupported statement *ast.TypeSwitchStmt
+>>> 30:    var out T
+31:>>> switch any(out).(type) {
+32:    case int:
+33:    switch vv := v.(type) {

--- a/tests/any2mochi/go/reduce_builtin.go.error
+++ b/tests/any2mochi/go/reduce_builtin.go.error
@@ -1,6 +1,0 @@
-tests/compiler/go/reduce_builtin.go.out:15: unsupported generics
->>> 14:    
-15:>>> func _reduce[T any](src []T, fn func(T, T) T, init T) T {
-16:    acc := init
-17:    for _, v := range src {
-

--- a/tests/any2mochi/go/reduce_builtin.go.mochi
+++ b/tests/any2mochi/go/reduce_builtin.go.mochi
@@ -1,0 +1,11 @@
+fun add(a: int, b: int): int {
+  return (a + b)
+}
+fun _reduce(src: list<T>, fn: func(T, T) T, init: T): T {
+  let acc = init
+  for v in src {
+  acc = fn(acc, v)
+}
+  return acc
+}
+print(str(_reduce([1, 2, 3], add, 0)))

--- a/tools/any2mochi/go_translator.go
+++ b/tools/any2mochi/go_translator.go
@@ -138,9 +138,8 @@ func (c *converter) translateFunc(fn *ast.FuncDecl) (string, error) {
 	if fn.Recv != nil {
 		return "", c.errorf(fn, "unsupported method declaration")
 	}
-	if fn.Type.TypeParams != nil {
-		return "", c.errorf(fn, "unsupported generics")
-	}
+	// Ignore generic type parameters so generic functions can be translated
+	// to regular Mochi functions for now.
 	var b strings.Builder
 	b.WriteString("fun ")
 	b.WriteString(fn.Name.Name)
@@ -548,9 +547,7 @@ func (c *converter) translateExpr(e ast.Expr) (string, error) {
 	}
 	switch ex := e.(type) {
 	case *ast.FuncLit:
-		if ex.Type.TypeParams != nil {
-			return "", c.errorf(ex, "unsupported generics")
-		}
+		// Generic parameters in function literals are ignored.
 		var b strings.Builder
 		b.WriteString("fun (")
 		if ex.Type.Params != nil {

--- a/tools/go2mochi/convert.go
+++ b/tools/go2mochi/convert.go
@@ -138,9 +138,8 @@ func (c *converter) translateFunc(fn *ast.FuncDecl) (string, error) {
 	if fn.Recv != nil {
 		return "", c.errorf(fn, "unsupported method declaration")
 	}
-	if fn.Type.TypeParams != nil {
-		return "", c.errorf(fn, "unsupported generics")
-	}
+	// Ignore generic type parameters to allow basic translation of generic
+	// functions.
 	var b strings.Builder
 	b.WriteString("fun ")
 	b.WriteString(fn.Name.Name)
@@ -498,9 +497,7 @@ func (c *converter) translateExpr(e ast.Expr) (string, error) {
 	}
 	switch ex := e.(type) {
 	case *ast.FuncLit:
-		if ex.Type.TypeParams != nil {
-			return "", c.errorf(ex, "unsupported generics")
-		}
+		// Generic parameters in function literals are ignored as well.
 		var b strings.Builder
 		b.WriteString("fun (")
 		if ex.Type.Params != nil {


### PR DESCRIPTION
## Summary
- allow Go generics in `any2mochi` translator
- keep translating Go code with generic functions instead of failing
- update golden files for `any2mochi`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868f66240748320985a237c26babd6d