### PR TITLE
Enhance TypeScript any2mochi fallback

### DIFF
--- a/tests/compiler/ts/dataset.error
+++ b/tests/compiler/ts/dataset.error
@@ -1,1 +1,0 @@
-node: unsupported syntax: FirstStatement

--- a/tests/compiler/ts/var_assignment.error
+++ b/tests/compiler/ts/var_assignment.error
@@ -1,1 +1,0 @@
-node: unsupported syntax: FirstStatement


### PR DESCRIPTION
## Summary
- extend TypeScript fallback parser to handle assignments and filter+map
- mirror enhancements in TypeScript helper
- clean up golden error outputs

## Testing
- `go vet ./...` *(fails: tools/any2mochi/sample/broken.go: expected operand)*
- `go test -tags slow ./tools/ts2mochi -run TestConvert_Golden` *(fails: cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_686a0ce6e220832084fd265f88f3f383