### PR TITLE
Improve Haskell converter

### DIFF
--- a/tools/any2mochi/x/hs/ast.go
+++ b/tools/any2mochi/x/hs/ast.go
@@ -1,6 +1,15 @@
 package hs
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// Field describes a record field in a data declaration.
+type Field struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
 
 // Item represents a minimal Haskell AST item parsed from source code.
 type Item struct {
@@ -8,15 +17,23 @@ type Item struct {
 	Name   string   `json:"name,omitempty"`
 	Params []string `json:"params,omitempty"`
 	Body   string   `json:"body,omitempty"`
+	Fields []Field  `json:"fields,omitempty"`
+	Line   int      `json:"line"`
 }
 
 // Parse parses a very small subset of Haskell source and returns a slice
-// of Items describing top level declarations.
-func Parse(src string) []Item {
+// of Items describing top level declarations. Unsupported lines cause an
+// error that includes the line number and snippet for easier debugging.
+func Parse(src string) ([]Item, error) {
 	lines := strings.Split(src, "\n")
 	var items []Item
-	for i, line := range lines {
+	var parseErr error
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
 		l := strings.TrimSpace(line)
+		if l == "" || strings.HasPrefix(l, "--") || strings.HasPrefix(l, "module ") || strings.HasPrefix(l, "import ") || strings.HasPrefix(l, "{-") {
+			continue
+		}
 		if strings.HasPrefix(l, "main =") {
 			body := strings.TrimSpace(strings.TrimPrefix(l, "main ="))
 			if body == "do" && i+1 < len(lines) {
@@ -24,16 +41,48 @@ func Parse(src string) []Item {
 				if strings.HasPrefix(next, "putStrLn") {
 					arg := strings.TrimSpace(strings.TrimPrefix(next, "putStrLn"))
 					arg = strings.Trim(arg, "()")
-					items = append(items, Item{Kind: "print", Body: arg})
+					items = append(items, Item{Kind: "print", Body: arg, Line: i + 1})
 				}
+				i++
 				continue
 			}
 			if strings.HasPrefix(body, "putStrLn") {
 				arg := strings.TrimSpace(strings.TrimPrefix(body, "putStrLn"))
 				arg = strings.Trim(arg, "()")
-				items = append(items, Item{Kind: "print", Body: arg})
+				items = append(items, Item{Kind: "print", Body: arg, Line: i + 1})
 			}
 			continue
+		}
+		if strings.HasPrefix(l, "data ") && strings.Contains(l, "{") {
+			parts := strings.Fields(strings.TrimSpace(strings.TrimPrefix(l, "data ")))
+			if len(parts) > 0 {
+				name := parts[0]
+				// capture lines until closing brace
+				j := i
+				buf := l
+				for j+1 < len(lines) && !strings.Contains(lines[j], "}") {
+					j++
+					buf += "\n" + strings.TrimSpace(lines[j])
+				}
+				if end := strings.Index(buf, "}"); end != -1 {
+					start := strings.Index(buf, "{")
+					fields := strings.Split(buf[start+1:end], ",")
+					var fs []Field
+					for _, f := range fields {
+						f = strings.TrimSpace(f)
+						if f == "" {
+							continue
+						}
+						parts := strings.Fields(f)
+						if len(parts) >= 3 && parts[1] == "::" {
+							fs = append(fs, Field{Name: parts[0], Type: parts[2]})
+						}
+					}
+					items = append(items, Item{Kind: "struct", Name: name, Fields: fs, Line: i + 1})
+					i = j
+					continue
+				}
+			}
 		}
 		if parts := strings.SplitN(l, "=", 2); len(parts) == 2 {
 			left := strings.Fields(strings.TrimSpace(parts[0]))
@@ -46,10 +95,22 @@ func Parse(src string) []Item {
 			if strings.HasPrefix(body, "do") {
 				continue
 			}
-			items = append(items, Item{Kind: "func", Name: name, Params: params, Body: body})
+			kind := "func"
+			if len(params) == 0 {
+				kind = "var"
+			}
+			items = append(items, Item{Kind: kind, Name: name, Params: params, Body: body, Line: i + 1})
+			continue
+		}
+		if parseErr == nil {
+			snippet := line
+			if len(snippet) > 60 {
+				snippet = snippet[:60]
+			}
+			parseErr = fmt.Errorf("unsupported syntax at line %d:\n  %s", i+1, strings.TrimSpace(snippet))
 		}
 	}
-	return items
+	return items, parseErr
 }
 
 // convertItems converts the Haskell AST items to Mochi source code.
@@ -79,6 +140,32 @@ func convertItems(items []Item) []byte {
 				out.WriteString(it.Body)
 				out.WriteString(" }\n")
 			}
+		case "var":
+			out.WriteString("let ")
+			out.WriteString(it.Name)
+			if it.Body != "" {
+				out.WriteString(" = ")
+				out.WriteString(it.Body)
+			}
+			out.WriteByte('\n')
+		case "struct":
+			out.WriteString("type ")
+			out.WriteString(it.Name)
+			if len(it.Fields) == 0 {
+				out.WriteString(" {}\n")
+				break
+			}
+			out.WriteString(" {\n")
+			for _, f := range it.Fields {
+				out.WriteString("  ")
+				out.WriteString(f.Name)
+				if f.Type != "" {
+					out.WriteString(": ")
+					out.WriteString(mapType(f.Type))
+				}
+				out.WriteByte('\n')
+			}
+			out.WriteString("}\n")
 		}
 	}
 	if out.Len() == 0 {

--- a/tools/any2mochi/x/hs/convert.go
+++ b/tools/any2mochi/x/hs/convert.go
@@ -76,6 +76,8 @@ func Convert(src string) ([]byte, error) {
 			if out := convertItems(items); out != nil {
 				return out, nil
 			}
+		} else if err2 != nil {
+			return nil, err2
 		}
 		if out := parseSimple(src); out != nil {
 			return out, nil
@@ -92,6 +94,8 @@ func Convert(src string) ([]byte, error) {
 			if res := convertItems(items); res != nil {
 				return res, nil
 			}
+		} else if err2 != nil {
+			return nil, err2
 		}
 		if simple := parseSimple(src); simple != nil {
 			return simple, nil
@@ -112,7 +116,7 @@ func ConvertFile(path string) ([]byte, error) {
 
 // parseCLI parses the source using the built-in parser and returns the items.
 func parseCLI(src string) ([]Item, error) {
-	return Parse(src), nil
+	return Parse(src)
 }
 
 func getSignature(src string, sym any2mochi.DocumentSymbol, ls any2mochi.LanguageServer) ([]string, string) {
@@ -407,6 +411,15 @@ func parseSimple(src string) []byte {
 				continue
 			}
 			var out strings.Builder
+			if len(params) == 0 {
+				out.WriteString("let ")
+				out.WriteString(name)
+				if body != "" {
+					out.WriteString(" = ")
+					out.WriteString(body)
+				}
+				return []byte(out.String())
+			}
 			out.WriteString("fun ")
 			out.WriteString(name)
 			out.WriteByte('(')


### PR DESCRIPTION
## Summary
- extend Haskell AST items with field information and line numbers
- support variable declarations and struct parsing
- skip next line when reading trivial `main` functions

## Testing
- `go vet ./tools/any2mochi/x/hs`
- `go test ./tools/any2mochi/x/hs -run TestConvertHs_Golden -tags slow` *(fails: missing golden files)*

------
https://chatgpt.com/codex/tasks/task_e_686a27963b288320a6b43146a1a326a6