### PR TITLE
Enhance C++ converter

### DIFF
--- a/tests/any2mochi/cpp/method.mochi
+++ b/tests/any2mochi/cpp/method.mochi
@@ -1,0 +1,6 @@
+type Circle {
+  radius: float
+}
+fun Circle_area(self: Circle): float {}
+fun Circle_describe(self: Circle) {}
+fun main(): int {}

--- a/tests/any2mochi/cpp/nested_types.mochi
+++ b/tests/any2mochi/cpp/nested_types.mochi
@@ -1,0 +1,8 @@
+type Address {
+  street: string
+}
+type Person {
+  name: string
+  addr: Address
+}
+fun main(): int {}

--- a/tools/any2mochi/convert_cpp.go
+++ b/tools/any2mochi/convert_cpp.go
@@ -24,54 +24,7 @@ func ConvertCpp(src string) ([]byte, error) {
 		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
 	}
 	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != protocol.SymbolKindFunction && s.Kind != protocol.SymbolKindMethod {
-			continue
-		}
-		signature := ""
-		if hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, s.SelectionRange.Start); err == nil {
-			if mc, ok := hov.Contents.(protocol.MarkupContent); ok {
-				lines := strings.Split(mc.Value, "\n")
-				for i := len(lines) - 1; i >= 0 && signature == ""; i-- {
-					l := strings.TrimSpace(lines[i])
-					if strings.Contains(l, "(") && strings.Contains(l, ")") {
-						signature = l
-					}
-				}
-			}
-		}
-		var params []cppParam
-		var ret string
-		if signature != "" {
-			params, ret = parseCppSignature(signature)
-		} else {
-			names, r := parseCppDetail(s.Detail)
-			ret = r
-			for _, n := range names {
-				params = append(params, cppParam{name: n})
-			}
-		}
-		out.WriteString("fun ")
-		out.WriteString(s.Name)
-		out.WriteByte('(')
-		for i, p := range params {
-			if i > 0 {
-				out.WriteString(", ")
-			}
-			out.WriteString(p.name)
-			if p.typ != "" {
-				out.WriteString(": ")
-				out.WriteString(p.typ)
-			}
-		}
-		out.WriteByte(')')
-		ret = mapCppType(ret)
-		if ret != "" && ret != "void" {
-			out.WriteString(": ")
-			out.WriteString(ret)
-		}
-		out.WriteString(" {}\n")
-	}
+	writeCppSymbols(&out, "", syms, src, ls)
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
@@ -85,6 +38,85 @@ func ConvertCppFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	return ConvertCpp(string(data))
+}
+
+func writeCppSymbols(out *strings.Builder, indent string, syms []protocol.DocumentSymbol, src string, ls LanguageServer) {
+	for _, s := range syms {
+		switch s.Kind {
+		case protocol.SymbolKindClass, protocol.SymbolKindStruct:
+			out.WriteString(indent)
+			out.WriteString("type ")
+			out.WriteString(s.Name)
+			out.WriteString(" {\n")
+			writeCppSymbols(out, indent+"  ", s.Children, src, ls)
+			out.WriteString(indent)
+			out.WriteString("}\n")
+		case protocol.SymbolKindField, protocol.SymbolKindProperty, protocol.SymbolKindVariable:
+			if strings.HasPrefix(s.Name, "using ") {
+				continue
+			}
+			typ := ""
+			if s.Detail != nil {
+				typ = mapCppType(*s.Detail)
+			}
+			out.WriteString(indent)
+			out.WriteString(s.Name)
+			if typ != "" {
+				out.WriteString(": ")
+				out.WriteString(typ)
+			}
+			out.WriteString("\n")
+		case protocol.SymbolKindFunction, protocol.SymbolKindMethod, protocol.SymbolKindConstructor:
+			signature := ""
+			if hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, s.SelectionRange.Start); err == nil {
+				if mc, ok := hov.Contents.(protocol.MarkupContent); ok {
+					lines := strings.Split(mc.Value, "\n")
+					for i := len(lines) - 1; i >= 0 && signature == ""; i-- {
+						l := strings.TrimSpace(lines[i])
+						if strings.Contains(l, "(") && strings.Contains(l, ")") {
+							signature = l
+						}
+					}
+				}
+			}
+			var params []cppParam
+			var ret string
+			if signature != "" {
+				params, ret = parseCppSignature(signature)
+			} else {
+				names, r := parseCppDetail(s.Detail)
+				ret = r
+				for _, n := range names {
+					params = append(params, cppParam{name: n})
+				}
+			}
+			out.WriteString(indent)
+			out.WriteString("fun ")
+			out.WriteString(s.Name)
+			out.WriteByte('(')
+			for i, p := range params {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				out.WriteString(p.name)
+				if p.typ != "" {
+					out.WriteString(": ")
+					out.WriteString(p.typ)
+				}
+			}
+			out.WriteByte(')')
+			ret = mapCppType(ret)
+			if ret != "" && ret != "void" {
+				out.WriteString(": ")
+				out.WriteString(ret)
+			}
+			out.WriteString(" {}\n")
+		default:
+			if len(s.Children) > 0 {
+				writeCppSymbols(out, indent, s.Children, src, ls)
+			}
+		}
+	}
 }
 
 func parseCppDetail(detail *string) ([]string, string) {


### PR DESCRIPTION
## Summary
- extend the `any2mochi` C++ converter to process struct definitions and member functions
- ignore `using` directives when converting
- add golden outputs for `method` and `nested_types`

## Testing
- `go test ./tools/any2mochi/...`

------
https://chatgpt.com/codex/tasks/task_e_686936bb78688320bbb52563429b35bc