### PR TITLE
Improve Racket parsing

### DIFF
--- a/tests/any2mochi/rkt/avg_builtin.rkt.mochi
+++ b/tests/any2mochi/rkt/avg_builtin.rkt.mochi
@@ -1,0 +1,8 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+print(( avg ( list 1 2 3 ) ))

--- a/tests/any2mochi/rkt/break_continue.rkt.mochi
+++ b/tests/any2mochi/rkt/break_continue.rkt.mochi
@@ -1,0 +1,8 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let numbers

--- a/tests/any2mochi/rkt/closure.rkt.mochi
+++ b/tests/any2mochi/rkt/closure.rkt.mochi
@@ -1,0 +1,10 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun makeAdder(n) {}
+let add10
+print(( add10 7 ))

--- a/tests/any2mochi/rkt/count_builtin.rkt.mochi
+++ b/tests/any2mochi/rkt/count_builtin.rkt.mochi
@@ -1,0 +1,8 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+print(( count ( list 1 2 3 ) ))

--- a/tests/any2mochi/rkt/dataset.rkt.mochi
+++ b/tests/any2mochi/rkt/dataset.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let people
+let names

--- a/tests/any2mochi/rkt/dataset_sort_take_limit.rkt.mochi
+++ b/tests/any2mochi/rkt/dataset_sort_take_limit.rkt.mochi
@@ -1,0 +1,10 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let products
+let expensive
+print("--- Top products (excluding most expensive) ---")

--- a/tests/any2mochi/rkt/fetch_builtin.rkt.mochi
+++ b/tests/any2mochi/rkt/fetch_builtin.rkt.mochi
@@ -1,0 +1,13 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun _fetch(url, opts) {}
+fun _load(path, opts) {}
+fun _save(rows, path, opts) {}
+fun _group_by(src, keyfn) {}
+let data
+print(( hash-ref data "message" ))

--- a/tests/any2mochi/rkt/fetch_options.rkt.mochi
+++ b/tests/any2mochi/rkt/fetch_options.rkt.mochi
@@ -1,0 +1,14 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun _fetch(url, opts) {}
+fun _load(path, opts) {}
+fun _save(rows, path, opts) {}
+fun _group_by(src, keyfn) {}
+let opts
+let data
+print(( hash-ref data "message" ))

--- a/tests/any2mochi/rkt/for_list_collection.rkt.mochi
+++ b/tests/any2mochi/rkt/for_list_collection.rkt.mochi
@@ -1,0 +1,7 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}

--- a/tests/any2mochi/rkt/for_loop.rkt.mochi
+++ b/tests/any2mochi/rkt/for_loop.rkt.mochi
@@ -1,0 +1,7 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}

--- a/tests/any2mochi/rkt/fun_call.rkt.mochi
+++ b/tests/any2mochi/rkt/fun_call.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun add(a, b) {}
+print(( add 2 3 ))

--- a/tests/any2mochi/rkt/generate_echo.rkt.mochi
+++ b/tests/any2mochi/rkt/generate_echo.rkt.mochi
@@ -1,0 +1,12 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun _genText(prompt, model, params) {}
+fun _genEmbed(text, model, params) {}
+fun _genStruct(ctor, fields, prompt, model, params) {}
+let poem
+print(poem)

--- a/tests/any2mochi/rkt/group_by.rkt.mochi
+++ b/tests/any2mochi/rkt/group_by.rkt.mochi
@@ -1,0 +1,13 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun _fetch(url, opts) {}
+fun _load(path, opts) {}
+fun _save(rows, path, opts) {}
+fun _group_by(src, keyfn) {}
+let xs
+let groups

--- a/tests/any2mochi/rkt/if_else.rkt.mochi
+++ b/tests/any2mochi/rkt/if_else.rkt.mochi
@@ -1,0 +1,8 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let x = 2

--- a/tests/any2mochi/rkt/index_multidim.rkt.mochi
+++ b/tests/any2mochi/rkt/index_multidim.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let xs
+print(( idx ( idx ( idx xs 0 ) 0 ) 0 ))

--- a/tests/any2mochi/rkt/input_builtin.rkt.mochi
+++ b/tests/any2mochi/rkt/input_builtin.rkt.mochi
@@ -1,0 +1,12 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+print("Enter first input:")
+let input1
+print("Enter second input:")
+let input2
+print(( format "~a ~a ~a ~a" "You entered:" input1 "," input2 ))

--- a/tests/any2mochi/rkt/json_builtin.rkt.mochi
+++ b/tests/any2mochi/rkt/json_builtin.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun to-jsexpr(v) {}
+print(( jsexpr->string ( to-jsexpr ( hash "a" 1 ) ) ))

--- a/tests/any2mochi/rkt/let_and_print.rkt.mochi
+++ b/tests/any2mochi/rkt/let_and_print.rkt.mochi
@@ -1,0 +1,10 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let a = 10
+let b = 20
+print(( _add a b ))

--- a/tests/any2mochi/rkt/load_save_json.rkt.mochi
+++ b/tests/any2mochi/rkt/load_save_json.rkt.mochi
@@ -1,0 +1,13 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun _fetch(url, opts) {}
+fun _load(path, opts) {}
+fun _save(rows, path, opts) {}
+fun _group_by(src, keyfn) {}
+let people
+let adults

--- a/tests/any2mochi/rkt/map_index.rkt.mochi
+++ b/tests/any2mochi/rkt/map_index.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let scores
+print(( idx scores "Bob" ))

