### PR TITLE
Add Python AST conversion in any2mochi

### DIFF
--- a/tests/any2mochi/py/hello_ast.mochi
+++ b/tests/any2mochi/py/hello_ast.mochi
@@ -1,0 +1,4 @@
+fun main() {
+  print("hello ast")
+}
+main()

--- a/tools/any2mochi/py_ast.go
+++ b/tools/any2mochi/py_ast.go
@@ -1,0 +1,176 @@
+package any2mochi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pyNode struct {
+	Type  string          `json:"_type"`
+	Name  string          `json:"name,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Body  []*pyNode       `json:"body,omitempty"`
+	Value json.RawMessage `json:"value,omitempty"`
+	Func  *pyNode         `json:"func,omitempty"`
+	Args  json.RawMessage `json:"args,omitempty"`
+}
+
+func (n *pyNode) valueNode() *pyNode {
+	if n == nil || len(n.Value) == 0 || n.Value[0] == '"' || n.Value[0] == '-' || (n.Value[0] >= '0' && n.Value[0] <= '9') {
+		return nil
+	}
+	var out pyNode
+	if err := json.Unmarshal(n.Value, &out); err != nil {
+		return nil
+	}
+	return &out
+}
+
+func (n *pyNode) constValue() any {
+	if n == nil || len(n.Value) == 0 {
+		return nil
+	}
+	var v any
+	_ = json.Unmarshal(n.Value, &v)
+	return v
+}
+
+func (n *pyNode) callArgs() []*pyNode {
+	if n == nil || len(n.Args) == 0 {
+		return nil
+	}
+	var arr []*pyNode
+	if err := json.Unmarshal(n.Args, &arr); err == nil {
+		return arr
+	}
+	var fn struct {
+		Args []*pyNode `json:"args"`
+	}
+	if err := json.Unmarshal(n.Args, &fn); err == nil {
+		return fn.Args
+	}
+	return nil
+}
+
+const pyASTScript = `import ast, json, sys
+
+def node_to_dict(node):
+    if isinstance(node, ast.AST):
+        fields = {}
+        for k, v in ast.iter_fields(node):
+            fields[k] = node_to_dict(v)
+        return {'_type': node.__class__.__name__, **fields}
+    elif isinstance(node, list):
+        return [node_to_dict(x) for x in node]
+    else:
+        return node
+
+tree = ast.parse(sys.stdin.read())
+json.dump(node_to_dict(tree), sys.stdout)`
+
+func parsePyAST(src string) (*pyNode, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, pyCmd, "-c", pyASTScript)
+	cmd.Stdin = strings.NewReader(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	var root pyNode
+	if err := json.Unmarshal(out.Bytes(), &root); err != nil {
+		return nil, err
+	}
+	return &root, nil
+}
+
+func emitPyAST(b *strings.Builder, n *pyNode, indent string) {
+	if n == nil {
+		return
+	}
+	switch n.Type {
+	case "Module":
+		for _, c := range n.Body {
+			emitPyAST(b, c, indent)
+		}
+	case "FunctionDef":
+		b.WriteString("fun ")
+		b.WriteString(n.Name)
+		b.WriteString("() {\n")
+		for _, st := range n.Body {
+			b.WriteString(indent)
+			b.WriteString("  ")
+			emitPyAST(b, st, indent+"  ")
+		}
+		b.WriteString(indent)
+		b.WriteString("}\n")
+	case "Expr":
+		emitPyExpr(b, n.valueNode())
+		b.WriteString("\n")
+	}
+}
+
+func emitPyExpr(b *strings.Builder, n *pyNode) {
+	if n == nil {
+		return
+	}
+	switch n.Type {
+	case "Call":
+		fn := n.Func
+		if fn != nil && fn.Type == "Name" && fn.ID == "print" {
+			b.WriteString("print(")
+			args := n.callArgs()
+			for i, a := range args {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				emitPyExpr(b, a)
+			}
+			b.WriteString(")")
+			return
+		}
+		if fn != nil && fn.Type == "Name" {
+			b.WriteString(fn.ID)
+		}
+		b.WriteString("(")
+		args := n.callArgs()
+		for i, a := range args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			emitPyExpr(b, a)
+		}
+		b.WriteString(")")
+	case "Name":
+		b.WriteString(n.ID)
+	case "Constant":
+		v := n.constValue()
+		switch vv := v.(type) {
+		case string:
+			fmt.Fprintf(b, "%q", vv)
+		default:
+			fmt.Fprintf(b, "%v", vv)
+		}
+	}
+}
+
+// ConvertPythonAST converts Python code to Mochi using a JSON AST.
+func ConvertPythonAST(src string) ([]byte, error) {
+	root, err := parsePyAST(src)
+	if err != nil {
+		return nil, err
+	}
+	var b strings.Builder
+	emitPyAST(&b, root, "")
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return nil, fmt.Errorf("no output")
+	}
+	return []byte(out + "\n"), nil
+}

--- a/tools/any2mochi/py_ast_test.go
+++ b/tools/any2mochi/py_ast_test.go
@@ -1,0 +1,43 @@
+package any2mochi
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func TestConvertPythonAST(t *testing.T) {
+	pySrc := "def main():\n    print('hi')\n\nmain()"
+	out, err := ConvertPythonAST(pySrc)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	expected := "fun main() {\n  print(\"hi\")\n}\nmain()\n"
+	if string(out) != expected {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+	prog, err := parser.ParseString(string(out))
+	if err != nil {
+		t.Fatalf("parse mochi: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	var buf bytes.Buffer
+	m := vm.New(p, &buf)
+	if err := m.Run(); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(buf.String()) != "hi" {
+		t.Fatalf("unexpected runtime output: %s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- enhance any2mochi with a Python AST parser
- convert a simple AST to runnable Mochi code
- verify conversion and runtime in tests
- add example output files

## Testing
- `go test ./tools/any2mochi -run TestConvertPythonAST -count=1`
- `go run ./cmd/mochi run tests/any2mochi/py/hello_ast.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6869d36725f88320a49b3b9240a412e6