### PR TITLE
Enhance Haskell conversion support

### DIFF
--- a/compile/x/hs/README.md
+++ b/compile/x/hs/README.md
@@ -30,6 +30,7 @@ The backend implements a small but practical subset of Mochi:
 - Lists and maps with literals, indexing and membership
 - Builtin helpers: `len`, `count`, `avg`, `str`, `push`, `keys`, `print`, `input`, `now`, `json`, `load` and `save`
 - User-defined struct types and literals
+- Enum type declarations
 - Dataset queries with `from`/`where`, sorting, skipping and taking
 - Grouped dataset queries with aggregates like `tpc-h/q1.mochi`
 - Test blocks with `expect` statements

--- a/tools/any2mochi/cmd/any2mochi/main.go
+++ b/tools/any2mochi/cmd/any2mochi/main.go
@@ -109,6 +109,27 @@ func convertRustCmd() *cobra.Command {
 	return cmd
 }
 
+func convertHsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-hs <file.hs>",
+		Short: "Convert Haskell source to Mochi",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			out, err := any2mochi.ConvertHs(string(data))
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	return cmd
+}
+
 func convertPythonCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert-py <file.py>",
@@ -256,6 +277,7 @@ func newRootCmd() *cobra.Command {
 		convertGoCmd(),
 		convertRustCmd(),
 		convertPythonCmd(),
+		convertHsCmd(),
 		convertTSCmd(),
 		convertCmd(),
 	)

--- a/tools/any2mochi/server.go
+++ b/tools/any2mochi/server.go
@@ -37,9 +37,9 @@ var Servers = map[string]LanguageServer{
 	"mlir":       {Command: "mlir-lsp-server", Args: nil, LangID: "mlir"},
 	"ocaml":      {Command: "ocamllsp", Args: nil, LangID: "ocaml"},
 	"pas":        {Command: "pasls", Args: nil, LangID: "pascal"},
-        "php":        {Command: "intelephense", Args: []string{"--stdio"}, LangID: "php"},
-       "prolog":     {Command: "prolog-lsp", Args: nil, LangID: "prolog"},
-        "pl":         {Command: "perlls", Args: nil, LangID: "perl"},
+	"php":        {Command: "intelephense", Args: []string{"--stdio"}, LangID: "php"},
+	"prolog":     {Command: "prolog-lsp", Args: nil, LangID: "prolog"},
+	"pl":         {Command: "perlls", Args: nil, LangID: "perl"},
 	"rb":         {Command: "solargraph", Args: []string{"stdio"}, LangID: "ruby"},
 	"rkt":        {Command: "racket-langserver", Args: nil, LangID: "racket"},
 	"rust":       {Command: "rust-analyzer", Args: nil, LangID: "rust"},
@@ -64,6 +64,38 @@ func EnsureServer(name string) error {
 	if name == "rust-analyzer" {
 		if _, err := exec.LookPath("rustup"); err == nil {
 			cmd := exec.Command("rustup", "component", "add", "rust-analyzer")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath(name); err == nil {
+				return nil
+			}
+		}
+	} else if name == "haskell-language-server-wrapper" {
+		if _, err := exec.LookPath("ghcup"); err == nil {
+			cmd := exec.Command("ghcup", "install", "hls")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath(name); err == nil {
+				return nil
+			}
+		}
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			cmd = exec.Command("apt-get", "install", "-y", "haskell-language-server")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath(name); err == nil {
+				return nil
+			}
+		}
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "haskell-language-server")
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()


### PR DESCRIPTION
## Summary
- add `convert-hs` command to `any2mochi`
- improve Haskell conversion: handle modules, enums and detect field types via hover
- ensure Haskell LSP installation via `ghcup`, `apt-get` or `brew`
- document enum support in Haskell backend README

## Testing
- `go run ./tools/any2mochi/cmd/any2mochi --help | grep hs`
- `go run ./tools/any2mochi/cmd/any2mochi convert-hs tests/compiler/hs/hello_world.hs.out` *(fails: Haskell-Language-Server-Wrapper not found)*


------
https://chatgpt.com/codex/tasks/task_e_686955f63f008320a1f827a1db506e0a