### PR TITLE
Refactor elixir converter

### DIFF
--- a/tools/any2mochi/cmd/any2mochi/main.go
+++ b/tools/any2mochi/cmd/any2mochi/main.go
@@ -181,49 +181,6 @@ func convertPythonCmd() *cobra.Command {
 	return cmd
 }
 
-func parseExCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "parse-ex <file.ex>",
-		Short: "Parse Elixir source and output JSON AST",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			data, err := os.ReadFile(args[0])
-			if err != nil {
-				return err
-			}
-			ast, err := any2mochi.ParseExAST(string(data))
-			if err != nil {
-				return err
-			}
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
-			return enc.Encode(ast)
-		},
-	}
-	return cmd
-}
-
-func convertExCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "convert-ex <file.ex>",
-		Short: "Convert Elixir source to Mochi",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			data, err := os.ReadFile(args[0])
-			if err != nil {
-				return err
-			}
-			out, err := any2mochi.ConvertEx2(string(data))
-			if err != nil {
-				return err
-			}
-			_, err = cmd.OutOrStdout().Write(out)
-			return err
-		},
-	}
-	return cmd
-}
-
 func convertTSCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert-ts <file.ts>",
@@ -374,8 +331,6 @@ func newRootCmd() *cobra.Command {
 		convertRustCmd(),
 		convertCppCmd(),
 		convertPythonCmd(),
-		parseExCmd(),
-		convertExCmd(),
 		convertHsCmd(),
 		convertTSCmd(),
 		convertCCmd(),

--- a/tools/any2mochi/convert_other_golden_test.go
+++ b/tools/any2mochi/convert_other_golden_test.go
@@ -5,6 +5,8 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	"mochi/tools/any2mochi/x/ex"
 )
 
 // TestConvertOther_Golden converts sample code for a variety of languages
@@ -26,7 +28,7 @@ func TestConvertOther_Golden(t *testing.T) {
 		{"cs", "*.cs.out", ConvertCsFile, "cs"},
 		{"dart", "*.dart.out", ConvertDartFile, "dart"},
 		{"erl", "*.erl.out", ConvertErlangFile, "erl"},
-		{"ex", "*.ex.out", ConvertExFile, "ex"},
+		{"ex", "*.ex.out", ex.FromLSPFile, "ex"},
 		{"fortran", "*.f90.out", ConvertFortranFile, "fortran"},
 		{"fs", "*.fs.out", ConvertFsFile, "fs"},
 		{"hs", "*.hs.out", ConvertHsFile, "hs"},

--- a/tools/any2mochi/x/ex/README.md
+++ b/tools/any2mochi/x/ex/README.md
@@ -1,0 +1,7 @@
+Package ex implements helpers for translating small Elixir programs into Mochi.
+The conversion relies on the Elixir language server to obtain symbol
+information and falls back to light‑weight parsing when necessary.
+
+The main entry points are `FromLSP`, which converts source code by querying the
+language server, and `Convert` which uses the bundled parser. Both functions
+return Mochi source.


### PR DESCRIPTION
## Summary
- move Elixir converter into `tools/any2mochi/x/ex`
- rename types and functions using Go conventions
- call helpers locally and update imports
- drop old CLI commands
- document new package

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6869d88c77948320a9c500a8196384c9