### PR TITLE
Disable Go LSP usage in any2mochi

### DIFF
--- a/tools/any2mochi/convert_go.go
+++ b/tools/any2mochi/convert_go.go
@@ -9,25 +9,26 @@ import (
 	"go/token"
 	"os"
 	"strings"
-
-	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-// ConvertGo converts Go source code to Mochi using the Go language server.
-// It parses the source with gopls and converts discovered symbols into
-// minimal Mochi stubs. Any diagnostics reported by the server are returned
-// as errors.
+// ConvertGo converts Go source code to Mochi without relying on a
+// language server. It parses the source using the standard library
+// and emits minimal Mochi stubs.
 func ConvertGo(src string) ([]byte, error) {
-	ls := Servers["go"]
-	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "src.go", src, parser.SkipObjectResolution)
 	if err != nil {
 		return nil, err
 	}
-	if len(diags) > 0 {
-		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
-	}
 	var out strings.Builder
-	writeGoSymbols(&out, nil, syms, src, ls)
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			writeGoFunc(&out, fset, d)
+		case *ast.GenDecl:
+			writeGoGenDecl(&out, fset, d)
+		}
+	}
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
@@ -43,140 +44,114 @@ func ConvertGoFile(path string) ([]byte, error) {
 	return ConvertGo(string(data))
 }
 
-func writeGoSymbols(out *strings.Builder, prefix []string, syms []protocol.DocumentSymbol, src string, ls LanguageServer) {
-	for _, s := range syms {
-		nameParts := prefix
-		if s.Name != "" {
-			nameParts = append(nameParts, s.Name)
-		}
-		switch s.Kind {
-		case protocol.SymbolKindFunction, protocol.SymbolKindMethod:
-			params, ret := parseGoDetail(s.Detail)
-			if len(params) == 0 && ret == "" {
-				if hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, s.SelectionRange.Start); err == nil {
-					if mc, ok := hov.Contents.(protocol.MarkupContent); ok {
-						params, ret = parseGoDetail(&mc.Value)
-					}
-				}
-			}
-			out.WriteString("fun ")
-			out.WriteString(strings.Join(nameParts, "."))
-			out.WriteByte('(')
-			for i, p := range params {
-				if i > 0 {
-					out.WriteString(", ")
-				}
-				out.WriteString(p.name)
-				if p.typ != "" {
-					out.WriteString(": ")
-					out.WriteString(p.typ)
-				}
-			}
-			out.WriteByte(')')
-			if ret != "" && ret != "void" {
-				out.WriteString(": ")
-				out.WriteString(ret)
-			}
-			out.WriteString(" {}\n")
-		case protocol.SymbolKindStruct, protocol.SymbolKindClass, protocol.SymbolKindInterface:
-			out.WriteString("type ")
-			out.WriteString(strings.Join(nameParts, "."))
-			fields := []protocol.DocumentSymbol{}
-			rest := []protocol.DocumentSymbol{}
-			for _, c := range s.Children {
-				if c.Kind == protocol.SymbolKindField {
-					fields = append(fields, c)
-				} else {
-					rest = append(rest, c)
-				}
-			}
-			if len(fields) == 0 && len(rest) == 0 {
-				out.WriteString(" {}\n")
-			} else {
-				out.WriteString(" {\n")
-				for _, f := range fields {
-					out.WriteString("  ")
-					out.WriteString(f.Name)
-					if f.Detail != nil && strings.TrimSpace(*f.Detail) != "" {
-						out.WriteString(": ")
-						out.WriteString(strings.TrimSpace(*f.Detail))
-					}
-					out.WriteByte('\n')
-				}
-				out.WriteString("}\n")
-				if len(rest) > 0 {
-					writeGoSymbols(out, nameParts, rest, src, ls)
-				}
-			}
-		case protocol.SymbolKindVariable, protocol.SymbolKindConstant:
-			if len(prefix) == 0 {
-				out.WriteString("let ")
-				out.WriteString(strings.Join(nameParts, "."))
-				if s.Detail != nil && strings.TrimSpace(*s.Detail) != "" {
-					out.WriteString(": ")
-					out.WriteString(strings.TrimSpace(*s.Detail))
-				}
-				out.WriteByte('\n')
-			}
-			if len(s.Children) > 0 {
-				writeGoSymbols(out, nameParts, s.Children, src, ls)
-			}
-		}
-		if len(s.Children) > 0 && s.Kind != protocol.SymbolKindStruct && s.Kind != protocol.SymbolKindClass && s.Kind != protocol.SymbolKindInterface && s.Kind != protocol.SymbolKindVariable && s.Kind != protocol.SymbolKindConstant {
-			writeGoSymbols(out, nameParts, s.Children, src, ls)
-		}
-	}
-}
-
 type goParam struct{ name, typ string }
 
