### PR TITLE
Improve any2mochi Go hover parsing

### DIFF
--- a/tools/any2mochi/convert_go.go
+++ b/tools/any2mochi/convert_go.go
@@ -135,6 +135,14 @@ func parseGoDetail(detail *string) ([]goParam, string) {
 		return nil, ""
 	}
 	d := strings.TrimSpace(*detail)
+	if strings.HasPrefix(d, "```") {
+		d = strings.Trim(d, "`")
+		d = strings.TrimSpace(d)
+		if strings.HasPrefix(d, "go\n") {
+			d = strings.TrimPrefix(d, "go\n")
+			d = strings.TrimSpace(d)
+		}
+	}
 	if d == "" {
 		return nil, ""
 	}


### PR DESCRIPTION
## Summary
- trim Markdown code fences when parsing hover details in `any2mochi`

## Testing
- `go vet ./tools/any2mochi`
- `go test ./tools/any2mochi -run '^TestConvertGo$' -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68694d6315008320b065e2e58502ca37