### PR TITLE
Improve Scheme parser diagnostics

### DIFF
--- a/tools/any2mochi/x/scheme/convert.go
+++ b/tools/any2mochi/x/scheme/convert.go
@@ -29,6 +29,8 @@ func Convert(src string) ([]byte, error) {
 		// fall back to the simple CLI-based parser
 		if simple, err := convertSimple(src); err == nil && len(simple) > 0 {
 			return simple, nil
+		} else if err != nil {
+			return nil, err
 		}
 		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", snippet(src))
 	}


### PR DESCRIPTION
## Summary
- expand Scheme AST nodes with source `Text`
- implement `ParseError` with snippets
- improve `parseList` and error handling in `Convert`

## Testing
- `go vet ./...`
- `go test ./tools/any2mochi/x/scheme -tags slow -run TestConvertScheme_Golden/dataset.scm -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686a3fd941e8832086a72325e13d642d