### PR TITLE
Improve Go converter fallback

### DIFF
--- a/tests/compiler/go/README.md
+++ b/tests/compiler/go/README.md
@@ -1,0 +1,19 @@
+# Go to Mochi Conversion
+
+This directory contains Go source snippets and corresponding Mochi output used to test the `any2mochi` Go converter.
+
+## Supported Features
+
+- Functions with parameters and a single return value
+- Variable declarations and assignments
+- `if` and `for` statements (including range loops)
+- Basic operations on slices, maps and structs
+- Print statements translated to `print`
+
+## Unsupported Features
+
+- Generics and type switches
+- Method declarations on types
+- Multiple return values
+- Complex `switch` statements and type assertions
+- Concurrency primitives and channels

--- a/tools/any2mochi/convert_go_golden_test.go
+++ b/tools/any2mochi/convert_go_golden_test.go
@@ -5,18 +5,14 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
-
-	gocode "mochi/compile/go"
 )
 
 func TestConvertGo_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	_ = gocode.EnsureGopls()
 	runConvertGolden(t, filepath.Join(root, "tests/compiler/go"), "*.go.out", ConvertGoFile, "go", ".mochi", ".error")
 }
 
 func TestConvertGoCompile_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	_ = gocode.EnsureGopls()
 	runConvertCompileGolden(t, filepath.Join(root, "tests/compiler/go"), "*.go.out", ConvertGoFile, "go", ".mochi", ".error")
 }

--- a/tools/any2mochi/convert_go_test.go
+++ b/tools/any2mochi/convert_go_test.go
@@ -4,19 +4,15 @@ package any2mochi
 
 import (
 	"testing"
-
-	gocode "mochi/compile/go"
 )
 
 func TestConvertGo(t *testing.T) {
-	_ = gocode.EnsureGopls()
-	requireBinary(t, "gopls")
-	src := "package foo\nfunc Add(x int, y int) int { return x + y }"
+	src := "package main\nfunc Add(x int, y int) int { return x + y }\nfunc main(){}"
 	out, err := ConvertGo(src)
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
-	if string(out) != "fun Add() {}\n" {
+	if string(out) != "fun Add(x: int, y: int): int {\n  return x + y\n}\n" {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }

--- a/tools/go2mochi/convert.go
+++ b/tools/go2mochi/convert.go
@@ -58,8 +58,15 @@ func Convert(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	return ConvertSource(src)
+}
+
+// ConvertSource converts Go source provided as a byte slice to Mochi code.
+// Only a small subset of Go is supported. If translation fails an error is
+// returned so callers can fall back to other implementations.
+func ConvertSource(src []byte) ([]byte, error) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	file, err := parser.ParseFile(fset, "src.go", src, parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- add ConvertSource function for Go->Mochi conversion
- fall back to pure Go parser in ConvertGo
- simplify Go tests to avoid language server requirement
- document supported Go features

## Testing
- `go test ./tools/go2mochi -run TestGo2Mochi_Golden -tags slow`
- `go test ./tools/any2mochi -run TestConvertGo$ -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68696045d0ec83209c637564a45e3dbb