### PR TITLE
Improve Rust converter

### DIFF
--- a/tests/compiler/rust/README.md
+++ b/tests/compiler/rust/README.md
@@ -12,6 +12,9 @@ This directory contains Rust source snippets used to verify the `any2mochi` Rust
 - Basic macros like `println!`
 - Constant and type alias declarations
 - Trailing expressions at the end of functions
+- Generic functions (type parameters are ignored)
+- `Vec<T>` and slice types convert to Mochi lists
+- Basic `Option<T>` unwrap to the inner type
 
 ## Unsupported Features
 


### PR DESCRIPTION
## Summary
- extend Rust converter with list/option type handling and generic fallback
- add fallback parsing for function bodies
- document newly supported Rust features

## Testing
- `go test ./tools/any2mochi -run TestConvertOther_Golden -tags slow` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6869629b2c2883209812b7998a5eefe3