### PR TITLE
Refactor Kotlin converter

### DIFF
--- a/tools/any2mochi/convert_kt_golden_test.go
+++ b/tools/any2mochi/convert_kt_golden_test.go
@@ -5,9 +5,11 @@ package any2mochi
 import (
 	"path/filepath"
 	"testing"
+
+	kt "mochi/tools/any2mochi/x/kt"
 )
 
 func TestConvertKt_Golden(t *testing.T) {
 	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/kt"), "*.kt.out", ConvertKtFile, "kt", ".mochi", ".error")
+	runConvertGolden(t, filepath.Join(root, "tests/compiler/kt"), "*.kt.out", kt.ConvertFile, "kt", ".mochi", ".error")
 }

--- a/tools/any2mochi/x/kt/README.md
+++ b/tools/any2mochi/x/kt/README.md
@@ -1,0 +1,14 @@
+# Kotlin Converter
+
+This experimental package provides a minimal Kotlin frontend for the `any2mochi` tool. Source code is parsed using the `ktast` helper CLI which emits a JSON AST. The converter walks this AST and emits stub Mochi code for the discovered symbols.
+
+## Supported Features
+* Top level and member functions
+* Simple `class` declarations with fields and methods
+* Basic control flow in function bodies (for/while loops, if/else)
+* Variable declarations using `val` and `var`
+
+## Unsupported Features
+* Generics beyond simple type mapping
+* Complex expressions and most Kotlin language features
+* Full type inference


### PR DESCRIPTION
## Summary
- move Kotlin converter into `x/kt` package
- rename converter APIs to match Go conventions
- document Kotlin converter features

## Testing
- `go test ./tools/any2mochi/...`

------
https://chatgpt.com/codex/tasks/task_e_6869f5343e0883209f2639586496ae40