### PR TITLE
Improve any2mochi Go conversion

### DIFF
--- a/tests/any2mochi/go/math_import_py.error
+++ b/tests/any2mochi/go/math_import_py.error
@@ -1,5 +1,1 @@
-tests/compiler/go/math_import_py.go.out:10: unsupported assignment
->>> 9:    var r float64 = 3.0
-10:>>> var area float64 = (func() float64 { v, _ := python.Attr("math", "pi"); return v.(float64) }() * func() float64 { v, _ := python.Attr("math", "pow", r, 2.0); return v.(float64) }())
-11:    fmt.Println("Area:", area)
-12:    }
+parse error: parse error: 2:29: unexpected token "{" (expected "<" TypeRef ("," TypeRef)* ">")


### PR DESCRIPTION
## Summary
- handle Go call assignments that discard extra return values
- convert Go type assertions to `as` casts
- add function type handling in `typeString`
- update golden error for `math_import_py`

## Testing
- `go test ./tools/any2mochi -run TestConvertGo_Golden -tags slow -update`
- `go test ./tools/any2mochi -run TestConvertGoCompile_Golden -tags slow -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68690f054250832097a10f9bc9fad8ec