### PR TITLE
Disable Dart LSP and add regex parser

### DIFF
--- a/tools/any2mochi/cmd/dartast/main.go
+++ b/tools/any2mochi/cmd/dartast/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"mochi/tools/any2mochi"
+)
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	prog := any2mochi.ParseDartToAST(string(data))
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(prog); err != nil {
+		panic(err)
+	}
+}

--- a/tools/any2mochi/convert_dart.go
+++ b/tools/any2mochi/convert_dart.go
@@ -1,8 +1,13 @@
 package any2mochi
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -11,21 +16,10 @@ import (
 
 // ConvertDart converts dart source code to Mochi.
 func ConvertDart(src string) ([]byte, error) {
-	ls := Servers["dart"]
-	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
-	if err != nil {
-		return nil, err
+	if out, err := convertDartCLI(src); err == nil {
+		return out, nil
 	}
-	if len(diags) > 0 {
-		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
-	}
-
-	var out strings.Builder
-	writeDartSymbols(&out, nil, syms, src, ls)
-	if out.Len() == 0 {
-		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
-	}
-	return []byte(out.String()), nil
+	return convertDartFallback(src)
 }
 
 // ConvertDartFile reads the dart file and converts it to Mochi.
@@ -326,4 +320,196 @@ func dartToMochiType(t string) string {
 		}
 	}
 	return t
+}
+
+// convertDartFallback performs a best-effort conversion using simple regex
+// parsing when no language server is available. Only a small subset of Dart is
+// supported.
+func convertDartFallback(src string) ([]byte, error) {
+	stmts := dartSplitStatements(src)
+	var out strings.Builder
+	indent := 0
+	ind := func() string { return strings.Repeat("  ", indent) }
+
+	funcRE := regexp.MustCompile(`^(?:[A-Za-z0-9_<>,\[\]\?]+\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)$`)
+	fieldRE := regexp.MustCompile(`^(?:final\s+|var\s+)?([A-Za-z0-9_<>,\[\]\?]+)\s+(\w+)`)
+
+	parseParams := func(s string) []string {
+		var params []string
+		for _, p := range strings.Split(s, ",") {
+			p = strings.TrimSpace(p)
+			p = strings.TrimPrefix(p, "required ")
+			if eq := strings.Index(p, "="); eq != -1 {
+				p = p[:eq]
+			}
+			fields := strings.Fields(p)
+			if len(fields) == 0 {
+				continue
+			}
+			name := fields[len(fields)-1]
+			if strings.HasPrefix(name, "this.") {
+				name = strings.TrimPrefix(name, "this.")
+			}
+			params = append(params, name)
+		}
+		return params
+	}
+
+	for i := 0; i < len(stmts); i++ {
+		s := strings.TrimSpace(stmts[i])
+		if s == "" {
+			continue
+		}
+		switch s {
+		case "{":
+			out.WriteString(ind())
+			out.WriteString("{\n")
+			indent++
+			continue
+		case "}":
+			if indent > 0 {
+				indent--
+			}
+			out.WriteString(ind())
+			out.WriteString("}\n")
+			continue
+		}
+
+		nextBlock := i+1 < len(stmts) && stmts[i+1] == "{"
+
+		if nextBlock && strings.HasPrefix(s, "class ") {
+			name := strings.TrimSpace(strings.TrimPrefix(s, "class "))
+			out.WriteString(ind())
+			out.WriteString("type ")
+			out.WriteString(name)
+			out.WriteString(" {\n")
+			indent++
+			i += 2 // skip "{" token
+			for i < len(stmts) {
+				line := strings.TrimSpace(stmts[i])
+				if line == "}" {
+					indent--
+					out.WriteString(ind())
+					out.WriteString("}\n")
+					break
+				}
+				if m := fieldRE.FindStringSubmatch(line); m != nil {
+					out.WriteString(ind())
+					out.WriteString(m[2])
+					if typ := dartToMochiType(m[1]); typ != "" && typ != "any" {
+						out.WriteString(": ")
+						out.WriteString(typ)
+					}
+					out.WriteByte('\n')
+				}
+				i++
+			}
+			continue
+		}
+
+		if nextBlock && funcRE.MatchString(s) {
+			m := funcRE.FindStringSubmatch(s)
+			out.WriteString(ind())
+			out.WriteString("fun ")
+			out.WriteString(m[1])
+			params := parseParams(m[2])
+			out.WriteByte('(')
+			for j, p := range params {
+				if j > 0 {
+					out.WriteString(", ")
+				}
+				out.WriteString(p)
+			}
+			out.WriteString(") {\n")
+			indent++
+			continue
+		}
+
+		line := convertDartStmt(s)
+		if line != "" {
+			out.WriteString(ind())
+			out.WriteString(line)
+			out.WriteByte('\n')
+		}
+	}
+	if out.Len() == 0 {
+		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+	}
+	return []byte(out.String()), nil
+}
+
+func convertDartCLI(src string) ([]byte, error) {
+	root, err := repoRoot()
+	if err != nil {
+		return nil, err
+	}
+	cli := filepath.Join(root, "tools", "any2mochi", "cmd", "dartast")
+	cmd := exec.Command("go", "run", cli)
+	cmd.Stdin = strings.NewReader(src)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("dartast: %s", strings.TrimSpace(stderr.String()))
+	}
+	var prog DartProgram
+	if err := json.Unmarshal(out.Bytes(), &prog); err != nil {
+		return nil, err
+	}
+	return convertDartFromAST(&prog, src)
+}
+
+func convertDartFromAST(p *DartProgram, src string) ([]byte, error) {
+	var out strings.Builder
+	for _, d := range p.Decls {
+		switch d.Kind {
+		case "class":
+			out.WriteString("type ")
+			out.WriteString(d.Name)
+			out.WriteString(" {\n")
+			for _, f := range d.Fields {
+				out.WriteString("  ")
+				out.WriteString(f.Name)
+				if f.Type != "" && f.Type != "any" {
+					out.WriteString(": ")
+					out.WriteString(f.Type)
+				}
+				out.WriteByte('\n')
+			}
+			out.WriteString("}\n")
+		case "func":
+			out.WriteString("fun ")
+			out.WriteString(d.Name)
+			out.WriteByte('(')
+			for i, p := range d.Params {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				out.WriteString(p)
+			}
+			out.WriteString(") {\n")
+			for _, line := range d.Body {
+				stmt := convertDartStmt(line)
+				if stmt == "" {
+					continue
+				}
+				out.WriteString("  ")
+				out.WriteString(stmt)
+				out.WriteByte('\n')
+			}
+			out.WriteString("}\n")
+		case "stmt":
+			stmt := convertDartStmt(d.Stmt)
+			if stmt == "" {
+				continue
+			}
+			out.WriteString(stmt)
+			out.WriteByte('\n')
+		}
+	}
+	if out.Len() == 0 {
+		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+	}
+	return []byte(out.String()), nil
 }

