### PR TITLE
Add features for Ruby converter and runtime

### DIFF
--- a/compile/x/rb/compiler.go
+++ b/compile/x/rb/compiler.go
@@ -1645,6 +1645,18 @@ func (c *Compiler) compileBuiltinCall(name string, args []string, origArgs []*pa
 		}
 		c.use("_reverse")
 		return fmt.Sprintf("_reverse(%s)", args[0]), true, nil
+	case "split":
+		if len(args) != 2 {
+			return "", true, fmt.Errorf("split expects 2 args")
+		}
+		c.use("_splitString")
+		return fmt.Sprintf("_splitString(%s, %s)", args[0], args[1]), true, nil
+	case "join":
+		if len(args) != 2 {
+			return "", true, fmt.Errorf("join expects 2 args")
+		}
+		c.use("_joinStrings")
+		return fmt.Sprintf("_joinStrings(%s, %s)", args[0], args[1]), true, nil
 	case "str":
 		if len(args) != 1 {
 			return "", true, fmt.Errorf("str expects 1 arg")
@@ -1677,23 +1689,23 @@ func (c *Compiler) compileBuiltinCall(name string, args []string, origArgs []*pa
 		}
 		c.use("_min")
 		return fmt.Sprintf("_min(%s)", args[0]), true, nil
-        case "max":
-                if len(args) != 1 {
-                        return "", true, fmt.Errorf("max expects 1 arg")
-                }
-                c.use("_max")
-                return fmt.Sprintf("_max(%s)", args[0]), true, nil
-       case "first":
-               if len(args) != 1 {
-                       return "", true, fmt.Errorf("first expects 1 arg")
-               }
-               c.use("_first")
-               return fmt.Sprintf("_first(%s)", args[0]), true, nil
-        case "json":
-                if len(args) != 1 {
-                        return "", true, fmt.Errorf("json expects 1 arg")
-                }
-                c.use("_json")
+	case "max":
+		if len(args) != 1 {
+			return "", true, fmt.Errorf("max expects 1 arg")
+		}
+		c.use("_max")
+		return fmt.Sprintf("_max(%s)", args[0]), true, nil
+	case "first":
+		if len(args) != 1 {
+			return "", true, fmt.Errorf("first expects 1 arg")
+		}
+		c.use("_first")
+		return fmt.Sprintf("_first(%s)", args[0]), true, nil
+	case "json":
+		if len(args) != 1 {
+			return "", true, fmt.Errorf("json expects 1 arg")
+		}
+		c.use("_json")
 		return fmt.Sprintf("_json(%s)", args[0]), true, nil
 	case "input":
 		if len(args) != 0 {

--- a/compile/x/rb/runtime.go
+++ b/compile/x/rb/runtime.go
@@ -205,7 +205,7 @@ end`
   list.min
 end`
 
-        helperMax = `def _max(v)
+	helperMax = `def _max(v)
   list = nil
   if v.respond_to?(:Items)
     list = v.Items
@@ -218,7 +218,7 @@ end`
   list.max
 end`
 
-       helperFirst = `def _first(v)
+	helperFirst = `def _first(v)
   list = nil
   if v.respond_to?(:Items)
     list = v.Items
@@ -264,6 +264,16 @@ end`
   else
     raise 'reverse expects list or string'
   end
+end`
+
+	helperSplitString = `def _splitString(s, sep)
+  raise 'split expects string' unless s.is_a?(String)
+  s.split(sep)
+end`
+
+	helperJoinStrings = `def _joinStrings(parts, sep)
+  raise 'join expects list' unless parts.is_a?(Array)
+  parts.map(&:to_s).join(sep)
 end`
 
 	helperGroup = `class MGroup
@@ -432,9 +442,9 @@ var helperMap = map[string]string{
 	"_genStruct":   helperGenStruct,
 	"_json":        helperJSON,
 	"_min":         helperMin,
-       "_max":         helperMax,
-       "_first":       helperFirst,
-       "_sum":         helperSum,
+	"_max":         helperMax,
+	"_first":       helperFirst,
+	"_sum":         helperSum,
 	"_eval":        helperEval,
 	"_group":       helperGroup,
 	"_group_by":    helperGroupBy,
@@ -442,6 +452,8 @@ var helperMap = map[string]string{
 	"_indexString": helperIndexString,
 	"_sliceString": helperSliceString,
 	"_reverse":     helperReverse,
+	"_splitString": helperSplitString,
+	"_joinStrings": helperJoinStrings,
 }
 
 func (c *Compiler) use(name string) { c.helpers[name] = true }

--- a/tests/any2mochi/rb/fibonacci.mochi
+++ b/tests/any2mochi/rb/fibonacci.mochi
@@ -1,0 +1,9 @@
+fun fib(n) {
+  if n <= 1 {
+    return n
+  }
+  (fib(n - 1) + fib(n - 2))
+}
+print(fib(0))
+print(fib(1))
+print(fib(6))

--- a/tools/any2mochi/convert_rb.go
+++ b/tools/any2mochi/convert_rb.go
@@ -72,6 +72,29 @@ func translateRb(src string) []byte {
 			out.WriteString(cond)
 			out.WriteString(" {\n")
 			level++
+		case strings.HasPrefix(line, "if "):
+			cond := strings.TrimSpace(strings.TrimPrefix(line, "if "))
+			out.WriteString(rbIndent(level))
+			out.WriteString("if ")
+			out.WriteString(cond)
+			out.WriteString(" {\n")
+			level++
+		case strings.HasPrefix(line, "elsif "):
+			if level > 0 {
+				level--
+				out.WriteString(rbIndent(level))
+				out.WriteString("} else if ")
+				out.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "elsif ")))
+				out.WriteString(" {\n")
+				level++
+			}
+		case line == "else":
+			if level > 0 {
+				level--
+				out.WriteString(rbIndent(level))
+				out.WriteString("} else {\n")
+				level++
+			}
 		case line == "end":
 			if level > 0 {
 				level--
@@ -94,6 +117,13 @@ func translateRb(src string) []byte {
 			out.WriteString("(")
 			out.WriteString(params)
 			out.WriteString(") {\n")
+			level++
+		case strings.HasPrefix(line, "class "):
+			name := strings.TrimSpace(strings.TrimPrefix(line, "class "))
+			out.WriteString(rbIndent(level))
+			out.WriteString("type ")
+			out.WriteString(name)
+			out.WriteString(" {\n")
 			level++
 		case strings.HasPrefix(line, "return "):
 			out.WriteString(rbIndent(level))

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- handle `if`/`else`/`elsif` and class definitions in Ruby converter
- add `split` and `join` helpers to Ruby runtime and compiler
- fix language server initialisation helper
- add Fibonacci golden file for Ruby converter tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869508c6b0c8320b01a116ba55c0cae