### PR TITLE
Improve any2mochi python converter

### DIFF
--- a/tests/any2mochi/py/error_example.error
+++ b/tests/any2mochi/py/error_example.error
@@ -1,2 +1,3 @@
 line 1: unsupported assignment
-  x = 1
+  1| x = 1
+  2| if x > 2:

--- a/tests/any2mochi/py/greet.mochi
+++ b/tests/any2mochi/py/greet.mochi
@@ -3,4 +3,3 @@ for i in range(3) {
     print(i)
   }
 }
-

--- a/tools/any2mochi/py/convert.go
+++ b/tools/any2mochi/py/convert.go
@@ -461,6 +461,12 @@ func parseLines(lines []string, indent string) ([]string, int) {
 			continue
 		}
 		switch {
+		case s == "break":
+			stmts = append(stmts, "break")
+			i++
+		case s == "continue":
+			stmts = append(stmts, "continue")
+			i++
 		case s == "return":
 			stmts = append(stmts, "return")
 			i++


### PR DESCRIPTION
## Summary
- extend python AST node representation with operand and values fields
- produce more helpful ConvertError context
- support break/continue/pass, unary ops, bool ops and lists
- move example outputs for greet and error_example under tests/any2mochi/py

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a066a4b408320a6911d46168510c2