### PR TITLE
Improve Zig any2mochi conversion

### DIFF
--- a/tests/any2mochi/zig/dataset_sort_take_limit.mochi
+++ b/tests/any2mochi/zig/dataset_sort_take_limit.mochi
@@ -1,0 +1,33 @@
+type Product {
+  name: string
+  price: int
+}
+fun _slice_list(comptime T: type, v: list<const T>, start: int, end: int, step: int): list<T> {
+  let s = start
+  let e = end
+  let st = step
+  let n: = v.len
+  if (s < 0) s += n
+  if (e < 0) e += n
+  if (st == 0) st = 1
+  if (s < 0) s = 0
+  if (e > n) e = n
+  if (st > 0 and e < s) e = s
+  if (st < 0 and e > s) e = s
+  let res = std.ArrayList(T).init(std.heap.page_allocator)
+  defer res.deinit()
+  let i: = s
+  while st > 0 and i < e) or (st < 0 and i > e)) : (i += st {
+    res.append(v[i]) catch unreachable
+  }
+  return res.toOwnedSlice() catch unreachable
+}
+fun main() {
+  let products: = &[_]i32{Product{ .name = "Laptop", .price = 1500 }, Product{ .name = "Smartphone", .price = 900 }, Product{ .name = "Tablet", .price = 600 }, Product{ .name = "Monitor", .price = 300 }, Product{ .name = "Keyboard", .price = 100 }, Product{ .name = "Mouse", .price = 50 }, Product{ .name = "Headphones", .price = 200 }}
+  let expensive: = blk: { var _tmp0 = std.ArrayList(struct { item: i32; key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp0.append([ .item = p, .key = -p.price ]) catch unreachable; } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch unreachable; } var _tmp2 = _tmp1.toOwnedSlice() catch unreachable; _tmp2 = _slice_list(i32, _tmp2, 1, (1 + 3), 1); break :blk _tmp2; }
+  print("{s}\n", ["--- Top products (excluding most expensive) ---"])
+  for item in expensive {
+    print("{any} {s} {any}\n", [item.name, "costs $", item.price])
+  }
+}
+main()


### PR DESCRIPTION
## Summary
- extend Zig AST parser to capture structs and line numbers
- support struct definitions in the Zig converter
- provide richer diagnostic output with code context
- add golden sample for dataset_sort_take_limit

## Testing
- `go run /tmp/convert.go tests/compiler/zig/simple_fn.zig.out`
- `go run /tmp/convert.go tests/compiler/zig/dataset_sort_take_limit.zig.out`

------
https://chatgpt.com/codex/tasks/task_e_686a18ffed908320a7cfb72acb286113