### PR TITLE
Improve Java converter

### DIFF
--- a/tests/any2mochi/java/dataset.error
+++ b/tests/any2mochi/java/dataset.error
@@ -5,4 +5,3 @@ line 3: unsupported line: public java.util.List<Object> get() {
   4| java.util.List<Object> _src = _toList(people);
   5| _src = _filter(_src, (Object person) -> { return (person.age >= 18); });
 
-

--- a/tests/any2mochi/java/dataset_sort_take_limit.error
+++ b/tests/any2mochi/java/dataset_sort_take_limit.error
@@ -1,8 +1,7 @@
-line 11: unsupported line: Product() {}
-  9| }
- 10| 
- 11| Product() {}
- 12| }
- 13| 
-
+line 3: unsupported line: public java.util.List<Object> get() {
+  1| Object[] products = new Product[]{new Product("Laptop", 1500), new Product("Smartphone", 900), new Product("Tablet", 600), new Product("Monitor", 300), new Product("Keyboard", 100), new Product("Mouse", 50), new Product("Headphones", 200)};
+  2| Object[] expensive = (new java.util.function.Supplier<java.util.List<Object>>() {
+  3| public java.util.List<Object> get() {
+  4| java.util.List<Object> _src = _toList(products);
+  5| java.util.List<_JoinSpec> _joins = java.util.List.of(
 

--- a/tools/any2mochi/x/java/parse.go
+++ b/tools/any2mochi/x/java/parse.go
@@ -133,6 +133,19 @@ func parseLegacy(src, pkg string) ([]string, error) {
 				if isFieldLine(t) {
 					typ, name := parseFieldLine(t)
 					st.Fields = append(st.Fields, structField{Name: name, Type: typ, Line: i + 1})
+					i++
+					continue
+				}
+				if strings.HasPrefix(t, stName+"(") {
+					// skip constructor definitions
+					depth := strings.Count(t, "{") - strings.Count(t, "}")
+					for depth > 0 && i+1 < len(lines) {
+						i++
+						t = strings.TrimSpace(lines[i])
+						depth += strings.Count(t, "{") - strings.Count(t, "}")
+					}
+					i++
+					continue
 				}
 				i++
 			}


### PR DESCRIPTION
## Summary
- skip constructor definitions when parsing Java classes
- update Java converter golden error messages for dataset examples

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a3a63fbd883208ad7598fe72826dc