### PR TITLE
Improve PHP any2mochi converter

### DIFF
--- a/tests/any2mochi/php/dataset.mochi
+++ b/tests/any2mochi/php/dataset.mochi
@@ -1,0 +1,6 @@
+type Person {
+  name: any
+  age: any
+}
+fun __construct() {}
+fun Closure() {}

--- a/tests/any2mochi/php/dataset_sort_take_limit.mochi
+++ b/tests/any2mochi/php/dataset_sort_take_limit.mochi
@@ -1,0 +1,12 @@
+type Product {
+  name: any
+  price: any
+}
+fun __construct() {}
+fun Closure() {}
+fun Closure() {}
+fun Closure() {}
+fun _query() {}
+fun Closure() {}
+fun Closure() {}
+fun Closure() {}

--- a/tests/any2mochi/php/string_for_loop.error
+++ b/tests/any2mochi/php/string_for_loop.error
@@ -1,0 +1,9 @@
+no convertible symbols found
+
+source snippet:
+  1: <?php
+  2: foreach ((is_string("cat") ? str_split("cat") : "cat") as $ch) {
+  3: 	echo $ch, PHP_EOL;
+  4: }
+  5: 
+exit status 1

--- a/tools/any2mochi/convert_php.go
+++ b/tools/any2mochi/convert_php.go
@@ -11,26 +11,50 @@ import (
 // ConvertPhp converts php source code to Mochi using the language server.
 func ConvertPhp(src string) ([]byte, error) {
 	ls := Servers["php"]
-	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
+	syms, _, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
 	if err != nil {
 		return nil, err
 	}
-	if len(diags) > 0 {
-		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
-	}
+	// Many PHP language servers emit diagnostics for standard library
+	// functions unless a full project is loaded. Ignore diagnostics so we
+	// can still extract symbols from standalone files.
 	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != protocol.SymbolKindFunction {
-			continue
-		}
-		out.WriteString("fun ")
-		out.WriteString(s.Name)
-		out.WriteString("() {}\n")
-	}
+	appendPhpSymbols(&out, syms)
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
 	return []byte(out.String()), nil
+}
+
+func appendPhpSymbols(out *strings.Builder, syms []protocol.DocumentSymbol) {
+	for _, s := range syms {
+		switch s.Kind {
+		case protocol.SymbolKindFunction, protocol.SymbolKindMethod, protocol.SymbolKindConstructor:
+			out.WriteString("fun ")
+			out.WriteString(s.Name)
+			out.WriteString("() {}\n")
+			if len(s.Children) > 0 {
+				appendPhpSymbols(out, s.Children)
+			}
+		case protocol.SymbolKindClass:
+			out.WriteString("type ")
+			out.WriteString(s.Name)
+			out.WriteString(" {\n")
+			for _, c := range s.Children {
+				switch c.Kind {
+				case protocol.SymbolKindField, protocol.SymbolKindProperty:
+					name := strings.TrimPrefix(c.Name, "$")
+					fmt.Fprintf(out, "  %s: any\n", name)
+				}
+			}
+			out.WriteString("}\n")
+			appendPhpSymbols(out, s.Children)
+		default:
+			if len(s.Children) > 0 {
+				appendPhpSymbols(out, s.Children)
+			}
+		}
+	}
 }
 
 // ConvertPhpFile reads the php file and converts it to Mochi.


### PR DESCRIPTION
## Summary
- support translating PHP classes to Mochi type definitions
- ignore PHP language server diagnostics so conversion can proceed
- add golden samples for PHP conversion
- convert class methods as functions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68690e36fba08320a3b4f4d2d2ff0a88