### PR TITLE
Improve Fortran any2mochi conversion

### DIFF
--- a/tools/any2mochi/x/fortran/README.md
+++ b/tools/any2mochi/x/fortran/README.md
@@ -6,11 +6,10 @@ This package provides an experimental frontend for converting Fortran 90 source 
 
 - Detection of program and function declarations
 - Basic parameter and return type inference
-- Conversion of `print`, assignments, `if` blocks, `do` loops and `return` statements
+- Conversion of `print`, assignments, `if` blocks, `do` loops`, `select case`, `cycle`/`exit` and `return` statements
 
 ## Unsupported features
 
-- Complex numeric formatting and intrinsic functions
-- Advanced control flow such as `select case`
+- Complex numeric formatting and other advanced intrinsics
 - Modules with extensive `contains` sections
 - Preprocessor directives and macros


### PR DESCRIPTION
## Summary
- improve error diagnostics with line/column pointers
- support more Fortran control flow in the converter (`select case`, `cycle`, `exit`)
- update documentation about supported features

## Testing
- `go test ./tools/any2mochi/x/fortran -run TestConvertFortran_Golden -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686a2793fb188320a11aab25da052082