### PR TITLE
Improve Go any2mochi parser

### DIFF
--- a/tools/any2mochi/sample/broken.error
+++ b/tools/any2mochi/sample/broken.error
@@ -1,5 +1,5 @@
-parse error at 5:1: expected operand, found '}'
-  4:     return x +
-  5: }
-  6: 
-
+line 7:1: expected operand, found '}'
+   6|     return x +
+   7| }
+    | ^
+   8|


### PR DESCRIPTION
## Summary
- provide column information in `ConvertError`
- improve `formatParseError` snippets
- enrich AST with doc strings, line numbers and variable values
- update broken Go sample error to match new output

## Testing
- `go build ./tools/any2mochi/go`
- `go test ./tools/any2mochi/go 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_686a27730e948320a65aad8f16de396d