### PR TITLE
Improve F# any2mochi

### DIFF
--- a/tests/any2mochi/fs/expect_simple.fs.error
+++ b/tests/any2mochi/fs/expect_simple.fs.error
@@ -1,4 +1,0 @@
-unsupported syntax at line 4: if not ((x = 3)) then failwith "expect failed"
-  3: let x = (1 + 2)
-  4: if not ((x = 3)) then failwith "expect failed"
-  5: ignore (printfn "%A" ("ok"))

--- a/tests/any2mochi/fs/expect_simple.fs.mochi
+++ b/tests/any2mochi/fs/expect_simple.fs.mochi
@@ -1,0 +1,3 @@
+let x = (1 + 2)
+expect((x = 3))
+print("ok")

--- a/tests/any2mochi/fs/list_set.fs.error
+++ b/tests/any2mochi/fs/list_set.fs.error
@@ -1,4 +1,0 @@
-unsupported syntax at line 4: nums.[1] <- 3
-  3: let mutable nums = [|1; 2|]
-  4: nums.[1] <- 3
-  5: ignore (printfn "%A" (nums.[1]))

--- a/tests/any2mochi/fs/list_set.fs.mochi
+++ b/tests/any2mochi/fs/list_set.fs.mochi
@@ -1,0 +1,3 @@
+var nums = [|1; 2|]
+nums[1] = 3
+print(nums[1])

--- a/tests/any2mochi/fs/map_typed_var.fs.error
+++ b/tests/any2mochi/fs/map_typed_var.fs.error
@@ -1,4 +1,0 @@
-unsupported syntax at line 3: let mutable m: Map<int,int> = Map.empty
-  2: 
-  3: let mutable m: Map<int,int> = Map.empty
-  4: ignore (printfn "%A" (Map.count (m)))

--- a/tests/any2mochi/fs/map_typed_var.fs.mochi
+++ b/tests/any2mochi/fs/map_typed_var.fs.mochi
@@ -1,0 +1,2 @@
+var m = Map.empty
+print(Map.count (m))


### PR DESCRIPTION
## Summary
- extend F# parser with typed vars, index assignments and expect recognition
- improve error snippet to show more surrounding lines
- normalise index syntax during conversion
- regenerate a few F# golden outputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a3a6010148320be6d3a5c80dadf56