### PR TITLE
Refactor Elixir converter

### DIFF
--- a/tools/any2mochi/convert_ex_golden_test.go
+++ b/tools/any2mochi/convert_ex_golden_test.go
@@ -5,9 +5,11 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	ex "mochi/tools/any2mochi/x/ex"
 )
 
 func TestConvertEx_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/ex"), "*.ex.out", ConvertExFile, "ex", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/ex"), "*.ex.out", ex.ConvertFile, "ex", ".mochi", ".error")
 }

--- a/tools/any2mochi/x/ex/README.md
+++ b/tools/any2mochi/x/ex/README.md
@@ -1,0 +1,22 @@
+# Elixir Converter
+
+This package contains the experimental Elixir frontend used by the `any2mochi` tool. It can convert a subset of Elixir source code into Mochi.
+
+Two conversion paths are available:
+
+1. `Convert` uses the Elixir language server to inspect source code.
+2. `ConvertParsed` parses the source using a small regular-expression based parser.
+
+`ConvertFile` and `ConvertFileParsed` are helpers that read files and invoke the respective functions.
+
+## Supported
+
+- Function definitions
+- Basic control flow (`if`, `for`, `while`)
+- Assignments and simple `IO.puts` calls
+
+## Unsupported
+
+- Macros and advanced pattern matching
+- Modules, records and other complex structures
+- Comprehensive type information

