### PR TITLE
Improve Racket conversion and backend

### DIFF
--- a/compile/x/rkt/README.md
+++ b/compile/x/rkt/README.md
@@ -38,7 +38,7 @@ go test ./compile/rkt -tags slow
 - Slice assignments, including multi-dimensional slices like `xs[0:1][1:2] = sub`
 - Negative indexing and slicing for strings and lists
 - Dataset queries with filtering via `where`, sorting, pagination with
-  `skip`/`take`, and simple `group by` clauses
+  `skip`/`take`, `distinct` results and simple `group by` clauses
 - Simple `struct` type declarations
 - Iteration over map keys
 - Function definitions and calls

--- a/compile/x/rkt/compiler.go
+++ b/compile/x/rkt/compiler.go
@@ -61,6 +61,9 @@ const datasetHelpers = `(define (_fetch url opts)
       (set! order (append order (list ks))))
     (set-_Group-Items! g (append (_Group-Items g) (list it))))
   (for/list ([ks order]) (hash-ref groups ks)))
+
+(define (_distinct xs)
+  (remove-duplicates xs))
 `
 
 const setOpsHelpers = `(define (union-all a b) (append (list->list a) (list->list b)))
@@ -1298,6 +1301,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			return "", err
 		}
 		var sortExpr, skipExpr, takeExpr string
+		distinct := q.Distinct
 		if q.Sort != nil {
 			sortExpr, err = c.compileExpr(q.Sort)
 			if err != nil {
@@ -1349,6 +1353,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		}
 		if takeExpr != "" {
 			b.WriteString(fmt.Sprintf("    (set! _res (take _res %s))\n", takeExpr))
+		}
+		if distinct {
+			b.WriteString("    (set! _res (_distinct _res))\n")
 		}
 		b.WriteString("    _res))")
 		return b.String(), nil
@@ -1419,6 +1426,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			return "", err
 		}
 		var sortExpr, skipExpr, takeExpr string
+		distinct := q.Distinct
 		if q.Sort != nil {
 			sortExpr, err = c.compileExpr(q.Sort)
 			if err != nil {
@@ -1499,6 +1507,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		if takeExpr != "" {
 			b.WriteString(fmt.Sprintf("    (set! _res (take _res %s))\n", takeExpr))
 		}
+		if distinct {
+			b.WriteString("    (set! _res (_distinct _res))\n")
+		}
 		b.WriteString("    _res))")
 		return b.String(), nil
 	}
@@ -1563,6 +1574,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	}
 
 	var whereExpr, sortExpr, skipExpr, takeExpr string
+	distinct := q.Distinct
 	if q.Where != nil {
 		whereExpr, err = c.compileExpr(q.Where)
 		if err != nil {
@@ -1650,6 +1662,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	}
 	if takeExpr != "" {
 		b.WriteString(fmt.Sprintf("  (set! _res (take _res %s))\n", takeExpr))
+	}
+	if distinct {
+		b.WriteString("  (set! _res (_distinct _res))\n")
 	}
 	b.WriteString("  _res)")
 	return b.String(), nil


### PR DESCRIPTION
## Summary
- enhance Racket converter to support namespaces and enums
- query hover info to infer variable types
- add `_distinct` helper and distinct query support for Racket backend
- document new feature in the Racket backend README

## Testing
- `go test ./tools/any2mochi -tags slow -run ConvertOther_Golden/rkt -count=1` *(fails: missing racket-langserver)*

------
https://chatgpt.com/codex/tasks/task_e_6869580a81608320a4e625cc7a2334b0