### PR TITLE
Improve C++ converter using hover data

### DIFF
--- a/tests/any2mochi/cpp/add_vector.mochi
+++ b/tests/any2mochi/cpp/add_vector.mochi
@@ -1,0 +1,2 @@
+fun add(a: int, b: int): int {}
+fun foo(x: list<int>, y: int): list<int> {}

--- a/tools/any2mochi/lsp.go
+++ b/tools/any2mochi/lsp.go
@@ -19,6 +19,18 @@ func EnsureAndParse(cmd string, args []string, langID, src string) ([]protocol.D
 	return syms, diags, err
 }
 
+// EnsureAndHover runs HoverAt after ensuring the language server is installed.
+func EnsureAndHover(cmd string, args []string, langID, src string, pos protocol.Position) (protocol.Hover, error) {
+	if err := EnsureServer(cmd); err != nil {
+		return protocol.Hover{}, err
+	}
+	hov, err := HoverAt(cmd, args, langID, src, pos)
+	if err != nil {
+		err = fmt.Errorf("hover failure: %w\n\nsource snippet:\n%s", err, numberedSnippet(src))
+	}
+	return hov, err
+}
+
 func numberedSnippet(src string) string {
 	lines := strings.Split(src, "\n")
 	if len(lines) > 10 {


### PR DESCRIPTION
## Summary
- expand tools/any2mochi to query hover info from language servers
- parse C++ function signatures with parameter types
- map C++ types to Mochi types (including vectors)
- add test fixture demonstrating typed C++ conversion

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686924bfc240832084bb3e761b4044e7