### PR TITLE
Improve Fortran converter diagnostics

### DIFF
--- a/tests/any2mochi/fortran/struct_nested.error
+++ b/tests/any2mochi/fortran/struct_nested.error
@@ -1,8 +1,9 @@
-line 11:1: Variable "line" declared twice in scope
+line 11:1 [error]: Variable "line" declared twice in scope
    9|     type(Point) :: end
   10|   end type Line
   11|   type(Line) :: line
      ^
   12|   type(Point) :: p1
   13|   type(Point) :: p2
+
 


### PR DESCRIPTION
## Summary
- improve diagnostics for any2mochi Fortran converter
- validate generated Mochi code
- support `type(<name>)` fields in Fortran structs
- refresh golden error for struct_nested

## Testing
- `go test -tags slow -run TestConvertFortran_Golden -v` *(fails: missing fortls command)*

------
https://chatgpt.com/codex/tasks/task_e_686a45c0c160832093dad090cc9b78c6