### PR TITLE
Improve any2mochi Go converter

### DIFF
--- a/tests/any2mochi/go/dataset_sort_take_limit.error
+++ b/tests/any2mochi/go/dataset_sort_take_limit.error
@@ -1,5 +1,2 @@
-tests/compiler/go/dataset_sort_take_limit.go.out:28: unsupported declaration
->>> 27:    }
-28:>>> type pair struct {
-29:    item Product
-30:    key  any
+line 6: parse error: unexpected token "[" (expected TypeRef)
+  fun _paginate(src: []T, skip: int, take: int): []T {}

--- a/tests/any2mochi/go/dataset_sort_take_limit.mochi
+++ b/tests/any2mochi/go/dataset_sort_take_limit.mochi
@@ -1,0 +1,6 @@
+type Product {
+  Name: string
+  Price: int
+}
+fun main() {}
+fun _paginate(src: []T, skip: int, take: int): []T {}

--- a/tests/any2mochi/go/typed_list_negative.error
+++ b/tests/any2mochi/go/typed_list_negative.error
@@ -1,5 +1,2 @@
-tests/compiler/go/typed_list_negative.go.out:47: unsupported declaration
->>> 46:    
-47:>>> var xs []int = []int{(-1), 0, 1}
-48:    
-49:    func main() {
+line 1: parse error: unexpected token "expect" (expected declaration)
+  fun expect(cond: bool) {}

--- a/tests/any2mochi/go/typed_list_negative.mochi
+++ b/tests/any2mochi/go/typed_list_negative.mochi
@@ -1,0 +1,10 @@
+fun expect(cond: bool) {}
+fun formatDuration(d: time.Duration): string {}
+fun printTestStart(name: string) {}
+fun printTestPass(d: time.Duration) {}
+fun printTestFail(err: error, d: time.Duration) {}
+fun test_values() {}
+let xs: []int = [(-1), 0, 1]
+fun main() {}
+fun _cast(v: any): T {}
+fun _convertMapAny(m: map[any]any): map[string]any {}


### PR DESCRIPTION
## Summary
- enhance Go converter for any2mochi to handle simple value initializers
- provide detailed diagnostics snippets
- regenerate golden examples for dataset_sort_take_limit and typed_list_negative

## Testing
- `go vet ./tools/any2mochi/go`
- `go run /tmp/gen.go`


------
https://chatgpt.com/codex/tasks/task_e_686a0622e39c8320b93a53aea1f95547