### PR TITLE
Improve C# any2mochi converter

### DIFF
--- a/tools/any2mochi/convert_cs.go
+++ b/tools/any2mochi/convert_cs.go
@@ -19,14 +19,7 @@ func ConvertCs(src string) ([]byte, error) {
 		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
 	}
 	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != protocol.SymbolKindFunction {
-			continue
-		}
-		out.WriteString("fun ")
-		out.WriteString(s.Name)
-		out.WriteString("() {}\n")
-	}
+	writeCsSymbols(&out, nil, syms)
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
@@ -40,4 +33,26 @@ func ConvertCsFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	return ConvertCs(string(data))
+}
+
+func writeCsSymbols(out *strings.Builder, prefix []string, syms []protocol.DocumentSymbol) {
+	for _, s := range syms {
+		nameParts := prefix
+		if s.Name != "" {
+			nameParts = append(nameParts, s.Name)
+		}
+		switch s.Kind {
+		case protocol.SymbolKindClass, protocol.SymbolKindStruct, protocol.SymbolKindInterface:
+			out.WriteString("type ")
+			out.WriteString(strings.Join(nameParts, "."))
+			out.WriteString(" {}\n")
+		case protocol.SymbolKindFunction, protocol.SymbolKindMethod, protocol.SymbolKindConstructor:
+			out.WriteString("fun ")
+			out.WriteString(strings.Join(nameParts, "."))
+			out.WriteString("() {}\n")
+		}
+		if len(s.Children) > 0 {
+			writeCsSymbols(out, nameParts, s.Children)
+		}
+	}
 }

--- a/tools/any2mochi/server.go
+++ b/tools/any2mochi/server.go
@@ -24,7 +24,7 @@ var Servers = map[string]LanguageServer{
 	"clj":        {Command: "clojure-lsp", Args: nil, LangID: "clojure"},
 	"cobol":      {Command: "cobol-lsp", Args: nil, LangID: "cobol"},
 	"jvm":        {Command: "jdtls", Args: nil, LangID: "jvm"},
-	"cs":         {Command: "omnisharp", Args: nil, LangID: "csharp"},
+	"cs":         {Command: "omnisharp", Args: []string{"-lsp"}, LangID: "csharp"},
 	"dart":       {Command: "dart", Args: []string{"language-server"}, LangID: "dart"},
 	"erlang":     {Command: "erlang_ls", Args: nil, LangID: "erlang"},
 	"ex":         {Command: "elixir-ls", Args: nil, LangID: "elixir"},
@@ -69,6 +69,8 @@ func EnsureServer(name string) error {
 		{"pip3", []string{"install", "--user", name}},
 		{"pip", []string{"install", "--user", name}},
 		{"go", []string{"install", name + "@latest"}},
+		{"dotnet", []string{"tool", "install", "-g", name}},
+		{"dotnet", []string{"tool", "update", "-g", name}},
 	}
 	for _, inst := range installers {
 		if _, err := exec.LookPath(inst.bin); err == nil {


### PR DESCRIPTION
## Summary
- add `-lsp` arg for OmniSharp language server
- support nested C# symbols when generating Mochi code
- attempt dotnet tool installation in EnsureServer

## Testing
- `go test ./...` *(fails: splitArgs redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_686918792b608320b8d360c73c38d38c