### PR TITLE
Add Kotlin conversion CLI

### DIFF
--- a/examples/kotlin_hello.ast.json
+++ b/examples/kotlin_hello.ast.json
@@ -1,0 +1,11 @@
+{
+  "functions": [
+    {
+      "name": "main",
+      "params": null,
+      "lines": [
+        "println(\"Hello from Kotlin\")"
+      ]
+    }
+  ]
+}

--- a/examples/kotlin_hello.kt
+++ b/examples/kotlin_hello.kt
@@ -1,0 +1,5 @@
+fun main() {
+    println("Hello from Kotlin")
+}
+
+main()

--- a/examples/kotlin_hello.mochi
+++ b/examples/kotlin_hello.mochi
@@ -1,0 +1,4 @@
+fun main() {
+  print("Hello from Kotlin")
+}
+main()

--- a/tools/any2mochi/cmd/any2mochi/main.go
+++ b/tools/any2mochi/cmd/any2mochi/main.go
@@ -122,6 +122,27 @@ func convertHsCmd() *cobra.Command {
 	return cmd
 }
 
+func convertKtCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-kt <file.kt>",
+		Short: "Convert Kotlin source to Mochi",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			out, err := any2mochi.ConvertKt(string(data))
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	return cmd
+}
+
 func convertPythonCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert-py <file.py>",
@@ -270,6 +291,7 @@ func newRootCmd() *cobra.Command {
 		convertRustCmd(),
 		convertPythonCmd(),
 		convertHsCmd(),
+		convertKtCmd(),
 		convertTSCmd(),
 		convertCmd(),
 	)

--- a/tools/any2mochi/convert_kt.go
+++ b/tools/any2mochi/convert_kt.go
@@ -350,7 +350,11 @@ func convertKtAST(ast *ktAST) ([]byte, error) {
 	var out strings.Builder
 	indent := 0
 	ind := func() string { return strings.Repeat("  ", indent) }
+	hasMain := false
 	for _, fn := range ast.Functions {
+		if fn.Name == "main" {
+			hasMain = true
+		}
 		out.WriteString(ind())
 		out.WriteString("fun ")
 		out.WriteString(fn.Name)
@@ -367,6 +371,9 @@ func convertKtAST(ast *ktAST) ([]byte, error) {
 		}
 		out.WriteString(ind())
 		out.WriteString("}\n")
+	}
+	if hasMain {
+		out.WriteString("main()\n")
 	}
 	if out.Len() == 0 {
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(""))


### PR DESCRIPTION
## Summary
- add `convert-kt` command to any2mochi CLI
- auto-call `main()` when Kotlin code defines `main`
- provide Kotlin example and AST

## Testing
- `go vet ./tools/any2mochi/...`
- `go run ./tools/any2mochi/cmd/any2mochi convert-kt examples/kotlin_hello.kt`
- `go run ./cmd/mochi run examples/kotlin_hello.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6869d4828ef08320b711d9c834f7e230