### PR TITLE
Enhance Lua conversion fallback

### DIFF
--- a/tests/any2mochi/lua/hello_world.error
+++ b/tests/any2mochi/lua/hello_world.error
@@ -1,5 +1,0 @@
-convert failure: Lua-Language-Server not found
-
-source snippet:
-  1: function __print(...)
-

--- a/tests/any2mochi/lua/hello_world.lua.mochi
+++ b/tests/any2mochi/lua/hello_world.lua.mochi
@@ -1,0 +1,1 @@
+print("Hello, world")


### PR DESCRIPTION
## Summary
- add fallback conversion when Lua language server isn't available
- map internal `__print` helper back to `print`
- improve parser error messages for Lua converter
- update golden output for hello_world

## Testing
- `go test ./tools/any2mochi/lua -run TestConvertLua_Golden/hello_world.lua -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686a0df0f4408320a14d5641ed46e653