### PR TITLE
Improve zig to mochi conversion

### DIFF
--- a/tests/any2mochi/zig/simple_fn.mochi
+++ b/tests/any2mochi/zig/simple_fn.mochi
@@ -1,3 +1,3 @@
-fun id(x): i32 {}
+fun id(x: int): int {}
 fun main() {}
 


### PR DESCRIPTION
## Summary
- extend Zig converter to use hover information for signatures
- parse parameter and return types
- add basic Zig type mapping
- update Zig golden file for any2mochi

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68694b47e6608320afee30fc4096626b