### PR TITLE
Improve TS any2mochi parsing

### DIFF
--- a/tests/any2mochi/ts/README.md
+++ b/tests/any2mochi/ts/README.md
@@ -16,6 +16,8 @@ This directory contains golden files used by `any2mochi` tests for converting Ty
 - Type aliases and enums when reported by the language server
 - AST parser now records start and end columns along with a snippet of the
   source for richer tooling and diagnostics
+- Variable declarations assigned a function are now recognised when the
+  TypeScript AST parser is available
 
 ## Unsupported features
 

--- a/tools/any2mochi/ts/convert.go
+++ b/tools/any2mochi/ts/convert.go
@@ -669,6 +669,37 @@ func writeTSDecls(out *strings.Builder, decls []TSAstDecl) {
 				out.WriteString(d.Ret)
 			}
 			out.WriteByte('\n')
+		case "funcvar":
+			out.WriteString("let ")
+			out.WriteString(d.Name)
+			out.WriteString(" = fun (")
+			for i, p := range d.Params {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				out.WriteString(p.Name)
+				if p.Typ != "" {
+					out.WriteString(": ")
+					out.WriteString(p.Typ)
+				}
+			}
+			out.WriteByte(')')
+			if d.Ret != "" && d.Ret != "void" {
+				out.WriteString(": ")
+				out.WriteString(d.Ret)
+			}
+			stmts := tsFunctionBody(d.Body)
+			if len(stmts) == 0 {
+				out.WriteString(" {}\n")
+			} else {
+				out.WriteString(" {\n")
+				for _, l := range stmts {
+					out.WriteString("  ")
+					out.WriteString(l)
+					out.WriteByte('\n')
+				}
+				out.WriteString("}\n")
+			}
 		case "func":
 			out.WriteString("fun ")
 			out.WriteString(d.Name)

--- a/tools/any2mochi/ts/parse_ast.go
+++ b/tools/any2mochi/ts/parse_ast.go
@@ -16,6 +16,7 @@ import (
 type TSAstDecl struct {
 	Kind      string    `json:"kind"`
 	Name      string    `json:"name"`
+	Node      string    `json:"node,omitempty"`
 	Params    []TSParam `json:"params,omitempty"`
 	Ret       string    `json:"ret,omitempty"`
 	Body      string    `json:"body,omitempty"`


### PR DESCRIPTION
## Summary
- extend TypeScript AST records with `node` information
- detect function-valued variable declarations and emit as `funcvar`
- support emitting these declarations in the converter
- document new capability in any2mochi README

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a39d2d73483208ca7db5f4b27ae34