### PR TITLE
Improve Kotlin support

### DIFF
--- a/compile/x/kt/compiler.go
+++ b/compile/x/kt/compiler.go
@@ -1903,7 +1903,7 @@ func ktUnpackArgs(names []string, indent string, env *types.Env) string {
 			if t, err := env.GetVar(n); err == nil {
 				switch tt := t.(type) {
 				case types.MapType:
-					b.WriteString(" as MutableMap<" + ktType(tt.Key) + ", " + ktType(tt.Value) + ">")
+					b.WriteString(" as Map<" + ktType(tt.Key) + ", " + ktType(tt.Value) + ">")
 				case types.ListType:
 					b.WriteString(" as List<" + ktType(tt.Elem) + ">")
 				case types.StructType, types.UnionType:

--- a/tools/any2mochi/convert_kt.go
+++ b/tools/any2mochi/convert_kt.go
@@ -44,7 +44,11 @@ func writeKtSymbols(out *strings.Builder, prefix []string, syms []protocol.Docum
 			nameParts = append(nameParts, s.Name)
 		}
 		switch s.Kind {
-		case protocol.SymbolKindClass, protocol.SymbolKindStruct, protocol.SymbolKindInterface:
+		case protocol.SymbolKindNamespace, protocol.SymbolKindPackage, protocol.SymbolKindModule:
+			if len(s.Children) > 0 {
+				writeKtSymbols(out, nameParts, s.Children, src, ls)
+			}
+		case protocol.SymbolKindClass, protocol.SymbolKindStruct, protocol.SymbolKindInterface, protocol.SymbolKindObject:
 			out.WriteString("type ")
 			out.WriteString(strings.Join(nameParts, "."))
 			fields := []protocol.DocumentSymbol{}

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- fix root URI initialization in any2mochi parse helper
- allow `any2mochi` Kotlin converter to traverse package namespaces
- cast query arguments to typed `Map` in Kotlin backend

## Testing
- `go vet ./...`
- `go test ./compile/x/kt -run TestKTCompiler_JOBQ1 -tags slow -count=1` *(fails: unresolved references)*

------
https://chatgpt.com/codex/tasks/task_e_68694f29af8c8320bbc13b2c67312d72