### PR TITLE
Add C# definition support

### DIFF
--- a/compile/x/cs/README.md
+++ b/compile/x/cs/README.md
@@ -163,6 +163,7 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Sorting and pagination with joins
 - Set operations on lists: `union`, `union all`, `except`, `intersect`
 - Built‑ins `print`, `len`, `count`, `avg`, `now` and `json`
+- C# collections like `IEnumerable<T>` and `ICollection<T>` map to Mochi `list<T>`
 - HTTP requests using `fetch`
 - Dataset helpers `_load` and `_save` supporting CSV, TSV, JSON, JSONL and YAML
 - Package declarations and imports

--- a/tools/any2mochi/lsp.go
+++ b/tools/any2mochi/lsp.go
@@ -41,6 +41,23 @@ func EnsureAndHoverWithRoot(cmd string, args []string, langID, src string, pos p
 	return hov, err
 }
 
+// EnsureAndDefinition runs DefinitionAt after ensuring the language server is installed.
+func EnsureAndDefinition(cmd string, args []string, langID, src string, pos protocol.Position) ([]protocol.Location, error) {
+	return EnsureAndDefinitionWithRoot(cmd, args, langID, src, pos, "")
+}
+
+// EnsureAndDefinitionWithRoot runs DefinitionAtWithRoot after ensuring the language server is installed.
+func EnsureAndDefinitionWithRoot(cmd string, args []string, langID, src string, pos protocol.Position, root string) ([]protocol.Location, error) {
+	if err := EnsureServer(cmd); err != nil {
+		return nil, err
+	}
+	locs, err := DefinitionAtWithRoot(cmd, args, langID, src, pos, root)
+	if err != nil {
+		err = fmt.Errorf("definition failure: %w\n\nsource snippet:\n%s", err, numberedSnippet(src))
+	}
+	return locs, err
+}
+
 func numberedSnippet(src string) string {
 	lines := strings.Split(src, "\n")
 	if len(lines) > 10 {

--- a/tools/any2mochi/parse.go
+++ b/tools/any2mochi/parse.go
@@ -143,10 +143,10 @@ func (c *client) initialize(ctx context.Context) error {
 func (c *client) initializeWithRoot(ctx context.Context, root string) error {
 	hierarchical := true
 	pid := protocol.Integer(os.Getpid())
-	root := protocol.DocumentUri("file:///")
+	rootURI := protocol.DocumentUri("file:///")
 	params := protocol.InitializeParams{
 		ProcessID: &pid,
-		RootURI:   &root,
+		RootURI:   &rootURI,
 		Capabilities: protocol.ClientCapabilities{
 			TextDocument: &protocol.TextDocumentClientCapabilities{
 				DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{
@@ -350,6 +350,97 @@ func HoverTextWithRoot(cmdName string, args []string, langID string, src string,
 	c.mu.Unlock()
 
 	return hoverString(hover), diags, nil
+}
+
+// DefinitionAt opens a language server and returns definition locations for the
+// specified position in the source.
+func DefinitionAt(cmdName string, args []string, langID string, src string, pos protocol.Position) ([]protocol.Location, error) {
+	return DefinitionAtWithRoot(cmdName, args, langID, src, pos, "")
+}
+
+// DefinitionAtWithRoot is like DefinitionAt but allows specifying a workspace root.
+func DefinitionAtWithRoot(cmdName string, args []string, langID string, src string, pos protocol.Position, root string) ([]protocol.Location, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, cmdName, args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	stream := jsonrpc2.NewBufferedStream(&pipe{r: stdout, w: stdin}, jsonrpc2.VSCodeObjectCodec{})
+	c := &client{cmd: cmd}
+	conn := jsonrpc2.NewConn(ctx, stream, jsonrpc2.HandlerWithError(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
+		return nil, nil
+	}))
+	c.conn = conn
+
+	if err := c.initializeWithRoot(ctx, root); err != nil {
+		c.Close()
+		return nil, err
+	}
+	var uri protocol.DocumentUri
+	if root != "" {
+		abs, _ := filepath.Abs(root)
+		ext := ""
+		switch langID {
+		case "fortran":
+			ext = ".f90"
+		case "c":
+			ext = ".c"
+		case "cpp":
+			ext = ".cpp"
+		case "python":
+			ext = ".py"
+		case "typescript":
+			ext = ".ts"
+		case "cs":
+			ext = ".cs"
+		}
+		uri = protocol.DocumentUri("file://" + filepath.ToSlash(filepath.Join(abs, "input"+ext)))
+	} else {
+		uri = protocol.DocumentUri("file:///input")
+	}
+	if err := c.conn.Notify(ctx, "textDocument/didOpen", protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: uri, LanguageID: langID, Version: 1, Text: src},
+	}); err != nil {
+		c.Close()
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := c.conn.Call(ctx, "textDocument/definition", protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position:     pos,
+	}, &raw); err != nil {
+		c.Close()
+		return nil, err
+	}
+	c.Close()
+
+	var locs []protocol.Location
+	if err := json.Unmarshal(raw, &locs); err == nil {
+		return locs, nil
+	}
+	var loc protocol.Location
+	if err := json.Unmarshal(raw, &loc); err == nil {
+		return []protocol.Location{loc}, nil
+	}
+	var links []protocol.LocationLink
+	if err := json.Unmarshal(raw, &links); err == nil {
+		for _, l := range links {
+			locs = append(locs, protocol.Location{URI: l.TargetURI, Range: l.TargetRange})
+		}
+		return locs, nil
+	}
+	return nil, fmt.Errorf("unexpected definition response")
 }
 
 func hoverString(h protocol.Hover) string {


### PR DESCRIPTION
## Summary
- improve C# type mapping for `ICollection<T>`/`IEnumerable<T>`/`IReadOnlyList<T>`
- gather field types with `textDocument/definition`
- expose `DefinitionAt` helper
- document collection mapping in C# backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686952d1453c8320bbf1458aa1caa1bf