### PR TITLE
Improve Python type mapping

### DIFF
--- a/compile/py/README.md
+++ b/compile/py/README.md
@@ -117,6 +117,16 @@ func EnsurePython() error {
 ```
 【F:compile/py/tools.go†L10-L42】
 
+## Supported Features
+
+The Python backend supports a large subset of Mochi. Highlights include:
+
+- Functions and variables with type inference
+- Classes with fields and methods (rendered as dataclasses)
+- Dataset queries and list/map operations
+- Stream handlers and agents with asynchronous execution
+- LLM helpers such as `gen_text` and `fetch`
+
 ## Unsupported Features
 
 The Python backend does not yet implement every language feature. Known


### PR DESCRIPTION
## Summary
- map Python collection and union types when converting to Mochi
- document supported features for the Python backend

## Testing
- `go test ./tools/any2mochi -run TestConvertPython$ -count=1 -tags slow`
- `go test ./tools/any2mochi -run ConvertPython_Golden -count=1 -tags slow` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686955c44ac08320829b7b0f236f5799