### PR TITLE
Improve go2mochi error info and update golden

### DIFF
--- a/tests/any2mochi/go/union_inorder.error
+++ b/tests/any2mochi/go/union_inorder.error
@@ -1,5 +1,0 @@
-tests/compiler/go/union_inorder.go.out:12: unsupported method declaration
->>> 11:    
-12:>>> func (Leaf) isTree() {}
-13:    
-14:    type Node struct {

--- a/tests/any2mochi/go/union_inorder.mochi
+++ b/tests/any2mochi/go/union_inorder.mochi
@@ -1,0 +1,24 @@
+type Leaf {
+}
+type Node {
+  Left: Tree
+  Value: int
+  Right: Tree
+}
+fun inorder(t: Tree): list<int> {
+  return fun (): list<int> {
+  let _t = t
+  if ok {
+  return _cast([])
+}
+  if ok {
+  let l = _tmp0.Left
+  let v = _tmp0.Value
+  let r = _tmp0.Right
+  return concat(concat([], concat(concat([], inorder(l)), [v])), inorder(r))
+}
+  var _zero: list<int>
+  return _zero
+}()
+}
+print(str(inorder(Node { Left: Leaf {  }, Value: 1, Right: Node { Left: Leaf {  }, Value: 2, Right: Leaf {  } } })))

--- a/tests/any2mochi/go/union_match.error
+++ b/tests/any2mochi/go/union_match.error
@@ -1,5 +1,0 @@
-tests/compiler/go/union_match.go.out:11: unsupported method declaration
->>> 10:    
-11:>>> func (Leaf) isTree() {}
-12:    
-13:    type Node struct {

--- a/tests/any2mochi/go/union_match.mochi
+++ b/tests/any2mochi/go/union_match.mochi
@@ -1,0 +1,18 @@
+type Leaf {
+}
+type Node {
+  Left: Tree
+  Value: int
+  Right: Tree
+}
+fun isLeaf(t: Tree): bool {
+  return fun (): bool {
+  let _t = t
+  if ok {
+  return true
+}
+  return false
+}()
+}
+print(str(isLeaf(Leaf {  })))
+print(str(isLeaf(Node { Left: Leaf {  }, Value: 1, Right: Leaf {  } })))

--- a/tests/any2mochi/go/union_slice.error
+++ b/tests/any2mochi/go/union_slice.error
@@ -1,5 +1,7 @@
-tests/compiler/go/union_slice.go.out:11: unsupported method declaration
->>> 10:    
-11:>>> func (Empty) isFoo() {}
-12:    
-13:    type Node struct {
+tests/compiler/go/union_slice.go.out:20:9: unsupported expr *ast.IndexListExpr
+  19| func listit() []Foo {
+  20| 	return _convSlice[Empty, Foo]([]Empty{Empty{}})
+             ^
+  21| }
+  22| 
+exit status 1


### PR DESCRIPTION
## Summary
- refine go2mochi snippet formatting
- report column numbers in errors
- ignore methods and interfaces when converting Go
- update union golden files

## Testing
- `go test ./tools/go2mochi/...`
- `go test ./...` *(fails: mochi/tools/any2mochi/sample build error)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cc3c4148320babf4026591f2396