### PR TITLE
Improve C conversion error diagnostics

### DIFF
--- a/tests/any2mochi/c/fetch_builtin.c.error
+++ b/tests/any2mochi/c/fetch_builtin.c.error
@@ -1,38 +1,47 @@
-clang: exit status 1: <stdin>:15:8: error: unknown type name 'map_string'
-   15 | static map_string _fetch(const char *url, void *opts) {
-      |        ^
-<stdin>:19:12: error: call to undeclared function '_read_all'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-   19 |     data = _read_all(url + 7);
-      |            ^
-<stdin>:19:10: error: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
-   19 |     data = _read_all(url + 7);
-      |          ^ ~~~~~~~~~~~~~~~~~~
-<stdin>:21:12: error: call to undeclared function '_read_all'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-   21 |     data = _read_all(url + 5);
-      |            ^
-<stdin>:21:10: error: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
-   21 |     data = _read_all(url + 5);
-      |          ^ ~~~~~~~~~~~~~~~~~~
-<stdin>:46:3: error: use of undeclared identifier 'list_map_string'
-   46 |   list_map_string rows = _parse_json(data);
-      |   ^
-<stdin>:48:7: error: use of undeclared identifier 'rows'
-   48 |   if (rows.len > 0)
-      |       ^
-<stdin>:49:12: error: use of undeclared identifier 'rows'
-   49 |     return rows.data[0];
-      |            ^
-<stdin>:50:10: error: call to undeclared function 'map_string_create'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-   50 |   return map_string_create(0);
-      |          ^
-<stdin>:54:22: error: member reference base type 'int' is not a structure or union
-   54 |   printf("%s\n", data.data["message"]);
-      |                  ~~~~^~~~~
-<stdin>:54:27: error: array subscript is not an integer
-   54 |   printf("%s\n", data.data["message"]);
-      |                           ^~~~~~~~~~
-11 errors generated.
-
+line 15:8: unknown type name 'map_string'
+  15| static map_string _fetch(const char *url, void *opts) {
+            ^
+  16|   (void)opts;
+line 19:12: call to undeclared function '_read_all'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  19|     data = _read_all(url + 7);
+                ^
+  20|   } else if (strncmp(url, "file:", 5) == 0) {
+line 19:10: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
+  19|     data = _read_all(url + 7);
+              ^
+  20|   } else if (strncmp(url, "file:", 5) == 0) {
+line 21:12: call to undeclared function '_read_all'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  21|     data = _read_all(url + 5);
+                ^
+  22|   } else {
+line 21:10: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
+  21|     data = _read_all(url + 5);
+              ^
+  22|   } else {
+line 46:3: use of undeclared identifier 'list_map_string'
+  46|   list_map_string rows = _parse_json(data);
+       ^
+  47|   free(data);
+line 48:7: use of undeclared identifier 'rows'
+  48|   if (rows.len > 0)
+           ^
+  49|     return rows.data[0];
+line 49:12: use of undeclared identifier 'rows'
+  49|     return rows.data[0];
+                ^
+  50|   return map_string_create(0);
+line 50:10: call to undeclared function 'map_string_create'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  50|   return map_string_create(0);
+              ^
+  51| }
+line 54:22: member reference base type 'int' is not a structure or union
+  54|   printf("%s\n", data.data["message"]);
+                          ^
+  55|   return 0;
+line 54:27: array subscript is not an integer
+  54|   printf("%s\n", data.data["message"]);
+                               ^
+  55|   return 0;
 
 source snippet:
   1: #include <stdio.h>
@@ -45,3 +54,4 @@ source snippet:
   8: } list_int;
   9: static list_int list_int_create(int len) {
  10:   list_int l;
+exit status 1

--- a/tools/any2mochi/x/c/types.go
+++ b/tools/any2mochi/x/c/types.go
@@ -1,11 +1,15 @@
 package c
 
+// function describes a parsed C function.
+// Additional location information is useful for better diagnostics
+// and potential future features.
 type function struct {
-	name   string
-	ret    string
-	params []param
-	body   []string
-	line   int
+	name      string
+	ret       string
+	params    []param
+	body      []string
+	startLine int // 1-indexed line of the function definition
+	endLine   int // 1-indexed line of the closing brace
 }
 
 type param struct {


### PR DESCRIPTION
## Summary
- enhance the C AST structure with start/end line info
- improve clang error formatting with context lines
- update failing C golden error output

## Testing
- `go build ./tools/any2mochi/x/c`
- `go test ./tools/any2mochi/x/c -run TestConvertC_Golden -tags slow` *(fails: missing golden files)*

------
https://chatgpt.com/codex/tasks/task_e_686a277ac8208320bf698a9ed4f8341d