### PR TITLE
Update any2mochi golden helper

### DIFF
--- a/tools/any2mochi/convert_go_golden_test.go
+++ b/tools/any2mochi/convert_go_golden_test.go
@@ -12,7 +12,7 @@ import (
 func TestConvertGo_Golden(t *testing.T) {
 	root := findRepoRoot(t)
 	_ = gocode.EnsureGopls()
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/go"), "*.go.out", ConvertGoFile, "go", ".go.mochi", ".go.error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/go"), "*.go.out", ConvertGoFile, "go", ".mochi", ".error")
 }
 
 func TestConvertGoCompile_Golden(t *testing.T) {

--- a/tools/any2mochi/convert_typescript_golden_test.go
+++ b/tools/any2mochi/convert_typescript_golden_test.go
@@ -13,8 +13,8 @@ import (
 func TestConvertTypeScript_Golden(t *testing.T) {
 	root := findRepoRoot(t)
 	_ = tscode.EnsureTSLanguageServer()
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/ts"), "*.ts.out", ConvertTypeScriptFile, "ts", ".ts.mochi", ".ts.error")
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/ts_simple"), "*.ts.out", ConvertTypeScriptFile, "ts", ".ts.mochi", ".ts.error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/ts"), "*.ts.out", ConvertTypeScriptFile, "ts", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/ts_simple"), "*.ts.out", ConvertTypeScriptFile, "ts", ".mochi", ".error")
 }
 
 func TestConvertTypeScriptCompile_Golden(t *testing.T) {


### PR DESCRIPTION
## Summary
- support legacy `.go.*` files in golden helpers
- rename `.go.*` golden files to modern names when updating
- remove empty `.error` files

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6868faa4a0588320986c85ce26bf1737