### PR TITLE
Improve Erlang any2mochi converter

### DIFF
--- a/tests/any2mochi/erlang/hello_world.erl.mochi
+++ b/tests/any2mochi/erlang/hello_world.erl.mochi
@@ -1,3 +1,4 @@
+// line 3
 fun main() {
   print("Hello, world\n")
 }

--- a/tools/any2mochi/x/erlang/README.md
+++ b/tools/any2mochi/x/erlang/README.md
@@ -5,7 +5,10 @@ This package provides an experimental Erlang frontend for the `any2mochi` tool. 
 ## Architecture
 
 1. `parse.go` invokes `parser/parser.escript` to obtain a lightweight AST of functions.
-2. `convert.go` walks this AST and emits Mochi `fun` definitions. Simple calls to `io:format` are rewritten as `print` statements.
+   The parser now records the line number and arity of each function for better diagnostics.
+2. `convert.go` walks this AST and emits Mochi `fun` definitions. Simple calls to
+   `io:format` or `io:fwrite` are rewritten as `print` statements and each emitted
+   function is prefixed with a comment indicating the original line number.
 
 `Convert` converts a source string, while `ConvertFile` is a helper that reads a file and calls `Convert`.
 
@@ -13,7 +16,8 @@ This package provides an experimental Erlang frontend for the `any2mochi` tool. 
 
 - Top-level function declarations
 - Detection of `main/0` and insertion of a `main()` call
-- Basic translation of `io:format/1` to `print`
+- Basic translation of `io:format/1` and `io:fwrite/1` to `print`
+- Functions include source line comments for easier debugging
 
 ## Unsupported features
 

--- a/tools/any2mochi/x/erlang/convert.go
+++ b/tools/any2mochi/x/erlang/convert.go
@@ -29,6 +29,9 @@ func Convert(src string) ([]byte, error) {
 		if f.Name == "main" {
 			hasMain = true
 		}
+		out.WriteString("// line ")
+		out.WriteString(fmt.Sprint(f.Line))
+		out.WriteByte('\n')
 		out.WriteString("fun ")
 		if f.Name == "" {
 			out.WriteString("fun")
@@ -50,6 +53,8 @@ func Convert(src string) ([]byte, error) {
 			for _, line := range f.Body {
 				if strings.HasPrefix(line, "io:format(") {
 					line = "print(" + strings.TrimPrefix(line, "io:format(")
+				} else if strings.HasPrefix(line, "io:fwrite(") {
+					line = "print(" + strings.TrimPrefix(line, "io:fwrite(")
 				}
 				out.WriteString("  ")
 				out.WriteString(line)

--- a/tools/any2mochi/x/erlang/parser/parser.escript
+++ b/tools/any2mochi/x/erlang/parser/parser.escript
@@ -13,7 +13,7 @@ output_funs(Forms) ->
     JsonFuns = [fun_to_json(F) || F <- Funs],
     io:format("{\"functions\":[~s]}\n", [string:join(JsonFuns, ",")]).
 
-fun_to_json({function,_,Name,_A,[Clause|_]}) ->
+fun_to_json({function,Line,Name,A,[Clause|_]}) ->
     {clause,_,Params,_G,Body} = Clause,
     ParamNames = [param_name(P) || P <- Params],
     BodyLines = [string:trim(io_lib:format("~s", [erl_pp:expr(E)])) || E <- Body],
@@ -21,6 +21,8 @@ fun_to_json({function,_,Name,_A,[Clause|_]}) ->
         "{\"name\":", json_string(atom_to_list(Name)),
         ",\"params\":", json_array(ParamNames),
         ",\"body\":", json_array(BodyLines),
+        ",\"line\":", integer_to_list(Line),
+        ",\"arity\":", integer_to_list(A),
         "}"]).
 
 param_name({var,_,Name}) -> atom_to_list(Name);


### PR DESCRIPTION
## Summary
- improve parser output to include line and arity
- better error messages when parser fails
- support `io:fwrite` conversion and add line comments in generated functions
- document new features in Erlang converter README
- update golden result for hello_world example

## Testing
- `make test STAGE=tools/any2mochi/x/erlang`
- `go test ./...` *(fails: syntax error in tools/any2mochi/sample)*

------
https://chatgpt.com/codex/tasks/task_e_686a0dc7df388320b58ce5584606d73d