### PR TITLE
Improve Racket any2mochi parser

### DIFF
--- a/tools/any2mochi/x/racket/read_ast.rkt
+++ b/tools/any2mochi/x/racket/read_ast.rkt
@@ -2,7 +2,9 @@
 (require json)
 (define in (current-input-port))
 (define src (port->string in))
-(define stx (read-syntax "source" (open-input-string src)))
+(define stx
+  (parameterize ([read-accept-reader #t])
+    (read-syntax "source" (open-input-string src))))
 (define (s->jsexpr x)
   (cond
     [(syntax? x) (hash 'type "syntax"


### PR DESCRIPTION
## Summary
- handle `#lang` modules when reading AST
- surface diagnostics from Racket LSP parsing
- add snippet helpers for better error messages
- merge token parsing results with AST parsing and capture variable values

## Testing
- `go test ./tools/any2mochi/x/racket -tags slow -run TestConvert_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_686a27a592588320a32d06055b67771a