### PR TITLE
Improve Scheme converter in any2mochi

### DIFF
--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- extend Scheme conversion using LSP hover info
- support struct/class symbols
- capture function return types
- fix variable shadowing in LSP helper

## Testing
- `go build ./tools/any2mochi`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686951596bb8832083787c9c7b3370b2