### PR TITLE
Extend Zig converter

### DIFF
--- a/tests/any2mochi/zig/README.md
+++ b/tests/any2mochi/zig/README.md
@@ -1,0 +1,19 @@
+# Zig to Mochi Converter
+
+This directory contains golden files for converting Zig source code to Mochi.
+
+## Supported Features
+
+- Top-level variable declarations
+- Function definitions with parameter and return types
+- Basic function body conversion including:
+  - `return` statements
+  - simple variable assignments
+  - call expressions with casts removed
+
+## Unsupported Features
+
+- Complex control flow (loops, if/else)
+- Struct and union definitions beyond field declarations
+- Generic functions and advanced type features
+- Error handling and defer blocks

--- a/tests/any2mochi/zig/simple_fn.error
+++ b/tests/any2mochi/zig/simple_fn.error
@@ -1,5 +1,0 @@
-convert failure: zls not found
-
-source snippet:
-  1: const std = @import("std");
-

--- a/tests/any2mochi/zig/simple_fn.mochi
+++ b/tests/any2mochi/zig/simple_fn.mochi
@@ -1,3 +1,7 @@
-fun id(x: int): int {}
-fun main() {}
-
+let std
+fun id(x: int): int {
+  return x
+}
+fun main() {
+  print("{any}\n", .{id(123)})
+}


### PR DESCRIPTION
## Summary
- enhance Zig converter to read function bodies
- produce minimal Mochi statements from return, assignments and calls
- document Zig conversion features
- update golden outputs

## Testing
- `go test ./tools/any2mochi`

------
https://chatgpt.com/codex/tasks/task_e_686959e3c0048320852e44d8f1398542