### PR TITLE
Improve Java any2mochi conversion

### DIFF
--- a/tests/any2mochi/java/dataset.error
+++ b/tests/any2mochi/java/dataset.error
@@ -1,2 +1,8 @@
-unsupported line: Object[] adults = (new java.util.function.Supplier<java.util.List<Object>>() {
+line 3: unsupported line: public java.util.List<Object> get() {
+  1| Object[] people = new Object[]{new java.util.HashMap<>(java.util.Map.of("name", "Alice", "age", 30)), new java.util.HashMap<>(java.util.Map.of("name", "Bob", "age", 15)), new java.util.HashMap<>(java.util.Map.of("name", "Charlie", "age", 65)), new java.util.HashMap<>(java.util.Map.of("name", "Diana", "age", 45))};
+  2| Object[] adults = (new java.util.function.Supplier<java.util.List<Object>>() {
+  3| public java.util.List<Object> get() {
+  4| java.util.List<Object> _src = _toList(people);
+  5| _src = _filter(_src, (Object person) -> { return (person.age >= 18); });
+
 

--- a/tests/any2mochi/java/dataset_sort_take_limit.error
+++ b/tests/any2mochi/java/dataset_sort_take_limit.error
@@ -1,2 +1,8 @@
-unsupported line: Object[] expensive = (new java.util.function.Supplier<java.util.List<Object>>() {
+line 11: unsupported line: Product() {}
+  9| }
+ 10| 
+ 11| Product() {}
+ 12| }
+ 13| 
+
 

--- a/tests/any2mochi/java/fun_expr_in_let.error
+++ b/tests/any2mochi/java/fun_expr_in_let.error
@@ -1,1 +1,0 @@
-unsupported line: java.util.function.Function<Integer, Integer> square =

--- a/tests/any2mochi/java/fun_expr_in_let.mochi
+++ b/tests/any2mochi/java/fun_expr_in_let.mochi
@@ -1,0 +1,5 @@
+fun main(args: String[]) {
+  var square = fn(x) { return x * x }
+  print(square(6))
+}
+

--- a/tests/any2mochi/java/input_builtin.error
+++ b/tests/any2mochi/java/input_builtin.error
@@ -1,1 +1,8 @@
-unsupported line: static java.util.Scanner _scanner = new java.util.Scanner(System.in);
+line 10: unsupported line: static java.util.Scanner _scanner = new java.util.Scanner(System.in);
+  8| }
+  9| 
+ 10| static java.util.Scanner _scanner = new java.util.Scanner(System.in);
+ 11| 
+ 12| static String _input() {
+
+

--- a/tests/any2mochi/java/load_save_json.error
+++ b/tests/any2mochi/java/load_save_json.error
@@ -1,1 +1,8 @@
-unsupported function declaration: static class Person {
+line 13: unsupported line: Person() {}
+ 11| }
+ 12| 
+ 13| Person() {}
+ 14| }
+ 15| 
+
+

--- a/tests/any2mochi/java/matrix_search.error
+++ b/tests/any2mochi/java/matrix_search.error
@@ -1,1 +1,8 @@
-unsupported line: while ((left <= right)) {
+line 4: unsupported line: }
+  2| if ((m == 0)) {
+  3| return false;
+  4| }
+  5| int n = matrix[0].length;
+  6| int left = 0;
+
+

--- a/tests/any2mochi/java/tpch_q1.error
+++ b/tests/any2mochi/java/tpch_q1.error
@@ -1,1 +1,8 @@
-unsupported line: expect((result == new Object[]{new java.util.HashMap<>(java.util.Map.of("returnflag", "N", "linestatus", "O", "sum_qty", 53, "sum_base_price", 3000, "sum_disc_price", (950 + 1800), "sum_charge", ((950 * 1.07) + (1800 * 1.05)), "avg_qty", 26.5, "avg_price", 1500, "avg_disc", 0.07500000000000001, "count_order", 2))}));
+line 6: unsupported line: static Object[] lineitem = new Object[]{new java.util.HashMap<>(java.util.Map.of("l_quantity", 17, "l_extendedprice", 1000, "l_discount", 0.05, "l_tax", 0.07, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-08-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 36, "l_extendedprice", 2000, "l_discount", 0.1, "l_tax", 0.05, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-09-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 25, "l_extendedprice", 1500, "l_discount", 0, "l_tax", 0.08, "l_returnflag", "R", "l_linestatus", "F", "l_shipdate", "1998-09-03"))};
+  4| }
+  5| 
+  6| static Object[] lineitem = new Object[]{new java.util.HashMap<>(java.util.Map.of("l_quantity", 17, "l_extendedprice", 1000, "l_discount", 0.05, "l_tax", 0.07, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-08-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 36, "l_extendedprice", 2000, "l_discount", 0.1, "l_tax", 0.05, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-09-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 25, "l_extendedprice", 1500, "l_discount", 0, "l_tax", 0.08, "l_returnflag", "R", "l_linestatus", "F", "l_shipdate", "1998-09-03"))};
+  7| 
+  8| static Object[] result = (new java.util.function.Supplier<java.util.List<Object>>() {
+
+

--- a/tests/any2mochi/java/update_stmt.error
+++ b/tests/any2mochi/java/update_stmt.error
@@ -1,1 +1,8 @@
-unsupported function declaration: static class Person {
+line 13: unsupported line: Person() {}
+ 11| }
+ 12| 
+ 13| Person() {}
+ 14| }
+ 15| 
+
+

--- a/tools/any2mochi/x/java/convert.go
+++ b/tools/any2mochi/x/java/convert.go
@@ -25,6 +25,7 @@ func Convert(src string) ([]byte, error) {
 // resemble Mochi syntax. It does not attempt full parsing.
 func convertJavaExpr(expr string, structs map[string][]string) string {
 	expr = strings.TrimSpace(expr)
+	expr = strings.TrimSuffix(expr, ";")
 	for strings.HasPrefix(expr, "(") && strings.HasSuffix(expr, ")") {
 		expr = strings.TrimSpace(expr[1 : len(expr)-1])
 	}
@@ -147,6 +148,12 @@ func convertJavaExpr(expr string, structs map[string][]string) string {
 		if len(parts) == 2 {
 			return convertJavaExpr(parts[0], structs) + " in " + convertJavaExpr(parts[1], structs)
 		}
+	}
+
+	if idx := strings.Index(expr, ".apply("); idx != -1 && strings.HasSuffix(expr, ")") {
+		name := expr[:idx]
+		arg := strings.TrimSuffix(expr[idx+7:], ")")
+		return convertJavaExpr(name, structs) + "(" + convertJavaExpr(arg, structs) + ")"
 	}
 
 	reBuiltin := []struct{ old, new string }{


### PR DESCRIPTION
## Summary
- expand java AST structs with position info and add legacy parser fallback
- improve multi-line join handling and `.apply` calls in java converter
- generate updated golden files for java conversion tests

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_686a2797a3c88320ae2cc38501f87404