### PR TITLE
Improve TypeScript converter

### DIFF
--- a/tests/any2mochi/ts/avg_builtin.ts.mochi
+++ b/tests/any2mochi/ts/avg_builtin.ts.mochi
@@ -1,2 +1,6 @@
 fun _avg() {}
+let list
+let n
+let sum
 fun main() {}
+let xs

--- a/tests/any2mochi/ts/break_continue.ts.mochi
+++ b/tests/any2mochi/ts/break_continue.ts.mochi
@@ -1,1 +1,3 @@
 fun main() {}
+let n
+let numbers

--- a/tests/any2mochi/ts/cast_struct.ts.mochi
+++ b/tests/any2mochi/ts/cast_struct.ts.mochi
@@ -1,1 +1,3 @@
 fun main() {}
+let todo
+let Todo

--- a/tests/any2mochi/ts/closure.ts.mochi
+++ b/tests/any2mochi/ts/closure.ts.mochi
@@ -1,2 +1,3 @@
+let add10
 fun main() {}
 fun makeAdder() {}

--- a/tests/any2mochi/ts/count_builtin.ts.mochi
+++ b/tests/any2mochi/ts/count_builtin.ts.mochi
@@ -1,2 +1,3 @@
 fun _count() {}
 fun main() {}
+let xs

--- a/tests/any2mochi/ts/cross_join.ts.mochi
+++ b/tests/any2mochi/ts/cross_join.ts.mochi
@@ -1,2 +1,13 @@
+let Customer
+let customers
 fun main() {}
 fun <function>() {}
+let _res
+let _src
+let c
+let o
+let entry
+let Order
+let orders
+let PairInfo
+let result

--- a/tests/any2mochi/ts/cross_join_triple.ts.mochi
+++ b/tests/any2mochi/ts/cross_join_triple.ts.mochi
@@ -1,2 +1,12 @@
+let bools
+let combos
+let letters
 fun main() {}
 fun <function>() {}
+let _res
+let _src
+let b
+let l
+let n
+let c
+let nums

--- a/tests/any2mochi/ts/dataset.ts.mochi
+++ b/tests/any2mochi/ts/dataset.ts.mochi
@@ -1,3 +1,6 @@
+let adults
 fun main() {}
 fun map() callback() {}
 fun people.filter() callback() {}
+let person
+let people

--- a/tests/any2mochi/ts/dataset_pushdown.ts.mochi
+++ b/tests/any2mochi/ts/dataset_pushdown.ts.mochi
@@ -1,15 +1,47 @@
 fun _count() {}
 fun _load() {}
+let d
+let delim
+let f
 fun filter() callback() {}
+let format
+let header
+let items
 fun items.filter() callback() {}
+let k
+let v
 fun map() callback() {}
+let n
+let n
+let start
+let text
+let y
 fun _parseCSV() {}
+let headers
+let i
+let j
+let lines
+let m
 fun map() callback() {}
+let out
+let parts
+let start
+let val
 fun _readInput() {}
+let data
 fun _save() {}
+let delim
+let format
+let header
+let headers
 fun headers.map() callback() {}
+let lines
+let row
 fun rows.map() callback() {}
 fun _toAnyMap() {}
 fun _writeOutput() {}
+let data
 fun main() {}
 fun map() callback() {}
+let names
+let Person

--- a/tests/any2mochi/ts/dataset_sort_take_limit.ts.mochi
+++ b/tests/any2mochi/ts/dataset_sort_take_limit.ts.mochi
@@ -1,5 +1,20 @@
+let expensive
 fun main() {}
 fun <function>() {}
+let _items
+let _n
+let _n
+let _pairs
 fun _items.map() callback() {}
+let p
 fun _pairs.map() callback() {}
 fun _pairs.sort() callback() {}
+let ak
+let bk
+let _res
+let _src
+let p
+let p
+let item
+let Product
+let products

--- a/tests/any2mochi/ts/fetch_builtin.ts.mochi
+++ b/tests/any2mochi/ts/fetch_builtin.ts.mochi
@@ -1,4 +1,19 @@
 fun _fetch() {}
+let ctrl
+let id
+let init
+let k
+let path
+let qs
+let resp
+let sep
 fun setTimeout() callback() {}
