### PR TITLE
Improve Zig support

### DIFF
--- a/compile/x/zig/compiler.go
+++ b/compile/x/zig/compiler.go
@@ -1652,6 +1652,13 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		return fmt.Sprintf("std.math.sqrt(%s)", arg), nil
 	}
+	if name == "abs" && len(call.Args) == 1 {
+		arg, err := c.compileExpr(call.Args[0], false)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("std.math.abs(%s)", arg), nil
+	}
 	if name == "lower" && len(call.Args) == 1 {
 		arg, err := c.compileExpr(call.Args[0], false)
 		if err != nil {

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{


### PR DESCRIPTION
## Summary
- enhance `ConvertZig` to walk all symbols via `writeZigSymbols`
- output Zig structs and variables when converting to Mochi
- add `abs` builtin handling in Zig compiler
- fix language server initialization bug

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869527189288320af99f5d3670f83ef