--- a/tests/any2mochi/rkt/map_iterate.rkt.mochi
+++ b/tests/any2mochi/rkt/map_iterate.rkt.mochi
@@ -1,0 +1,10 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let m
+let sum = 0
+print(sum)

--- a/tests/any2mochi/rkt/map_len.rkt.mochi
+++ b/tests/any2mochi/rkt/map_len.rkt.mochi
@@ -1,0 +1,8 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+print(( count ( hash "a" 1 "b" 2 ) ))

--- a/tests/any2mochi/rkt/map_set.rkt.mochi
+++ b/tests/any2mochi/rkt/map_set.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let scores
+print(( idx scores "b" ))

--- a/tests/any2mochi/rkt/now_builtin.rkt.mochi
+++ b/tests/any2mochi/rkt/now_builtin.rkt.mochi
@@ -1,0 +1,8 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+print(( > ( inexact->exact ( floor ( * ( current-inexact-milliseconds ) 1000000 ) ) ) 0 ))

--- a/tests/any2mochi/rkt/slice_multidim.rkt.mochi
+++ b/tests/any2mochi/rkt/slice_multidim.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let xs
+print(( idx ( idx xs 0 ) 1 ))

--- a/tests/any2mochi/rkt/str_builtin.rkt.mochi
+++ b/tests/any2mochi/rkt/str_builtin.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let x = 42
+print(( format "~a" x ))

--- a/tests/any2mochi/rkt/string_for_loop.rkt.mochi
+++ b/tests/any2mochi/rkt/string_for_loop.rkt.mochi
@@ -1,0 +1,7 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}

--- a/tests/any2mochi/rkt/string_index.rkt.mochi
+++ b/tests/any2mochi/rkt/string_index.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let text = "hello"
+print(( idx text 1 ))

--- a/tests/any2mochi/rkt/string_negative_index.rkt.mochi
+++ b/tests/any2mochi/rkt/string_negative_index.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let text = "hello"
+print(( idx text ( - 1 ) ))

--- a/tests/any2mochi/rkt/tpc-h_q1.rkt.mochi
+++ b/tests/any2mochi/rkt/tpc-h_q1.rkt.mochi
@@ -1,0 +1,15 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun _fetch(url, opts) {}
+fun _load(path, opts) {}
+fun _save(rows, path, opts) {}
+fun _group_by(src, keyfn) {}
+fun to-jsexpr(v) {}
+fun test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {}
+let lineitem
+let result

--- a/tests/any2mochi/rkt/two_sum.rkt.mochi
+++ b/tests/any2mochi/rkt/two_sum.rkt.mochi
@@ -1,0 +1,11 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun twoSum(nums, target) {}
+let result
+print(( idx result 0 ))
+print(( idx result 1 ))

--- a/tests/any2mochi/rkt/typed_list_negative.rkt.mochi
+++ b/tests/any2mochi/rkt/typed_list_negative.rkt.mochi
@@ -1,0 +1,9 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+fun test_values() {}
+let xs

--- a/tests/any2mochi/rkt/while_loop.rkt.mochi
+++ b/tests/any2mochi/rkt/while_loop.rkt.mochi
@@ -1,0 +1,8 @@
+fun idx(x, i) {}
+fun slice(x, s, e) {}
+fun count(x) {}
+fun avg(x) {}
+fun _add(a, b) {}
+fun _div(a, b) {}
+fun expect(cond) {}
+let i = 0

--- a/tools/any2mochi/x/racket/golden_test.go
+++ b/tools/any2mochi/x/racket/golden_test.go
@@ -5,9 +5,11 @@ package racket
 import (
 	"path/filepath"
 	"testing"
+
+	any2mochi "mochi/tools/any2mochi"
 )
 
 func TestConvert_Golden(t *testing.T) {
-	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/rkt"), "*.rkt.out", ConvertFile, "rkt", ".mochi", ".error")
+	root := any2mochi.FindRepoRoot(t)
+	any2mochi.RunConvertGolden(t, filepath.Join(root, "tests/compiler/rkt"), "*.rkt.out", ConvertFile, "rkt", ".mochi", ".error")
 }

--- a/tools/any2mochi/x/racket/read_ast.rkt
+++ b/tools/any2mochi/x/racket/read_ast.rkt
@@ -1,0 +1,18 @@
+#lang racket
+(require json)
+(define in (current-input-port))
+(define src (port->string in))
+(define stx (read-syntax "source" (open-input-string src)))
+(define (s->jsexpr x)
+  (cond
+    [(syntax? x) (hash 'type "syntax"
+                       'datum (s->jsexpr (syntax-e x))
+                       'pos (syntax-position x)
+                       'span (syntax-span x))]
+    [(pair? x) (map s->jsexpr x)]
+    [(list? x) (map s->jsexpr x)]
+    [(vector? x) (map s->jsexpr (vector->list x))]
+    [(symbol? x) (symbol->string x)]
+    [else x]))
+(write-json (s->jsexpr stx))
+(newline)


### PR DESCRIPTION
## Summary
- add a small Racket parser helper using `read-syntax`
- expose line numbers in the Racket AST items
- prefer parsing with the Racket helper when available
- fix `golden_test` to use helper functions
- regenerate Racket golden outputs

## Testing
- `go build ./tools/any2mochi/x/racket`
- `go test -tags slow ./tools/any2mochi/x/racket -run TestConvert_Golden -update`


------
https://chatgpt.com/codex/tasks/task_e_686a12e0dd4c832082574fc52e6e4091