+let t
+let text
+let text
+let v
+let _pending
 fun _waitAll() {}
+let data
 fun main() {}
+let Msg

--- a/tests/any2mochi/ts/fetch_options.ts.mochi
+++ b/tests/any2mochi/ts/fetch_options.ts.mochi
@@ -1,5 +1,19 @@
 fun _fetch() {}
+let ctrl
+let id
+let init
+let k
+let path
+let qs
+let resp
+let sep
 fun setTimeout() callback() {}
+let t
+let text
+let text
+let v
+let _pending
 fun _toAnyMap() {}
 fun _waitAll() {}
+let body
 fun main() {}

--- a/tests/any2mochi/ts/fetch_stmt.ts.mochi
+++ b/tests/any2mochi/ts/fetch_stmt.ts.mochi
@@ -1,4 +1,19 @@
 fun _fetch() {}
+let ctrl
+let id
+let init
+let k
+let path
+let qs
+let resp
+let sep
 fun setTimeout() callback() {}
+let t
+let text
+let text
+let v
+let _pending
 fun _waitAll() {}
 fun main() {}
+let todo
+let Todo

--- a/tests/any2mochi/ts/for_loop.ts.mochi
+++ b/tests/any2mochi/ts/for_loop.ts.mochi
@@ -1,1 +1,2 @@
 fun main() {}
+let i

--- a/tests/any2mochi/ts/generate_struct.ts.mochi
+++ b/tests/any2mochi/ts/generate_struct.ts.mochi
@@ -1,2 +1,4 @@
 fun _gen_struct() {}
+let info
+let Info
 fun main() {}

--- a/tests/any2mochi/ts/group_by_left_join.ts.mochi
+++ b/tests/any2mochi/ts/group_by_left_join.ts.mochi
@@ -1,13 +1,61 @@
 fun _count() {}
 fun _equal() {}
+let ak
+let bk
+let i
+let k
 fun _query() {}
+let items
 fun src.map() callback() {}
 fun items.filter() callback() {}
+let j
+let joined
+let keep
+let keep
+let keep
+let left
+let left
+let left
+let m
+let m
+let m
+let matched
+let n
+let n
+let pairs
 fun items.map() callback() {}
 fun pairs.map() callback() {}
 fun pairs.sort() callback() {}
+let ak
+let bk
+let r
+let res
+let ri
+let ri
+let right
+let right
+let right
+let undef
+let undef
+let customers
 fun main() {}
 fun <function>() {}
+let _g
+let _items
+let _itemsG
 fun _order.map() callback() {}
+let _key
+let _ks
+let _map
+let _order
+let _r
+let _res
+let _src
+let c
 fun g.items.filter() callback() {}
 fun map() callback() {}
+let g
+let o
+let s
+let orders
+let stats

--- a/tests/any2mochi/ts/index_concat.ts.mochi
+++ b/tests/any2mochi/ts/index_concat.ts.mochi
@@ -1,1 +1,3 @@
+let groups
+let idx
 fun main() {}

--- a/tests/any2mochi/ts/input_builtin.ts.mochi
+++ b/tests/any2mochi/ts/input_builtin.ts.mochi
@@ -1,2 +1,5 @@
 fun _input() {}
+let v
+let input1
+let input2
 fun main() {}

--- a/tests/any2mochi/ts/join.ts.mochi
+++ b/tests/any2mochi/ts/join.ts.mochi
@@ -1,8 +1,43 @@
 fun _query() {}
+let items
 fun src.map() callback() {}
 fun items.filter() callback() {}
+let j
+let joined
+let keep
+let keep
+let keep
+let left
+let left
+let left
+let m
+let m
+let m
+let matched
+let n
+let n
+let pairs
 fun items.map() callback() {}
 fun pairs.map() callback() {}
 fun pairs.sort() callback() {}
+let ak
+let bk
+let r
+let res
+let ri
+let ri
+let right
+let right
+let right
+let undef
+let undef
+let Customer
+let customers
 fun main() {}
 fun <function>() {}
+let _src
+let entry
+let Order
+let orders
+let PairInfo
+let result

--- a/tests/any2mochi/ts/load_json_stdin.ts.mochi
+++ b/tests/any2mochi/ts/load_json_stdin.ts.mochi
@@ -1,14 +1,46 @@
 fun _count() {}
 fun _load() {}
