### PR TITLE
Improve Python to Mochi converter

### DIFF
--- a/compile/py/README.md
+++ b/compile/py/README.md
@@ -127,8 +127,9 @@ The Python backend supports a large subset of Mochi. Highlights include:
 - Stream handlers and agents with asynchronous execution
 - LLM helpers such as `gen_text` and `fetch`
 - Basic round–tripping of Python source back to Mochi using the built in
-  `any2mochi` converter. Function bodies with simple assignments, `print`
-  calls and `return` statements are now parsed when converting from Python.
+  `any2mochi` converter. Function bodies with assignments, `print` calls,
+  `return` statements as well as basic `if`, `for` and `while` blocks are
+  parsed when converting from Python.
 
 ## Unsupported Features
 


### PR DESCRIPTION
## Summary
- extend `any2mochi` Python converter to parse simple control flow (`if`, `for`, `while`)
- document new support in Python backend README

## Testing
- `go test ./tools/any2mochi -tags slow -run TestConvertPython -update` *(failed: runtime error)*

------
https://chatgpt.com/codex/tasks/task_e_6869637da440832092adcfcc2eb723f4