--- a/tools/any2mochi/x/ex/convert.go
+++ b/tools/any2mochi/x/ex/convert.go
@@ -1,6 +1,9 @@
-package any2mochi
+package ex
 
 import (
+	any2mochi "mochi/tools/any2mochi"
+
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -8,32 +11,58 @@ import (
 	excode "mochi/compile/x/ex"
 )
 
-// ConvertEx converts Elixir source code to Mochi using the language server
+func snippet(src string) string {
+	lines := strings.Split(src, "\n")
+	if len(lines) > 10 {
+		lines = lines[:10]
+	}
+	for i, l := range lines {
+		lines[i] = fmt.Sprintf("%3d: %s", i+1, l)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func diagnostics(src string, diags []any2mochi.Diagnostic) string {
+	lines := strings.Split(src, "\n")
+	var out strings.Builder
+	for _, d := range diags {
+		start := int(d.Range.Start.Line)
+		msg := d.Message
+		line := ""
+		if start < len(lines) {
+			line = strings.TrimSpace(lines[start])
+		}
+		out.WriteString(fmt.Sprintf("line %d: %s\n  %s\n", start+1, msg, line))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+// Convert converts Elixir source code to Mochi using the language server
 // for basic parsing. It supports a small subset of Elixir consisting of
 // simple function definitions. When the language server fails to provide
 // usable details the converter falls back to light-weight regex matching of
 // the source. Basic control flow such as `if`, `for` and `while` blocks is
 // recognized along with assignments and IO.puts statements.
-func ConvertEx(src string) ([]byte, error) {
+func Convert(src string) ([]byte, error) {
 	_ = excode.Ensure()
-	ls := Servers["ex"]
-	syms, diags, err := EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
+	ls := any2mochi.Servers["ex"]
+	syms, diags, err := any2mochi.EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
 	if err != nil {
 		return nil, err
 	}
 	if len(diags) > 0 {
-		return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
+		return nil, fmt.Errorf("%s", diagnostics(src, diags))
 	}
 
 	lines := strings.Split(src, "\n")
 	var out strings.Builder
 	foundMain := false
 	for _, s := range syms {
-		if s.Kind != SymbolKindFunction {
+		if s.Kind != any2mochi.SymbolKindFunction {
 			continue
 		}
-		params, ret := getExSignature(src, s.SelectionRange.Start, ls)
-		code := convertExFunc(lines, s, params, ret)
+		params, ret := getSignature(src, s.SelectionRange.Start, ls)
+		code := convertFunc(lines, s, params, ret)
 		if code == "" {
 			continue
 		}
@@ -47,21 +76,21 @@ func ConvertEx(src string) ([]byte, error) {
 		out.WriteString("main()\n")
 	}
 	if out.Len() == 0 {
-		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", snippet(src))
 	}
 	return []byte(out.String()), nil
 }
 
-// ConvertExFile reads the Elixir file at path and converts it to Mochi.
-func ConvertExFile(path string) ([]byte, error) {
+// ConvertFile reads the Elixir file at path and converts it to Mochi.
+func ConvertFile(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return ConvertEx(string(data))
+	return Convert(string(data))
 }
 
-func convertExFunc(lines []string, sym DocumentSymbol, params []string, ret string) string {
+func convertFunc(lines []string, sym any2mochi.DocumentSymbol, params []string, ret string) string {
 	start := int(sym.Range.Start.Line)
 	end := int(sym.Range.End.Line)
 	if start < 0 || end >= len(lines) || start >= end {
@@ -166,16 +195,16 @@ func convertExFunc(lines []string, sym DocumentSymbol, params []string, ret stri
 	return b.String()
 }
 
-func getExSignature(src string, pos Position, ls LanguageServer) ([]string, string) {
-	hov, err := EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, pos)
+func getSignature(src string, pos any2mochi.Position, ls any2mochi.LanguageServer) ([]string, string) {
+	hov, err := any2mochi.EnsureAndHover(ls.Command, ls.Args, ls.LangID, src, pos)
 	if err != nil {
 		return nil, ""
 	}
 	sig := hoverString(hov)
-	return parseExSignature(sig)
+	return parseSignature(sig)
 }
 
-func parseExSignature(sig string) ([]string, string) {
+func parseSignature(sig string) ([]string, string) {
 	sig = strings.ReplaceAll(sig, "\n", " ")
 	open := strings.Index(sig, "(")
 	close := strings.Index(sig, ")")
@@ -186,9 +215,9 @@ func parseExSignature(sig string) ([]string, string) {
 	rest := sig[close+1:]
 	ret := ""
 	if idx := strings.Index(rest, "::"); idx != -1 {
-		ret = mapExType(strings.TrimSpace(rest[idx+2:]))
+		ret = mapType(strings.TrimSpace(rest[idx+2:]))
 	} else if idx := strings.Index(rest, "->"); idx != -1 {
-		ret = mapExType(strings.TrimSpace(rest[idx+2:]))
+		ret = mapType(strings.TrimSpace(rest[idx+2:]))
 	}
 	var params []string
 	if paramsPart != "" {
@@ -210,7 +239,7 @@ func parseExSignature(sig string) ([]string, string) {
 	return params, ret
 }
 
-func mapExType(t string) string {
+func mapType(t string) string {
 	switch t {
 	case "integer()":
 		return "int"
@@ -222,5 +251,37 @@ func mapExType(t string) string {
 		return "bool"
 	default:
 		return t
+	}
+}
+
+func hoverString(h any2mochi.Hover) string {
+	switch v := h.Contents.(type) {
+	case any2mochi.MarkupContent:
+		return v.Value
+	case any2mochi.MarkedString:
+		b, err := json.Marshal(v)
+		if err == nil {
+			var ms any2mochi.MarkedStringStruct
+			if err := json.Unmarshal(b, &ms); err == nil {
+				if ms.Value != "" {
+					return ms.Value
+				}
+			}
+			var s string
+			if err := json.Unmarshal(b, &s); err == nil {
+				return s
+			}
+		}
+		return ""
+	case []any2mochi.MarkedString:
+		parts := make([]string, 0, len(v))
+		for _, m := range v {
+			parts = append(parts, hoverString(any2mochi.Hover{Contents: m}))
+		}
+		return strings.Join(parts, "\n")
+	case string:
+		return v
+	default:
+		return fmt.Sprint(v)
 	}
 }

--- a/tools/any2mochi/x/ex/parse.go
+++ b/tools/any2mochi/x/ex/parse.go
@@ -1,4 +1,4 @@
-package any2mochi
+package ex
 
 import (
 	"fmt"
@@ -7,16 +7,16 @@ import (
 	"strings"
 )
 
-// ExFunc represents a parsed Elixir function.
-type ExFunc struct {
+// Func represents a parsed Elixir function.
+type Func struct {
 	Name   string   `json:"name"`
 	Params []string `json:"params"`
 	Body   []string `json:"body"`
 }
 
-// ExAST is a collection of functions in a source file.
-type ExAST struct {
-	Funcs []ExFunc `json:"funcs"`
+// AST is a collection of functions in a source file.
+type AST struct {
+	Funcs []Func `json:"funcs"`
 }
 
 var fnHeader = regexp.MustCompile(`^def\s+([a-zA-Z0-9_]+)(?:\(([^)]*)\))?\s*do\s*$`)
@@ -36,10 +36,10 @@ func parseParams(paramStr string) []string {
 	return out
 }
 
-// ParseExAST parses a subset of Elixir into an AST structure.
-func ParseExAST(src string) (*ExAST, error) {
+// Parse parses a subset of Elixir into an AST structure.
+func Parse(src string) (*AST, error) {
 	lines := strings.Split(src, "\n")
-	ast := &ExAST{}
+	ast := &AST{}
 	for i := 0; i < len(lines); i++ {
 		line := strings.TrimSpace(lines[i])
 		m := fnHeader.FindStringSubmatch(line)
@@ -57,7 +57,7 @@ func ParseExAST(src string) (*ExAST, error) {
 			}
 			body = append(body, l)
 		}
-		ast.Funcs = append(ast.Funcs, ExFunc{Name: name, Params: params, Body: body})
+		ast.Funcs = append(ast.Funcs, Func{Name: name, Params: params, Body: body})
 	}
 	if len(ast.Funcs) == 0 {
 		return nil, fmt.Errorf("no functions found")
@@ -79,8 +79,8 @@ func translateLine(l string) string {
 	return l
 }
 
-// ConvertExAST converts a parsed ExAST to Mochi source code.
-func ConvertExAST(ast *ExAST) ([]byte, error) {
+// ConvertAST converts a parsed AST to Mochi source code.
+func ConvertAST(ast *AST) ([]byte, error) {
 	var out strings.Builder
 	for _, fn := range ast.Funcs {
 		out.WriteString("fun ")
@@ -107,20 +107,20 @@ func ConvertExAST(ast *ExAST) ([]byte, error) {
 	return []byte(out.String()), nil
 }
 
-// ConvertEx2 parses Elixir source using ParseExAST and converts it to Mochi.
-func ConvertEx2(src string) ([]byte, error) {
-	ast, err := ParseExAST(src)
+// ConvertParsed parses Elixir source using Parse and converts it to Mochi.
+func ConvertParsed(src string) ([]byte, error) {
+	ast, err := Parse(src)
 	if err != nil {
 		return nil, err
 	}
-	return ConvertExAST(ast)
+	return ConvertAST(ast)
 }
 
-// ConvertExFile2 reads an Elixir file and converts it using ConvertEx2.
-func ConvertExFile2(path string) ([]byte, error) {
+// ConvertFileParsed reads an Elixir file and converts it using ConvertParsed.
+func ConvertFileParsed(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return ConvertEx2(string(data))
+	return ConvertParsed(string(data))
 }


### PR DESCRIPTION
## Summary
- move Elixir converter into `tools/any2mochi/x/ex`
- rename functions and structs to follow Go conventions
- add helper functions and README for the new package
- update golden test to use the new package

## Testing
- `go build ./tools/any2mochi/...`
- `go test ./...` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6869f5267f008320b8fa492426afba3f