### PR TITLE
Improve Scheme converter and compiler

### DIFF
--- a/compile/x/scheme/README.md
+++ b/compile/x/scheme/README.md
@@ -16,7 +16,7 @@ The Scheme backend converts a limited subset of Mochi programs into Scheme sourc
 - `if`, `for` and `while` statements
 - Lists and maps with literals, indexing, membership checks and mutation
 - String and list slicing
-- Built‑ins: `len`, `count`, `avg`, `str`, `push`, `keys`, `print`, `input`, `_fetch`, `_load`, `_save`
+- Built‑ins: `len`, `count`, `avg`, `sum`, `max`, `min`, `str`, `push`, `keys`, `print`, `input`, `_fetch`, `_load`, `_save`
 - Simple `test` blocks with `expect` assertions
 - List set operators `union`, `union_all`, `except` and `intersect`
 - Struct type declarations and methods

--- a/compile/x/scheme/compiler.go
+++ b/compile/x/scheme/compiler.go
@@ -163,6 +163,19 @@ const groupHelpers = `(define (_count v)
                 (cdr lst)))
     m))
 
+(define (_min v)
+  (let ((lst (cond
+               ((and (pair? v) (assq 'Items v)) (cdr (assq 'Items v)))
+               ((list? v) v)
+               (else '())))
+        (m 0))
+    (when (not (null? lst))
+      (set! m (car lst))
+      (for-each (lambda (n)
+                  (when (< n m) (set! m n)))
+                (cdr lst)))
+    m))
+
 (define (_group_by src keyfn)
 
 (define (_group_by src keyfn)
@@ -1151,6 +1164,12 @@ func (c *Compiler) compileCall(call *parser.CallExpr, recv string) (string, erro
 		}
 		c.needGroup = true
 		return fmt.Sprintf("(_max %s)", args[0]), nil
+	case "min":
+		if len(args) != 1 {
+			return "", fmt.Errorf("min expects 1 arg")
+		}
+		c.needGroup = true
+		return fmt.Sprintf("(_min %s)", args[0]), nil
 	case "sum":
 		if len(args) != 1 {
 			return "", fmt.Errorf("sum expects 1 arg")


### PR DESCRIPTION
## Summary
- enhance Scheme language server converter to support field and variable types
- implement new `min` aggregation for Scheme backend
- document new aggregator in Scheme backend README

## Testing
- `go test ./compile/x/scheme -tags slow -run Test` *(fails: chibi-scheme not installed)*
- `go test ./tools/any2mochi -tags slow -update` *(fails: missing language servers)*

------
https://chatgpt.com/codex/tasks/task_e_686958c8274c83208db53f4851fcc912