### PR TITLE
Improve Elixir any2mochi support

### DIFF
--- a/tests/any2mochi/ex/hello.ast.json
+++ b/tests/any2mochi/ex/hello.ast.json
@@ -6,8 +6,13 @@
       "body": [
         "IO.puts(1 + 2)"
       ],
-      "start": 2,
-      "end": 4
+      "start": 1,
+      "end": 3,
+      "raw": [
+        "def main do",
+        "  IO.puts(1 + 2)",
+        "end"
+      ]
     }
   ]
 }

--- a/tools/any2mochi/x/ex/convert.go
+++ b/tools/any2mochi/x/ex/convert.go
@@ -51,7 +51,10 @@ func Convert(src string) ([]byte, error) {
 		return nil, err
 	}
 	if len(diags) > 0 {
-		return nil, fmt.Errorf("%s", diagnostics(src, diags))
+		lines := strings.Split(src, "\n")
+		d := diags[0]
+		line := int(d.Range.Start.Line) + 1
+		return nil, newConvertError(line, lines, d.Message)
 	}
 
 	lines := strings.Split(src, "\n")
@@ -76,7 +79,7 @@ func Convert(src string) ([]byte, error) {
 		out.WriteString("main()\n")
 	}
 	if out.Len() == 0 {
-		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", snippet(src))
+		return nil, &ConvertError{Msg: "no convertible symbols found", Snip: snippet(src)}
 	}
 	return []byte(out.String()), nil
 }


### PR DESCRIPTION
## Summary
- improve `any2mochi` Elixir parser
- add detailed conversion errors
- expose raw lines and doc comments in the parsed AST
- update golden AST file

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a27913a7c83208deb1c0256a6dcef