### PR TITLE
Add basic F# parser CLI

### DIFF
--- a/examples/fs/error.error
+++ b/examples/fs/error.error
@@ -1,0 +1,1 @@
+unsupported

--- a/examples/fs/error.fs
+++ b/examples/fs/error.fs
@@ -1,0 +1,1 @@
+open System

--- a/examples/fs/hello.fs
+++ b/examples/fs/hello.fs
@@ -1,0 +1,3 @@
+open System
+let x = 1 + 2
+ignore (printfn "%A" (x))

--- a/examples/fs/hello.mochi
+++ b/examples/fs/hello.mochi
@@ -1,0 +1,2 @@
+let x = 1 + 2
+print(x)

--- a/tools/any2mochi/cmd/fsparse/main.go
+++ b/tools/any2mochi/cmd/fsparse/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type Var struct {
+	Name string `json:"name"`
+	Expr string `json:"expr"`
+}
+
+type Program struct {
+	Vars   []Var    `json:"vars"`
+	Prints []string `json:"prints"`
+}
+
+var printRe = regexp.MustCompile(`ignore\s*\(printfn\s*"%A"\s*\((.*)\)\)`)
+var letRe = regexp.MustCompile(`^let\s+(\w+)\s*=\s*(.*)$`)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	prog := Program{}
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if m := printRe.FindStringSubmatch(line); m != nil {
+			expr := strings.TrimSpace(m[1])
+			prog.Prints = append(prog.Prints, expr)
+			continue
+		}
+		if m := letRe.FindStringSubmatch(line); m != nil {
+			prog.Vars = append(prog.Vars, Var{Name: m[1], Expr: strings.TrimSpace(m[2])})
+		}
+	}
+	enc := json.NewEncoder(os.Stdout)
+	_ = enc.Encode(prog)
+}

--- a/tools/any2mochi/parse_fs.go
+++ b/tools/any2mochi/parse_fs.go
@@ -1,0 +1,32 @@
+package any2mochi
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+)
+
+type FsVar struct {
+	Name string `json:"name"`
+	Expr string `json:"expr"`
+}
+
+type FsProgram struct {
+	Vars   []FsVar  `json:"vars"`
+	Prints []string `json:"prints"`
+}
+
+func parseFsAST(src string) (*FsProgram, error) {
+	cmd := exec.Command("fsparse")
+	cmd.Stdin = bytes.NewBufferString(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	var prog FsProgram
+	if err := json.Unmarshal(out.Bytes(), &prog); err != nil {
+		return nil, err
+	}
+	return &prog, nil
+}


### PR DESCRIPTION
## Summary
- implement `fsparse` CLI that parses simple F# source and outputs a JSON AST
- support parsing via the CLI in `ConvertFs`
- add helper to invoke the CLI and unmarshal the AST
- provide small example showing successful conversion and failing case

## Testing
- `gofmt -w tools/any2mochi/cmd/fsparse/main.go tools/any2mochi/parse_fs.go tools/any2mochi/convert_fs.go`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869d42c516c8320af1267d700041996