### PR TITLE
Improve Zig converter

### DIFF
--- a/tests/any2mochi/zig/README.md
+++ b/tests/any2mochi/zig/README.md
@@ -10,8 +10,10 @@ This directory contains golden files for converting Zig source code to Mochi.
   - `return` statements
   - simple variable assignments
   - `if`/`else` blocks
-  - `while` and `for` loops
-  - call expressions with casts removed
+- `while` and `for` loops
+- call expressions with casts removed
+- typed variable declarations
+- improved while loop parsing
 
 ## Unsupported Features
 

--- a/tests/any2mochi/zig/dataset_sort_take_limit.mochi
+++ b/tests/any2mochi/zig/dataset_sort_take_limit.mochi
@@ -6,7 +6,7 @@ fun _slice_list(comptime T: type, v: list<const T>, start: int, end: int, step: 
   let s = start
   let e = end
   let st = step
-  let n: = v.len
+  let n: int = v.len
   if (s < 0) s += n
   if (e < 0) e += n
   if (st == 0) st = 1
@@ -16,15 +16,15 @@ fun _slice_list(comptime T: type, v: list<const T>, start: int, end: int, step: 
   if (st < 0 and e > s) e = s
   let res = std.ArrayList(T).init(std.heap.page_allocator)
   defer res.deinit()
-  let i: = s
-  while st > 0 and i < e) or (st < 0 and i > e)) : (i += st {
+  let i: int = s
+  while (st > 0 and i < e) or (st < 0 and i > e) {
     res.append(v[i]) catch unreachable
   }
   return res.toOwnedSlice() catch unreachable
 }
 fun main() {
-  let products: = &[_]i32{Product{ .name = "Laptop", .price = 1500 }, Product{ .name = "Smartphone", .price = 900 }, Product{ .name = "Tablet", .price = 600 }, Product{ .name = "Monitor", .price = 300 }, Product{ .name = "Keyboard", .price = 100 }, Product{ .name = "Mouse", .price = 50 }, Product{ .name = "Headphones", .price = 200 }}
-  let expensive: = blk: { var _tmp0 = std.ArrayList(struct { item: i32; key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp0.append([ .item = p, .key = -p.price ]) catch unreachable; } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch unreachable; } var _tmp2 = _tmp1.toOwnedSlice() catch unreachable; _tmp2 = _slice_list(i32, _tmp2, 1, (1 + 3), 1); break :blk _tmp2; }
+  let products: list<const i32> = &[_]i32{Product{ .name = "Laptop", .price = 1500 }, Product{ .name = "Smartphone", .price = 900 }, Product{ .name = "Tablet", .price = 600 }, Product{ .name = "Monitor", .price = 300 }, Product{ .name = "Keyboard", .price = 100 }, Product{ .name = "Mouse", .price = 50 }, Product{ .name = "Headphones", .price = 200 }}
+  let expensive: list<const i32> = blk: { var _tmp0 = std.ArrayList(struct { item: i32; key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp0.append([ .item = p, .key = -p.price ]) catch unreachable; } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch unreachable; } var _tmp2 = _tmp1.toOwnedSlice() catch unreachable; _tmp2 = _slice_list(i32, _tmp2, 1, (1 + 3), 1); break :blk _tmp2; }
   print("{s}\n", ["--- Top products (excluding most expensive) ---"])
   for item in expensive {
     print("{any} {s} {any}\n", [item.name, "costs $", item.price])

--- a/tools/zigast/main.go
+++ b/tools/zigast/main.go
@@ -23,17 +23,19 @@ type Var struct {
 }
 
 type Func struct {
-	Name   string   `json:"name"`
-	Params string   `json:"params"`
-	Ret    string   `json:"ret"`
-	Line   int      `json:"line"`
-	Lines  []string `json:"lines"`
+	Name    string   `json:"name"`
+	Params  string   `json:"params"`
+	Ret     string   `json:"ret"`
+	Line    int      `json:"line"`
+	EndLine int      `json:"endLine"`
+	Lines   []string `json:"lines"`
 }
 
 type Struct struct {
-	Name   string  `json:"name"`
-	Line   int     `json:"line"`
-	Fields []Field `json:"fields"`
+	Name    string  `json:"name"`
+	Line    int     `json:"line"`
+	EndLine int     `json:"endLine"`
+	Fields  []Field `json:"fields"`
 }
 
 type Field struct {
@@ -132,6 +134,7 @@ func parse(src string) AST {
 						curFunc.Lines = append(curFunc.Lines, l)
 					}
 				}
+				curFunc.EndLine = lineNum + 1
 				curFunc = nil
 				depth = 0
 				lineNum++
@@ -154,6 +157,7 @@ func parse(src string) AST {
 						}
 					}
 				}
+				curStruct.EndLine = lineNum + 1
 				curStruct = nil
 				depth = 0
 				lineNum++


### PR DESCRIPTION
## Summary
- enhance `zigast` parser with end line info
- support typed variable declarations and better while handling
- attempt to use `zig ast-check` in `parseCLI`
- add detailed `ConvertError`
- refresh Zig golden files

## Testing
- `go run /tmp/convert_zig.go tests/compiler/zig/dataset_sort_take_limit.zig.out /tmp/out.mochi`
- `go run /tmp/convert_zig.go tests/compiler/zig/simple_fn.zig.out /tmp/simple.mochi`

------
https://chatgpt.com/codex/tasks/task_e_686a27b03fc08320ad468c3cdef256f8