### PR TITLE
Refactor C converter

### DIFF
--- a/tools/any2mochi/c_types.go
+++ b/tools/any2mochi/c_types.go
@@ -1,8 +1,0 @@
-package any2mochi
-
-type cFunc struct {
-	name   string
-	ret    string
-	params []cParam
-	body   []string
-}

--- a/tools/any2mochi/convert_c_golden_test.go
+++ b/tools/any2mochi/convert_c_golden_test.go
@@ -5,9 +5,11 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	c "mochi/tools/any2mochi/x/c"
 )
 
 func TestConvertC_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/c"), "*.c.out", ConvertCFile, "c", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/c"), "*.c.out", c.ConvertFile, "c", ".mochi", ".error")
 }

--- a/tools/any2mochi/x/c/README.md
+++ b/tools/any2mochi/x/c/README.md
@@ -1,0 +1,22 @@
+# C Converter
+
+This package provides an experimental C frontend for the `any2mochi` tool.
+It converts a subset of C into Mochi. When a language server is available
+(typically `clangd`), it is used to retrieve symbols and type information.
+If no server is configured, the converter falls back to invoking `clang` to
+produce a JSON AST.
+
+The main entry point is `Convert` which accepts a source string. `ConvertFile`
+reads a file and calls `Convert`.
+
+## Supported Features
+
+- Function declarations and simple bodies
+- Structs, unions and enums
+- Basic variable declarations
+
+## Unsupported Features
+
+- Preprocessor directives and macros
+- Pointer arithmetic and complex casts
+- Switch statements and other advanced control flow

--- a/tools/any2mochi/x/c/types.go
+++ b/tools/any2mochi/x/c/types.go
@@ -1,0 +1,8 @@
+package c
+
+type function struct {
+	name   string
+	ret    string
+	params []param
+	body   []string
+}


### PR DESCRIPTION
## Summary
- refactor tools/any2mochi C converter into subpackage `x/c`
- rename functions and types to follow Go conventions
- update tests to use new package path
- add README for C converter

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6869f5115b148320866b289af6474824