### PR TITLE
Improve C# any2mochi converter

### DIFF
--- a/tests/any2mochi/cs/dataset.cs.mochi
+++ b/tests/any2mochi/cs/dataset.cs.mochi
@@ -1,0 +1,14 @@
+type Person {
+  name: string
+  age: int
+}
+type Program {
+}
+fun Program.Main() {
+  var people = new Person[] { new Person { name = "Alice", age = 30 }, new Person { name = "Bob", age = 15 }, new Person { name = "Charlie", age = 65 } }
+  var names = new List<dynamic>(people.Select(p => p.name))
+  for n in names {
+  print(n)
+  }
+}
+

--- a/tests/any2mochi/cs/load_json.error
+++ b/tests/any2mochi/cs/load_json.error
@@ -1,0 +1,5 @@
+line 72: unsupported line
+ 71|     
+ 72|     static T _cast<T>(dynamic v) {
+   |                                   ^
+ 73|         if (v is T tv) return tv;


### PR DESCRIPTION
## Summary
- handle numeric suffix stripping and basic foreach loops in C# converter
- detect var declarations more robustly
- enrich C# parser with `EndLine` info and detailed error context
- add dataset and load_json golden files for C# tests

## Testing
- `go test -tags slow ./tools/any2mochi/x/cs -run TestConvertCs_Golden -count=1 -trimpath` *(fails: missing golden output files)*

------
https://chatgpt.com/codex/tasks/task_e_686a39d715548320aa87d8737cc2bdc2