### PR TITLE
Improve Rust converter diagnostics

### DIFF
--- a/compile/x/rust/expressions.go
+++ b/compile/x/rust/expressions.go
@@ -820,7 +820,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 	case p.Save != nil:
 		return c.compileSaveExpr(p.Save)
 	default:
-		return "", fmt.Errorf("unsupported expression")
+		return "", fmt.Errorf("unsupported expression at %d:%d", p.Pos.Line, p.Pos.Column)
 	}
 }
 

--- a/compile/x/rust/statements.go
+++ b/compile/x/rust/statements.go
@@ -54,7 +54,7 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 	case s.Expect != nil:
 		return c.compileExpect(s.Expect)
 	default:
-		return fmt.Errorf("unsupported statement")
+		return fmt.Errorf("unsupported statement at %d:%d", s.Pos.Line, s.Pos.Column)
 	}
 }
 

--- a/tests/any2mochi/rust/trait_def.rs.error
+++ b/tests/any2mochi/rust/trait_def.rs.error
@@ -1,7 +1,4 @@
-no convertible symbols found
-
-source snippet:
-  1: trait Foo {
-  2:     fn bar(&self);
-  3: }
-  4:
+unsupported item TRAIT at 1:1
+  1 | trait Foo {
+    | ^
+  2 |     fn bar(&self);


### PR DESCRIPTION
## Summary
- include parent kind and snippet info in Rust AST nodes
- return detailed errors for unsupported Rust items when converting
- add `snippetAt` helper and use for TRAIT diagnostics
- surface line numbers for unsupported statements/expressions in Rust backend
- update trait_def error golden

## Testing
- `gofmt -w tools/any2mochi/x/rust/ast.go tools/any2mochi/x/rust/convert.go`


------
https://chatgpt.com/codex/tasks/task_e_686a3a764e748320afc1cbce0fbb34fa