### PR TITLE
Improve Erlang converter

### DIFF
--- a/compile/x/erlang/compiler.go
+++ b/compile/x/erlang/compiler.go
@@ -349,6 +349,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 }
 
 func (c *Compiler) compileFun(fun *parser.FunStmt) error {
+	c.writeln(fmt.Sprintf("%% line %d", fun.Pos.Line))
 	params := []string{}
 	savedVars := c.vars
 	savedCounts := c.counts
@@ -392,6 +393,7 @@ func (c *Compiler) compileFun(fun *parser.FunStmt) error {
 }
 
 func (c *Compiler) compileMethod(structName string, fun *parser.FunStmt) error {
+	c.writeln(fmt.Sprintf("%% line %d", fun.Pos.Line))
 	params := []string{"Self"}
 	savedVars := c.vars
 	savedCounts := c.counts

--- a/tests/any2mochi/erl/dataset.erl.error
+++ b/tests/any2mochi/erl/dataset.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: -record(person, {name, age}).
+  6: 
+  7: main(_) ->
+  8:     People = [#person{name="Alice", age=30}, #person{name="Bob", age=15}, #person{name="Charlie", age=65}],
+  9:     Names = [P#person.name || P <- [P || P <- People, (P#person.age >= 18)]],
+ 10:     mochi_foreach(fun(N) ->

--- a/tests/any2mochi/erl/dataset_sort_take_limit.erl.error
+++ b/tests/any2mochi/erl/dataset_sort_take_limit.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: -record(product, {name, price}).
+  6: 
+  7: main(_) ->
+  8:     Products = [#product{name="Laptop", price=1500}, #product{name="Smartphone", price=900}, #product{name="Tablet", price=600}, #product{name="Monitor", price=300}, #product{name="Keyboard", price=100}, #product{name="Mouse", price=50}, #product{name="Headphones", price=200}],
+  9:     Expensive = (fun() ->
+ 10:     Items = [{-P#product.price, P} || P <- Products],

--- a/tests/any2mochi/erl/group_by.erl.error
+++ b/tests/any2mochi/erl/group_by.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: main(_) ->
+  6:     Xs = [1, 1, 2],
+  7:     Groups = [#{k => maps:get(key, G), c => mochi_count(G)} || G <- mochi_group_by(Xs, fun(X) -> X end)],
+  8:     mochi_foreach(fun(G) ->
+  9:         mochi_print([maps:get(k, G), maps:get(c, G)])
+ 10:     end, Groups).

--- a/tests/any2mochi/erl/load_save_json.erl.error
+++ b/tests/any2mochi/erl/load_save_json.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: main(_) ->
+  6:     Rows = mochi_load("", #{format => "json"}),
+  7:     mochi_save(Rows, "", #{format => "json"}).
+  8: 
+  9: 
+ 10: mochi_load(Path, Opts) ->

--- a/tests/any2mochi/erl/method.erl.error
+++ b/tests/any2mochi/erl/method.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: -record(circle, {radius}).
+  6: circle_area(Self) ->
+  7:     try
+  8:         A = ((3.14 * Self#circle.radius) * Self#circle.radius),
+  9:         mochi_print(["Calculating area:", A]),
+ 10:         throw({return, A})

--- a/tests/any2mochi/erl/outer_join.erl.error
+++ b/tests/any2mochi/erl/outer_join.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: main(_) ->
+  6:     Customers = [#{id => 1, name => "Alice"}, #{id => 2, name => "Bob"}, #{id => 3, name => "Charlie"}, #{id => 4, name => "Diana"}],
+  7:     Orders = [#{id => 100, customerId => 1, total => 250}, #{id => 101, customerId => 2, total => 125}, #{id => 102, customerId => 1, total => 300}, #{id => 103, customerId => 5, total => 80}],
+  8:     Result = [#{order => O, customer => C} || {O, C} <- mochi_outer_join(Orders, Customers, fun(O, C) -> (maps:get(customerId, O) == maps:get(id, C)) end)],
+  9:     mochi_print(["--- Outer Join using syntax ---"]),
+ 10:     mochi_foreach(fun(Row) ->

--- a/tests/any2mochi/erl/q1.erl.error
+++ b/tests/any2mochi/erl/q1.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1, test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0]).
+  4: 
+  5: test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() ->
+  6:     mochi_expect((Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => ((950 * 1.07) + (1800 * 1.05)), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}])).
+  7: 
+  8: main(_) ->
+  9:     Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
+ 10:     Result = [#{returnflag => maps:get(returnflag, maps:get(key, G)), linestatus => maps:get(linestatus, maps:get(key, G)), sum_qty => mochi_sum([maps:get(l_quantity, X) || X <- G]), sum_base_price => mochi_sum([maps:get(l_extendedprice, X) || X <- G]), sum_disc_price => mochi_sum([(maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) || X <- G]), sum_charge => mochi_sum([((maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) * (1 + maps:get(l_tax, X))) || X <- G]), avg_qty => mochi_avg([maps:get(l_quantity, X) || X <- G]), avg_price => mochi_avg([maps:get(l_extendedprice, X) || X <- G]), avg_disc => mochi_avg([maps:get(l_discount, X) || X <- G]), count_order => mochi_count(G)} || G <- mochi_group_by([Row || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")], fun(Row) -> #{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)} end)],

--- a/tests/any2mochi/erl/right_join.erl.error
+++ b/tests/any2mochi/erl/right_join.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: main(_) ->
+  6:     Customers = [#{id => 1, name => "Alice"}, #{id => 2, name => "Bob"}, #{id => 3, name => "Charlie"}, #{id => 4, name => "Diana"}],
+  7:     Orders = [#{id => 100, customerId => 1, total => 250}, #{id => 101, customerId => 2, total => 125}, #{id => 102, customerId => 1, total => 300}],
+  8:     Result = [#{customerName => maps:get(name, C), order => O} || {C, O} <- mochi_right_join(Customers, Orders, fun(C, O) -> (maps:get(customerId, O) == maps:get(id, C)) end)],
+  9:     mochi_print(["--- Right Join using syntax ---"]),
+ 10:     mochi_foreach(fun(Entry) ->

--- a/tests/any2mochi/erl/tpch_q1.erl.error
+++ b/tests/any2mochi/erl/tpch_q1.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1, test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0]).
+  4: 
+  5: test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() ->
+  6:     mochi_expect((Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => ((950 * 1.07) + (1800 * 1.05)), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}])).
+  7: 
+  8: main(_) ->
+  9:     Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
+ 10:     Result = [#{returnflag => maps:get(returnflag, maps:get(key, G)), linestatus => maps:get(linestatus, maps:get(key, G)), sum_qty => mochi_sum([maps:get(l_quantity, X) || X <- G]), sum_base_price => mochi_sum([maps:get(l_extendedprice, X) || X <- G]), sum_disc_price => mochi_sum([(maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) || X <- G]), sum_charge => mochi_sum([((maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) * (1 + maps:get(l_tax, X))) || X <- G]), avg_qty => mochi_avg([maps:get(l_quantity, X) || X <- G]), avg_price => mochi_avg([maps:get(l_extendedprice, X) || X <- G]), avg_disc => mochi_avg([maps:get(l_discount, X) || X <- G]), count_order => mochi_count(G)} || G <- mochi_group_by([Row || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")], fun(Row) -> #{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)} end)],

--- a/tests/any2mochi/erl/update_statement.erl.error
+++ b/tests/any2mochi/erl/update_statement.erl.error
@@ -1,0 +1,11 @@
+exit status 1
+  1: #!/usr/bin/env escript
+  2: -module(main).
+  3: -export([main/1]).
+  4: 
+  5: -record(person, {name, age, status}).
+  6: 
+  7: 
+  8: main(_) ->
+  9:     People = [#person{name="Alice", age=17, status="minor"}, #person{name="Bob", age=25, status="unknown"}, #person{name="Charlie", age=18, status="unknown"}, #person{name="Diana", age=16, status="minor"}],
+ 10:     People_1 = [ (case (Item#person.age >= 18) of true -> Item#person{status="adult", age=(Item#person.age + 1)}; _ -> Item end) || Item <- People ]

--- a/tools/any2mochi/x/erlang/parse.go
+++ b/tools/any2mochi/x/erlang/parse.go
@@ -17,14 +17,16 @@ type Func struct {
 	Params   []string `json:"params"`
 	Body     []string `json:"body"`
 	Line     int      `json:"line"`
+	EndLine  int      `json:"end"`
 	Arity    int      `json:"arity"`
 	Exported bool     `json:"exported"`
 }
 
 type Record struct {
-	Name   string   `json:"name"`
-	Fields []string `json:"fields"`
-	Line   int      `json:"line"`
+	Name    string   `json:"name"`
+	Fields  []string `json:"fields"`
+	Line    int      `json:"line"`
+	EndLine int      `json:"end,omitempty"`
 }
 
 type AST struct {


### PR DESCRIPTION
## Summary
- enhance `parser.escript` to report parse errors and add end line info
- include end line details in the Go parser
- show start-end line comments when converting Erlang to Mochi
- emit detailed parse error snippets
- mark line numbers in Erlang compiler output
- add golden `.error` files for Erlang conversion failures

## Testing
- `go test ./tools/any2mochi/x/erlang -run TestConvertErl_Golden -tags slow -count=1 -update`


------
https://chatgpt.com/codex/tasks/task_e_686a45bc40f083209b5236059880db33