### PR TITLE
Improve C language support

### DIFF
--- a/compile/x/c/compiler.go
+++ b/compile/x/c/compiler.go
@@ -1764,7 +1764,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) string {
 				name := c.newTemp()
 				if isStr {
 					c.need(needStringHeader)
-					c.writeln(fmt.Sprintf("char* %s = ({ int _len = strlen(%s); int _s = %s; int _e = %s; if (_s < 0) _s += _len; if (_e < 0) _e += _len; if (_s < 0) _s = 0; if (_e > _len) _e = _len; if (_s > _e) _s = _e; char* _b = (char*)malloc(_e - _s + 1); memcpy(_b, %s + _s, _e - _s); _b[_e - _s] = '\\0'; _b; });", name, expr, start, end, expr))
+					c.need(needSliceString)
+					c.writeln(fmt.Sprintf("char* %s = slice_string(%s, %s, %s);", name, expr, start, end))
 					if c.env != nil {
 						c.env.SetVar(name, types.StringType{}, true)
 					}

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- enhance C converter to use hover for missing info
- generate enums and variables when converting C
- use helper for string slicing in C backend
- fix LSP initialization regression

## Testing
- `go build ./tools/any2mochi`
- `go build ./compile/x/c`

------
https://chatgpt.com/codex/tasks/task_e_68694f77090c8320a3894b97994f86b4