### PR TITLE
Add Java AST parser to any2mochi

### DIFF
--- a/cmd/javaast/main.go
+++ b/cmd/javaast/main.go
@@ -1,14 +1,82 @@
 package main
 
 import (
-	"io/ioutil"
+	"bytes"
+	"io"
 	"os"
+	"os/exec"
 )
 
+const pyScript = `import sys, json, re
+src = sys.stdin.read()
+lines = src.splitlines()
+structs = []
+funcs = []
+
+i = 0
+while i < len(lines):
+    line = lines[i].strip()
+    m = re.match(r'static class (\w+)', line)
+    if m:
+        name = m.group(1)
+        i += 1
+        fields = []
+        while i < len(lines) and not lines[i].strip().startswith('}'):
+            fl = lines[i].strip()
+            fm = re.match(r'(\w+) (\w+);', fl)
+            if fm:
+                fields.append({"name": fm.group(2), "type": fm.group(1)})
+            i += 1
+        structs.append({"name": name, "fields": fields})
+        while i < len(lines) and not lines[i].strip().startswith('}'):
+            i += 1
+        if i < len(lines):
+            i += 1
+        continue
+    m = re.match(r'(?:public )?static ([\w<>\[\]]+) (\w+)\(([^)]*)\)\s*{', line)
+    if m:
+        ret = m.group(1)
+        fname = m.group(2)
+        params = []
+        ps = m.group(3).strip()
+        if ps:
+            for p in ps.split(','):
+                p = p.strip()
+                if not p:
+                    continue
+                parts = p.split()
+                if len(parts) == 2:
+                    params.append({"name": parts[1], "type": parts[0]})
+        i += 1
+        body = []
+        depth = 1
+        while i < len(lines) and depth > 0:
+            l = lines[i]
+            if '{' in l:
+                depth += l.count('{')
+            if '}' in l:
+                depth -= l.count('}')
+            if depth > 0:
+                body.append(l.strip())
+            i += 1
+        funcs.append({"name": fname, "ret": ret, "params": params, "body": body})
+        continue
+    i += 1
+
+json.dump({"structs": structs, "funcs": funcs}, sys.stdout)`
+
 func main() {
-	if _, err := ioutil.ReadAll(os.Stdin); err != nil {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
 		panic(err)
 	}
-	os.Stderr.WriteString("java parsing not supported\n")
-	os.Exit(1)
+	cmd := exec.Command("python3", "-c", pyScript)
+	cmd.Stdin = bytes.NewReader(data)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		os.Stderr.WriteString(err.Error())
+		os.Exit(1)
+	}
+	os.Stdout.Write(out.Bytes())
 }

--- a/tests/compiler/java/dataset_generated.error
+++ b/tests/compiler/java/dataset_generated.error
@@ -1,0 +1,1 @@
+unsupported line: public java.util.List<Object> get() {

--- a/tests/compiler/java/simple_fn_generated.mochi
+++ b/tests/compiler/java/simple_fn_generated.mochi
@@ -1,0 +1,6 @@
+fun id(x: int): int {
+  return x
+}
+fun main(args: String[]) {
+  print(id(123))
+}

--- a/tools/any2mochi/parse_java.go
+++ b/tools/any2mochi/parse_java.go
@@ -1,10 +1,114 @@
 package any2mochi
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"os/exec"
+	"strings"
 )
 
-// parseJava invokes the mochi-javaast CLI to convert Java source to Mochi statements.
+type javaAST struct {
+	Structs []struct {
+		Name   string `json:"name"`
+		Fields []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"fields"`
+	} `json:"structs"`
+	Funcs []struct {
+		Name   string `json:"name"`
+		Ret    string `json:"ret"`
+		Params []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"params"`
+		Body []string `json:"body"`
+	} `json:"funcs"`
+}
+
 func parseJava(src string) ([]string, error) {
-	return nil, fmt.Errorf("java parsing not supported")
+	cmd := exec.Command("mochi-javaast")
+	cmd.Stdin = strings.NewReader(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	var ast javaAST
+	if err := json.Unmarshal(out.Bytes(), &ast); err != nil {
+		return nil, err
+	}
+	var lines []string
+	structs := make(map[string][]string)
+	for _, st := range ast.Structs {
+		lines = append(lines, fmt.Sprintf("type %s {", st.Name))
+		var fields []string
+		for _, f := range st.Fields {
+			lines = append(lines, fmt.Sprintf("  %s: %s", f.Name, mapJavaType(f.Type)))
+			fields = append(fields, f.Name)
+		}
+		lines = append(lines, "}")
+		structs[st.Name] = fields
+	}
+	for _, fn := range ast.Funcs {
+		var params []string
+		for _, p := range fn.Params {
+			name := p.Name
+			if p.Type != "" {
+				name += ": " + mapJavaType(p.Type)
+			}
+			params = append(params, name)
+		}
+		header := fmt.Sprintf("fun %s(%s)", fn.Name, strings.Join(params, ", "))
+		rt := mapJavaType(fn.Ret)
+		if rt != "" && rt != "void" {
+			header += ": " + rt
+		}
+		lines = append(lines, header+" {")
+		body, err := javaBodyLines(fn.Body, structs)
+		if err != nil {
+			return nil, fmt.Errorf("%s", err)
+		}
+		for _, b := range body {
+			lines = append(lines, "  "+b)
+		}
+		lines = append(lines, "}")
+	}
+	return lines, nil
+}
+
+func javaBodyLines(body []string, structs map[string][]string) ([]string, error) {
+	var out []string
+	for _, line := range body {
+		l := strings.TrimSpace(line)
+		if l == "" {
+			continue
+		}
+		if strings.HasPrefix(l, "System.out.println(") && strings.HasSuffix(l, ");") {
+			expr := strings.TrimSuffix(strings.TrimPrefix(l, "System.out.println("), ");")
+			out = append(out, "print("+convertJavaExpr(expr, structs)+")")
+			continue
+		}
+		if strings.HasPrefix(l, "return") {
+			expr := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(l, "return"), ";"))
+			if expr == "" {
+				out = append(out, "return")
+			} else {
+				out = append(out, "return "+convertJavaExpr(expr, structs))
+			}
+			continue
+		}
+		if isVarAssign(l + ";") {
+			name, expr := parseVarAssign(l + ";")
+			out = append(out, "var "+name+" = "+convertJavaExpr(expr, structs))
+			continue
+		}
+		if left, right, ok := parseSimpleAssign(l + ";"); ok {
+			out = append(out, left+" = "+convertJavaExpr(right, structs))
+			continue
+		}
+		return nil, fmt.Errorf("unsupported line: %s", l)
+	}
+	return out, nil
 }


### PR DESCRIPTION
## Summary
- implement `mochi-javaast` command that parses Java with a small Python
  script and outputs JSON
- parse Java using the new CLI and convert the limited AST to Mochi
- add sample conversion results

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6869d44ac3f48320a9732ce44f96ee3d