### PR TITLE
Add Fortran conversion and compiler updates

### DIFF
--- a/compile/x/fortran/README.md
+++ b/compile/x/fortran/README.md
@@ -24,7 +24,7 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 - list operations: `union`, `union all`, `except` and `intersect` on integer, float and string lists
 - basic dataset queries with `from`/`where`/`select` and optional `skip`/`take`
 - struct types declared with `type` blocks and simple struct literals
-- built-ins: `len`, `append`, `count`, `avg`, `str`, `now`
+ - built-ins: `len`, `append`, `count`, `avg`, `str`, `abs`, `now`
 - printing via `print()`
 - `package` and `export` declarations (ignored during code generation)
 - `import` statements emit Fortran `include` lines

--- a/compile/x/fortran/compiler.go
+++ b/compile/x/fortran/compiler.go
@@ -1472,6 +1472,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr, recv string) (string, 
 		}
 		c.needsStrInt = true
 		return fmt.Sprintf("str_int(%s)", args[0]), nil
+	case "abs":
+		if len(args) != 1 {
+			return "", fmt.Errorf("abs expects 1 arg")
+		}
+		return fmt.Sprintf("abs(%s)", args[0]), nil
 	case "avg":
 		if len(args) != 1 {
 			return "", fmt.Errorf("avg expects 1 arg")

--- a/tools/any2mochi/convert_fortran.go
+++ b/tools/any2mochi/convert_fortran.go
@@ -9,6 +9,8 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
+type ftParam struct{ name, typ string }
+
 // ConvertFortran converts Fortran source code to a minimal Mochi representation
 // using the fortls language server.
 func ConvertFortran(src string) ([]byte, error) {
@@ -25,7 +27,7 @@ func convertFortran(src, root string) ([]byte, error) {
 		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
 	}
 	var out strings.Builder
-	writeFtSymbols(&out, nil, syms)
+	writeFtSymbols(&out, nil, syms, src, ls, root)
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
@@ -41,7 +43,82 @@ func ConvertFortranFile(path string) ([]byte, error) {
 	return convertFortran(string(data), filepath.Dir(path))
 }
 
-func writeFtSymbols(out *strings.Builder, prefix []string, syms []protocol.DocumentSymbol) {
+func getFtSignatureWithRoot(src string, pos protocol.Position, ls LanguageServer, root string) ([]ftParam, string) {
+	hov, err := EnsureAndHoverWithRoot(ls.Command, ls.Args, ls.LangID, src, pos, root)
+	if err != nil {
+		return nil, ""
+	}
+	mc, ok := hov.Contents.(protocol.MarkupContent)
+	if !ok {
+		return nil, ""
+	}
+	return parseFtSignature(mc.Value)
+}
+
+func parseFtSignature(sig string) ([]ftParam, string) {
+	lines := strings.Split(sig, "\n")
+	if len(lines) == 0 {
+		return nil, ""
+	}
+	first := strings.TrimSpace(lines[0])
+	lower := strings.ToLower(first)
+	open := strings.Index(first, "(")
+	close := strings.LastIndex(first, ")")
+	paramsPart := ""
+	if open != -1 && close != -1 && close > open {
+		paramsPart = first[open+1 : close]
+	}
+	ret := ""
+	if idx := strings.Index(lower, "function"); idx != -1 {
+		typ := strings.TrimSpace(first[:idx])
+		ret = mapFtType(typ)
+	}
+	var params []ftParam
+	if paramsPart != "" {
+		for _, p := range strings.Split(paramsPart, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				params = append(params, ftParam{name: p})
+			}
+		}
+	}
+	for _, line := range lines[1:] {
+		line = strings.TrimSpace(line)
+		idx := strings.Index(line, "::")
+		if idx == -1 {
+			continue
+		}
+		names := strings.Split(line[idx+2:], ",")
+		typ := mapFtType(strings.TrimSpace(line[:idx]))
+		for _, n := range names {
+			n = strings.TrimSpace(n)
+			for i := range params {
+				if params[i].name == n {
+					params[i].typ = typ
+				}
+			}
+		}
+	}
+	return params, ret
+}
+
+func mapFtType(t string) string {
+	t = strings.ToLower(t)
+	switch {
+	case strings.Contains(t, "real"):
+		return "float"
+	case strings.Contains(t, "integer"):
+		return "int"
+	case strings.Contains(t, "character"):
+		return "string"
+	case strings.Contains(t, "logical"):
+		return "bool"
+	default:
+		return ""
+	}
+}
+
+func writeFtSymbols(out *strings.Builder, prefix []string, syms []protocol.DocumentSymbol, src string, ls LanguageServer, root string) {
 	for _, s := range syms {
 		nameParts := prefix
 		if s.Name != "" {
@@ -51,10 +128,27 @@ func writeFtSymbols(out *strings.Builder, prefix []string, syms []protocol.Docum
 		case protocol.SymbolKindModule, protocol.SymbolKindFunction:
 			out.WriteString("fun ")
 			out.WriteString(strings.Join(nameParts, "."))
-			out.WriteString("() {}\n")
+			params, ret := getFtSignatureWithRoot(src, s.SelectionRange.Start, ls, root)
+			out.WriteByte('(')
+			for i, p := range params {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				out.WriteString(p.name)
+				if p.typ != "" {
+					out.WriteString(": ")
+					out.WriteString(p.typ)
+				}
+			}
+			out.WriteByte(')')
+			if ret != "" {
+				out.WriteString(": ")
+				out.WriteString(ret)
+			}
+			out.WriteString(" {}\n")
 		}
 		if len(s.Children) > 0 {
-			writeFtSymbols(out, nameParts, s.Children)
+			writeFtSymbols(out, nameParts, s.Children, src, ls, root)
 		}
 	}
 }

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- enhance Fortran any2mochi conversion using hover data
- fix LSP initialization variable shadowing
- add `abs` builtin for Fortran compiler
- document new builtin in Fortran backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68694e7c1390832089661f543936276c