### PR TITLE
Disable Dart LSP and add regex parser

### DIFF
--- a/tools/any2mochi/server.go
+++ b/tools/any2mochi/server.go
@@ -25,7 +25,7 @@ var Servers = map[string]LanguageServer{
 	"cobol":      {Command: "cobol-lsp", Args: nil, LangID: "cobol"},
 	"jvm":        {Command: "jdtls", Args: nil, LangID: "jvm"},
 	"cs":         {Command: "omnisharp", Args: []string{"-lsp"}, LangID: "csharp"},
-	"dart":       {Command: "dart", Args: []string{"language-server"}, LangID: "dart"},
+	"dart":       {Command: "", Args: nil, LangID: "dart"},
 	"erlang":     {Command: "erlang_ls", Args: nil, LangID: "erlang"},
 	"ex":         {Command: "elixir-ls", Args: nil, LangID: "elixir"},
 	"fortran":    {Command: "fortls", Args: nil, LangID: "fortran"},


### PR DESCRIPTION
## Summary
- disable the Dart language server entry
- implement a simplified Dart parser using regex and strings
- update `ConvertDart` to use the fallback parser

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68696f619f1483208a4a018c9bd3786a