### PR TITLE
Improve Prolog any2mochi AST support

### DIFF
--- a/tools/any2mochi/x/prolog/convert.go
+++ b/tools/any2mochi/x/prolog/convert.go
@@ -321,6 +321,29 @@ func parseBody(body string) []string {
 			} else {
 				out = append(out, "  // "+c)
 			}
+		case strings.HasPrefix(c, "dict_create("):
+			re := regexp.MustCompile(`dict_create\(([^,]+),\s*([^,]+),\s*\[([^\]]*)\]\)`)
+			m := re.FindStringSubmatch(c)
+			if len(m) == 4 {
+				varName := strings.TrimSpace(m[1])
+				typ := strings.TrimSpace(m[2])
+				fields := strings.Split(m[3], ",")
+				var parts []string
+				for _, f := range fields {
+					kv := strings.SplitN(strings.TrimSpace(f), "-", 2)
+					if len(kv) == 2 {
+						parts = append(parts, kv[0]+": "+kv[1])
+					}
+				}
+				out = append(out, "  let "+varName+" = "+strings.Title(typ)+" { "+strings.Join(parts, ", ")+" }")
+			} else {
+				out = append(out, "  // "+c)
+			}
+		case strings.Contains(c, " = [") && strings.HasSuffix(c, "]"):
+			parts := strings.SplitN(c, "=", 2)
+			name := strings.TrimSpace(parts[0])
+			list := strings.TrimSpace(parts[1])
+			out = append(out, "  let "+name+" = "+list)
 		case strings.Contains(c, " is "):
 			parts := strings.SplitN(c, " is ", 2)
 			name := strings.TrimSpace(parts[0])


### PR DESCRIPTION
## Summary
- extend `pl_ast.pl` to emit char offsets
- add start/end fields in Go AST parser
- expose line number calculation for clauses
- teach Prolog converter to recognise `dict_create` and list literals

## Testing
- `go build ./...`
- `go test ./... -run TestNonexistent -count=1` *(fails: non-constant format string in convert_lua.go)*

------
https://chatgpt.com/codex/tasks/task_e_686a27a1c1a88320996ee123516c18f6