### PR TITLE
Improve Go converter with LSP info

### DIFF
--- a/tools/any2mochi/convert_go.go
+++ b/tools/any2mochi/convert_go.go
@@ -1,7 +1,12 @@
 package any2mochi
 
 import (
+	"bytes"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
 	"os"
 	"strings"
 
@@ -22,7 +27,7 @@ func ConvertGo(src string) ([]byte, error) {
 		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
 	}
 	var out strings.Builder
-	writeGoSymbols(&out, nil, syms)
+	writeGoSymbols(&out, nil, syms, src, ls)
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
@@ -38,7 +43,7 @@ func ConvertGoFile(path string) ([]byte, error) {
 	return ConvertGo(string(data))
 }
 
-func writeGoSymbols(out *strings.Builder, prefix []string, syms []protocol.DocumentSymbol) {
+func writeGoSymbols(out *strings.Builder, prefix []string, syms []protocol.DocumentSymbol, src string, ls LanguageServer) {
 	for _, s := range syms {
 		nameParts := prefix
 		if s.Name != "" {
@@ -46,15 +51,26 @@ func writeGoSymbols(out *strings.Builder, prefix []string, syms []protocol.Docum
 		}
 		switch s.Kind {
 		case protocol.SymbolKindFunction, protocol.SymbolKindMethod:
+			params, ret := parseGoDetail(s.Detail)
+			if len(params) == 0 && ret == "" {
+				if hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, s.SelectionRange.Start); err == nil {
+					if mc, ok := hov.Contents.(protocol.MarkupContent); ok {
+						params, ret = parseGoDetail(&mc.Value)
+					}
+				}
+			}
 			out.WriteString("fun ")
 			out.WriteString(strings.Join(nameParts, "."))
-			params, ret := parseGoDetail(s.Detail)
 			out.WriteByte('(')
 			for i, p := range params {
 				if i > 0 {
 					out.WriteString(", ")
 				}
-				out.WriteString(p)
+				out.WriteString(p.name)
+				if p.typ != "" {
+					out.WriteString(": ")
+					out.WriteString(p.typ)
+				}
 			}
 			out.WriteByte(')')
 			if ret != "" && ret != "void" {
@@ -65,19 +81,56 @@ func writeGoSymbols(out *strings.Builder, prefix []string, syms []protocol.Docum
 		case protocol.SymbolKindStruct, protocol.SymbolKindClass, protocol.SymbolKindInterface:
 			out.WriteString("type ")
 			out.WriteString(strings.Join(nameParts, "."))
-			out.WriteString(" {}\n")
+			fields := []protocol.DocumentSymbol{}
+			rest := []protocol.DocumentSymbol{}
+			for _, c := range s.Children {
+				if c.Kind == protocol.SymbolKindField {
+					fields = append(fields, c)
+				} else {
+					rest = append(rest, c)
+				}
+			}
+			if len(fields) == 0 && len(rest) == 0 {
+				out.WriteString(" {}\n")
+			} else {
+				out.WriteString(" {\n")
+				for _, f := range fields {
+					out.WriteString("  ")
+					out.WriteString(f.Name)
+					if f.Detail != nil && strings.TrimSpace(*f.Detail) != "" {
+						out.WriteString(": ")
+						out.WriteString(strings.TrimSpace(*f.Detail))
+					}
+					out.WriteByte('\n')
+				}
+				out.WriteString("}\n")
+				if len(rest) > 0 {
+					writeGoSymbols(out, nameParts, rest, src, ls)
+				}
+			}
 		case protocol.SymbolKindVariable, protocol.SymbolKindConstant:
-			out.WriteString("let ")
-			out.WriteString(strings.Join(nameParts, "."))
-			out.WriteByte('\n')
+			if len(prefix) == 0 {
+				out.WriteString("let ")
+				out.WriteString(strings.Join(nameParts, "."))
+				if s.Detail != nil && strings.TrimSpace(*s.Detail) != "" {
+					out.WriteString(": ")
+					out.WriteString(strings.TrimSpace(*s.Detail))
+				}
+				out.WriteByte('\n')
+			}
+			if len(s.Children) > 0 {
+				writeGoSymbols(out, nameParts, s.Children, src, ls)
+			}
 		}
-		if len(s.Children) > 0 {
-			writeGoSymbols(out, nameParts, s.Children)
+		if len(s.Children) > 0 && s.Kind != protocol.SymbolKindStruct && s.Kind != protocol.SymbolKindClass && s.Kind != protocol.SymbolKindInterface && s.Kind != protocol.SymbolKindVariable && s.Kind != protocol.SymbolKindConstant {
+			writeGoSymbols(out, nameParts, s.Children, src, ls)
 		}
 	}
 }
 
-func parseGoDetail(detail *string) ([]string, string) {
+type goParam struct{ name, typ string }
+
+func parseGoDetail(detail *string) ([]goParam, string) {
 	if detail == nil {
 		return nil, ""
 	}
@@ -85,23 +138,41 @@ func parseGoDetail(detail *string) ([]string, string) {
 	if d == "" {
 		return nil, ""
 	}
-	open := strings.Index(d, "(")
-	close := strings.LastIndex(d, ")")
-	if open == -1 || close == -1 || close < open {
+	if !strings.HasPrefix(d, "func") {
 		return nil, strings.TrimSpace(d)
 	}
-	paramsPart := d[open+1 : close]
-	params := []string{}
-	for _, p := range strings.Split(paramsPart, ",") {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		fields := strings.Fields(p)
-		if len(fields) > 0 {
-			params = append(params, fields[0])
+	src := "package p\n" + d + "{}"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "src.go", src, 0)
+	if err != nil || len(file.Decls) == 0 {
+		return nil, ""
+	}
+	fn, ok := file.Decls[0].(*ast.FuncDecl)
+	if !ok {
+		return nil, ""
+	}
+	var params []goParam
+	if fn.Type.Params != nil {
+		for _, p := range fn.Type.Params.List {
+			typ := exprString(fset, p.Type)
+			if len(p.Names) == 0 {
+				params = append(params, goParam{"", typ})
+				continue
+			}
+			for _, n := range p.Names {
+				params = append(params, goParam{n.Name, typ})
+			}
 		}
 	}
-	ret := strings.TrimSpace(d[close+1:])
+	ret := ""
+	if fn.Type.Results != nil && len(fn.Type.Results.List) == 1 && len(fn.Type.Results.List[0].Names) == 0 {
+		ret = exprString(fset, fn.Type.Results.List[0].Type)
+	}
 	return params, ret
+}
+
+func exprString(fset *token.FileSet, e ast.Expr) string {
+	var b bytes.Buffer
+	printer.Fprint(&b, fset, e)
+	return b.String()
 }


### PR DESCRIPTION
## Summary
- enhance Go language converter in `any2mochi`
  - support field extraction for struct types
  - include variable types when available
  - fetch function signatures via hover when details are missing
  - parse signatures using Go parser to retain parameter types

## Testing
- `go vet ./tools/any2mochi/...`
- `go test ./tools/any2mochi -run ConvertGo -tags slow -count=1` *(fails: send on closed channel)*

------
https://chatgpt.com/codex/tasks/task_e_686949aba5908320944dfe37e0c00094