### PR TITLE
Improve Swift converter

### DIFF
--- a/tests/any2mochi/swift/struct_literal.swift.error
+++ b/tests/any2mochi/swift/struct_literal.swift.error
@@ -1,1 +1,0 @@
-parse error: parse error: 5:11: unexpected token "(" (expected "{" Statement* "}")

--- a/tests/any2mochi/swift/struct_literal.swift.mochi
+++ b/tests/any2mochi/swift/struct_literal.swift.mochi
@@ -1,0 +1,10 @@
+type Point {
+  x: int
+  y: int
+}
+fun main() {
+    let p = Point { x: 1, y: 2 }
+    print(p.x)
+}
+main()
+

--- a/tests/any2mochi/swift/union_decl.swift.error
+++ b/tests/any2mochi/swift/union_decl.swift.error
@@ -1,1 +1,0 @@
-parse error: parse error: 7:11: unexpected token "(" (expected "{" Statement* "}")

--- a/tests/any2mochi/swift/union_decl.swift.mochi
+++ b/tests/any2mochi/swift/union_decl.swift.mochi
@@ -1,0 +1,12 @@
+type Ok {
+  value: int
+}
+type Err {
+  msg: string
+}
+fun main() {
+    let r = Ok { value: 7 }
+    print(1)
+}
+main()
+


### PR DESCRIPTION
## Summary
- expand Swift any2mochi converter
- add struct/enum handling and struct literal rewriting
- keep detailed ConvertError
- update golden Swift outputs for struct literals and union declarations

## Testing
- `go run /tmp/runconvert.go tests/compiler/swift/struct_literal.swift.out`
- `go run /tmp/runconvert.go tests/compiler/swift/union_decl.swift.out`

------
https://chatgpt.com/codex/tasks/task_e_686a27aecc188320ab1de09b28ed9059