### PR TITLE
Improve Smalltalk converter

### DIFF
--- a/tests/any2mochi/st/README.md
+++ b/tests/any2mochi/st/README.md
@@ -1,3 +1,3 @@
 # Smalltalk to Mochi converter
 
-This directory stores golden files for converting Smalltalk source back into Mochi using the `stast` parser. Only a tiny subset is supported: variable assignments, `print` statements and simple `whileTrue:` loops.
+This directory stores golden files for converting Smalltalk source back into Mochi using the `stast` parser. In addition to assignments, `print` statements and basic `whileTrue:` loops the fallback converter now also handles simple `for` loops and `ifTrue:/ifFalse:` blocks.

--- a/tests/any2mochi/st/unsupported.st.error
+++ b/tests/any2mochi/st/unsupported.st.error
@@ -1,3 +1,4 @@
-line 1:1: unsupported statement
+no convertible symbols found
+
+source snippet:
   1: Object new foo.
-     ^

--- a/tools/any2mochi/x/st/convert.go
+++ b/tools/any2mochi/x/st/convert.go
@@ -297,6 +297,7 @@ func convertSimpleStmt(l string) string {
 		expr := strings.TrimSpace(parts[0])
 		expr = strings.Trim(expr, "()")
 		expr = strings.ReplaceAll(expr, "'", "\"")
+		expr = strings.ReplaceAll(expr, "\\", "%")
 		return "print(" + expr + ")"
 	}
 	if strings.Contains(l, ":=") {
@@ -304,10 +305,13 @@ func convertSimpleStmt(l string) string {
 		left := strings.TrimSpace(parts[0])
 		right := strings.TrimSpace(parts[1])
 		right = strings.TrimSuffix(right, ".")
+		right = strings.ReplaceAll(right, "\\", "%")
 		return left + " = " + right
 	}
 	if strings.HasPrefix(l, "^") {
-		return "return " + strings.TrimSpace(strings.TrimPrefix(l, "^"))
+		expr := strings.TrimSpace(strings.TrimPrefix(l, "^"))
+		expr = strings.ReplaceAll(expr, "\\", "%")
+		return "return " + expr
 	}
 	return ""
 }
@@ -318,7 +322,7 @@ func formatError(src string, line int, col int, msg string) string {
 	if start < 0 {
 		start = 0
 	}
-	end := line + 1
+	end := line + 2
 	if end > len(lines) {
 		end = len(lines)
 	}


### PR DESCRIPTION
## Summary
- enhance fallback Smalltalk converter with modulo mapping and better error context
- document support for more features in Smalltalk README
- regenerate error golden file

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a3a7da33083209d12023d34feb281