### PR TITLE
Improve cpp any2mochi error output

### DIFF
--- a/tests/any2mochi/cpp/dataset.cpp.error
+++ b/tests/any2mochi/cpp/dataset.cpp.error
@@ -1,10 +1,10 @@
-tests/compiler/cpp/dataset.cpp.out: clang++: exit status 1: <stdin>:14:33: error: 'auto' not allowed in template argument
-   14 |   auto names = ([&]() -> vector<auto> {
-      |                                 ^~~~
-<stdin>:15:12: error: 'auto' not allowed in template argument
-   15 |     vector<auto> _res;
-      |            ^~~~
-2 errors generated.
-
+tests/compiler/cpp/dataset.cpp.out: line 14:33: clang++: exit status 1: <stdin>:14:33: error: 'auto' not allowed in template argument
+13:                         Person{string("Charlie"), 65}};
 14:>>>   auto names = ([&]() -> vector<auto> {
+                                    ^
 15:        vector<auto> _res;
+line 15:12: clang++: exit status 1: <stdin>:15:12: error: 'auto' not allowed in template argument
+14:      auto names = ([&]() -> vector<auto> {
+15:>>>     vector<auto> _res;
+               ^
+16:        for (auto &p : people) {


### PR DESCRIPTION
## Summary
- enrich cpp AST structures with line info
- parse clang++ output even on failure
- provide detailed error messages with context
- update cpp dataset golden error

## Testing
- `go test ./tools/any2mochi/x/cpp -c`

------
https://chatgpt.com/codex/tasks/task_e_686a277cc08c8320b1a26b9d1f7898d0