### PR TITLE
Add convert-cpp command and clang AST filtering

### DIFF
--- a/tests/any2mochi/cpp/hello_example.mochi
+++ b/tests/any2mochi/cpp/hello_example.mochi
@@ -1,0 +1,6 @@
+fun main(): int {
+  print("Hello")
+  return 0
+}
+
+main()

--- a/tools/any2mochi/cmd/any2mochi/main.go
+++ b/tools/any2mochi/cmd/any2mochi/main.go
@@ -101,6 +101,27 @@ func convertRustCmd() *cobra.Command {
 	return cmd
 }
 
+func convertCppCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-cpp <file.cpp>",
+		Short: "Convert C++ source to Mochi",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			out, err := any2mochi.ConvertCpp(string(data))
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	return cmd
+}
+
 func convertHsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert-hs <file.hs>",
@@ -268,6 +289,7 @@ func newRootCmd() *cobra.Command {
 		parseCmd(),
 		convertGoCmd(),
 		convertRustCmd(),
+		convertCppCmd(),
 		convertPythonCmd(),
 		convertHsCmd(),
 		convertTSCmd(),


### PR DESCRIPTION
## Summary
- add `convert-cpp` subcommand to any2mochi CLI
- filter clang JSON AST nodes to avoid system headers
- trim braces when parsing C++ function bodies
- add a C++ conversion example with expected output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869d3c0eeb083208f77f5e55dc31bf6