### PR TITLE
Add Go-based Ruby converter

### DIFF
--- a/tests/any2mochi/rb/hello_world.error
+++ b/tests/any2mochi/rb/hello_world.error
@@ -1,4 +1,0 @@
-convert failure: solargraph not found
-
-source snippet:
-  1: puts(["Hello, world"].join(" "))

--- a/tests/any2mochi/rb/hello_world.mochi
+++ b/tests/any2mochi/rb/hello_world.mochi
@@ -1,0 +1,2 @@
+print("Hello, world")
+

--- a/tests/any2mochi/rb/let_and_print.mochi
+++ b/tests/any2mochi/rb/let_and_print.mochi
@@ -1,0 +1,4 @@
+let a = 10
+let b = 20
+print(a + b)
+


### PR DESCRIPTION
## Summary
- drop the Ruby helper script
- implement Ruby translation directly in Go
- keep language-server validation when converting Ruby sources
- update hello world golden file
- add golden file for `let_and_print` example

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68690e43e7948320b9019e79ac695a37