### PR TITLE
Add Elixir AST parser tool

### DIFF
--- a/tests/any2mochi/ex/hello.ast.json
+++ b/tests/any2mochi/ex/hello.ast.json
@@ -1,0 +1,11 @@
+{
+  "funcs": [
+    {
+      "name": "main",
+      "params": null,
+      "body": [
+        "IO.puts(1 + 2)"
+      ]
+    }
+  ]
+}

--- a/tests/any2mochi/ex/hello.mochi
+++ b/tests/any2mochi/ex/hello.mochi
@@ -1,0 +1,4 @@
+fun main() {
+  print(1 + 2)
+}
+main()

--- a/tools/any2mochi/cmd/any2mochi/main.go
+++ b/tools/any2mochi/cmd/any2mochi/main.go
@@ -143,6 +143,49 @@ func convertPythonCmd() *cobra.Command {
 	return cmd
 }
 
+func parseExCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "parse-ex <file.ex>",
+		Short: "Parse Elixir source and output JSON AST",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			ast, err := any2mochi.ParseExAST(string(data))
+			if err != nil {
+				return err
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(ast)
+		},
+	}
+	return cmd
+}
+
+func convertExCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-ex <file.ex>",
+		Short: "Convert Elixir source to Mochi",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			out, err := any2mochi.ConvertEx2(string(data))
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	return cmd
+}
+
 func convertTSCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert-ts <file.ts>",
@@ -269,6 +312,8 @@ func newRootCmd() *cobra.Command {
 		convertGoCmd(),
 		convertRustCmd(),
 		convertPythonCmd(),
+		parseExCmd(),
+		convertExCmd(),
 		convertHsCmd(),
 		convertTSCmd(),
 		convertCmd(),

--- a/tools/any2mochi/parse_ex.go
+++ b/tools/any2mochi/parse_ex.go
@@ -1,0 +1,126 @@
+package any2mochi
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// ExFunc represents a parsed Elixir function.
+type ExFunc struct {
+	Name   string   `json:"name"`
+	Params []string `json:"params"`
+	Body   []string `json:"body"`
+}
+
+// ExAST is a collection of functions in a source file.
+type ExAST struct {
+	Funcs []ExFunc `json:"funcs"`
+}
+
+var fnHeader = regexp.MustCompile(`^def\s+([a-zA-Z0-9_]+)(?:\(([^)]*)\))?\s*do\s*$`)
+
+func parseParams(paramStr string) []string {
+	if strings.TrimSpace(paramStr) == "" {
+		return nil
+	}
+	parts := strings.Split(paramStr, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// ParseExAST parses a subset of Elixir into an AST structure.
+func ParseExAST(src string) (*ExAST, error) {
+	lines := strings.Split(src, "\n")
+	ast := &ExAST{}
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		m := fnHeader.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		name := m[1]
+		params := parseParams(m[2])
+		var body []string
+		for j := i + 1; j < len(lines); j++ {
+			l := strings.TrimSpace(lines[j])
+			if l == "end" {
+				i = j
+				break
+			}
+			body = append(body, l)
+		}
+		ast.Funcs = append(ast.Funcs, ExFunc{Name: name, Params: params, Body: body})
+	}
+	if len(ast.Funcs) == 0 {
+		return nil, fmt.Errorf("no functions found")
+	}
+	return ast, nil
+}
+
+func translateLine(l string) string {
+	l = strings.TrimSpace(l)
+	if strings.HasPrefix(l, "IO.puts(") && strings.HasSuffix(l, ")") {
+		expr := strings.TrimSuffix(strings.TrimPrefix(l, "IO.puts("), ")")
+		return "print(" + strings.TrimSpace(expr) + ")"
+	}
+	if idx := strings.Index(l, "="); idx > 0 {
+		left := strings.TrimSpace(l[:idx])
+		right := strings.TrimSpace(l[idx+1:])
+		return "let " + left + " = " + right
+	}
+	return l
+}
+
+// ConvertExAST converts a parsed ExAST to Mochi source code.
+func ConvertExAST(ast *ExAST) ([]byte, error) {
+	var out strings.Builder
+	for _, fn := range ast.Funcs {
+		out.WriteString("fun ")
+		out.WriteString(fn.Name)
+		out.WriteByte('(')
+		out.WriteString(strings.Join(fn.Params, ", "))
+		out.WriteString(") {\n")
+		for _, l := range fn.Body {
+			if l == "" {
+				continue
+			}
+			out.WriteString("  ")
+			out.WriteString(translateLine(l))
+			out.WriteByte('\n')
+		}
+		out.WriteString("}\n")
+		if fn.Name == "main" {
+			out.WriteString("main()\n")
+		}
+	}
+	if out.Len() == 0 {
+		return nil, fmt.Errorf("empty ast")
+	}
+	return []byte(out.String()), nil
+}
+
+// ConvertEx2 parses Elixir source using ParseExAST and converts it to Mochi.
+func ConvertEx2(src string) ([]byte, error) {
+	ast, err := ParseExAST(src)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertExAST(ast)
+}
+
+// ConvertExFile2 reads an Elixir file and converts it using ConvertEx2.
+func ConvertExFile2(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertEx2(string(data))
+}


### PR DESCRIPTION
## Summary
- support parsing Elixir using a small AST struct
- expose `parse-ex` and `convert-ex` commands
- add example AST output and converted Mochi code

## Testing
- `go build ./...`
- `go run ./tools/any2mochi/cmd/any2mochi convert-ex /tmp/hello.ex`
- `go run ./cmd/mochi run /tmp/hello.mochi > /tmp/hello.out`

------
https://chatgpt.com/codex/tasks/task_e_6869d4146bb88320baf74deed6e44feb