### PR TITLE
Improve C++ any2mochi conversion

### DIFF
--- a/compile/x/cpp/README.md
+++ b/compile/x/cpp/README.md
@@ -252,3 +252,22 @@ Some LeetCode solutions use language constructs that the C++ backend can't yet t
 * Automatic language imports (`import python "..." auto`)
 * Extern object declarations
 * Map helper functions like `keys()` and `values()`
+
+## C++ to Mochi converter
+
+The `any2mochi` tool can translate C++ code back into Mochi. It relies solely on
+information reported by `clangd` over LSP to build minimal Mochi stubs.
+
+### Supported features
+
+* Struct and enum declarations
+* Top-level variable bindings
+* Function definitions with basic bodies including assignments, returns and
+  `std::cout` statements
+
+### Unsupported features
+
+* Complex control flow such as `for` loops with initializers or range-based
+  loops
+* Templates and macros
+* Preprocessor directives

--- a/tests/any2mochi/cpp/enum.mochi
+++ b/tests/any2mochi/cpp/enum.mochi
@@ -4,4 +4,3 @@ type Color {
   Blue
 }
 fun main(): int {}
-

--- a/tests/any2mochi/cpp/hello_world.mochi
+++ b/tests/any2mochi/cpp/hello_world.mochi
@@ -1,1 +1,4 @@
-fun main(): int {}
+fun main(): int {
+  print((string("Hello, world")))
+  return 0
+}


### PR DESCRIPTION
## Summary
- parse simple C++ function bodies in any2mochi
- ignore `using namespace` artifacts
- document C++ converter features
- update golden files for C++ examples

## Testing
- `go run /tmp/convert_all.go tests/compiler/cpp/hello_world.cpp.out tests/compiler/cpp/enum.cpp.out`
- `gofmt -w tools/any2mochi/convert_cpp.go`

------
https://chatgpt.com/codex/tasks/task_e_686960d5f13483209840728d1d39cc4f