--- a/tools/any2mochi/dartast.go
+++ b/tools/any2mochi/dartast.go
@@ -1,0 +1,97 @@
+package any2mochi
+
+import (
+	"regexp"
+	"strings"
+)
+
+// DartProgram represents a very small subset of Dart parsed into a generic AST.
+type DartProgram struct {
+	Decls []DartDecl `json:"decls"`
+}
+
+type DartDecl struct {
+	Kind   string      `json:"kind"`
+	Name   string      `json:"name,omitempty"`
+	Params []string    `json:"params,omitempty"`
+	Fields []DartField `json:"fields,omitempty"`
+	Body   []string    `json:"body,omitempty"`
+	Stmt   string      `json:"stmt,omitempty"`
+}
+
+type DartField struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+}
+
+// ParseDartToAST parses the given Dart source using simple regex rules.
+// It supports only a tiny subset of the language and is intended as a
+// best-effort fallback when no real parser is available.
+func ParseDartToAST(src string) *DartProgram {
+	stmts := dartSplitStatements(src)
+	funcRE := regexp.MustCompile(`^(?:[A-Za-z0-9_<>,\[\]\?]+\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)$`)
+	fieldRE := regexp.MustCompile(`^(?:final\s+|var\s+)?([A-Za-z0-9_<>,\[\]\?]+)\s+(\w+)`)
+	parseParams := func(s string) []string {
+		var params []string
+		for _, p := range strings.Split(s, ",") {
+			p = strings.TrimSpace(p)
+			p = strings.TrimPrefix(p, "required ")
+			if eq := strings.Index(p, "="); eq != -1 {
+				p = p[:eq]
+			}
+			fields := strings.Fields(p)
+			if len(fields) == 0 {
+				continue
+			}
+			name := fields[len(fields)-1]
+			if strings.HasPrefix(name, "this.") {
+				name = strings.TrimPrefix(name, "this.")
+			}
+			params = append(params, name)
+		}
+		return params
+	}
+
+	var prog DartProgram
+	for i := 0; i < len(stmts); i++ {
+		s := strings.TrimSpace(stmts[i])
+		if s == "" {
+			continue
+		}
+		nextBlock := i+1 < len(stmts) && stmts[i+1] == "{"
+		if nextBlock && strings.HasPrefix(s, "class ") {
+			name := strings.TrimSpace(strings.TrimPrefix(s, "class "))
+			decl := DartDecl{Kind: "class", Name: name}
+			i += 2 // skip "{" token
+			for i < len(stmts) {
+				line := strings.TrimSpace(stmts[i])
+				if line == "}" {
+					break
+				}
+				if m := fieldRE.FindStringSubmatch(line); m != nil {
+					decl.Fields = append(decl.Fields, DartField{Name: m[2], Type: dartToMochiType(m[1])})
+				}
+				i++
+			}
+			prog.Decls = append(prog.Decls, decl)
+			continue
+		}
+		if nextBlock && funcRE.MatchString(s) {
+			m := funcRE.FindStringSubmatch(s)
+			decl := DartDecl{Kind: "func", Name: m[1], Params: parseParams(m[2])}
+			i += 2 // skip "{" token
+			for i < len(stmts) {
+				line := strings.TrimSpace(stmts[i])
+				if line == "}" {
+					break
+				}
+				decl.Body = append(decl.Body, line)
+				i++
+			}
+			prog.Decls = append(prog.Decls, decl)
+			continue
+		}
+		prog.Decls = append(prog.Decls, DartDecl{Kind: "stmt", Stmt: s})
+	}
+	return &prog
+}

--- a/tools/any2mochi/server.go
+++ b/tools/any2mochi/server.go
@@ -25,7 +25,7 @@ var Servers = map[string]LanguageServer{
 	"cobol":      {Command: "cobol-lsp", Args: nil, LangID: "cobol"},
 	"jvm":        {Command: "jdtls", Args: nil, LangID: "jvm"},
 	"cs":         {Command: "omnisharp", Args: []string{"-lsp"}, LangID: "csharp"},
-	"dart":       {Command: "dart", Args: []string{"language-server"}, LangID: "dart"},
+	"dart":       {Command: "", Args: nil, LangID: "dart"},
 	"erlang":     {Command: "erlang_ls", Args: nil, LangID: "erlang"},
 	"ex":         {Command: "elixir-ls", Args: nil, LangID: "elixir"},
 	"fortran":    {Command: "fortls", Args: nil, LangID: "fortran"},


### PR DESCRIPTION
## Summary
- disable the Dart language server entry
- implement a simplified Dart parser using regex and strings
- update `ConvertDart` to use the fallback parser


------
https://chatgpt.com/codex/tasks/task_e_68696f619f1483208a4a018c9bd3786a