### PR TITLE
Improve Cobol converter

### DIFF
--- a/tools/any2mochi/convert_cobol.go
+++ b/tools/any2mochi/convert_cobol.go
@@ -50,29 +50,44 @@ func writeCobolSymbols(out *strings.Builder, ls LanguageServer, src string, pref
 				detail = *s.Detail
 			}
 			if detail == "" {
-				if d, _, err := HoverText(ls.Command, ls.Args, ls.LangID, src, s.SelectionRange.Start); err == nil {
-					detail = d
+				if hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, s.SelectionRange.Start); err == nil {
+					detail = hoverString(hov)
 				}
 			}
-			params := parseCobolParams(detail)
+			params, ret := parseCobolSignature(detail)
 
 			out.WriteString("fun ")
 			out.WriteString(strings.Join(nameParts, "."))
 			out.WriteByte('(')
 			if len(params) > 0 {
-				out.WriteString(strings.Join(params, ", "))
+				names := make([]string, len(params))
+				for i, p := range params {
+					names[i] = p.name
+				}
+				out.WriteString(strings.Join(names, ", "))
 			}
-			out.WriteString(") {}\n")
+			out.WriteByte(')')
+			if ret != "" && ret != "void" {
+				out.WriteString(": ")
+				out.WriteString(ret)
+			}
+			out.WriteString(" {}\n")
 
-		case protocol.SymbolKindVariable, protocol.SymbolKindConstant:
+		case protocol.SymbolKindVariable, protocol.SymbolKindConstant, protocol.SymbolKindField, protocol.SymbolKindProperty:
 			out.WriteString("var ")
 			out.WriteString(strings.Join(nameParts, "."))
 			out.WriteString(" = nil\n")
 
-		case protocol.SymbolKindClass, protocol.SymbolKindStruct, protocol.SymbolKindInterface:
+		case protocol.SymbolKindClass, protocol.SymbolKindStruct, protocol.SymbolKindInterface, protocol.SymbolKindEnum:
 			out.WriteString("type ")
 			out.WriteString(strings.Join(nameParts, "."))
 			out.WriteString(" {}\n")
+
+		case protocol.SymbolKindNamespace, protocol.SymbolKindPackage, protocol.SymbolKindModule:
+			if len(s.Children) > 0 {
+				writeCobolSymbols(out, ls, src, nameParts, s.Children)
+			}
+			continue
 		}
 
 		if len(s.Children) > 0 {
@@ -102,7 +117,44 @@ func parseCobolParams(detail string) []string {
 		name := fields[len(fields)-1]
 		name = strings.TrimSuffix(name, ".")
 		name = strings.TrimPrefix(name, "using")
+		name = strings.TrimPrefix(name, "by")
+		name = strings.TrimPrefix(name, "value")
+		name = strings.TrimPrefix(name, "reference")
 		params = append(params, name)
 	}
 	return params
+}
+
+type cobolParam struct{ name string }
+
+func parseCobolSignature(detail string) ([]cobolParam, string) {
+	params := parseCobolParams(detail)
+	ret := ""
+	lower := strings.ToLower(detail)
+	if idx := strings.Index(lower, "returning"); idx != -1 {
+		r := strings.TrimSpace(detail[idx+len("returning"):])
+		r = strings.TrimSuffix(r, ".")
+		if f := strings.Fields(r); len(f) > 0 {
+			ret = mapCobolType(f[0])
+		}
+	}
+	out := make([]cobolParam, len(params))
+	for i, p := range params {
+		out[i] = cobolParam{name: p}
+	}
+	return out, ret
+}
+
+func mapCobolType(t string) string {
+	t = strings.ToLower(t)
+	switch {
+	case strings.Contains(t, "9"):
+		return "int"
+	case strings.Contains(t, "x"), strings.Contains(t, "char"), strings.Contains(t, "string"):
+		return "string"
+	case strings.Contains(t, "comp-2"), strings.Contains(t, "float"), strings.Contains(t, "decimal"):
+		return "float"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
## Summary
- extend COBOL converter to fetch hover information
- support namespaces, fields and enums when generating Mochi code
- add basic parsing of COBOL signatures and return types

## Testing
- `go vet ./...`
- `go test ./tools/any2mochi -run TestConvertOther_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68693ad08c348320a628e984e6231322