### PR TITLE
Add basic OCaml parsing via tree-sitter

### DIFF
--- a/tests/any2mochi/ocaml/bool_ops.error
+++ b/tests/any2mochi/ocaml/bool_ops.error
@@ -1,7 +1,0 @@
-no convertible symbols found
-
-source snippet:
-  1: print_endline (string_of_bool (true && false));;
-  2: print_endline (string_of_bool (true || false));;
-  3: print_endline (string_of_bool (not false));;
-  4: 

--- a/tests/any2mochi/ocaml/bool_ops.mochi
+++ b/tests/any2mochi/ocaml/bool_ops.mochi
@@ -1,0 +1,4 @@
+print(str(true && false))
+print(str(true || false))
+print(str(!false))
+

--- a/tools/any2mochi/convert_ocaml.go
+++ b/tools/any2mochi/convert_ocaml.go
@@ -9,6 +9,18 @@ import (
 
 // ConvertOcaml converts ocaml source code to Mochi using the language server.
 func ConvertOcaml(src string) ([]byte, error) {
+	if !UseLSP {
+		prog, err := parseOcaml(src)
+		if err != nil {
+			return nil, err
+		}
+		code := formatOcamlProgram(prog)
+		if len(code) == 0 {
+			return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+		}
+		return code, nil
+	}
+
 	ls := Servers["ocaml"]
 	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
 	if err != nil {

--- a/tools/any2mochi/ocaml_ast.js
+++ b/tools/any2mochi/ocaml_ast.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const Parser = require('tree-sitter');
+const Ocaml = require('tree-sitter-ocaml');
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: ocaml_ast.js <file>');
+  process.exit(1);
+}
+const source = fs.readFileSync(file, 'utf8');
+const parser = new Parser();
+parser.setLanguage(Ocaml.ocaml);
+const tree = parser.parse(source);
+function text(node) { return source.slice(node.startIndex, node.endIndex); }
+
+const prog = { funcs: [], prints: [] };
+for (const child of tree.rootNode.namedChildren) {
+  if (child.type === 'value_definition') {
+    const binding = child.namedChildren.find(c => c.type === 'let_binding');
+    if (!binding) continue;
+    const nameNode = binding.namedChildren.find(c => c.type === 'value_name');
+    const name = nameNode ? text(nameNode) : '';
+    const params = [];
+    for (const c of binding.namedChildren) {
+      if (c.type === 'parameter') {
+        const pat = c.namedChildren.find(n => n.type === 'value_pattern');
+        if (pat) params.push(text(pat));
+      }
+    }
+    const eqIdx = binding.children.findIndex(c => c.type === '=');
+    let body = '';
+    if (eqIdx !== -1 && eqIdx + 1 < binding.children.length) {
+      const node = binding.children[eqIdx + 1];
+      body = text({ startIndex: node.startIndex, endIndex: binding.endIndex });
+    }
+    if (params.length > 0) {
+      prog.funcs.push({ name, params, body: body.trim() });
+    } else {
+      prog.prints.push(body.trim().replace(/;$/, ''));
+    }
+  } else if (child.type === 'expression_item') {
+    prog.prints.push(text(child).trim().replace(/;$/, ''));
+  }
+}
+console.log(JSON.stringify(prog));

--- a/tools/any2mochi/parse_ocaml.go
+++ b/tools/any2mochi/parse_ocaml.go
@@ -1,0 +1,105 @@
+package any2mochi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type ocamlProgram struct {
+	Funcs  []ocamlFunc `json:"funcs"`
+	Prints []string    `json:"prints"`
+}
+
+type ocamlFunc struct {
+	Name   string   `json:"name"`
+	Params []string `json:"params"`
+	Body   string   `json:"body"`
+}
+
+func parseOcaml(src string) (*ocamlProgram, error) {
+	tmp, err := os.CreateTemp("", "ocaml-*.ml")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(src); err != nil {
+		return nil, err
+	}
+	tmp.Close()
+	root, err := repoRoot()
+	if err != nil {
+		return nil, err
+	}
+	script := filepath.Join(root, "tools", "any2mochi", "ocaml_ast.js")
+	cmd := exec.Command("node", script, tmp.Name())
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := stderr.String()
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("node: %s", msg)
+	}
+	var prog ocamlProgram
+	if err := json.Unmarshal(out.Bytes(), &prog); err != nil {
+		return nil, err
+	}
+	return &prog, nil
+}
+
+func formatOcamlProgram(p *ocamlProgram) []byte {
+	var out bytes.Buffer
+	for _, fn := range p.Funcs {
+		out.WriteString("fun ")
+		out.WriteString(fn.Name)
+		out.WriteByte('(')
+		for i, n := range fn.Params {
+			if i > 0 {
+				out.WriteString(", ")
+			}
+			out.WriteString(n)
+		}
+		out.WriteString(") {\n  ")
+		body := fn.Body
+		body = strings.ReplaceAll(body, "print_endline", "print")
+		body = strings.ReplaceAll(body, "string_of_int", "str")
+		body = strings.ReplaceAll(body, "string_of_float", "str")
+		body = strings.ReplaceAll(body, "string_of_bool", "str")
+		body = strings.ReplaceAll(body, "str (", "str(")
+		body = strings.ReplaceAll(body, "print (", "print(")
+		body = strings.ReplaceAll(body, "not ", "!")
+		out.WriteString(body)
+		out.WriteString("\n}\n")
+	}
+	for _, pstr := range p.Prints {
+		line := strings.TrimSpace(pstr)
+		line = strings.ReplaceAll(line, "string_of_int", "str")
+		line = strings.ReplaceAll(line, "string_of_float", "str")
+		line = strings.ReplaceAll(line, "string_of_bool", "str")
+		line = strings.ReplaceAll(line, "str (", "str(")
+		line = strings.ReplaceAll(line, "print (", "print(")
+		line = strings.ReplaceAll(line, "not ", "!")
+		if strings.HasPrefix(line, "print_endline") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "print_endline"))
+			if strings.HasPrefix(line, "(") && strings.HasSuffix(line, ")") {
+				line = strings.TrimSuffix(strings.TrimPrefix(line, "("), ")")
+			}
+			out.WriteString("print(")
+			out.WriteString(strings.TrimSpace(line))
+			out.WriteString(")\n")
+		} else {
+			out.WriteString("print(")
+			out.WriteString(line)
+			out.WriteString(")\n")
+		}
+	}
+	return out.Bytes()
+}


### PR DESCRIPTION
## Summary
- support OCaml parsing without LSP using a new tree‑sitter based CLI
- convert parsed OCaml constructs into Mochi code
- update bool_ops golden files

## Testing
- `go run run_ocaml.go tests/compiler/ocaml/bool_ops.ml.out` *(manual)*
- `go run ./cmd/mochi run bool_ops.mochi` *(manual)*

------
https://chatgpt.com/codex/tasks/task_e_6869d43ca2ac8320b64eccff7728b3a2