### PR TITLE
Improve cs parser diagnostics

### DIFF
--- a/tools/any2mochi/convert_lua.go
+++ b/tools/any2mochi/convert_lua.go
@@ -24,7 +24,7 @@ func ConvertLua(src string) ([]byte, error) {
 
 	chunk, pErr := luaparse.Parse(bytes.NewReader([]byte(src)), "src.lua")
 	if pErr != nil {
-		return nil, fmt.Errorf(formatLuaParseError(pErr, src))
+		return nil, fmt.Errorf("%s", formatLuaParseError(pErr, src))
 	}
 	fnMap := map[int]*luaast.FunctionExpr{}
 	collectLuaFuncs(chunk, fnMap)
@@ -45,7 +45,7 @@ func ConvertLua(src string) ([]byte, error) {
 		if len(diags) > 0 {
 			return nil, fmt.Errorf("%s", formatDiagnostics(src, diags))
 		}
-		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", NumberedSnippet(src))
 	}
 	return []byte(out.String()), nil
 }

--- a/tools/any2mochi/helpers.go
+++ b/tools/any2mochi/helpers.go
@@ -21,7 +21,7 @@ func EnsureServer(cmd string) error {
 }
 
 // numberedSnippet formats the first few lines of src with line numbers.
-func numberedSnippet(src string) string {
+func NumberedSnippet(src string) string {
 	lines := strings.Split(src, "\n")
 	if len(lines) > 10 {
 		lines = lines[:10]

--- a/tools/any2mochi/x/cs/convert.go
+++ b/tools/any2mochi/x/cs/convert.go
@@ -184,14 +184,7 @@ type param struct {
 }
 
 func snippet(src string) string {
-	lines := strings.Split(src, "\n")
-	if len(lines) > 10 {
-		lines = lines[:10]
-	}
-	for i, l := range lines {
-		lines[i] = fmt.Sprintf("%3d: %s", i+1, l)
-	}
-	return strings.Join(lines, "\n")
+	return any2mochi.NumberedSnippet(src)
 }
 
 func diagnostics(src string, diags []any2mochi.Diagnostic) string {


### PR DESCRIPTION
## Summary
- enhance any2mochi's C# simple parser with start/end line tracking
- surface unsupported syntax line in errors
- export `NumberedSnippet` helper and use in C# converter
- fix Lua converter parse error formatting

## Testing
- `go test ./...`
- `go test ./tools/any2mochi/x/cs -run TestConvertCs_Golden/hello_world.cs -tags slow -count=1 -update`


------
https://chatgpt.com/codex/tasks/task_e_686a277e3be08320bb4eb6e96d21d553