### PR TITLE
Add enum support for C++ conversion

### DIFF
--- a/tests/any2mochi/cpp/enum.mochi
+++ b/tests/any2mochi/cpp/enum.mochi
@@ -1,0 +1,7 @@
+type Color {
+  Red
+  Green
+  Blue
+}
+fun main(): int {}
+

--- a/tests/compiler/cpp/enum.cpp.out
+++ b/tests/compiler/cpp/enum.cpp.out
@@ -1,0 +1,2 @@
+enum Color { Red, Green, Blue };
+int main() { return 0; }


### PR DESCRIPTION
## Summary
- enhance C++ converter to handle enums and recover field types via hover
- map `bool` type and add fallback field type detection
- include cpp enum example

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68694c2f53148320b2652028c025f4ad