### PR TITLE
Refactor Clojure any2mochi converter

### DIFF
--- a/tools/any2mochi/x/clj/README.md
+++ b/tools/any2mochi/x/clj/README.md
@@ -1,11 +1,21 @@
 # Clojure Converter
 
-This package contains the experimental Clojure frontend used by the
-`any2mochi` tool.  It converts a small subset of Clojure source code into
-Mochi.  The implementation relies on the Clojure command line tool to
-parse source files via `parse.clj`.
+This package provides an experimental frontend that translates a limited subset of Clojure source code into Mochi.
 
-The main entry point is `Convert` which returns Mochi code for a source
-string. `ConvertFile` is a helper that reads a file and invokes
-`Convert`.
+## Architecture
 
+`Convert` first attempts to parse the input by invoking `parse.clj` through the Clojure command line tool. The script emits a simplified JSON AST which is translated into Mochi by `programToMochi`. If the script is unavailable, the converter falls back to a running language server via LSP.
+
+A very small parser written in Go is used for extracting function bodies and for interpreting the minimal AST nodes.
+
+## Supported Features
+
+- `defn` function definitions
+- `def` variable bindings
+- arithmetic expressions: `+`, `-`, `*`, `/`, `mod`, `quot`
+- basic function calls and `println`
+- returning a value via `throw (ex-info "return" {:value x})`
+
+## Unsupported Features
+
+Most of the Clojure language is not handled. Macros, complex data structures, namespaces, conditionals and loops are currently unsupported.


### PR DESCRIPTION
## Summary
- refactor Clojure converter to use `Program` struct and unexported types
- rename helper `convertAST` to `programToMochi`
- replace `NodeToSexpr` with `nodeToSexpr`
- update architecture notes in `tools/any2mochi/x/clj/README.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869f51ce3348320882eed5c044e8f28