### PR TITLE
Improve F# converter

### DIFF
--- a/tests/any2mochi/fs/README.md
+++ b/tests/any2mochi/fs/README.md
@@ -1,0 +1,17 @@
+# F# to Mochi Converter
+
+This directory stores golden files for converting F# source code to Mochi using the `fsautocomplete` language server.
+
+## Supported Features
+- Function signatures with parameter types inferred from hover information
+- Basic statement parsing for generated F# code including:
+  - `print` calls via `printfn`
+  - `for` and `while` loops
+  - simple variable assignments
+  - return statements generated with `Return_*` exceptions
+
+## Unsupported Features
+- Complex pattern matching and discriminated unions
+- Advanced type providers or generics
+- Module and namespace declarations
+- Preprocessor directives and attributes


### PR DESCRIPTION
## Summary
- improve `ConvertFs` to parse basic statement bodies
- handle loops, prints and assignments using regex fallbacks
- document feature coverage for the F# converter

## Testing
- `gofmt -w tools/any2mochi/convert_fs.go`
- `go test ./tools/any2mochi -run TestConvertOther_Golden -tags slow -count=1` *(fails: fsautocomplete not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869618de9f8832085d25ad7aa36361c