### PR TITLE
Simplify Dart converter

### DIFF
--- a/tests/any2mochi/dart/two_sum.mochi
+++ b/tests/any2mochi/dart/two_sum.mochi
@@ -1,16 +1,3 @@
-fun twoSum(nums, target) {
-  var n = nums.length
-  for i in 0..n {
-    for j in (i + 1)..n {
-      if ((nums[i] + nums[j]) == target) {
-        return [i, j]
-      }
-    }
-  }
-  return [-1, -1]
-}
-fun main() {
-  var result = twoSum([2, 7, 11, 15], 9)
-  print(result[0])
-  print(result[1])
-}
+fun twoSum(nums, target) {}
+fun main() {}
+

--- a/tools/any2mochi/convert_dart.go
+++ b/tools/any2mochi/convert_dart.go
@@ -1,26 +1,12 @@
 package any2mochi
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"unicode"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
-)
-
-var (
-	dartFuncStart = regexp.MustCompile(`^(?:\w+\s+)?(\w+)\(([^)]*)\)\s*\{$`)
-	dartMainStart = regexp.MustCompile(`^void\s+main\(\)\s*\{$`)
-	dartForLoop   = regexp.MustCompile(`^for\s*\(\s*var\s+(\w+)\s*=\s*([^;]+);\s*([^;]+);\s*([^\)]+)\)\s*\{$`)
-	dartVarDecl   = regexp.MustCompile(`^(?:var|dynamic)\s+(\w+)\s*=\s*(.+);$`)
-	dartAssign    = regexp.MustCompile(`^(\w+)\s*=\s*(.+);$`)
-	dartIf        = regexp.MustCompile(`^if\s*\((.+)\)\s*\{$`)
-	dartElseIf    = regexp.MustCompile(`^else\s+if\s*\((.+)\)\s*\{$`)
-	dartReturn    = regexp.MustCompile(`^return\s+(.+);$`)
-	dartPrint     = regexp.MustCompile(`^print\((.+)\);$`)
 )
 
 // ConvertDart converts dart source code to Mochi.
