### PR TITLE
Improve TypeScript any2mochi parser

### DIFF
--- a/tools/any2mochi/ts/parse_ast.go
+++ b/tools/any2mochi/ts/parse_ast.go
@@ -28,6 +28,9 @@ type TSAstDecl struct {
 	EndLine   int       `json:"end,omitempty"`
 	EndCol    int       `json:"endCol,omitempty"`
 	Snippet   string    `json:"snippet,omitempty"`
+	StartOff  int       `json:"startOff,omitempty"`
+	EndOff    int       `json:"endOff,omitempty"`
+	Doc       string    `json:"doc,omitempty"`
 }
 
 // parseTSAST parses src using a Deno helper and returns the AST.


### PR DESCRIPTION
## Summary
- enhance TypeScript fallback parser to inline simple arrow function IIFEs
- enrich AST parsing with byte offsets and doc strings
- rewrite `parse_ts_ast.ts` to use the official TypeScript compiler API

## Testing
- `go run /tmp/convert.go tests/compiler/ts/cross_join.ts.out`

------
https://chatgpt.com/codex/tasks/task_e_686a4552c68c83208e64c5168d484787