### PR TITLE
Improve Python converter

### DIFF
--- a/tools/any2mochi/sample/error_example.error
+++ b/tools/any2mochi/sample/error_example.error
@@ -1,0 +1,2 @@
+line 1: unsupported assignment
+  x = 1

--- a/tools/any2mochi/sample/error_example.py
+++ b/tools/any2mochi/sample/error_example.py
@@ -1,0 +1,6 @@
+x = 1
+if x > 2:
+    y = f"val {x}"
+else:
+    for i in range(3):
+        print(i)

--- a/tools/any2mochi/sample/greet.mochi
+++ b/tools/any2mochi/sample/greet.mochi
@@ -1,0 +1,6 @@
+for i in range(3) {
+  if i % 2 == 0 {
+    print(i)
+  }
+}
+

--- a/tools/any2mochi/sample/greet.py
+++ b/tools/any2mochi/sample/greet.py
@@ -1,0 +1,3 @@
+for i in range(3):
+    if i % 2 == 0:
+        print(i)


### PR DESCRIPTION
## Summary
- rename Node to ASTNode and extend with additional fields
- support loops and comparisons in the Python AST converter
- provide sample converted code and error output showing line numbers

## Testing
- `go test ./tools/any2mochi/py -run TestConvertAST -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869ffaf1c008320acc455da4b8fc6f5