### PR TITLE
Refactor Scheme converter location

### DIFF
--- a/tools/any2mochi/convert_scheme_golden_test.go
+++ b/tools/any2mochi/convert_scheme_golden_test.go
@@ -5,14 +5,16 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	scheme "mochi/tools/any2mochi/x/scheme"
 )
 
 func TestConvertScheme_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/scheme"), "*.scm.out", ConvertSchemeFile, "scheme", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/scheme"), "*.scm.out", scheme.ConvertFile, "scheme", ".mochi", ".error")
 }
 
 func TestConvertSchemeCompile_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertCompileGolden(t, filepath.Join(root, "tests/compiler/scheme"), "*.scm.out", ConvertSchemeFile, "scheme", ".mochi", ".error")
+	runConvertCompileGolden(t, filepath.Join(root, "tests/compiler/scheme"), "*.scm.out", scheme.ConvertFile, "scheme", ".mochi", ".error")
 }

--- a/tools/any2mochi/x/scheme/README.md
+++ b/tools/any2mochi/x/scheme/README.md
@@ -1,0 +1,15 @@
+# Scheme Converter
+
+This package contains the experimental Scheme frontend used by the `any2mochi` tool. It converts a very small subset of Scheme source code into Mochi. When a Scheme language server is available it is used to extract symbols and hover information. If not, a lightweight `schemeast` helper parses the file.
+
+The main entry point is `Convert` which returns Mochi code for a source string. `ConvertFile` reads a file and invokes `Convert`.
+
+## Supported features
+
+- Top level function and variable definitions
+- Basic parameter extraction and return types when provided
+
+## Unsupported features
+
+- Full Scheme syntax and macros
+- Advanced type inference and complex expressions

--- a/tools/any2mochi/x/scheme/cmd/schemeast/main.go
+++ b/tools/any2mochi/x/scheme/cmd/schemeast/main.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"mochi/tools/any2mochi"
+	"mochi/tools/any2mochi/x/scheme"
 )
 
 func main() {
@@ -21,7 +21,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	items, err := any2mochi.ParseSchemeItems(string(data))
+	items, err := scheme.ParseItems(string(data))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/tools/any2mochi/x/scheme/parser.go
+++ b/tools/any2mochi/x/scheme/parser.go
@@ -1,11 +1,11 @@
-package any2mochi
+package scheme
 
 import "strings"
 
 // SchemeItem represents a top level Scheme definition extracted from the source.
 // Only a minimal subset is supported: function definitions with parameter names
 // and simple variable definitions.
-type SchemeItem struct {
+type Item struct {
 	Kind   string   `json:"kind"`
 	Name   string   `json:"name"`
 	Params []string `json:"params,omitempty"`
@@ -14,13 +14,13 @@ type SchemeItem struct {
 // ParseSchemeItems parses Scheme source and returns a slice of SchemeItem.
 // The parser handles a tiny subset of Scheme syntax sufficient for the
 // conversion tests.
-func ParseSchemeItems(src string) ([]SchemeItem, error) {
-	toks := tokenizeScheme(src)
-	nodes, _, err := parseSchemeList(toks, 0)
+func ParseItems(src string) ([]Item, error) {
+	toks := tokenize(src)
+	nodes, _, err := parseList(toks, 0)
 	if err != nil {
 		return nil, err
 	}
-	var items []SchemeItem
+	var items []Item
 	for _, n := range nodes {
 		if len(n.list) == 0 {
 			continue
@@ -41,16 +41,16 @@ func ParseSchemeItems(src string) ([]SchemeItem, error) {
 					params = append(params, p.atom)
 				}
 			}
-			items = append(items, SchemeItem{Kind: "func", Name: name, Params: params})
+			items = append(items, Item{Kind: "func", Name: name, Params: params})
 		} else if def.atom != "" {
 			// variable definition
-			items = append(items, SchemeItem{Kind: "var", Name: def.atom})
+			items = append(items, Item{Kind: "var", Name: def.atom})
 		}
 	}
 	return items, nil
 }
 
-type schemeToken struct {
+type token struct {
 	typ int
 	val string
 }
@@ -62,8 +62,8 @@ const (
 	scTokString
 )
 
-func tokenizeScheme(src string) []schemeToken {
-	var toks []schemeToken
+func tokenize(src string) []token {
+	var toks []token
 	i := 0
 	for i < len(src) {
 		c := src[i]
@@ -75,10 +75,10 @@ func tokenizeScheme(src string) []schemeToken {
 		case ' ', '\t', '\n', '\r':
 			i++
 		case '(':
-			toks = append(toks, schemeToken{scTokLParen, "("})
+			toks = append(toks, token{scTokLParen, "("})
 			i++
 		case ')':
-			toks = append(toks, schemeToken{scTokRParen, ")"})
+			toks = append(toks, token{scTokRParen, ")"})
 			i++
 		case '"':
 			j := i + 1
@@ -94,9 +94,9 @@ func tokenizeScheme(src string) []schemeToken {
 				j++
 			}
 			if j <= len(src) {
-				toks = append(toks, schemeToken{scTokString, src[i:j]})
+				toks = append(toks, token{scTokString, src[i:j]})
 			} else {
-				toks = append(toks, schemeToken{scTokString, src[i:]})
+				toks = append(toks, token{scTokString, src[i:]})
 			}
 			i = j
 		default:
@@ -104,34 +104,34 @@ func tokenizeScheme(src string) []schemeToken {
 			for j < len(src) && !strings.ContainsRune("()\n\t\r ", rune(src[j])) {
 				j++
 			}
-			toks = append(toks, schemeToken{scTokAtom, src[i:j]})
+			toks = append(toks, token{scTokAtom, src[i:j]})
 			i = j
 		}
 	}
 	return toks
 }
 
-type schemeNode struct {
+type node struct {
 	atom string
-	list []schemeNode
+	list []node
 }
 
-func parseSchemeList(toks []schemeToken, i int) ([]schemeNode, int, error) {
-	var nodes []schemeNode
+func parseList(toks []token, i int) ([]node, int, error) {
+	var nodes []node
 	for i < len(toks) {
 		tok := toks[i]
 		switch tok.typ {
 		case scTokRParen:
 			return nodes, i, nil
 		case scTokLParen:
-			lst, j, err := parseSchemeList(toks, i+1)
+			lst, j, err := parseList(toks, i+1)
 			if err != nil {
 				return nil, 0, err
 			}
-			nodes = append(nodes, schemeNode{list: lst})
+			nodes = append(nodes, node{list: lst})
 			i = j + 1
 		case scTokAtom, scTokString:
-			nodes = append(nodes, schemeNode{atom: tok.val})
+			nodes = append(nodes, node{atom: tok.val})
 			i++
 		default:
 			i++


### PR DESCRIPTION
## Summary
- relocate Scheme conversion logic under `tools/any2mochi/x/scheme`
- remove Scheme specific code from the root `any2mochi` package
- update CLI and tests for the new package path
- document the Scheme converter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869f54a7f208320a08467ffc36c088e