+let d
+let delim
+let f
 fun filter() callback() {}
+let format
+let header
+let items
 fun items.filter() callback() {}
+let k
+let v
 fun map() callback() {}
+let n
+let n
+let start
+let text
+let y
 fun _parseCSV() {}
+let headers
+let i
+let j
+let lines
+let m
 fun map() callback() {}
+let out
+let parts
+let start
+let val
 fun _readInput() {}
+let data
 fun _save() {}
+let delim
+let format
+let header
+let headers
 fun headers.map() callback() {}
+let lines
+let row
 fun rows.map() callback() {}
 fun _toAnyMap() {}
 fun _writeOutput() {}
+let data
 fun main() {}
+let people
+let Person

--- a/tests/any2mochi/ts/load_jsonl_stdin.ts.mochi
+++ b/tests/any2mochi/ts/load_jsonl_stdin.ts.mochi
@@ -1,14 +1,46 @@
 fun _count() {}
 fun _load() {}
+let d
+let delim
+let f
 fun filter() callback() {}
+let format
+let header
+let items
 fun items.filter() callback() {}
+let k
+let v
 fun map() callback() {}
+let n
+let n
+let start
+let text
+let y
 fun _parseCSV() {}
+let headers
+let i
+let j
+let lines
+let m
 fun map() callback() {}
+let out
+let parts
+let start
+let val
 fun _readInput() {}
+let data
 fun _save() {}
+let delim
+let format
+let header
+let headers
 fun headers.map() callback() {}
+let lines
+let row
 fun rows.map() callback() {}
 fun _toAnyMap() {}
 fun _writeOutput() {}
+let data
 fun main() {}
+let people
+let Person

--- a/tests/any2mochi/ts/local_recursion.ts.mochi
+++ b/tests/any2mochi/ts/local_recursion.ts.mochi
@@ -1,5 +1,10 @@
+let _Node
 fun fromList() {}
 fun helper() {}
+let mid
 fun inorder() {}
 fun <function>() {}
+let _t
+let Leaf
 fun main() {}
+let Tree

--- a/tests/any2mochi/ts/map_any_hint.ts.mochi
+++ b/tests/any2mochi/ts/map_any_hint.ts.mochi
@@ -1,3 +1,4 @@
 fun _Node() {}
 fun Leaf() {}
 fun main() {}
+let tree

--- a/tests/any2mochi/ts/map_iterate.ts.mochi
+++ b/tests/any2mochi/ts/map_iterate.ts.mochi
@@ -1,1 +1,5 @@
+let m
 fun main() {}
+let k
+let kKey
+let sum

--- a/tests/any2mochi/ts/map_keys.ts.mochi
+++ b/tests/any2mochi/ts/map_keys.ts.mochi
@@ -1,2 +1,3 @@
+let m
 fun main() {}
 fun map() callback() {}

--- a/tests/any2mochi/ts/map_ops.ts.mochi
+++ b/tests/any2mochi/ts/map_ops.ts.mochi
@@ -1,1 +1,2 @@
+let m
 fun main() {}

--- a/tests/any2mochi/ts/match_capture.ts.mochi
+++ b/tests/any2mochi/ts/match_capture.ts.mochi
@@ -1,3 +1,7 @@
+let _Node
 fun depth() {}
 fun <function>() {}
+let _t
+let Leaf
 fun main() {}
+let Tree

--- a/tests/any2mochi/ts/match_underscore.ts.mochi
+++ b/tests/any2mochi/ts/match_underscore.ts.mochi
@@ -1,3 +1,7 @@
+let _Node
+let Leaf
 fun main() {}
+let Tree
 fun value_of_root() {}
 fun <function>() {}
+let _t

--- a/tests/any2mochi/ts/math_import_ts.ts.mochi
+++ b/tests/any2mochi/ts/math_import_ts.ts.mochi
@@ -1,1 +1,3 @@
+let base
 fun main() {}
+let p

--- a/tests/any2mochi/ts/matrix_search.ts.mochi
+++ b/tests/any2mochi/ts/matrix_search.ts.mochi
@@ -1,2 +1,10 @@
 fun main() {}
 fun searchMatrix() {}
