### PR TITLE
Improve PHP any2mochi

### DIFF
--- a/tests/any2mochi/php/dataset.php.mochi
+++ b/tests/any2mochi/php/dataset.php.mochi
@@ -1,0 +1,5 @@
+type Person {
+  name: any
+  age: any
+  fun __construct(fields) {}
+}

--- a/tests/any2mochi/php/dataset_sort_take_limit.php.mochi
+++ b/tests/any2mochi/php/dataset_sort_take_limit.php.mochi
@@ -1,0 +1,6 @@
+type Product {
+  name: any
+  price: any
+  fun __construct(fields) {}
+}
+fun _query(src, joins, opts) {}

--- a/tests/any2mochi/php/string_for_loop.php.error
+++ b/tests/any2mochi/php/string_for_loop.php.error
@@ -1,0 +1,6 @@
+tests/compiler/php/string_for_loop.php.out: no convertible symbols found
+  1: <?php
+  2: foreach ((is_string("cat") ? str_split("cat") : "cat") as $ch) {
+  3: 	echo $ch, PHP_EOL;
+  4: }
+  5:


### PR DESCRIPTION
## Summary
- improve `any2mochi` PHP parser structures and error handling
- add line information to parsed functions and classes
- give better diagnostics for PHP parse errors and empty conversions
- update PHP golden files

## Testing
- `go test ./tools/any2mochi/x/php -tags slow -run TestConvertPhp_Golden/dataset.php -update`
- `go test ./tools/any2mochi/x/php -tags slow -run TestConvertPhp_Golden/dataset_sort_take_limit.php -update`
- `go test ./tools/any2mochi/x/php -tags slow -run TestConvertPhp_Golden/string_for_loop.php -update`
- `go test ./tools/any2mochi/x/php -c -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686a12c1ab7083208447b7b489406534