### PR TITLE
Improve C converter with fallback parsing

### DIFF
--- a/tests/any2mochi/c/README.md
+++ b/tests/any2mochi/c/README.md
@@ -5,9 +5,13 @@ This directory stores golden files for converting C source to Mochi.
 ## Supported
 - struct and type declarations
 - function signatures
-- simple function bodies (returns, loops, if statements, `printf` as `print`)
+- simple function bodies (returns, loops, if/else, `while`, `do/while`)
+- `printf` converted to `print`
+- `scanf` converted to `input`
+- fallback regex parser when the language server is unavailable
 
 ## Unsupported
 - pointer operations and casts
 - complex expressions and macros
 - preprocessor directives
+- advanced pointer arithmetic and memory management

--- a/tests/any2mochi/c/while_loop.c.mochi
+++ b/tests/any2mochi/c/while_loop.c.mochi
@@ -1,0 +1,9 @@
+fun main(): int {
+  var x = 0
+  x = input()
+  while (x > 0) {
+    print(x)
+    x = x - 1
+  }
+  return 0
+}


### PR DESCRIPTION
## Summary
- extend any2mochi C converter with a regex fallback when clangd is unavailable or reports errors
- support while, do/while and scanf statements
- add a new example demonstrating the fallback
- document supported features in `tests/any2mochi/c/README.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686962f869f483208cf56948bc2ceadd