### PR TITLE
Enhance OCaml LSP converter

### DIFF
--- a/compile/x/ocaml/README.md
+++ b/compile/x/ocaml/README.md
@@ -41,6 +41,7 @@ mochi build --target ocaml main.mochi -o main.ml
 - dataset queries with `from`/`where`/`select` and optional `skip`, `take` and `sort by`
 - `fetch`, `load` and `save` expressions
 - test blocks and `expect` statements
+- struct and enum type declarations
 
 
 The output can be compiled with `ocamlc`:
@@ -72,7 +73,6 @@ These tests verify both the generated program output and the emitted `.ml` code.
  - Partial dataset queries (joins and grouping not implemented)
 - Comprehensive pattern matching and union types
 - Modules and `import` declarations
-- Struct and enum type declarations
 - `generate` expressions
 - Agent and model blocks
 - Concurrency primitives like `spawn` and channels


### PR DESCRIPTION
## Summary
- improve OCaml conversion to walk nested symbols and support record types
- update OCaml backend docs

## Testing
- `go vet ./...`
- `go test ./tools/any2mochi -run TestConvertOther_Golden -update -tags slow` *(fails: ocamllsp missing)*

------
https://chatgpt.com/codex/tasks/task_e_686956f46ccc83209fecb709280a8ee1