### PR TITLE
Improve Smalltalk converter

### DIFF
--- a/tests/any2mochi/st/for_loop.st.mochi
+++ b/tests/any2mochi/st/for_loop.st.mochi
@@ -1,0 +1,3 @@
+for i in 1..4 {
+  print(i)
+}

--- a/tests/any2mochi/st/unsupported.st.error
+++ b/tests/any2mochi/st/unsupported.st.error
@@ -1,4 +1,2 @@
-no convertible statements found
-
-source snippet:
+line 1: unsupported statement
   1: Object new foo.

--- a/tests/any2mochi/st/while_loop.st.mochi
+++ b/tests/any2mochi/st/while_loop.st.mochi
@@ -1,0 +1,5 @@
+var i = 0
+while (i < 3) {
+  print(i)
+  var i = (i + 1)
+}

--- a/tools/any2mochi/x/st/convert.go
+++ b/tools/any2mochi/x/st/convert.go
@@ -12,7 +12,7 @@ import (
 // Convert converts Smalltalk source code to Mochi using the language server.
 func Convert(src string) ([]byte, error) {
 	if ast, err := parseCLI(src); err == nil {
-		if out, err := convertAST(ast); err == nil {
+		if out, err := convertAST(ast, src); err == nil {
 			return out, nil
 		}
 	}
@@ -310,6 +310,24 @@ func convertSimpleStmt(l string) string {
 		return "return " + strings.TrimSpace(strings.TrimPrefix(l, "^"))
 	}
 	return ""
+}
+
+func formatError(src string, line int, msg string) string {
+	lines := strings.Split(src, "\n")
+	start := line - 2
+	if start < 0 {
+		start = 0
+	}
+	end := line + 1
+	if end > len(lines) {
+		end = len(lines)
+	}
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("line %d: %s\n", line, msg))
+	for i := start; i < end; i++ {
+		out.WriteString(fmt.Sprintf("%3d: %s\n", i+1, lines[i]))
+	}
+	return strings.TrimSpace(out.String())
 }
 
 func numberedSnippet(src string) string {


### PR DESCRIPTION
## Summary
- add loop support to `stast` parser and track line numbers
- improve Smalltalk conversion with new AST fields and detailed error messages
- add golden tests for `for_loop` and `while_loop`
- update existing error output for unsupported constructs

## Testing
- `go build ./tools/any2mochi/x/st`
- `go build ./tools/stast`
- `go test ./tools/any2mochi/x/st`

------
https://chatgpt.com/codex/tasks/task_e_686a18c8e3048320a242c656f12219c0