### PR TITLE
Add rust AST parsing CLI

### DIFF
--- a/examples/rust_demo/add.mochi
+++ b/examples/rust_demo/add.mochi
@@ -1,0 +1,7 @@
+fun add(a: int, b: int): int {
+  return a + b
+}
+fun main() {
+  print(add(2, 3))
+}
+main()

--- a/tools/any2mochi/cmd/rust2mochi/main.go
+++ b/tools/any2mochi/cmd/rust2mochi/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"mochi/tools/any2mochi"
+)
+
+func main() {
+	flag.Parse()
+	var data []byte
+	var err error
+	if flag.NArg() == 1 {
+		data, err = os.ReadFile(flag.Arg(0))
+	} else {
+		data, err = io.ReadAll(os.Stdin)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ast, err := any2mochi.ParseRustAST(string(data))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	out, err := any2mochi.ConvertRustAST(string(data), ast)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Stdout.Write(out)
+}

--- a/tools/any2mochi/cmd/rustparse/main.go
+++ b/tools/any2mochi/cmd/rustparse/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"mochi/tools/any2mochi"
+)
+
+func main() {
+	flag.Parse()
+	var data []byte
+	var err error
+	if flag.NArg() == 1 {
+		data, err = os.ReadFile(flag.Arg(0))
+	} else {
+		data, err = io.ReadAll(os.Stdin)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ast, err := any2mochi.ParseRustAST(string(data))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(ast)
+}

--- a/tools/any2mochi/rust_ast.go
+++ b/tools/any2mochi/rust_ast.go
@@ -1,0 +1,72 @@
+package any2mochi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// RustASTNode represents a node in the Rust syntax tree.
+type RustASTNode struct {
+	Kind     string         `json:"kind"`
+	Start    int            `json:"start"`
+	End      int            `json:"end"`
+	Children []*RustASTNode `json:"children,omitempty"`
+}
+
+func toRustASTNode(n *node) *RustASTNode {
+	if n == nil {
+		return nil
+	}
+	out := &RustASTNode{Kind: n.kind, Start: n.start, End: n.end}
+	for _, c := range n.children {
+		out.Children = append(out.Children, toRustASTNode(c))
+	}
+	return out
+}
+
+func fromRustASTNode(r *RustASTNode) *node {
+	if r == nil {
+		return nil
+	}
+	n := &node{kind: r.Kind, start: r.Start, end: r.End}
+	for _, c := range r.Children {
+		n.children = append(n.children, fromRustASTNode(c))
+	}
+	return n
+}
+
+// ParseRustAST parses the given Rust source code using rust-analyzer and returns
+// the syntax tree as a RustASTNode.
+func ParseRustAST(src string) (*RustASTNode, error) {
+	ls := Servers["rust"]
+	if ls.Command == "" {
+		ls.Command = "rust-analyzer"
+	}
+	if err := EnsureServer(ls.Command); err != nil {
+		return nil, err
+	}
+	ast, err := runRustAnalyzerParse(ls.Command, src)
+	if err != nil {
+		return nil, err
+	}
+	tree := parseTree(ast)
+	if tree == nil {
+		return nil, fmt.Errorf("parse failed")
+	}
+	return toRustASTNode(tree), nil
+}
+
+// ParseRustASTFile reads the Rust file and parses it to a RustASTNode.
+func ParseRustASTFile(path string) (*RustASTNode, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRustAST(string(data))
+}
+
+// MarshalRustAST writes the RustASTNode as JSON.
+func MarshalRustAST(ast *RustASTNode) ([]byte, error) {
+	return json.MarshalIndent(ast, "", "  ")
+}


### PR DESCRIPTION
## Summary
- expose Rust AST parsing helpers
- use the AST for conversion
- provide `rustparse` and `rust2mochi` tools
- show generated example

## Testing
- `go vet ./...`
- `go run ./cmd/mochi run /tmp/add.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6869d4f9ad448320ac20d6fef3fdfbee