### PR TITLE
Improve rust conversion tooling

### DIFF
--- a/tests/any2mochi/rust/trait_def.rs.error
+++ b/tests/any2mochi/rust/trait_def.rs.error
@@ -1,0 +1,7 @@
+no convertible symbols found
+
+source snippet:
+  1: trait Foo {
+  2:     fn bar(&self);
+  3: }
+  4:

--- a/tests/compiler/rust/trait_def.rs.out
+++ b/tests/compiler/rust/trait_def.rs.out
@@ -1,0 +1,3 @@
+trait Foo {
+    fn bar(&self);
+}

--- a/tools/any2mochi/x/rust/ast.go
+++ b/tools/any2mochi/x/rust/ast.go
@@ -11,15 +11,16 @@ import (
 
 // RustASTNode represents a node in the Rust syntax tree.
 type ASTNode struct {
-	Kind        string     `json:"kind"`
-	Start       int        `json:"start"`
-	End         int        `json:"end"`
-	Children    []*ASTNode `json:"children,omitempty"`
-	StartLine   int        `json:"startLine,omitempty"`
-	StartColumn int        `json:"startColumn,omitempty"`
-	EndLine     int        `json:"endLine,omitempty"`
-	EndColumn   int        `json:"endColumn,omitempty"`
-	Text        string     `json:"text,omitempty"`
+        Kind        string     `json:"kind"`
+        Start       int        `json:"start"`
+        End         int        `json:"end"`
+        Children    []*ASTNode `json:"children,omitempty"`
+        StartLine   int        `json:"startLine,omitempty"`
+        StartColumn int        `json:"startColumn,omitempty"`
+        EndLine     int        `json:"endLine,omitempty"`
+        EndColumn   int        `json:"endColumn,omitempty"`
+        Text        string     `json:"text,omitempty"`
+       Snippet     string     `json:"snippet,omitempty"`
 }
 
 func position(src string, off int) (line, col int) {
@@ -37,21 +38,22 @@ func position(src string, off int) (line, col int) {
 }
 
 func toASTNode(src string, n *node) *ASTNode {
-	if n == nil {
-		return nil
-	}
-	sl, sc := position(src, n.start)
-	el, ec := position(src, n.end)
-	out := &ASTNode{
-		Kind:        n.kind,
-		Start:       n.start,
-		End:         n.end,
-		StartLine:   sl,
-		StartColumn: sc,
-		EndLine:     el,
-		EndColumn:   ec,
-		Text:        strings.TrimSpace(src[n.start:n.end]),
-	}
+        if n == nil {
+                return nil
+        }
+        sl, sc := position(src, n.start)
+        el, ec := position(src, n.end)
+       out := &ASTNode{
+                Kind:        n.kind,
+                Start:       n.start,
+                End:         n.end,
+                StartLine:   sl,
+                StartColumn: sc,
+                EndLine:     el,
+                EndColumn:   ec,
+                Text:        strings.TrimSpace(src[n.start:n.end]),
+                Snippet:     lineSnippet(src, sl),
+        }
 	for _, c := range n.children {
 		out.Children = append(out.Children, toASTNode(src, c))
 	}
@@ -101,5 +103,13 @@ func ParseASTFile(path string) (*ASTNode, error) {
 
 // MarshalAST writes the ASTNode as JSON.
 func MarshalAST(ast *ASTNode) ([]byte, error) {
-	return json.MarshalIndent(ast, "", "  ")
+        return json.MarshalIndent(ast, "", "  ")
+}
+
+func lineSnippet(src string, line int) string {
+       lines := strings.Split(src, "\n")
+       if line-1 < 0 || line-1 >= len(lines) {
+               return ""
+       }
+       return strings.TrimSpace(lines[line-1])
 }

--- a/tools/any2mochi/x/rust/convert.go
+++ b/tools/any2mochi/x/rust/convert.go
@@ -568,16 +568,20 @@ func convertImpl(src string, n *node) []string {
 }
 
 func runRustAnalyzerParse(cmd, src string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	c := exec.CommandContext(ctx, cmd, "parse")
-	c.Stdin = strings.NewReader(src)
-	var out bytes.Buffer
-	c.Stdout = &out
-	if err := c.Run(); err != nil {
-		return "", err
-	}
-	return out.String(), nil
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+        c := exec.CommandContext(ctx, cmd, "parse")
+        c.Stdin = strings.NewReader(src)
+       var out, stderr bytes.Buffer
+       c.Stdout = &out
+       c.Stderr = &stderr
+       if err := c.Run(); err != nil {
+               if msg := strings.TrimSpace(stderr.String()); msg != "" {
+                       return "", fmt.Errorf("%v: %s", err, msg)
+               }
+               return "", err
+        }
+        return out.String(), nil
 }
 
 func convertRustTree(src string, tree *node) ([]byte, error) {


### PR DESCRIPTION
## Summary
- extend `ASTNode` with a `Snippet` field for better diagnostics
- capture stderr from `rust-analyzer` for clearer errors
- add `lineSnippet` helper for AST nodes
- provide new rust golden test demonstrating missing trait conversion

## Testing
- `go test -tags slow ./tools/any2mochi/x/rust -run TestConvertRust_Golden/trait_def.rs -v`
- `go test -tags slow ./tools/any2mochi/x/rust -run TestConvertRust_Golden -v`


------
https://chatgpt.com/codex/tasks/task_e_686a27a6bee08320ad40613e436b6d2e