### PR TITLE
Improve PHP converter

### DIFF
--- a/compile/x/php/README.md
+++ b/compile/x/php/README.md
@@ -16,6 +16,7 @@ php main.php
 The PHP compiler implements a subset of Mochi including:
 
 - variable declarations and assignments
+- top-level variables and constants
 - `if`, `for`, `while` and range loops
 - functions and closures
 - lists and maps with indexing and updates

--- a/tools/any2mochi/convert_php.go
+++ b/tools/any2mochi/convert_php.go
@@ -107,7 +107,14 @@ func appendPhpSymbols(out *strings.Builder, prefix []string, syms []protocol.Doc
 				}
 			}
 		case protocol.SymbolKindVariable, protocol.SymbolKindConstant:
-			// ignore local variables
+			if len(prefix) == 0 {
+				name := strings.TrimPrefix(s.Name, "$")
+				typ := phpFieldType(src, s.SelectionRange.Start, ls)
+				if typ == "" {
+					typ = "any"
+				}
+				fmt.Fprintf(out, "let %s: %s\n", name, typ)
+			}
 		default:
 			if len(s.Children) > 0 {
 				appendPhpSymbols(out, nameParts, s.Children, src, ls)


### PR DESCRIPTION
## Summary
- handle global variables and constants when converting PHP to Mochi
- document PHP backend support for top-level variables in README

## Testing
- `go test ./tools/any2mochi -run TestConvertOther_Golden/ -count=1 -tags slow` *(fails: unable to install asm-lsp)*

------
https://chatgpt.com/codex/tasks/task_e_68695759049083209bcfeef6d9a2a091