+let col
+let left
+let m
+let mid
+let n
+let right
+let row
+let value

--- a/tests/any2mochi/ts/nested_loop_matrix.ts.mochi
+++ b/tests/any2mochi/ts/nested_loop_matrix.ts.mochi
@@ -1,1 +1,5 @@
+let i
 fun main() {}
+let j
+let row
+let matrix

--- a/tests/any2mochi/ts/package_import.ts.mochi
+++ b/tests/any2mochi/ts/package_import.ts.mochi
@@ -1,4 +1,7 @@
 fun main() {}
+let mathutils
 fun <function>() {}
 fun add() {}
 fun square() {}
+let sq
+let sum

--- a/tests/any2mochi/ts/plus_one.ts.mochi
+++ b/tests/any2mochi/ts/plus_one.ts.mochi
@@ -1,2 +1,6 @@
 fun main() {}
 fun plusOne() {}
+let carry
+let i
+let result
+let sum

--- a/tests/any2mochi/ts/reserved_keyword_var.ts.mochi
+++ b/tests/any2mochi/ts/reserved_keyword_var.ts.mochi
@@ -1,1 +1,2 @@
 fun main() {}
+let map

--- a/tests/any2mochi/ts/save_json_stdout.ts.mochi
+++ b/tests/any2mochi/ts/save_json_stdout.ts.mochi
@@ -1,13 +1,45 @@
 fun _load() {}
+let d
+let delim
+let f
 fun filter() callback() {}
+let format
+let header
+let items
 fun items.filter() callback() {}
+let k
+let v
 fun map() callback() {}
+let n
+let n
+let start
+let text
+let y
 fun _parseCSV() {}
+let headers
+let i
+let j
+let lines
+let m
 fun map() callback() {}
+let out
+let parts
+let start
+let val
 fun _readInput() {}
+let data
 fun _save() {}
+let delim
+let format
+let header
+let headers
 fun headers.map() callback() {}
+let lines
+let row
 fun rows.map() callback() {}
 fun _toAnyMap() {}
 fun _writeOutput() {}
+let data
 fun main() {}
+let people
+let Person

--- a/tests/any2mochi/ts/shadow_builtin.ts.mochi
+++ b/tests/any2mochi/ts/shadow_builtin.ts.mochi
@@ -1,1 +1,2 @@
+let count
 fun main() {}

--- a/tests/any2mochi/ts/str_builtin.ts.mochi
+++ b/tests/any2mochi/ts/str_builtin.ts.mochi
@@ -1,1 +1,2 @@
 fun main() {}
+let x

--- a/tests/any2mochi/ts/string_for_loop.ts.mochi
+++ b/tests/any2mochi/ts/string_for_loop.ts.mochi
@@ -1,1 +1,2 @@
 fun main() {}
+let ch

--- a/tests/any2mochi/ts/string_negative_index.ts.mochi
+++ b/tests/any2mochi/ts/string_negative_index.ts.mochi
@@ -1,2 +1,4 @@
 fun _indexString() {}
+let runes
 fun main() {}
+let text

--- a/tests/any2mochi/ts/string_slice.ts.mochi
+++ b/tests/any2mochi/ts/string_slice.ts.mochi
@@ -1,2 +1,6 @@
 fun _sliceString() {}
+let end
+let n
+let runes
+let start
 fun main() {}

--- a/tests/any2mochi/ts/tpch_q2.ts.mochi
+++ b/tests/any2mochi/ts/tpch_q2.ts.mochi
@@ -1,22 +1,84 @@
 fun _equal() {}
+let ak
+let bk
+let i
+let k
 fun _json() {}
 fun _sort() {}
+let k
+let keys
+let o
 fun _min() {}
+let list
+let m
+let n
+let num
 fun _query() {}
+let items
 fun src.map() callback() {}
 fun items.filter() callback() {}
+let j
+let joined
+let keep
+let keep
+let keep
+let left
+let left
+let left
+let m
+let m
+let m
+let matched
+let n
+let n
+let pairs
 fun items.map() callback() {}
 fun pairs.map() callback() {}
 fun pairs.sort() callback() {}
+let ak
+let bk
+let r
+let res
+let ri
+let ri
+let right
+let right
+let right
+let undef
+let undef
+let costs
+let europe_nations
+let europe_suppliers
 fun main() {}
 fun <function>() {}
