### PR TITLE
Improve Scala parser info

### DIFF
--- a/tools/any2mochi/x/scala/convert.go
+++ b/tools/any2mochi/x/scala/convert.go
@@ -612,11 +612,11 @@ func diagnostics(src string, diags []any2mochi.Diagnostic) string {
 		start := int(d.Range.Start.Line)
 		col := int(d.Range.Start.Character)
 		msg := d.Message
-		from := start - 1
+		from := start - 2
 		if from < 0 {
 			from = 0
 		}
-		to := start + 1
+		to := start + 2
 		if to >= len(lines) {
 			to = len(lines) - 1
 		}


### PR DESCRIPTION
## Summary
- expand `Func` in Scala AST parse to include raw signature
- prefer `scala-cli` if available when parsing Scala sources
- show more context in Scala language server diagnostics

## Testing
- `go test ./...`
- `go test ./tools/any2mochi/x/scala -run TestConvertScala_Golden -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_686a406bf90c832089d06eff3901f76a