### PR TITLE
Refactor Smalltalk converter location

### DIFF
--- a/tools/any2mochi/convert_st_golden_test.go
+++ b/tools/any2mochi/convert_st_golden_test.go
@@ -5,9 +5,11 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	st "mochi/tools/any2mochi/x/st"
 )
 
 func TestConvertSt_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/st"), "*.st.out", ConvertStFile, "st", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/st"), "*.st.out", st.ConvertFile, "st", ".mochi", ".error")
 }

--- a/tools/any2mochi/x/st/README.md
+++ b/tools/any2mochi/x/st/README.md
@@ -1,0 +1,17 @@
+# Smalltalk Converter
+
+This package contains an experimental Smalltalk frontend for the `any2mochi` tool. It converts a minimal subset of Smalltalk source code to Mochi. The conversion first tries to use the Squeak language server. When the server is unavailable the converter falls back to a very small regex based parser defined in `parse_cli.go`.
+
+The main entry points are `Convert` and `ConvertFile` from `convert.go` which return Mochi code for a Smalltalk source string or file.
+
+## Supported Features
+
+- Global variable assignments
+- `print` statements
+- `return` expressions
+- Simple `while` loops
+- Basic class declarations with fields and methods
+
+## Unsupported Features
+
+Any syntax beyond the constructs listed above is ignored or commented in the generated Mochi code. Complex method bodies, nested classes, imports, packages and most Smalltalk expressions are not supported.


### PR DESCRIPTION
## Summary
- move Smalltalk conversion code into `tools/any2mochi/x/st`
- update tests to use the new package path
- provide helper functions inside the `st` package
- document the converter in `tools/any2mochi/x/st/README.md`

## Testing
- `go vet ./tools/any2mochi/x/st/...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869f55181848320a70cf3aca9915a4a