+let _src
 fun <function>() {}
+let _src
 fun <function>() {}
+let _src
 fun <function>() {}
+let _items
+let _pairs
 fun _items.map() callback() {}
+let x
 fun _pairs.map() callback() {}
 fun _pairs.sort() callback() {}
+let ak
+let bk
+let _res
+let _src
+let x
+let x
 fun map() callback() {}
 fun part.filter() callback() {}
 fun target_partsupp.map() callback() {}
+let min_cost
+let nation
+let part
+let partsupp
+let region
+let result
+let supplier
+let target_parts
+let target_partsupp
 fun test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part() {}

--- a/tests/any2mochi/ts/two_sum.ts.mochi
+++ b/tests/any2mochi/ts/two_sum.ts.mochi
@@ -1,2 +1,6 @@
 fun main() {}
+let result
 fun twoSum() {}
+let i
+let j
+let n

--- a/tests/any2mochi/ts/typed_list_negative.ts.mochi
+++ b/tests/any2mochi/ts/typed_list_negative.ts.mochi
@@ -1,2 +1,3 @@
 fun main() {}
 fun test_values() {}
+let xs

--- a/tests/any2mochi/ts/underscore_for_loop.ts.mochi
+++ b/tests/any2mochi/ts/underscore_for_loop.ts.mochi
@@ -1,1 +1,7 @@
+let c
+let m
 fun main() {}
+let _
+let _
+let _
+let _

--- a/tests/any2mochi/ts/union.ts.mochi
+++ b/tests/any2mochi/ts/union.ts.mochi
@@ -1,7 +1,18 @@
 fun _equal() {}
+let ak
+let bk
+let i
+let k
+let _Node
 fun depth() {}
 fun <function>() {}
+let _t
 fun <function>() {}
 fun <function>() {}
 fun <function>() {}
+let _t
+let dl
+let dr
+let Leaf
 fun main() {}
+let Tree

--- a/tests/any2mochi/ts/union_inorder.ts.mochi
+++ b/tests/any2mochi/ts/union_inorder.ts.mochi
@@ -1,3 +1,7 @@
+let _Node
 fun inorder() {}
 fun <function>() {}
+let _t
+let Leaf
 fun main() {}
+let Tree

--- a/tests/any2mochi/ts/union_match.ts.mochi
+++ b/tests/any2mochi/ts/union_match.ts.mochi
@@ -1,3 +1,7 @@
+let _Node
 fun isLeaf() {}
 fun <function>() {}
+let _t
+let Leaf
 fun main() {}
+let Tree

--- a/tests/any2mochi/ts/union_ops.ts.mochi
+++ b/tests/any2mochi/ts/union_ops.ts.mochi
@@ -1,5 +1,18 @@
 fun _except() {}
+let it
+let remove
+let res
 fun _intersect() {}
+let it
+let keep
+let res
+let seen
 fun _union() {}
+let it
+let it
+let res
+let seen
 fun _union_all() {}
+let a
+let b
 fun main() {}

--- a/tests/any2mochi/ts/union_slice.ts.mochi
+++ b/tests/any2mochi/ts/union_slice.ts.mochi
@@ -1,2 +1,5 @@
+let _Node
+let Empty
+let Foo
 fun listit() {}
 fun main() {}

--- a/tests/any2mochi/ts/update_statement.ts.mochi
+++ b/tests/any2mochi/ts/update_statement.ts.mochi
@@ -1,3 +1,14 @@
 fun _equal() {}
+let ak
+let bk
+let i
+let k
 fun main() {}
+let _i
+let _item
+let age
+let name
+let status
+let people
+let Person
 fun test_update_adult_status() {}

--- a/tests/any2mochi/ts/var_assignment.ts.mochi
+++ b/tests/any2mochi/ts/var_assignment.ts.mochi
@@ -1,1 +1,2 @@
 fun main() {}
+let x

--- a/tests/any2mochi/ts/while_loop.ts.mochi
+++ b/tests/any2mochi/ts/while_loop.ts.mochi
@@ -1,1 +1,2 @@
+let i
 fun main() {}

