### PR TITLE
Refactor any2mochi C++ converter

### DIFF
--- a/tools/any2mochi/convert_cpp_golden_test.go
+++ b/tools/any2mochi/convert_cpp_golden_test.go
@@ -5,9 +5,11 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	cpp "mochi/tools/any2mochi/x/cpp"
 )
 
 func TestConvertCpp_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/cpp"), "*.cpp.out", ConvertCppFile, "cpp", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/cpp"), "*.cpp.out", cpp.ConvertFile, "cpp", ".mochi", ".error")
 }

--- a/tools/any2mochi/x/cpp/README.md
+++ b/tools/any2mochi/x/cpp/README.md
@@ -1,0 +1,20 @@
+# C++ Converter
+
+This package provides an experimental C++ frontend for the `any2mochi` tool. It
+uses a configured language server when available and falls back to parsing the
+`clang++` JSON AST to produce minimal Mochi stubs.
+
+## Supported Features
+
+- Extraction of classes, structs, enums and functions via LSP document symbols
+  when a C++ language server is available.
+- Basic conversion of functions and enums using `clang++` when no server is
+  present.
+- Limited translation of simple function bodies (prints, returns and basic
+  assignments).
+
+## Unsupported Features
+
+- Full C++ syntax or complex templates
+- Advanced expression parsing
+- Comprehensive type inference


### PR DESCRIPTION
## Summary
- move C++ converter into `tools/any2mochi/x/cpp`
- rename types and functions to follow std Go style
- adjust tests to use new package
- document the C++ converter architecture

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869f516bafc8320acc23304da4574e4