### PR TITLE
Improve Fortran conversion support

### DIFF
--- a/tests/any2mochi/fortran/struct_literal.mochi
+++ b/tests/any2mochi/fortran/struct_literal.mochi
@@ -1,1 +1,9 @@
-fun main() {}
+fun main() {
+  p = Point(x=1, y=2)
+  print(p.x)
+}
+
+type Point {
+  x: int
+  y: int
+}


### PR DESCRIPTION
## Summary
- extend Fortran any2mochi converter to detect simple derived types
- update struct_literal.mochi golden output accordingly

## Testing
- `gofmt -w tools/any2mochi/x/fortran/convert.go`

------
https://chatgpt.com/codex/tasks/task_e_686a3e081050832090013d9666e904eb