### PR TITLE
Improve C# converter

### DIFF
--- a/tests/any2mochi/cs/load_json.cs.mochi
+++ b/tests/any2mochi/cs/load_json.cs.mochi
@@ -1,0 +1,96 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+type Program {
+}
+fun Program.Main() {
+  var people = _load("people.json", new Dictionary<string, string> { { "format", "json" } }).Select(e => _cast<Person>(e)).ToList()
+  Dictionary<string, string>[] adults = new List<Dictionary<string, dynamic>>(people.Select(p => new Dictionary<string, dynamic> { { "name", p.name }, { "email", p.email } }))
+  for a in adults {
+  print(string.Join(" ", new [] { Convert.ToString(a.name), Convert.ToString(a.email) }))
+  }
+}
+fun Program._load(path: string, Dictionary<string, opts): list<any> {
+  var format = opts != null && opts.ContainsKey("format") ? Convert.ToString(opts["format"]) : "csv"
+  var header = opts != null && opts.ContainsKey("header") ? Convert.ToBoolean(opts["header"]) : true
+  var delim = opts != null && opts.ContainsKey("delimiter") ? Convert.ToString(opts["delimiter"])[0] : ','
+  var text
+  if string.IsNullOrEmpty(path) || path == "-" {
+  text = Console.In.ReadToEnd()
+  } else {
+  text = File.ReadAllText(path)
+  }
+  switch (format) {
+  case "jsonl":
+  var list = new List<dynamic>()
+  for line in text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)) list.Add(JsonSerializer.Deserialize<dynamic>(line)) {
+  return list
+  case "json":
+  return JsonSerializer.Deserialize<List<dynamic>>(text)
+  case "yaml":
+  var deser = new DeserializerBuilder().Build()
+  var obj = deser.Deserialize<object>(new StringReader(text))
+  if obj is IList<object> lst) return lst.Cast<dynamic>().ToList() {
+  if obj is IDictionary<object, object> m {
+  var d = new Dictionary<string, object>()
+  for kv in m) d[Convert.ToString(kv.Key)] = kv.Value {
+  return new List<dynamic> { d }
+  }
+  return new List<dynamic>()
+  case "tsv":
+  delim = '    '; goto default
+  default:
+  var lines = text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+  var out = new List<dynamic>()
+  var headers = null
+  for int i in 0..lines.Length {
+  var parts = lines[i].Split(delim)
+  if i == 0 && header) { headers = parts; continue; } {
+  var obj = new Dictionary<string, object>()
+  for int j in 0..parts.Length {
+  var key = headers != null && j < headers.Length ? headers[j] : $"col{j}"
+  obj[key] = parts[j]
+  }
+  out.Add(obj)
+  }
+  return out
+  }
+}
+fun Program._cast(v: any) {
+  if v is T tv) return tv {
+  if typeof(T) == typeof(int) {
+  if v is int) return (T)v {
+  if v is double) return (T)(object)(int)(double)v {
+  if v is float) return (T)(object)(int)(float)v {
+  }
+  if typeof(T) == typeof(double) {
+  if v is int) return (T)(object)(double)(int)v {
+  if v is double) return (T)v {
+  if v is float) return (T)(object)(double)(float)v {
+  }
+  if typeof(T) == typeof(float) {
+  if v is int) return (T)(object)(float)(int)v {
+  if v is double) return (T)(object)(float)(double)v {
+  if v is float) return (T)v {
+  }
+  if typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Dictionary<,>) && v is System.Collections.IDictionary d {
+  var args = typeof(T).GetGenericArguments()
+  var res = (System.Collections.IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(args))
+  var mCast = typeof(Program).GetMethod("_cast")
+  for kv in d {
+  var k = mCast.MakeGenericMethod(args[0]).Invoke(null, new object[]{kv.Key})
+  var val = mCast.MakeGenericMethod(args[1]).Invoke(null, new object[]{kv.Value})
+  res.Add(k, val)
+  }
+  return (T)res
+  }
+  if v is System.Collections.Generic.IDictionary<object, object> dm {
+  var m = new Dictionary<string, object>()
+  for kv in dm) m[Convert.ToString(kv.Key)] = kv.Value {
+  v = m
+  }
+  var json = JsonSerializer.Serialize(v)
+  return JsonSerializer.Deserialize<T>(json)
+}

--- a/tests/any2mochi/cs/load_json.error
+++ b/tests/any2mochi/cs/load_json.error
@@ -1,5 +1,0 @@
-line 72: unsupported line
- 71|     
- 72|     static T _cast<T>(dynamic v) {
-   |                                   ^
- 73|         if (v is T tv) return tv;

--- a/tools/any2mochi/x/cs/convert.go
+++ b/tools/any2mochi/x/cs/convert.go
@@ -462,6 +462,8 @@ func mapType(t string) string {
 		return "string"
 	case "bool":
 		return "bool"
+	case "dynamic", "object":
+		return "any"
 	}
 	if strings.HasSuffix(t, ">") {
 		if open := strings.Index(t, "<"); open != -1 {

--- a/tools/any2mochi/x/cs/parse.go
+++ b/tools/any2mochi/x/cs/parse.go
@@ -42,7 +42,7 @@ type Param struct {
 
 var (
 	typeRE      = regexp.MustCompile(`(?i)^\s*(?:public\s+)?(class|struct|interface|enum)\s+([A-Za-z_][A-Za-z0-9_]*)`)
-	funcRE      = regexp.MustCompile(`(?i)^\s*(?:public\s+|private\s+|protected\s+)?(?:static\s+)?([A-Za-z0-9_<>\[\]]+)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*{`)
+	funcRE      = regexp.MustCompile(`(?i)^\s*(?:public\s+|private\s+|protected\s+)?(?:static\s+)?([A-Za-z0-9_<>\[\]]+)\s+([A-Za-z_][A-Za-z0-9_]*)(?:<[^>]+>)?\s*\(([^)]*)\)\s*{`)
 	fieldRE     = regexp.MustCompile(`(?i)^\s*(?:public\s+|private\s+|protected\s+)?([A-Za-z0-9_<>\[\]]+)\s+([A-Za-z_][A-Za-z0-9_]*)`)
 	usingRE     = regexp.MustCompile(`^\s*using\s+`)
 	namespaceRE = regexp.MustCompile(`^\s*namespace\s+`)


### PR DESCRIPTION
## Summary
- support generic method signatures in the C# any2mochi converter
- map `dynamic`/`object` types to `any`
- regenerate C# golden output for `load_json`

## Testing
- `go test ./...`
- `go test ./tools/any2mochi/x/cs -run TestConvertCs_Golden -update -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686a3d8d03d0832095b5ab6b344fa5da