### PR TITLE
Improve C++ parsing in any2mochi

### DIFF
--- a/tools/any2mochi/x/cpp/convert.go
+++ b/tools/any2mochi/x/cpp/convert.go
@@ -407,6 +407,13 @@ func convertBody(src string, r any2mochi.Range) []string {
 			} else {
 				out = append(out, l)
 			}
+		case strings.HasPrefix(l, "while ("):
+			if m := regexp.MustCompile(`^while \((.*)\)\s*\{?$`).FindStringSubmatch(l); m != nil {
+				cond := strings.TrimSpace(m[1])
+				out = append(out, fmt.Sprintf("while %s {", cond))
+			} else {
+				out = append(out, l)
+			}
 		case strings.HasPrefix(l, "if ("):
 			if m := regexp.MustCompile(`^if \((.*)\)\s*\{?$`).FindStringSubmatch(l); m != nil {
 				cond := strings.TrimSpace(m[1])


### PR DESCRIPTION
## Summary
- expand `structDef` to hold method info
- parse C++ methods from clang AST and emit them as functions
- support translating `while` loops when converting C++ bodies

## Testing
- `go test ./tools/any2mochi/x/cpp -tags=slow -list TestConvertCpp_Golden` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686a45b4c0348320aa3b7b2530ff0f56