### PR TITLE
Improve COBOL converter

### DIFF
--- a/compile/x/cobol/README.md
+++ b/compile/x/cobol/README.md
@@ -237,11 +237,31 @@ Programs relying on these constructs will fail to compile.
 
 ## COBOL to Mochi converter
 
-The repository also includes a minimal converter in `tools/any2mochi` that can
+The repository also includes a converter in `tools/any2mochi` that can
 translate simple COBOL programs back to Mochi using the language server. The
-converter currently understands only a handful of statements:
+converter now understands a small selection of statements:
 
-- procedure bodies containing `DISPLAY` statements are mapped to `print` calls
+- procedure bodies containing `DISPLAY` statements which become `print` calls
+- `MOVE` and `COMPUTE` assignments
+- increment operations such as `ADD 1 TO VAR`
+- basic `IF/ELSE` blocks
+- loops written with `PERFORM UNTIL` or `PERFORM VARYING`
 
-Additional COBOL constructs are ignored. The converter is intentionally
-lightweight and meant only as a demonstration.
+Any other COBOL constructs are ignored. The converter remains lightweight and
+is intended purely as a demonstration.
+
+### Supported features
+
+- `DISPLAY` statements converted to `print`
+- `MOVE`/`COMPUTE` assignments
+- `ADD ... TO` increments
+- Simple `IF/ELSE` blocks
+- `PERFORM UNTIL` and `PERFORM VARYING` loops
+
+### Unsupported features
+
+- File I/O and data sections
+- Procedure calls beyond simple loops
+- `GOTO`, `STOP RUN` and other control flow statements
+- Advanced arithmetic like `DIVIDE`, `MULTIPLY`
+- Anything not listed in supported features

--- a/tools/any2mochi/convert_cobol.go
+++ b/tools/any2mochi/convert_cobol.go
@@ -283,12 +283,141 @@ func linesInRange(src string, r protocol.Range) []string {
 // Only a very small subset used by the tests is recognised.
 func parseCobolStatements(lines []string) []string {
 	var out []string
-	for _, l := range lines {
-		ll := strings.TrimSpace(strings.TrimSuffix(l, "."))
+	for i := 0; i < len(lines); i++ {
+		ll := strings.TrimSpace(strings.TrimSuffix(lines[i], "."))
 		switch {
 		case strings.HasPrefix(ll, "DISPLAY "):
 			expr := strings.TrimSpace(strings.TrimPrefix(ll, "DISPLAY "))
 			out = append(out, "print("+expr+")")
+
+		case strings.HasPrefix(ll, "MOVE "):
+			rest := strings.TrimSpace(strings.TrimPrefix(ll, "MOVE "))
+			parts := strings.Split(rest, " TO ")
+			if len(parts) == 2 {
+				expr := strings.TrimSpace(parts[0])
+				dest := strings.TrimSpace(parts[1])
+				out = append(out, dest+" = "+expr)
+			}
+
+		case strings.HasPrefix(ll, "COMPUTE "):
+			expr := strings.TrimSpace(strings.TrimPrefix(ll, "COMPUTE "))
+			out = append(out, expr)
+
+		case strings.HasPrefix(ll, "ADD "):
+			rest := strings.TrimSpace(strings.TrimPrefix(ll, "ADD "))
+			parts := strings.Split(rest, " TO ")
+			if len(parts) == 2 {
+				val := strings.TrimSpace(parts[0])
+				dest := strings.TrimSpace(parts[1])
+				out = append(out, dest+" = "+dest+" + "+val)
+			}
+
+		case strings.HasPrefix(ll, "PERFORM UNTIL "):
+			cond := strings.TrimSpace(strings.TrimPrefix(ll, "PERFORM UNTIL "))
+			body := []string{}
+			for j := i + 1; j < len(lines); j++ {
+				n := strings.TrimSpace(lines[j])
+				if n == "END-PERFORM" {
+					i = j
+					break
+				}
+				body = append(body, lines[j])
+			}
+			isNot := strings.HasPrefix(cond, "NOT ")
+			if isNot {
+				cond = strings.TrimSpace(strings.TrimPrefix(cond, "NOT "))
+				out = append(out, "while "+cond+" {")
+			} else {
+				out = append(out, "while !("+cond+") {")
+			}
+			inner := parseCobolStatements(body)
+			for _, st := range inner {
+				out = append(out, "  "+st)
+			}
+			out = append(out, "}")
+
+		case strings.HasPrefix(ll, "PERFORM VARYING "):
+			rest := strings.TrimSpace(strings.TrimPrefix(ll, "PERFORM VARYING "))
+			parts := strings.Split(rest, " FROM ")
+			if len(parts) != 2 {
+				break
+			}
+			varName := strings.TrimSpace(parts[0])
+			rest = parts[1]
+			parts = strings.Split(rest, " BY ")
+			if len(parts) != 2 {
+				break
+			}
+			start := strings.TrimSpace(parts[0])
+			rest = parts[1]
+			parts = strings.Split(rest, " UNTIL ")
+			if len(parts) != 2 {
+				break
+			}
+			step := strings.TrimSpace(parts[0])
+			cond := strings.TrimSpace(parts[1])
+			body := []string{}
+			for j := i + 1; j < len(lines); j++ {
+				n := strings.TrimSpace(lines[j])
+				if n == "END-PERFORM" {
+					i = j
+					break
+				}
+				body = append(body, lines[j])
+			}
+			end := ""
+			if strings.Contains(cond, ">=") {
+				end = strings.TrimSpace(strings.Split(cond, ">=")[1])
+			} else if strings.Contains(cond, "<=") {
+				end = strings.TrimSpace(strings.Split(cond, "<=")[1])
+			}
+			loop := "for " + strings.ToLower(varName) + " in range(" + start + ", " + end
+			if step != "1" && step != "-1" {
+				loop += ", " + step
+			}
+			loop += ") {"
+			out = append(out, loop)
+			inner := parseCobolStatements(body)
+			for _, st := range inner {
+				out = append(out, "  "+st)
+			}
+			out = append(out, "}")
+
+		case strings.HasPrefix(ll, "IF "):
+			cond := strings.TrimSpace(strings.TrimPrefix(ll, "IF "))
+			thenLines := []string{}
+			elseLines := []string{}
+			j := i + 1
+			inElse := false
+			for ; j < len(lines); j++ {
+				n := strings.TrimSpace(lines[j])
+				if n == "ELSE" {
+					inElse = true
+					continue
+				}
+				if n == "END-IF" {
+					break
+				}
+				if inElse {
+					elseLines = append(elseLines, lines[j])
+				} else {
+					thenLines = append(thenLines, lines[j])
+				}
+			}
+			i = j
+			out = append(out, "if "+cond+" {")
+			inner := parseCobolStatements(thenLines)
+			for _, st := range inner {
+				out = append(out, "  "+st)
+			}
+			if len(elseLines) > 0 {
+				out = append(out, "} else {")
+				inner2 := parseCobolStatements(elseLines)
+				for _, st := range inner2 {
+					out = append(out, "  "+st)
+				}
+			}
+			out = append(out, "}")
 		}
 	}
 	return out


### PR DESCRIPTION
## Summary
- extend COBOL language server converter
- parse assignments, loops and conditionals
- document COBOL converter capabilities

## Testing
- `go test ./...`
- `go test ./tools/any2mochi -tags slow -run ConvertOther_Golden -update` *(fails: cobol-lsp missing)*

------
https://chatgpt.com/codex/tasks/task_e_68696101633083209a82da04b9addc45