### PR TITLE
Improve Dart toolchain

### DIFF
--- a/compile/x/dart/helpers.go
+++ b/compile/x/dart/helpers.go
@@ -402,3 +402,14 @@ func isAny(t types.Type) bool {
 	_, ok := t.(types.AnyType)
 	return ok
 }
+
+func isLiteralExpr(e *parser.Expr) bool {
+	if e == nil || len(e.Binary.Right) != 0 || len(e.Binary.Left.Ops) != 0 {
+		return false
+	}
+	p := e.Binary.Left.Value
+	if p == nil || len(p.Ops) != 0 || p.Target == nil {
+		return false
+	}
+	return p.Target.Lit != nil
+}

--- a/tools/any2mochi/x/dart/convert.go
+++ b/tools/any2mochi/x/dart/convert.go
@@ -470,6 +470,26 @@ func parseStatements(body string) []string {
 			cond := strings.TrimSpace(strings.TrimSuffix(l[6:], "{"))
 			out = append(out, strings.Repeat("  ", indent)+"while "+cond+" {")
 			indent++
+		case strings.HasPrefix(l, "} else if ") && strings.HasSuffix(l, "{"):
+			if indent > 0 {
+				indent--
+			}
+			cond := strings.TrimSpace(strings.TrimSuffix(l[len("} else if "):], "{"))
+			out = append(out, strings.Repeat("  ", indent)+"} else if "+cond+" {")
+			indent++
+		case strings.HasPrefix(l, "else if ") && strings.HasSuffix(l, "{"):
+			if indent > 0 {
+				indent--
+			}
+			cond := strings.TrimSpace(strings.TrimSuffix(l[len("else if "):], "{"))
+			out = append(out, strings.Repeat("  ", indent)+"else if "+cond+" {")
+			indent++
+		case l == "} else {":
+			if indent > 0 {
+				indent--
+			}
+			out = append(out, strings.Repeat("  ", indent)+"} else {")
+			indent++
 		case l == "else {":
 			if indent > 0 {
 				indent--


### PR DESCRIPTION
## Summary
- better parse `else if` variants in Dart converter
- add detection of literal match patterns for Dart compiler
- add helper to recognise literal expressions

## Testing
- `go test -tags slow ./tools/any2mochi/x/dart -update`
- `go test -tags slow ./compile/x/dart -run TestDartCompiler_GoldenOutput -update` *(fails: type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686a3e6ea8e0832099a29443013040f3