### PR TITLE
Improve Rust to Mochi conversion

### DIFF
--- a/tests/compiler/rust/README.md
+++ b/tests/compiler/rust/README.md
@@ -1,0 +1,22 @@
+# Rust to Mochi Conversion
+
+This directory contains Rust source snippets used to verify the `any2mochi` Rust converter.
+
+## Supported Features
+
+- Functions with parameters and return types
+- `struct` definitions and associated `impl` methods
+- `enum` definitions and `match` expressions
+- `for` and `while` loops with `break` and `continue`
+- `if`/`else` blocks
+- Basic macros like `println!`
+- Constant and type alias declarations
+- Trailing expressions at the end of functions
+
+## Unsupported Features
+
+- Full generic type handling
+- Trait definitions and implementations
+- Module system and imports
+- Complex macros beyond `println!`
+- Pattern match guards and `if let` constructs

--- a/tests/compiler/rust/avg_builtin.mochi
+++ b/tests/compiler/rust/avg_builtin.mochi
@@ -1,7 +1,7 @@
 fun main() {
   print(_avg(&vec![1, 2, 3]))
 }
-fun _avg(v) {
+fun _avg(v: [T]) {
   if v.is_empty() {
     return 0.0
   }
@@ -9,4 +9,5 @@ fun _avg(v) {
   for &it in v {
     sum += Into::<f64>::into(it)
   }
+  return sum / v.len() as f64
 }

--- a/tests/compiler/rust/closure.mochi
+++ b/tests/compiler/rust/closure.mochi
@@ -1,4 +1,4 @@
-fun makeAdder(n) {
+fun makeAdder(n: int) {
   return Box::new(move |x: i64| x + n)
 }
 fun main() {

--- a/tests/compiler/rust/count_builtin.mochi
+++ b/tests/compiler/rust/count_builtin.mochi
@@ -1,5 +1,6 @@
 fun main() {
   print(_count(&vec![1, 2, 3]))
 }
-fun _count(v) {
+fun _count(v: [T]) {
+  return v.len() as i32
 }

--- a/tests/compiler/rust/factorial.mochi
+++ b/tests/compiler/rust/factorial.mochi
@@ -1,4 +1,4 @@
-fun factorial(n) {
+fun factorial(n: int) {
   if n <= 1 {
     return 1
   }

--- a/tests/compiler/rust/fetch_builtin.mochi
+++ b/tests/compiler/rust/fetch_builtin.mochi
@@ -5,7 +5,7 @@ fun main() {
   var data: Msg = _fetch::<Msg>("file://tests/compiler/rust/fetch_builtin.json", std::collections::HashMap::new())
   print(data.message)
 }
-fun _fetch(_url, _opts) {
+fun _fetch(_url: string, _opts: std::collections::HashMap) {
   var data = String::new()
   if _url.starts_with("file://") {
     if let Ok(text) = std::fs::read_to_string(&_url[7..]) {
@@ -15,4 +15,5 @@ fun _fetch(_url, _opts) {
     var out = Command::new("curl").arg("-s").arg(_url).output().unwrap()
     data = String::from_utf8_lossy(&out.stdout).to_string()
   }
+  return serde_json::from_str::<T>(&data).unwrap()
 }

--- a/tests/compiler/rust/fetch_http.mochi
+++ b/tests/compiler/rust/fetch_http.mochi
@@ -8,7 +8,7 @@ fun main() {
   var todo: Todo = _fetch::<Todo>("https://jsonplaceholder.typicode.com/todos/1", std::collections::HashMap::new())
   print(todo.title)
 }
-fun _fetch(_url, _opts) {
+fun _fetch(_url: string, _opts: std::collections::HashMap) {
   var data = String::new()
   if _url.starts_with("file://") {
     if let Ok(text) = std::fs::read_to_string(&_url[7..]) {
@@ -18,4 +18,5 @@ fun _fetch(_url, _opts) {
     var out = Command::new("curl").arg("-s").arg(_url).output().unwrap()
     data = String::from_utf8_lossy(&out.stdout).to_string()
   }
+  return serde_json::from_str::<T>(&data).unwrap()
 }

--- a/tests/compiler/rust/fibonacci.mochi
+++ b/tests/compiler/rust/fibonacci.mochi
@@ -1,4 +1,4 @@
-fun fib(n) {
+fun fib(n: int) {
   if n <= 1 {
     return n
   }

--- a/tests/compiler/rust/fun_call.mochi
+++ b/tests/compiler/rust/fun_call.mochi
@@ -1,4 +1,4 @@
-fun add(a, b) {
+fun add(a: int, b: int) {
   return a + b
 }
 fun main() {

--- a/tests/compiler/rust/group_by.mochi
+++ b/tests/compiler/rust/group_by.mochi
@@ -26,5 +26,6 @@ fun main() {
     print(g.k, g.c)
   }
 }
-fun _count(v) {
+fun _count(v: [T]) {
+  return v.len() as i32
 }

--- a/tests/compiler/rust/if_else.mochi
+++ b/tests/compiler/rust/if_else.mochi
@@ -1,4 +1,4 @@
-fun foo(n) {
+fun foo(n: int) {
   if n < 0 {
     return -1
   }

--- a/tests/compiler/rust/list_set_ops.mochi
+++ b/tests/compiler/rust/list_set_ops.mochi
@@ -5,27 +5,30 @@ fun main() {
   print(_except(&a, &b).iter().map(|v| format!("{}", v)).collect::<Vec<_>>().join(" "))
   print(_intersect(&a, &b).iter().map(|v| format!("{}", v)).collect::<Vec<_>>().join(" "))
 }
-fun _except(a, b) {
+fun _except(a: [T], b: [T]) {
   var res = Vec::new()
   for it in a {
     if !b.contains(it) {
       res.push(it.clone())
     }
   }
+  return res
 }
-fun _intersect(a, b) {
+fun _intersect(a: [T], b: [T]) {
   var res = Vec::new()
   for it in a {
     if b.contains(it) && !res.contains(it) {
       res.push(it.clone())
     }
   }
+  return res
 }
-fun _union(a, b) {
+fun _union(a: [T], b: [T]) {
   var res = a.to_vec()
   for it in b {
     if !res.contains(it) {
       res.push(it.clone())
     }
   }
+  return res
 }

--- a/tests/compiler/rust/load_save_json.mochi
+++ b/tests/compiler/rust/load_save_json.mochi
@@ -6,7 +6,7 @@ fun main() {
   var people = _load::<Person>("people.json", std::collections::HashMap::from([("format".to_string(), "json")]))
   _save(people, "out.json", std::collections::HashMap::from([("format".to_string(), "json")]))
 }
-fun _load(_path, _opts) {
+fun _load(_path: string, _opts: std::collections::HashMap) {
   var data = String::new()
   if _path.is_empty() || _path == "-" {
     std::io::stdin().read_to_string(&mut data).unwrap()
@@ -17,8 +17,9 @@ fun _load(_path, _opts) {
   if let Ok(v) = serde_json::from_str::<T>(&data) {
     return vec![v]
   }
+  return Vec::new()
 }
-fun _save(_src, _path, _opts) {
+fun _save(_src: [T], _path: string, _opts: std::collections::HashMap) {
   if let Ok(text) = serde_json::to_string(_src) {
     if _path.is_empty() || _path == "-" {
       print(text)

--- a/tests/compiler/rust/local_recursion.mochi
+++ b/tests/compiler/rust/local_recursion.mochi
@@ -1,10 +1,10 @@
 type Tree =
   Leaf
   | Node(left: Tree, value: int, right: Tree)
-fun fromList(nums) {
+fun fromList(nums: Vec) {
   return helper(0, nums.len() as i64)
 }
-fun inorder(t) {
+fun inorder(t: Tree) {
   return (|| {
     match t {
         Tree::Leaf => { vec![] },

--- a/tests/compiler/rust/matrix_search.mochi
+++ b/tests/compiler/rust/matrix_search.mochi
@@ -1,4 +1,4 @@
-fun searchMatrix(matrix, target) {
+fun searchMatrix(matrix: Vec, target: int) {
   var m = matrix.len() as i64
   if m == 0 {
     return false

--- a/tests/compiler/rust/nested_inner_fn.mochi
+++ b/tests/compiler/rust/nested_inner_fn.mochi
@@ -1,4 +1,4 @@
-fun outer(a) {
+fun outer(a: int) {
   return inner(10)
 }
 fun main() {

--- a/tests/compiler/rust/string_in.mochi
+++ b/tests/compiler/rust/string_in.mochi
@@ -1,5 +1,6 @@
 fun main() {
   print(_in_string("hello", "lo"))
 }
-fun _in_string(s, sub) {
+fun _in_string(s: string, sub: string) {
+  return s.contains(sub)
 }

--- a/tests/compiler/rust/string_slice.mochi
+++ b/tests/compiler/rust/string_slice.mochi
@@ -1,7 +1,7 @@
 fun main() {
   print(_slice_string("hello", 1, 4))
 }
-fun _slice_string(s, start, end) {
+fun _slice_string(s: string, start: int, end: int) {
   var sidx = start
   var eidx = end
   var chars: Vec<char> = s.chars().collect()
@@ -21,4 +21,5 @@ fun _slice_string(s, start, end) {
   if eidx < sidx {
     eidx = sidx
   }
+  return chars[sidx as usize..eidx as usize].iter().collect()
 }

--- a/tests/compiler/rust/test_block.mochi
+++ b/tests/compiler/rust/test_block.mochi
@@ -6,7 +6,7 @@ fun main() {
   print("ok")
   test_addition_works()
 }
-fun expect(cond) {
+fun expect(cond: bool) {
   if !cond {
     panic!("expect failed")
   }

--- a/tests/compiler/rust/tpch_q1.mochi
+++ b/tests/compiler/rust/tpch_q1.mochi
@@ -76,7 +76,7 @@ fun main() {
 
   json(result)
 }
-fun _avg(v) {
+fun _avg(v: [T]) {
   if v.is_empty() {
     return 0.0
   }
@@ -84,10 +84,12 @@ fun _avg(v) {
   for &it in v {
     sum += Into::<f64>::into(it)
   }
+  return sum / v.len() as f64
 }
-fun _count(v) {
+fun _count(v: [T]) {
+  return v.len() as i32
 }
-fun _sum(v) {
+fun _sum(v: [T]) {
   if v.is_empty() {
     return 0.0
   }
@@ -95,4 +97,5 @@ fun _sum(v) {
   for &it in v {
     sum += Into::<f64>::into(it)
   }
+  return sum
 }

--- a/tests/compiler/rust/two_sum.mochi
+++ b/tests/compiler/rust/two_sum.mochi
@@ -1,4 +1,4 @@
-fun twoSum(nums, target) {
+fun twoSum(nums: Vec, target: int) {
   var n = nums.len() as i64
   for i in 0..n {
     for j in i + 1..n {

--- a/tests/compiler/rust/type_methods.mochi
+++ b/tests/compiler/rust/type_methods.mochi
@@ -1,7 +1,7 @@
 type Counter {
   value: int
 extend Counter {
-  fun inc() {
+  fun inc(): int {
     self.value = self.value + 1
     return self.value
   }

--- a/tests/compiler/rust/union_match.mochi
+++ b/tests/compiler/rust/union_match.mochi
@@ -1,7 +1,7 @@
 type Tree =
   Leaf
   | Node(left: Tree, value: int, right: Tree)
-fun isLeaf(t) {
+fun isLeaf(t: Tree) {
   return (|| {
     match t {
         Tree::Leaf => { true },


### PR DESCRIPTION
## Summary
- extend `any2mochi` Rust converter with constant and type alias support
- handle trailing expressions in Rust functions
- strip generic parameters when converting types
- update golden `.mochi` outputs for Rust samples
- document supported/unsupported Rust features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68695839a4ac83208bd228c5fd765753