--- a/tests/any2mochi/ts/while_membership.ts.mochi
+++ b/tests/any2mochi/ts/while_membership.ts.mochi
@@ -1,1 +1,5 @@
+let count
+let i
 fun main() {}
+let n
+let set

--- a/tools/any2mochi/convert_typescript.go
+++ b/tools/any2mochi/convert_typescript.go
@@ -1,11 +1,31 @@
 package any2mochi
 
-import "os"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
 
-// ConvertTypeScript converts TypeScript source code to a minimal Mochi representation using the language server.
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// ConvertTypeScript converts TypeScript source code to Mochi by
+// querying the language server for document symbols and formatting
+// them into simple Mochi declarations.
 func ConvertTypeScript(src string) ([]byte, error) {
 	ls := Servers["typescript"]
-	return ConvertWithServer(ls.Command, ls.Args, ls.LangID, src)
+	syms, diags, err := ParseAndEnsure(ls.Command, ls.Args, ls.LangID, src)
+	if err != nil {
+		return nil, fmt.Errorf("convert failure: %w\n\nsource snippet:\n%s", err, numberedSnippet(src))
+	}
+	if len(diags) > 0 {
+		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
+	}
+	code := formatTSSymbols(syms)
+	if code == "" {
+		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+	}
+	return []byte(code), nil
 }
 
 // ConvertTypeScriptFile reads the TS file and converts it to Mochi.
@@ -21,7 +41,19 @@ func ConvertTypeScriptFile(path string) ([]byte, error) {
 // symbols encoded as JSON.
 func ConvertTypeScriptWithJSON(src string) ([]byte, []byte, error) {
 	ls := Servers["typescript"]
-	return ConvertWithServerJSON(ls.Command, ls.Args, ls.LangID, src)
+	syms, diags, err := ParseAndEnsure(ls.Command, ls.Args, ls.LangID, src)
+	if err != nil {
+		return nil, nil, fmt.Errorf("convert failure: %w\n\nsource snippet:\n%s", err, numberedSnippet(src))
+	}
+	if len(diags) > 0 {
+		return nil, nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
+	}
+	code := formatTSSymbols(syms)
+	if code == "" {
+		return nil, nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+	}
+	js, _ := json.MarshalIndent(syms, "", "  ")
+	return []byte(code), js, nil
 }
 
 // ConvertTypeScriptFileWithJSON reads the TS file and converts it to Mochi
@@ -32,4 +64,25 @@ func ConvertTypeScriptFileWithJSON(path string) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 	return ConvertTypeScriptWithJSON(string(data))
+}
+
+func formatTSSymbols(syms []protocol.DocumentSymbol) string {
+	var out strings.Builder
+	for _, s := range syms {
+		switch s.Kind {
+		case protocol.SymbolKindFunction:
+			out.WriteString("fun ")
+			out.WriteString(s.Name)
+			out.WriteString("() {}\n")
+		case protocol.SymbolKindVariable, protocol.SymbolKindConstant:
+			out.WriteString("let ")
+			out.WriteString(s.Name)
+			out.WriteByte('\n')
+		case protocol.SymbolKindClass, protocol.SymbolKindInterface, protocol.SymbolKindStruct:
+			out.WriteString("type ")
+			out.WriteString(s.Name)
+			out.WriteString(" {}\n")
+		}
+	}
+	return out.String()
 }

--- a/tools/ts2mochi/convert.go
+++ b/tools/ts2mochi/convert.go
@@ -93,6 +93,9 @@ func parseProgram(path string) (*Program, []byte, error) {
 	}
 	script := filepath.Join(root, "tools", "ts2mochi", "ast.js")
 	cmd := exec.Command("node", script, path)
+	if np := nodeModulePath(); np != "" {
+		cmd.Env = append(os.Environ(), "NODE_PATH="+np)
+	}
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
@@ -242,4 +245,13 @@ func formatExpr(e Expr) string {
 	default:
 		return ""
 	}
+}
+
+func nodeModulePath() string {
+	cmd := exec.Command("npm", "root", "-g")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
## Summary
- use TypeScript language server instead of ts2mochi
- emit stub declarations for variables, functions and types
- refresh golden outputs for TypeScript conversion tests

## Testing
- `go test -tags slow ./tools/any2mochi -run ConvertTypeScript_Golden -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868f95e43b4832081e04af01d508820