### PR TITLE
Improve Smalltalk converter

### DIFF
--- a/compile/x/st/README.md
+++ b/compile/x/st/README.md
@@ -25,6 +25,7 @@ The backend implements a minimal subset of Mochi:
 - `for` and `while` loops with `break` and `continue`
 - Functions with a single return value
 - Lists and maps with indexing, concatenation, and iteration
+- Class fields and global variables
 - Basic `type` declarations compiled to dictionaries with constructor helpers
 - Built-ins `print`, `len`, `str`, `count`, `avg`, `input`, `now`, `json`,
   `append`, `eval`, and `reduce`


### PR DESCRIPTION
## Summary
- enhance `ConvertSt` to emit fields and global variables based on LSP symbols
- document support for class fields and globals in the Smalltalk backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686958fa025c8320904da5e7cc3106c8