### PR TITLE
Enhance Clojure support

### DIFF
--- a/compile/x/clj/helpers.go
+++ b/compile/x/clj/helpers.go
@@ -347,6 +347,22 @@ func identName(e *parser.Expr) (string, bool) {
 	return "", false
 }
 
+// callPattern returns the call expression if e is a direct function call with no operators.
+func callPattern(e *parser.Expr) (*parser.CallExpr, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.Call == nil {
+		return nil, false
+	}
+	return p.Target.Call, true
+}
+
 // isListPushCall returns the variable name and argument if the expression is a
 // simple list.push(x) call.
 func isListPushCall(e *parser.Expr) (string, *parser.Expr, bool) {


### PR DESCRIPTION
## Summary
- improve Clojure converter to read more symbol kinds and fetch hover info when return type missing
- add callPattern helper for analysing match patterns
- extend Clojure backend match compilation with union variant support

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68694cc367e483209bc75bfcfc7cb6c5