### PR TITLE
Improve TypeScript converter

### DIFF
--- a/tools/any2mochi/convert_typescript.go
+++ b/tools/any2mochi/convert_typescript.go
@@ -77,14 +77,18 @@ func writeTSSymbols(out *strings.Builder, prefix []string, syms []protocol.Docum
 			writeTSClass(out, nameParts, s, src, ls)
 		case protocol.SymbolKindVariable, protocol.SymbolKindConstant, protocol.SymbolKindField, protocol.SymbolKindProperty:
 			if s.Name != "" && len(prefix) == 0 {
-				typ := tsFieldType(src, s, ls)
-				out.WriteString("let ")
-				out.WriteString(s.Name)
-				if typ != "" {
-					out.WriteString(": ")
-					out.WriteString(typ)
+				if fields, alias := tsAliasDef(src, s, ls); len(fields) > 0 || alias != "" {
+					writeTSAlias(out, s.Name, fields, alias)
+				} else {
+					typ := tsFieldType(src, s, ls)
+					out.WriteString("let ")
+					out.WriteString(s.Name)
+					if typ != "" {
+						out.WriteString(": ")
+						out.WriteString(typ)
+					}
+					out.WriteByte('\n')
 				}
-				out.WriteByte('\n')
 			}
 		case protocol.SymbolKindFunction, protocol.SymbolKindMethod, protocol.SymbolKindConstructor:
 			writeTSFunc(out, strings.Join(nameParts, "."), s, src, ls)
@@ -194,6 +198,76 @@ func tsFieldType(src string, sym protocol.DocumentSymbol, ls LanguageServer) str
 	return ""
 }
 
+type tsField struct {
+	name string
+	typ  string
+}
+
+// tsAliasDef returns fields for a type alias object or the aliased type.
+// When neither can be determined it returns nil and empty string.
+func tsAliasDef(src string, sym protocol.DocumentSymbol, ls LanguageServer) ([]tsField, string) {
+	hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, sym.SelectionRange.Start)
+	if err != nil {
+		return nil, ""
+	}
+	if mc, ok := hov.Contents.(protocol.MarkupContent); ok {
+		lines := strings.Split(mc.Value, "\n")
+		reading := false
+		var fields []tsField
+		for _, l := range lines {
+			l = strings.TrimSpace(l)
+			if !reading {
+				if strings.HasPrefix(l, "type "+sym.Name) {
+					if idx := strings.Index(l, "="); idx != -1 {
+						after := strings.TrimSpace(l[idx+1:])
+						if strings.HasPrefix(after, "{") {
+							reading = true
+							continue
+						}
+						return nil, tsToMochiType(strings.TrimSuffix(after, ";"))
+					}
+				}
+			} else {
+				if strings.HasPrefix(l, "}") {
+					break
+				}
+				l = strings.TrimSuffix(l, ";")
+				if idx := strings.Index(l, ":"); idx != -1 {
+					name := strings.TrimSpace(l[:idx])
+					typ := tsToMochiType(strings.TrimSpace(l[idx+1:]))
+					fields = append(fields, tsField{name: name, typ: typ})
+				}
+			}
+		}
+		if len(fields) > 0 {
+			return fields, ""
+		}
+	}
+	return nil, ""
+}
+
+func writeTSAlias(out *strings.Builder, name string, fields []tsField, alias string) {
+	out.WriteString("type ")
+	out.WriteString(name)
+	if len(fields) == 0 {
+		out.WriteString(" = ")
+		out.WriteString(alias)
+		out.WriteByte('\n')
+		return
+	}
+	out.WriteString(" {\n")
+	for _, f := range fields {
+		out.WriteString("  ")
+		out.WriteString(f.name)
+		if f.typ != "" {
+			out.WriteString(": ")
+			out.WriteString(f.typ)
+		}
+		out.WriteByte('\n')
+	}
+	out.WriteString("}\n")
+}
+
 type tsParam struct {
 	name string
 	typ  string
@@ -257,6 +331,27 @@ func splitTSParams(s string) []string {
 
 func tsToMochiType(t string) string {
 	t = strings.TrimSpace(t)
+	if strings.Contains(t, "|") {
+		parts := strings.Split(t, "|")
+		var keep []string
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "null" || p == "undefined" {
+				continue
+			}
+			mp := tsToMochiType(p)
+			if mp != "" {
+				keep = append(keep, mp)
+			}
+		}
+		if len(keep) == 1 {
+			return keep[0]
+		}
+		if len(keep) > 1 {
+			return "any"
+		}
+		return ""
+	}
 	switch t {
 	case "", "any", "unknown", "object":
 		return ""
@@ -282,6 +377,24 @@ func tsToMochiType(t string) string {
 			inner = "any"
 		}
 		return "list<" + inner + ">"
+	}
+	if strings.HasPrefix(t, "Record<") && strings.HasSuffix(t, ">") {
+		parts := splitTSParams(t[len("Record<") : len(t)-1])
+		key := "any"
+		val := "any"
+		if len(parts) > 0 {
+			k := tsToMochiType(parts[0])
+			if k != "" {
+				key = k
+			}
+		}
+		if len(parts) > 1 {
+			v := tsToMochiType(parts[1])
+			if v != "" {
+				val = v
+			}
+		}
+		return "map<" + key + "," + val + ">"
 	}
 	return t
 }


### PR DESCRIPTION
## Summary
- extend any2mochi TypeScript support
- add detection of type aliases from hover info
- support Record and union types
- use type alias output when available

## Testing
- `go build ./tools/any2mochi`
- `go test ./tools/any2mochi -run TestParseTypeScript -count=1 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68694a2321ec832098f3b507b9dc3c73