### PR TITLE
Add CLI-based Swift AST conversion

### DIFF
--- a/tests/compiler/swift/simple_fn_cli.mochi
+++ b/tests/compiler/swift/simple_fn_cli.mochi
@@ -1,0 +1,8 @@
+fun id(x: int): int {
+    let x = x
+    return x
+}
+fun main() {
+    print(id(123))
+}
+main()


### PR DESCRIPTION
## Summary
- parse Swift source by dumping JSON AST via `swiftc`
- map Swift types from `interface_type`
- generate runnable Mochi code from parsed structures
- add sample conversion output

## Testing
- `go test ./...`
- `go run /tmp/run_convert.go > /tmp/simple_fn.mochi`
- `go run ./cmd/mochi run /tmp/simple_fn.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6869d52b2f7c83208bcba016b32267e5