### PR TITLE
Improve Pascal converter with fallback parser

### DIFF
--- a/tests/any2mochi/pas/README.md
+++ b/tests/any2mochi/pas/README.md
@@ -1,0 +1,13 @@
+# Pascal to Mochi conversion
+
+This directory contains golden files for converting Pascal programs to Mochi.
+
+## Supported Features
+- Enum type declarations
+- Variable declarations with simple types
+- Basic assignments and `writeln` statements in program bodies
+
+## Unsupported Features
+- Records and complex type definitions
+- Generic functions and procedures
+- Advanced control flow and built-in functions

--- a/tests/any2mochi/pas/enum.error
+++ b/tests/any2mochi/pas/enum.error
@@ -1,4 +1,1 @@
-convert failure: pasls not found
 
-source snippet:
-  1: program main;

--- a/tests/any2mochi/pas/enum.mochi
+++ b/tests/any2mochi/pas/enum.mochi
@@ -1,0 +1,8 @@
+type Color {
+  Red
+  Green
+  Blue
+}
+let c: Color
+c = Green
+print(c)

--- a/tools/any2mochi/convert_pas.go
+++ b/tools/any2mochi/convert_pas.go
@@ -13,7 +13,8 @@ func ConvertPas(src string) ([]byte, error) {
 	ls := Servers["pas"]
 	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
 	if err != nil {
-		return nil, err
+		// fall back to very small regex based parser when pasls is missing
+		return convertPasFallback(src)
 	}
 	if len(diags) > 0 {
 		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
@@ -329,4 +330,94 @@ func convertPasBody(src string, sym protocol.DocumentSymbol) string {
 		}
 	}
 	return strings.Join(out, "\n")
+}
+
+// convertPasFallback converts a small subset of Pascal syntax to Mochi when no
+// language server is available. It recognises simple type declarations,
+// variable definitions and statements inside the main program block.
+func convertPasFallback(src string) ([]byte, error) {
+	lines := strings.Split(src, "\n")
+	var out []string
+	inBody := false
+	for i := 0; i < len(lines); i++ {
+		l := strings.TrimSpace(lines[i])
+		lower := strings.ToLower(l)
+		if !inBody {
+			switch {
+			case strings.HasPrefix(lower, "type") && strings.Contains(l, "("):
+				name := ""
+				if idx := strings.Index(strings.ToLower(l), "type"); idx != -1 {
+					rest := strings.TrimSpace(l[idx+len("type"):])
+					eq := strings.Index(rest, "=")
+					if eq != -1 {
+						name = strings.TrimSpace(rest[:eq])
+						rest = rest[eq+1:]
+					}
+					vals := rest
+					for !strings.Contains(vals, ")") && i+1 < len(lines) {
+						i++
+						vals += strings.TrimSpace(lines[i])
+					}
+					if cIdx := strings.Index(vals, "("); cIdx != -1 {
+						vals = vals[cIdx+1:]
+					}
+					if end := strings.Index(vals, ")"); end != -1 {
+						vals = vals[:end]
+					}
+					var members []string
+					for _, part := range strings.Split(vals, ",") {
+						v := strings.TrimSpace(strings.TrimSuffix(part, ";"))
+						if v != "" {
+							members = append(members, v)
+						}
+					}
+					if name != "" && len(members) > 0 {
+						out = append(out, "type "+name+" {")
+						for _, m := range members {
+							out = append(out, "  "+m)
+						}
+						out = append(out, "}")
+					}
+				}
+			case strings.HasPrefix(lower, "var") && strings.Contains(l, ":"):
+				rest := strings.TrimSpace(strings.TrimPrefix(l, "var"))
+				rest = strings.TrimSuffix(rest, ";")
+				if idx := strings.Index(rest, ":"); idx != -1 {
+					name := strings.TrimSpace(rest[:idx])
+					typ := pasToMochiType(strings.TrimSpace(rest[idx+1:]))
+					if name != "" {
+						if typ != "" {
+							out = append(out, "let "+name+": "+typ)
+						} else {
+							out = append(out, "let "+name)
+						}
+					}
+				}
+			case lower == "begin":
+				inBody = true
+			}
+			continue
+		}
+		if lower == "end." || lower == "end;" {
+			inBody = false
+			continue
+		}
+		if l == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(lower, "writeln("):
+			expr := strings.TrimSuffix(strings.TrimPrefix(l, "writeln("), ");")
+			out = append(out, "print("+expr+")")
+		case strings.Contains(l, ":="):
+			parts := strings.SplitN(l, ":=", 2)
+			name := strings.TrimSpace(parts[0])
+			expr := strings.TrimSpace(strings.TrimSuffix(parts[1], ";"))
+			out = append(out, name+" = "+expr)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("convert failure: no convertible content")
+	}
+	return []byte(strings.Join(out, "\n")), nil
 }


### PR DESCRIPTION
## Summary
- add a simple regex-based fallback in `ConvertPas` when `pasls` is unavailable
- translate basic enum declarations, variable declarations and statements
- update Pascal golden files and document feature support

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68696246c324832092b14d1a467484b6