### PR TITLE
Improve Elixir any2mochi parser

### DIFF
--- a/tests/any2mochi/ex/hello.ast.json
+++ b/tests/any2mochi/ex/hello.ast.json
@@ -5,7 +5,9 @@
       "params": null,
       "body": [
         "IO.puts(1 + 2)"
-      ]
+      ],
+      "start": 2,
+      "end": 4
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend Elixir AST structures with start and end line numbers
- validate source using the official `elixir` parser when available
- emit detailed error when no functions are found
- update sample AST fixture with new fields

## Testing
- `go test ./tools/any2mochi/x/ex -c`

------
https://chatgpt.com/codex/tasks/task_e_686a0db6813483209e59311b34db19e4