### PR TITLE
Refactor PHP converter into subpackage

### DIFF
--- a/tools/any2mochi/convert_php_golden_test.go
+++ b/tools/any2mochi/convert_php_golden_test.go
@@ -5,9 +5,11 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	php "mochi/tools/any2mochi/x/php"
 )
 
 func TestConvertPhp_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/php"), "*.php.out", ConvertPhpFile, "php", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/php"), "*.php.out", php.ConvertFile, "php", ".mochi", ".error")
 }

--- a/tools/any2mochi/phpast/main.go
+++ b/tools/any2mochi/phpast/main.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"mochi/tools/any2mochi"
+	php "mochi/tools/any2mochi/x/php"
 )
 
 func main() {
@@ -13,7 +13,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	prog, err := any2mochi.ParsePhp(string(data))
+	prog, err := php.Parse(string(data))
 	if err != nil {
 		panic(err)
 	}

--- a/tools/any2mochi/x/php/convert.go
+++ b/tools/any2mochi/x/php/convert.go
@@ -1,4 +1,4 @@
-package any2mochi
+package php
 
 import (
 	"fmt"
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// ConvertPhp parses PHP source using ParsePhp and emits minimal Mochi stubs.
-func ConvertPhp(src string) ([]byte, error) {
-	prog, err := ParsePhp(src)
+// Convert parses PHP source code and emits minimal Mochi stubs.
+func Convert(src string) ([]byte, error) {
+	prog, err := Parse(src)
 	if err != nil {
 		return nil, err
 	}
@@ -53,16 +53,27 @@ func ConvertPhp(src string) ([]byte, error) {
 		out.WriteString(") {}\n")
 	}
 	if out.Len() == 0 {
-		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", snippet(src))
 	}
 	return []byte(out.String()), nil
 }
 
-// ConvertPhpFile reads the php file and converts it to Mochi.
-func ConvertPhpFile(path string) ([]byte, error) {
+func snippet(src string) string {
+	lines := strings.Split(src, "\n")
+	if len(lines) > 10 {
+		lines = lines[:10]
+	}
+	for i, l := range lines {
+		lines[i] = fmt.Sprintf("%3d: %s", i+1, l)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ConvertFile reads the php file and converts it to Mochi.
+func ConvertFile(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return ConvertPhp(string(data))
+	return Convert(string(data))
 }


### PR DESCRIPTION
## Summary
- refactor any2mochi PHP support into `x/php`
- update tests and tools to use the new package
- adjust type and function names to match Go conventions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869f1c622ec8320a09ad689cf1b823b