### PR TITLE
Improve Kotlin any2mochi converter

### DIFF
--- a/compile/x/kt/README.md
+++ b/compile/x/kt/README.md
@@ -21,6 +21,8 @@ The Kotlin backend converts Mochi programs into Kotlin source files so they can 
 - Extern variables, functions and objects via `ExternRegistry`
 - True 64-bit integers using Kotlin `Long`
 - Map literals, indexing, membership checks with `in`, and iteration over keys in `for` loops
+- Kotlin to Mochi converter uses LSP data to extract functions, classes and
+  properties including parameter and return types
 
 ## Unsupported Features
 
@@ -45,6 +47,7 @@ The Kotlin backend still lacks several features available in other compilers:
 - Asynchronous functions (`async`/`await`)
 - Waiting for asynchronous stream handlers with `_waitAll`
 - Destructuring bindings in `let` and `var` statements
+- The Kotlin to Mochi converter does not translate function bodies or generics
 
 ## Building
 


### PR DESCRIPTION
## Summary
- enhance Kotlin to Mochi converter to read parameter and field types via LSP
- extend type mapping for nullable, map and generic types
- document Kotlin converter in backend README

## Testing
- `go vet ./...`
- `go test -tags slow ./tools/any2mochi -run TestConvertOther_Golden -count=1 -timeout 30s` *(fails: asm-lsp not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695659a4408320b6f17387c47cb498