### PR TITLE
Improve Haskell converter and compiler

### DIFF
--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- extend Haskell converter to process structs, variables and nested symbols
- improve haskell type parsing helpers
- support union types in Haskell backend compiler
- fix variable shadowing in LSP init routine

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68694ec827308320b4d9b4ae17c791da