@@ -28,52 +14,15 @@ func ConvertDart(src string) ([]byte, error) {
 	ls := Servers["dart"]
 	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
 	if err != nil {
-		// fall back to simple parser on failure
-		if out, err2 := convertDartSimple(src); err2 == nil {
-			return out, nil
-		}
 		return nil, err
 	}
 	if len(diags) > 0 {
 		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
 	}
+
 	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != protocol.SymbolKindFunction {
-			continue
-		}
-		snippet := extractRange(src, s.Range)
-		if snippet == "" {
-			continue
-		}
-		fnOut, err := convertDartSimple(snippet)
-		if err != nil {
-			// best effort using just the symbol information
-			out.WriteString("fun ")
-			out.WriteString(s.Name)
-			detail := ""
-			if s.Detail != nil {
-				detail = *s.Detail
-			}
-			params, ret := parseDartDetail(detail)
-			out.WriteByte('(')
-			if len(params) > 0 {
-				out.WriteString(strings.Join(params, ", "))
-			}
-			out.WriteByte(')')
-			if ret != "" && ret != "void" {
-				out.WriteString(": ")
-				out.WriteString(ret)
-			}
-			out.WriteString(" {}\n")
-			continue
-		}
-		out.Write(fnOut)
-	}
+	writeDartSymbols(&out, nil, syms)
 	if out.Len() == 0 {
-		if fallback, err2 := convertDartSimple(src); err2 == nil {
-			return fallback, nil
-		}
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
 	return []byte(out.String()), nil
@@ -86,129 +35,6 @@ func ConvertDartFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	return ConvertDart(string(data))
-}
-
-func extractRange(src string, r protocol.Range) string {
-	lines := strings.Split(src, "\n")
-	if int(r.Start.Line) >= len(lines) || int(r.End.Line) >= len(lines) {
-		return ""
-	}
-	var out strings.Builder
-	for i := int(r.Start.Line); i <= int(r.End.Line); i++ {
-		line := lines[i]
-		if i == int(r.Start.Line) && int(r.Start.Character) < len(line) {
-			line = line[r.Start.Character:]
-		}
-		if i == int(r.End.Line) && int(r.End.Character) < len(line) {
-			line = line[:r.End.Character]
-		}
-		out.WriteString(line)
-		if i < int(r.End.Line) {
-			out.WriteByte('\n')
-		}
-	}
-	return out.String()
-}
-
-func convertDartSimple(src string) ([]byte, error) {
-	scanner := bufio.NewScanner(strings.NewReader(src))
-	var out strings.Builder
-	indent := 0
-	found := false
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "import ") {
-			continue
-		}
-		if m := dartFuncStart.FindStringSubmatch(line); m != nil {
-			found = true
-			name := m[1]
-			params := parseParams(m[2])
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("fun " + name + "(")
-			out.WriteString(strings.Join(params, ", "))
-			out.WriteString(") {\n")
-			indent++
-			continue
-		}
-		if dartMainStart.MatchString(line) {
-			found = true
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("fun main() {\n")
-			indent++
-			continue
-		}
-		if line == "}" {
-			indent--
-			if indent < 0 {
-				indent = 0
-			}
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("}\n")
-			continue
-		}
-		if m := dartForLoop.FindStringSubmatch(line); m != nil {
-			found = true
-			name := m[1]
-			start := strings.TrimSpace(m[2])
-			cond := strings.TrimSpace(m[3])
-			if strings.HasPrefix(cond, name) {
-				cond = strings.TrimSpace(cond[len(name):])
-			}
-			end := strings.TrimSpace(strings.TrimLeft(strings.TrimLeft(cond, "<"), "="))
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("for " + name + " in " + start + ".." + end + " {\n")
-			indent++
-			continue
-		}
-		if m := dartVarDecl.FindStringSubmatch(line); m != nil {
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("var " + m[1] + " = " + m[2] + "\n")
-			continue
-		}
-		if m := dartAssign.FindStringSubmatch(line); m != nil {
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString(m[1] + " = " + m[2] + "\n")
-			continue
-		}
-		if m := dartIf.FindStringSubmatch(line); m != nil {
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("if " + m[1] + " {\n")
-			indent++
-			continue
-		}
-		if m := dartElseIf.FindStringSubmatch(line); m != nil {
-			indent--
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("} else if " + m[1] + " {\n")
-			indent++
-			continue
-		}
-		if line == "else {" {
-			indent--
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("} else {\n")
-			indent++
-			continue
-		}
-		if m := dartReturn.FindStringSubmatch(line); m != nil {
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("return " + m[1] + "\n")
-			continue
-		}
-		if m := dartPrint.FindStringSubmatch(line); m != nil {
-			out.WriteString(strings.Repeat("  ", indent))
-			out.WriteString("print(" + m[1] + ")\n")
-			continue
-		}
-		// unrecognized line, comment it
-		out.WriteString(strings.Repeat("  ", indent))
-		out.WriteString("// " + line + "\n")
-	}
-	if !found {
-		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
-	}
-	return []byte(out.String()), nil
 }
 
 func parseDartDetail(detail string) ([]string, string) {
@@ -235,22 +61,37 @@ func parseDartDetail(detail string) ([]string, string) {
 	return params, retPart
 }
 
-func parseParams(list string) []string {
-	if strings.TrimSpace(list) == "" {
-		return nil
-	}
-	parts := strings.Split(list, ",")
-	params := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
+func writeDartSymbols(out *strings.Builder, prefix []string, syms []protocol.DocumentSymbol) {
+	for _, s := range syms {
+		nameParts := prefix
+		if s.Name != "" {
+			nameParts = append(nameParts, s.Name)
 		}
-		fields := strings.FieldsFunc(p, func(r rune) bool { return unicode.IsSpace(r) || r == '=' })
-		if len(fields) == 0 {
-			continue
+		switch s.Kind {
+		case protocol.SymbolKindFunction, protocol.SymbolKindMethod, protocol.SymbolKindConstructor:
+			out.WriteString("fun ")
+			out.WriteString(strings.Join(nameParts, "."))
+			detail := ""
+			if s.Detail != nil {
+				detail = *s.Detail
+			}
+			params, ret := parseDartDetail(detail)
+			out.WriteByte('(')
+			for i, p := range params {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				out.WriteString(p)
+			}
+			out.WriteByte(')')
+			if ret != "" && ret != "void" {
+				out.WriteString(": ")
+				out.WriteString(ret)
+			}
+			out.WriteString(" {}\n")
 		}
-		params = append(params, fields[len(fields)-1])
+		if len(s.Children) > 0 {
+			writeDartSymbols(out, nameParts, s.Children)
+		}
 	}
-	return params
 }


### PR DESCRIPTION
## Summary
- remove regex-based fallback from Dart converter
- use LSP document symbols only for conversion
- update golden output for Dart two_sum example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686924fa3d3883209175ad9930022578