### PR TITLE
Add Erlang parser to any2mochi

### DIFF
--- a/tests/any2mochi/erlang/empty.erl.error
+++ b/tests/any2mochi/erlang/empty.erl.error
@@ -1,0 +1,6 @@
+no convertible symbols found
+
+source snippet:
+  1: %% none
+  2: 
+exit status 1

--- a/tests/any2mochi/erlang/hello_world.erl.mochi
+++ b/tests/any2mochi/erlang/hello_world.erl.mochi
@@ -1,0 +1,4 @@
+fun main() {
+  print("Hello, world\n")
+}
+main()

--- a/tools/any2mochi/convert_erlang.go
+++ b/tools/any2mochi/convert_erlang.go
@@ -8,183 +8,52 @@ import (
 
 // ConvertErlang converts erlang source code to Mochi using the language server.
 func ConvertErlang(src string) ([]byte, error) {
-	ls := Servers["erlang"]
-	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
+	funcs, err := parseErlangAST(src)
 	if err != nil {
 		return nil, err
 	}
-	if len(diags) > 0 {
-		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
-	}
 	var out strings.Builder
-	for _, s := range syms {
-		if s.Kind != SymbolKindFunction {
-			continue
-		}
-		var params []erlParam
-		var ret string
-		if hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, s.SelectionRange.Start); err == nil {
-			if mc, ok := hov.Contents.(MarkupContent); ok {
-				params, ret = parseErlangHover(mc.Value)
-			}
-		}
-		if s.Name == "" {
-			s.Name = "fun"
+	hasMain := false
+	for _, f := range funcs {
+		if f.Name == "main" {
+			hasMain = true
 		}
 		out.WriteString("fun ")
-		out.WriteString(s.Name)
+		if f.Name == "" {
+			out.WriteString("fun")
+		} else {
+			out.WriteString(f.Name)
+		}
 		out.WriteByte('(')
-		for i, p := range params {
+		for i, p := range f.Params {
 			if i > 0 {
 				out.WriteString(", ")
 			}
-			out.WriteString(p.name)
-			if p.typ != "" {
-				out.WriteString(": ")
-				out.WriteString(p.typ)
-			}
+			out.WriteString(p)
 		}
 		out.WriteByte(')')
-		if ret != "" && ret != "ok" {
-			out.WriteString(": ")
-			out.WriteString(ret)
-		}
-		body := parseErlangBody(src, s.Range)
-		if len(body) == 0 {
+		if len(f.Body) == 0 {
 			out.WriteString(" {}\n")
 		} else {
 			out.WriteString(" {\n")
-			for _, line := range body {
+			for _, line := range f.Body {
+				if strings.HasPrefix(line, "io:format(") {
+					line = "print(" + strings.TrimPrefix(line, "io:format(")
+				}
+				out.WriteString("  ")
 				out.WriteString(line)
 				out.WriteByte('\n')
 			}
 			out.WriteString("}\n")
 		}
 	}
+	if hasMain {
+		out.WriteString("main()\n")
+	}
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
 	return []byte(out.String()), nil
-}
-
-func parseErlangParams(paramStr string) []erlParam {
-	paramStr = strings.TrimSpace(paramStr)
-	if paramStr == "" {
-		return nil
-	}
-	parts := strings.Split(paramStr, ",")
-	out := make([]erlParam, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		// remove pattern matches like X = Y
-		if idx := strings.Index(p, "="); idx >= 0 {
-			p = strings.TrimSpace(p[:idx])
-		}
-		typ := ""
-		if idx := strings.Index(p, "::"); idx >= 0 {
-			typ = mapErlangType(strings.TrimSpace(p[idx+2:]))
-			p = strings.TrimSpace(p[:idx])
-		}
-		fields := strings.Fields(p)
-		name := ""
-		if len(fields) > 0 {
-			name = fields[len(fields)-1]
-		}
-		out = append(out, erlParam{name: name, typ: typ})
-	}
-	return out
-}
-
-func parseErlangHover(sig string) ([]erlParam, string) {
-	sig = strings.ReplaceAll(sig, "\n", " ")
-	open := strings.Index(sig, "(")
-	close := strings.Index(sig, ")")
-	arrow := strings.Index(sig, "->")
-	if open == -1 || close == -1 || arrow == -1 || close < open || arrow < close {
-		return nil, ""
-	}
-	params := parseErlangParams(sig[open+1 : close])
-	ret := strings.TrimSpace(sig[arrow+2:])
-	if idx := strings.IndexAny(ret, ". "); idx >= 0 {
-		ret = strings.TrimSpace(ret[:idx])
-	}
-	ret = mapErlangType(ret)
-	return params, ret
-}
-
-func mapErlangType(t string) string {
-	switch strings.TrimSpace(t) {
-	case "integer()":
-		return "int"
-	case "float()", "number()":
-		return "float"
-	case "binary()", "string()":
-		return "string"
-	case "boolean()", "bool()":
-		return "bool"
-	default:
-		return strings.TrimSpace(t)
-	}
-}
-
-func offsetFromPosition(src string, pos Position) int {
-	lines := strings.Split(src, "\n")
-	if int(pos.Line) >= len(lines) {
-		return len(src)
-	}
-	off := 0
-	for i := 0; i < int(pos.Line); i++ {
-		off += len(lines[i]) + 1
-	}
-	col := int(pos.Character)
-	if col > len(lines[int(pos.Line)]) {
-		col = len(lines[int(pos.Line)])
-	}
-	return off + col
-}
-
-func parseErlangBody(src string, rng Range) []string {
-	start := offsetFromPosition(src, rng.Start)
-	end := offsetFromPosition(src, rng.End)
-	if start >= end || start < 0 || end > len(src) {
-		return nil
-	}
-	body := strings.TrimSpace(src[start:end])
-	if idx := strings.Index(body, "->"); idx >= 0 {
-		body = body[idx+2:]
-	}
-	body = strings.TrimSpace(body)
-	if strings.HasSuffix(body, ".") {
-		body = strings.TrimSuffix(body, ".")
-	}
-	stmts := strings.Split(body, ",")
-	var out []string
-	for i, s := range stmts {
-		s = strings.TrimSpace(s)
-		if s == "" {
-			continue
-		}
-		if eq := strings.Index(s, "="); eq >= 0 && !strings.Contains(s[:eq], " ") {
-			name := strings.TrimSpace(s[:eq])
-			expr := strings.TrimSpace(s[eq+1:])
-			out = append(out, "  var "+name+" = "+expr)
-			continue
-		}
-		if i == len(stmts)-1 {
-			out = append(out, "  return "+s)
-		} else {
-			out = append(out, "  "+s)
-		}
-	}
-	return out
-}
-
-type erlParam struct {
-	name string
-	typ  string
 }
 
 // ConvertErlangFile reads the erlang file and converts it to Mochi.

--- a/tools/any2mochi/erlang_parser/parser.escript
+++ b/tools/any2mochi/erlang_parser/parser.escript
@@ -1,0 +1,43 @@
+#!/usr/bin/env escript
+%%! -noshell -smp enable
+
+main([File]) ->
+    case epp:parse_file(File, []) of
+        {ok, Forms} -> output_funs(Forms);
+        {error, Reason} -> io:format("{\"error\":\"~p\"}\n", [Reason]), halt(1)
+    end,
+    halt(0).
+
+output_funs(Forms) ->
+    Funs = [F || F <- Forms, element(1,F) == function],
+    JsonFuns = [fun_to_json(F) || F <- Funs],
+    io:format("{\"functions\":[~s]}\n", [string:join(JsonFuns, ",")]).
+
+fun_to_json({function,_,Name,_A,[Clause|_]}) ->
+    {clause,_,Params,_G,Body} = Clause,
+    ParamNames = [param_name(P) || P <- Params],
+    BodyLines = [string:trim(io_lib:format("~s", [erl_pp:expr(E)])) || E <- Body],
+    lists:flatten([
+        "{\"name\":", json_string(atom_to_list(Name)),
+        ",\"params\":", json_array(ParamNames),
+        ",\"body\":", json_array(BodyLines),
+        "}"]).
+
+param_name({var,_,Name}) -> atom_to_list(Name);
+param_name({atom,_,Name}) -> atom_to_list(Name);
+param_name(_) -> "_".
+
+json_string(S) ->
+    Esc = escape_string(S),
+    lists:concat(["\"", Esc, "\""]).
+
+escape_string([]) -> [];
+escape_string([$\"|T]) -> [$\\,$\"|escape_string(T)];
+escape_string([$\n|T]) -> [$\\,$n|escape_string(T)];
+escape_string([$\r|T]) -> [$\\,$r|escape_string(T)];
+escape_string([$\t|T]) -> [$\\,$t|escape_string(T)];
+escape_string([H|T]) -> [H|escape_string(T)].
+
+json_array(L) ->
+    Items = [json_string(X) || X <- L],
+    lists:concat(["[", string:join(Items, ","), "]"]).

--- a/tools/any2mochi/parse_erlang.go
+++ b/tools/any2mochi/parse_erlang.go
@@ -1,0 +1,51 @@
+package any2mochi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type erlFunc struct {
+	Name   string   `json:"name"`
+	Params []string `json:"params"`
+	Body   []string `json:"body"`
+}
+
+func parseErlangAST(src string) ([]erlFunc, error) {
+	tmp, err := os.CreateTemp("", "src-*.erl")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(src); err != nil {
+		return nil, err
+	}
+	tmp.Close()
+	script := filepath.Join("tools", "any2mochi", "erlang_parser", "parser.escript")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "escript", script, tmp.Name())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	var res struct {
+		Functions []erlFunc `json:"functions"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		return nil, err
+	}
+	for i := range res.Functions {
+		for j := range res.Functions[i].Body {
+			res.Functions[i].Body[j] = strings.ReplaceAll(res.Functions[i].Body[j], "\n", "\\n")
+		}
+	}
+	return res.Functions, nil
+}


### PR DESCRIPTION
## Summary
- add an escript based parser that emits Erlang AST in JSON
- add `parseErlangAST` helper and update conversion logic
- emit a call to `main()` for runnable output
- include generated `.mochi` and `.error` examples for Erlang

## Testing
- `go vet ./...`
- `go test ./...`
- `/tmp/mochi run /tmp/test.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6869d41fbd608320bdab3ef2808abc39