### PR TITLE
Improve Prolog converter

### DIFF
--- a/compile/x/pl/README.md
+++ b/compile/x/pl/README.md
@@ -329,14 +329,20 @@ Mochi language features are not yet implemented:
 ## any2mochi Converter
 
 `tools/any2mochi` includes a Prolog converter that uses `prolog-lsp` to generate
-stub Mochi functions from existing Prolog source files.
+Mochi code from existing Prolog source files. When the language server is not
+available, the converter falls back to a simple regex based parser.
 
 ### Supported Features
 
 - Extraction of predicate names and arity via document symbols.
 - Parameter names retrieved from hover information when available.
+- Basic parsing of predicate bodies to convert `write/1` calls and simple
+  assignments.
+- Regex fallback when `prolog-lsp` is missing.
 
 ### Unsupported Features
 
 - Type information or return values.
 - Directives and module metadata not reported by the language server.
+- Control flow constructs such as loops or conditionals.
+- Complex expressions and dataset helpers.

--- a/tools/any2mochi/convert_prolog.go
+++ b/tools/any2mochi/convert_prolog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -18,6 +19,10 @@ func convertProlog(src, root string) ([]byte, error) {
 	ls := Servers["prolog"]
 	syms, diags, err := EnsureAndParseWithRoot(ls.Command, ls.Args, ls.LangID, src, root)
 	if err != nil {
+		// fallback to regex based parsing if the language server is missing
+		if strings.Contains(err.Error(), "not found") {
+			return convertPrologFallback(src)
+		}
 		return nil, err
 	}
 	if len(diags) > 0 {
@@ -62,7 +67,12 @@ func writePrologSymbols(out *strings.Builder, ls LanguageServer, src string, sym
 				}
 				out.WriteString(p)
 			}
-			out.WriteString(") {}\n")
+			out.WriteString(") {\n")
+			for _, line := range parsePrologBodyFromRange(src, s.Range) {
+				out.WriteString(line)
+				out.WriteByte('\n')
+			}
+			out.WriteString("}\n")
 		default:
 			if len(s.Children) > 0 {
 				writePrologSymbols(out, ls, src, s.Children, root)
@@ -118,4 +128,159 @@ func parseInt(s string) int {
 		n = n*10 + int(r-'0')
 	}
 	return n
+}
+
+func prologOffsetFromPosition(src string, pos protocol.Position) int {
+	lines := strings.Split(src, "\n")
+	if int(pos.Line) >= len(lines) {
+		return len(src)
+	}
+	off := 0
+	for i := 0; i < int(pos.Line); i++ {
+		off += len(lines[i]) + 1
+	}
+	col := int(pos.Character)
+	if col > len(lines[int(pos.Line)]) {
+		col = len(lines[int(pos.Line)])
+	}
+	return off + col
+}
+
+func parsePrologBodyFromRange(src string, rng protocol.Range) []string {
+	start := prologOffsetFromPosition(src, rng.Start)
+	end := prologOffsetFromPosition(src, rng.End)
+	if start >= end || start < 0 || end > len(src) {
+		return nil
+	}
+	body := strings.TrimSpace(src[start:end])
+	if idx := strings.Index(body, ":-"); idx >= 0 {
+		body = body[idx+2:]
+	}
+	body = strings.TrimSpace(body)
+	if strings.HasSuffix(body, ".") {
+		body = strings.TrimSuffix(body, ".")
+	}
+	return parsePrologBody(body)
+}
+
+// convertPrologFallback attempts a best effort conversion using regular
+// expressions when no language server is available.
+func convertPrologFallback(src string) ([]byte, error) {
+	funcs := parsePrologFuncs(src)
+	if len(funcs) == 0 {
+		if strings.Contains(src, "main :-") || strings.Contains(src, "main:-") {
+			funcs = append(funcs, prologFunc{name: "main", body: ""})
+		} else {
+			return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+		}
+	}
+	var out strings.Builder
+	for _, f := range funcs {
+		out.WriteString("fun ")
+		out.WriteString(f.name)
+		out.WriteByte('(')
+		for i, p := range f.params {
+			if i > 0 {
+				out.WriteString(", ")
+			}
+			out.WriteString(p)
+		}
+		out.WriteString(") {\n")
+		for _, line := range parsePrologBody(f.body) {
+			out.WriteString(line)
+			out.WriteByte('\n')
+		}
+		out.WriteString("}\n")
+	}
+	return []byte(out.String()), nil
+}
+
+type prologFunc struct {
+	name   string
+	params []string
+	body   string
+}
+
+// parsePrologFuncs extracts top-level predicate definitions using regex.
+func parsePrologFuncs(src string) []prologFunc {
+	var funcs []prologFunc
+	re := regexp.MustCompile(`(?ms)^\s*(\w+)(?:\(([^)]*)\))?\s*:-\s*(.*?)\.`)
+	matches := re.FindAllStringSubmatch(src, -1)
+	for _, m := range matches {
+		name := m[1]
+		paramList := strings.TrimSpace(m[2])
+		params := []string{}
+		if paramList != "" {
+			for _, p := range strings.Split(paramList, ",") {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					params = append(params, p)
+				}
+			}
+		}
+		body := strings.TrimSpace(m[3])
+		// drop trailing period
+		if strings.HasSuffix(body, ".") {
+			body = strings.TrimSuffix(body, ".")
+		}
+		funcs = append(funcs, prologFunc{name: name, params: params, body: body})
+	}
+	return funcs
+}
+
+// parsePrologBody splits a predicate body into Mochi statements.
+func parsePrologBody(body string) []string {
+	clauses := splitClauses(body)
+	var out []string
+	for _, c := range clauses {
+		c = strings.TrimSpace(c)
+		switch {
+		case c == "" || c == "true":
+			continue
+		case strings.HasPrefix(c, "write("):
+			arg := strings.TrimSuffix(strings.TrimPrefix(c, "write("), ")")
+			out = append(out, "  print("+arg+")")
+		case c == "nl":
+			// ignore newline, print adds newline automatically
+			continue
+		case strings.Contains(c, " is "):
+			parts := strings.SplitN(c, " is ", 2)
+			name := strings.TrimSpace(parts[0])
+			expr := strings.TrimSpace(parts[1])
+			out = append(out, "  let "+name+" = "+expr)
+		default:
+			out = append(out, "  // "+c)
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, "  pass")
+	}
+	return out
+}
+
+// splitClauses splits a Prolog body by commas at depth 0.
+func splitClauses(body string) []string {
+	var clauses []string
+	depth := 0
+	start := 0
+	for i, r := range body {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				clause := strings.TrimSpace(body[start:i])
+				clauses = append(clauses, clause)
+				start = i + 1
+			}
+		}
+	}
+	if start < len(body) {
+		clauses = append(clauses, strings.TrimSpace(body[start:]))
+	}
+	return clauses
 }


### PR DESCRIPTION
## Summary
- add regex based fallback for Prolog conversion when no LSP is available
- parse simple predicate bodies and offset helpers
- document Prolog any2mochi features in compile/x/pl/README

## Testing
- `go test ./tools/any2mochi -run ConvertProlog -tags slow -update`

------
https://chatgpt.com/codex/tasks/task_e_6869626a12388320a644a8997f258527