### PR TITLE
Implement smalltalk union variants

### DIFF
--- a/compile/x/st/compiler.go
+++ b/compile/x/st/compiler.go
@@ -256,7 +256,30 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 
 func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 	if len(t.Variants) > 0 {
-		// union types not yet supported
+		c.writeln("!Main class methodsFor: 'types'!")
+		for _, v := range t.Variants {
+			fields := make([]string, len(v.Fields))
+			for i, f := range v.Fields {
+				fields[i] = f.Name
+			}
+			header := "new" + v.Name
+			if len(fields) > 0 {
+				header += ": " + fields[0]
+				for _, f := range fields[1:] {
+					header += " " + f + ": " + f
+				}
+			}
+			c.writeln(header + " | dict |")
+			c.indent++
+			c.writeln("dict := Dictionary new.")
+			c.writeln(fmt.Sprintf("dict at: '__name' put: '%s'.", v.Name))
+			for _, f := range fields {
+				c.writeln(fmt.Sprintf("dict at: '%s' put: %s.", f, f))
+			}
+			c.writeln("^ dict")
+			c.indent--
+			c.writelnNoIndent("!")
+		}
 		return nil
 	}
 	fields := make([]string, 0, len(t.Members))

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- fix initializeWithRoot shadowed variable
- implement Smalltalk union constructors

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6869519025f88320b1e68c516b7856c5