### PR TITLE
Improve TS to Mochi conversion

### DIFF
--- a/tests/any2mochi/ts/avg_builtin.ts.mochi
+++ b/tests/any2mochi/ts/avg_builtin.ts.mochi
@@ -1,2 +1,5 @@
 fun _avg() {}
-fun main() {}
+
+fun main() {
+  print(_avg(xs))
+}

--- a/tests/any2mochi/ts/simple_fn.ts.mochi
+++ b/tests/any2mochi/ts/simple_fn.ts.mochi
@@ -1,2 +1,7 @@
-fun id() {}
-fun main() {}
+fun id(x: int): int {
+  return x
+}
+
+fun main() {
+  print(123)
+}

--- a/tools/any2mochi/convert_typescript.go
+++ b/tools/any2mochi/convert_typescript.go
@@ -160,7 +160,29 @@ func writeTSFunc(out *strings.Builder, name string, sym protocol.DocumentSymbol,
 		out.WriteString(": ")
 		out.WriteString(ret)
 	}
-	out.WriteString(" {}\n")
+	start := indexForPosition(src, sym.Range.Start)
+	end := indexForPosition(src, sym.Range.End)
+	body := ""
+	if start < end && end <= len(src) {
+		snippet := src[start:end]
+		if open := strings.Index(snippet, "{"); open != -1 {
+			if close := strings.LastIndex(snippet, "}"); close != -1 && close > open {
+				body = snippet[open+1 : close]
+			}
+		}
+	}
+	stmts := tsFunctionBody(body)
+	if len(stmts) == 0 {
+		out.WriteString(" {}\n")
+		return
+	}
+	out.WriteString(" {\n")
+	for _, line := range stmts {
+		out.WriteString("  ")
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	out.WriteString("}\n")
 }
 
 func tsHoverSignature(src string, sym protocol.DocumentSymbol, ls LanguageServer) ([]tsParam, string) {

--- a/tools/any2mochi/parse_ts_simple.go
+++ b/tools/any2mochi/parse_ts_simple.go
@@ -1,0 +1,75 @@
+package any2mochi
+
+import (
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// tsFunctionBody parses a subset of TypeScript statements and returns
+// corresponding Mochi statements. Unsupported statements are ignored.
+func tsFunctionBody(src string) []string {
+	var lines []string
+	s := strings.TrimSpace(src)
+	for len(s) > 0 {
+		// trim leading whitespace and semicolons
+		s = strings.TrimLeft(s, " \t\n\r;")
+		if len(s) == 0 {
+			break
+		}
+		switch {
+		case strings.HasPrefix(s, "return "):
+			end := strings.Index(s, ";")
+			if end == -1 {
+				end = len(s)
+			}
+			expr := strings.TrimSpace(s[len("return "):end])
+			lines = append(lines, "return "+expr)
+			if end < len(s) {
+				s = s[end+1:]
+			} else {
+				s = ""
+			}
+			continue
+		case strings.HasPrefix(s, "console.log("):
+			end := strings.Index(s, ")")
+			if end == -1 {
+				end = len(s)
+			}
+			expr := strings.TrimSpace(s[len("console.log("):end])
+			lines = append(lines, "print("+expr+")")
+			sem := strings.Index(s[end:], ";")
+			if sem != -1 {
+				s = s[end+sem+1:]
+			} else {
+				s = s[end:]
+			}
+			continue
+		default:
+			if idx := strings.Index(s, ";"); idx != -1 {
+				s = s[idx+1:]
+			} else {
+				s = ""
+			}
+		}
+	}
+	return lines
+}
+
+// indexForPosition converts a protocol position to a byte offset in src.
+func indexForPosition(src string, pos protocol.Position) int {
+	lines := strings.Split(src, "\n")
+	if int(pos.Line) >= len(lines) {
+		return len(src)
+	}
+	idx := 0
+	for i := 0; i < int(pos.Line); i++ {
+		idx += len(lines[i]) + 1
+	}
+	if int(pos.Character) > len(lines[int(pos.Line)]) {
+		idx += len(lines[int(pos.Line)])
+	} else {
+		idx += int(pos.Character)
+	}
+	return idx
+}

--- a/tools/ts2mochi/README.md
+++ b/tools/ts2mochi/README.md
@@ -1,18 +1,22 @@
 # ts2mochi
 
 This package converts a limited subset of TypeScript into Mochi source code. It is
-mainly used for testing the TypeScript backend by round tripping compiler output.
+implemented in pure Go and relies on the TypeScript language server to obtain
+symbol information. It is mainly used for testing the TypeScript backend by
+round‑tripping compiler output.
 
 ## Supported features
 
-- Function declarations with numeric parameters
+- Function declarations with parameter and return types derived via the
+  language server
 - `return` statements
-- `console.log` as `print`
+- `console.log` translated to `print`
 - Numeric literals and identifiers
 - Array literals
+- Simple call expressions
 
 ## Unsupported features
 
 The converter is intentionally small and does not understand most
 TypeScript syntax such as loops, conditionals, classes, generics or
-module systems.
+module systems. Unsupported statements in function bodies are ignored.


### PR DESCRIPTION
## Summary
- enhance TypeScript converter to read function bodies
- add simple parser for `return` and `console.log` statements
- document converter capabilities in tools/ts2mochi
- update golden outputs for simple TypeScript samples

## Testing
- `go test ./tools/any2mochi -run TestConvertTypeScript -tags slow` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68695a4b0fe083208abd32dc3a4f9a0e