### PR TITLE
Improve any2mochi Erlang output

### DIFF
--- a/tests/any2mochi/erl/dataset.erl.mochi
+++ b/tests/any2mochi/erl/dataset.erl.mochi
@@ -3,7 +3,7 @@ type Person {
   name: any
   age: any
 }
-// line 7
+// line 7 (exported)
 fun main(_) {
   People =
   [#person{name = "Alice", age = 30},

--- a/tests/any2mochi/erl/dataset_sort_take_limit.erl.mochi
+++ b/tests/any2mochi/erl/dataset_sort_take_limit.erl.mochi
@@ -3,7 +3,7 @@ type Product {
   name: any
   price: any
 }
-// line 7
+// line 7 (exported)
 fun main(_) {
   Products =
   [#product{name = "Laptop", price = 1500},

--- a/tests/any2mochi/erl/group_by.erl.mochi
+++ b/tests/any2mochi/erl/group_by.erl.mochi
@@ -1,4 +1,4 @@
-// line 5
+// line 5 (exported)
 fun main(_) {
   Xs = [1, 1, 2]
   Groups =

--- a/tests/any2mochi/erl/load_save_json.erl.mochi
+++ b/tests/any2mochi/erl/load_save_json.erl.mochi
@@ -1,4 +1,4 @@
-// line 5
+// line 5 (exported)
 fun main(_) {
   Rows = mochi_load("", #{format => "json"})
   mochi_save(Rows, "", #{format => "json"})

--- a/tests/any2mochi/erl/method.erl.mochi
+++ b/tests/any2mochi/erl/method.erl.mochi
@@ -22,7 +22,7 @@ fun circle_describe(Self) {
   V
   end
 }
-// line 23
+// line 23 (exported)
 fun main(_) {
   C = #circle{radius = 5}
   circle_describe(C)

--- a/tests/any2mochi/erl/outer_join.erl.mochi
+++ b/tests/any2mochi/erl/outer_join.erl.mochi
@@ -1,4 +1,4 @@
-// line 5
+// line 5 (exported)
 fun main(_) {
   Customers =
   [#{id => 1, name => "Alice"},

--- a/tests/any2mochi/erl/q1.erl.mochi
+++ b/tests/any2mochi/erl/q1.erl.mochi
@@ -1,4 +1,4 @@
-// line 5
+// line 5 (exported)
 fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {
   mochi_expect(Result
   ==
@@ -13,7 +13,7 @@ fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {
   avg_disc => 0.07500000000000001,
   count_order => 2}])
 }
-// line 8
+// line 8 (exported)
 fun main(_) {
   Lineitem =
   [#{l_quantity => 17,

--- a/tests/any2mochi/erl/right_join.erl.mochi
+++ b/tests/any2mochi/erl/right_join.erl.mochi
@@ -1,4 +1,4 @@
-// line 5
+// line 5 (exported)
 fun main(_) {
   Customers =
   [#{id => 1, name => "Alice"},

--- a/tests/any2mochi/erl/tpch_q1.erl.mochi
+++ b/tests/any2mochi/erl/tpch_q1.erl.mochi
@@ -1,4 +1,4 @@
-// line 5
+// line 5 (exported)
 fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {
   mochi_expect(Result
   ==
@@ -13,7 +13,7 @@ fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {
   avg_disc => 0.07500000000000001,
   count_order => 2}])
 }
-// line 8
+// line 8 (exported)
 fun main(_) {
   Lineitem =
   [#{l_quantity => 17,

--- a/tests/any2mochi/erl/update_statement.erl.mochi
+++ b/tests/any2mochi/erl/update_statement.erl.mochi
@@ -4,7 +4,7 @@ type Person {
   age: any
   status: any
 }
-// line 8
+// line 8 (exported)
 fun main(_) {
   People =
   [#person{name = "Alice", age = 17, status = "minor"},

--- a/tools/any2mochi/x/erlang/README.md
+++ b/tools/any2mochi/x/erlang/README.md
@@ -5,7 +5,7 @@ This package provides an experimental Erlang frontend for the `any2mochi` tool. 
 ## Architecture
 
 1. `parse.go` invokes `parser/parser.escript` to obtain a lightweight AST of functions.
-   The parser now records the line number and arity of each function for better diagnostics.
+   The parser now records the line number, arity and export status of each function for better diagnostics.
 2. `convert.go` walks this AST and emits Mochi `fun` definitions. Simple calls to
    `io:format` or `io:fwrite` are rewritten as `print` statements and each emitted
    function is prefixed with a comment indicating the original line number.
@@ -18,10 +18,12 @@ This package provides an experimental Erlang frontend for the `any2mochi` tool. 
 - Detection of `main/0` and insertion of a `main()` call
 - Basic translation of `io:format/1` and `io:fwrite/1` to `print`
 - Functions include source line comments for easier debugging
+- Exported functions are annotated with `(exported)` comments
+- Record declarations are translated into Mochi `type` blocks
 
 ## Unsupported features
 
 - Module attributes and includes
 - Pattern matching or guards
-- Type specifications and records
+- Type specifications
 - Anything beyond simple function bodies

--- a/tools/any2mochi/x/erlang/convert.go
+++ b/tools/any2mochi/x/erlang/convert.go
@@ -58,14 +58,17 @@ func Convert(src string) ([]byte, error) {
 		out.WriteString("}\n")
 	}
 	hasMain := false
-	for _, f := range ast.Functions {
-		if f.Name == "main" {
-			hasMain = true
-		}
-		out.WriteString("// line ")
-		out.WriteString(fmt.Sprint(f.Line))
-		out.WriteByte('\n')
-		out.WriteString("fun ")
+        for _, f := range ast.Functions {
+                if f.Name == "main" {
+                        hasMain = true
+                }
+                out.WriteString("// line ")
+                out.WriteString(fmt.Sprint(f.Line))
+                if f.Exported {
+                        out.WriteString(" (exported)")
+                }
+                out.WriteByte('\n')
+                out.WriteString("fun ")
 		if f.Name == "" {
 			out.WriteString("fun")
 		} else {


### PR DESCRIPTION
## Summary
- show `(exported)` marker for exported Erlang functions
- document export detection in Erlang converter README
- update Erlang golden files

## Testing
- `go test ./tools/any2mochi/x/erlang -tags slow -run TestConvertErl_Golden`


------
https://chatgpt.com/codex/tasks/task_e_686a3db4e19c832094575e4e231e07c9