-func parseGoDetail(detail *string) ([]goParam, string) {
-	if detail == nil {
-		return nil, ""
+func writeGoFunc(out *strings.Builder, fset *token.FileSet, fn *ast.FuncDecl) {
+	if fn.Name == nil {
+		return
 	}
-	d := strings.TrimSpace(*detail)
-	if strings.HasPrefix(d, "```") {
-		d = strings.Trim(d, "`")
-		d = strings.TrimSpace(d)
-		if strings.HasPrefix(d, "go\n") {
-			d = strings.TrimPrefix(d, "go\n")
-			d = strings.TrimSpace(d)
-		}
+	name := fn.Name.Name
+	if fn.Recv != nil && len(fn.Recv.List) > 0 {
+		recv := exprString(fset, fn.Recv.List[0].Type)
+		name = recv + "." + name
 	}
-	if d == "" {
-		return nil, ""
-	}
-	if !strings.HasPrefix(d, "func") {
-		return nil, strings.TrimSpace(d)
-	}
-	src := "package p\n" + d + "{}"
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "src.go", src, 0)
-	if err != nil || len(file.Decls) == 0 {
-		return nil, ""
-	}
-	fn, ok := file.Decls[0].(*ast.FuncDecl)
-	if !ok {
-		return nil, ""
-	}
-	var params []goParam
+	out.WriteString("fun ")
+	out.WriteString(name)
+	out.WriteByte('(')
+	first := true
 	if fn.Type.Params != nil {
 		for _, p := range fn.Type.Params.List {
 			typ := exprString(fset, p.Type)
 			if len(p.Names) == 0 {
-				params = append(params, goParam{"", typ})
+				if !first {
+					out.WriteString(", ")
+				}
+				out.WriteString("_")
+				if typ != "" {
+					out.WriteString(": ")
+					out.WriteString(typ)
+				}
+				first = false
 				continue
 			}
 			for _, n := range p.Names {
-				params = append(params, goParam{n.Name, typ})
+				if !first {
+					out.WriteString(", ")
+				}
+				out.WriteString(n.Name)
+				if typ != "" {
+					out.WriteString(": ")
+					out.WriteString(typ)
+				}
+				first = false
 			}
 		}
 	}
-	ret := ""
+	out.WriteByte(')')
 	if fn.Type.Results != nil && len(fn.Type.Results.List) == 1 && len(fn.Type.Results.List[0].Names) == 0 {
-		ret = exprString(fset, fn.Type.Results.List[0].Type)
+		ret := exprString(fset, fn.Type.Results.List[0].Type)
+		if ret != "" && ret != "void" {
+			out.WriteString(": ")
+			out.WriteString(ret)
+		}
 	}
-	return params, ret
+	out.WriteString(" {}\n")
+}
+
+func writeGoGenDecl(out *strings.Builder, fset *token.FileSet, d *ast.GenDecl) {
+	switch d.Tok {
+	case token.TYPE:
+		for _, spec := range d.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if st, ok := ts.Type.(*ast.StructType); ok {
+				out.WriteString("type ")
+				out.WriteString(ts.Name.Name)
+				out.WriteString(" {\n")
+				for _, f := range st.Fields.List {
+					typ := exprString(fset, f.Type)
+					if len(f.Names) == 0 {
+						out.WriteString("  ")
+						out.WriteString(typ)
+						out.WriteByte('\n')
+						continue
+					}
+					for _, n := range f.Names {
+						out.WriteString("  ")
+						out.WriteString(n.Name)
+						if typ != "" {
+							out.WriteString(": ")
+							out.WriteString(typ)
+						}
+						out.WriteByte('\n')
+					}
+				}
+				out.WriteString("}\n")
+			}
+		}
+	case token.VAR, token.CONST:
+		for _, spec := range d.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			typ := ""
+			if vs.Type != nil {
+				typ = exprString(fset, vs.Type)
+			}
+			for _, n := range vs.Names {
+				out.WriteString("let ")
+				out.WriteString(n.Name)
+				if typ != "" {
+					out.WriteString(": ")
+					out.WriteString(typ)
+				}
+				out.WriteByte('\n')
+			}
+		}
+	}
 }
 
 func exprString(fset *token.FileSet, e ast.Expr) string {


### PR DESCRIPTION
## Summary
- stop using Go language server in any2mochi
- parse Go source directly with the standard `go/parser`

## Testing
- `go vet ./...`
- `go test ./tools/any2mochi -run TestConvertGo -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68696ee7ab5c8320a79eeaa7f2f6b052