### PR TITLE
Add simple Fortran parser CLI

### DIFF
--- a/cmd/ft2mochi/main.go
+++ b/cmd/ft2mochi/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"mochi/tools/any2mochi"
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: ft2mochi <file.f90>")
+		os.Exit(1)
+	}
+	any2mochi.UseLSP = false
+	data, err := os.ReadFile(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	code, err := any2mochi.ConvertFortran(string(data))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Stdout.Write(code)
+}

--- a/examples/fortran/hello.f90
+++ b/examples/fortran/hello.f90
@@ -1,0 +1,3 @@
+program main
+  print *, "Hello, Mochi"
+end program main

--- a/examples/fortran/hello.mochi
+++ b/examples/fortran/hello.mochi
@@ -1,0 +1,1 @@
+print("Hello, Mochi")

--- a/tools/any2mochi/ft_ast.py
+++ b/tools/any2mochi/ft_ast.py
@@ -1,0 +1,28 @@
+import sys, json, re
+
+src = sys.stdin.read().splitlines()
+funcs = []
+i = 0
+while i < len(src):
+    line = src[i].strip()
+    m = re.match(r"(program|function|subroutine)\s+(\w+)(?:\(([^)]*)\))?", line, re.IGNORECASE)
+    if m:
+        kind, name, params = m.groups()
+        params = [p.strip() for p in params.split(',')] if params else []
+        body = []
+        i += 1
+        while i < len(src):
+            l = src[i].strip()
+            if re.match(r"end\s+(program|function|subroutine)\s+"+re.escape(name), l, re.IGNORECASE):
+                break
+            if l.lower().startswith('print'):
+                parts = l.split(',',1)
+                expr = parts[1].strip() if len(parts) > 1 else ''
+                body.append({'kind':'print','expr':expr})
+            elif '=' in l:
+                left,right = l.split('=',1)
+                body.append({'kind':'assign','var':left.strip(),'expr':right.strip()})
+            i += 1
+        funcs.append({'name':name,'params':params,'body':body})
+    i += 1
+json.dump({'funcs':funcs}, sys.stdout)


### PR DESCRIPTION
## Summary
- enhance any2mochi with optional CLI-based Fortran parsing
- provide Python helper `ft_ast.py`
- create new `ft2mochi` command to run conversion
- example converting a Fortran program

## Testing
- `go build ./cmd/ft2mochi`
- `go vet ./...`
- `go run ./cmd/ft2mochi examples/fortran/hello.f90 > examples/fortran/hello.mochi`
- `go run ./cmd/mochi run examples/fortran/hello.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6869d438c1488320bf666c9254145a2c