### PR TITLE
Improve F# any2mochi parser

### DIFF
--- a/tests/any2mochi/fs/closure.fs.error
+++ b/tests/any2mochi/fs/closure.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: exception Return_makeAdder of (int -> int)
-  2: 
-  3: exception Return_makeAdder of (int -> int)
-  4: let rec makeAdder (n: int) : int -> int =
-  5:     try
+unsupported syntax at line 8: failwith "unreachable"
+  7:         raise (Return_makeAdder ((fun (x: int) -> (x + n))))
+  8:         failwith "unreachable"
+  9:     with Return_makeAdder v -> v
+ 10:

--- a/tests/any2mochi/fs/fold_pure_let.fs.error
+++ b/tests/any2mochi/fs/fold_pure_let.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: exception Return_sumN of int
-  2: 
-  3: exception Return_sumN of int
-  4: let rec sumN (n: int) : int =
-  5:     try
+unsupported syntax at line 8: failwith "unreachable"
+  7:         raise (Return_sumN (((n * ((n + 1))) / 2)))
+  8:         failwith "unreachable"
+  9:     with Return_sumN v -> v
+ 10:

--- a/tests/any2mochi/fs/fun_call.fs.error
+++ b/tests/any2mochi/fs/fun_call.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: exception Return_add of int
-  2: 
-  3: exception Return_add of int
-  4: let rec add (a: int) (b: int) : int =
-  5:     try
+unsupported syntax at line 9: failwith "unreachable"
+  8:         raise (Return_add ((a + b)))
+  9:         failwith "unreachable"
+ 10:     with Return_add v -> v
+ 11:

--- a/tests/any2mochi/fs/if_else.fs.error
+++ b/tests/any2mochi/fs/if_else.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: exception Return_foo of int
-  2: 
-  3: exception Return_foo of int
-  4: let rec foo (n: int) : int =
-  5:     try
+unsupported syntax at line 11: else
+ 10:             raise (Return_foo (0))
+ 11:         else
+ 12:             raise (Return_foo (1))
+ 13:         failwith "unreachable"

--- a/tests/any2mochi/fs/list_prepend.fs.error
+++ b/tests/any2mochi/fs/list_prepend.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: exception Return_prepend of int[][]
-  2: 
-  3: exception Return_prepend of int[][]
-  4: let rec prepend (level: int[]) (result: int[][]) : int[][] =
-  5:     try
+unsupported syntax at line 10: failwith "unreachable"
+  9:         raise (Return_prepend (result))
+ 10:         failwith "unreachable"
+ 11:     with Return_prepend v -> v
+ 12:

--- a/tests/any2mochi/fs/load_save_json.fs.error
+++ b/tests/any2mochi/fs/load_save_json.fs.error
@@ -1,5 +1,3 @@
-unsupported syntax at line 4: let _cast<'T> (v: obj) : 'T =
-  3: let format = "format"
-  4: let _cast<'T> (v: obj) : 'T =
-  5:   match v with
-  6:   | :? 'T as t -> t
+unsupported syntax at line 110: ignore (_save people None Some (Map.ofList [(format, "json")]))
+109: let people = _load None Some (Map.ofList [(format, "json")]) |> List.map (fun row -> _cast<Person>(row))
+110: ignore (_save people None Some (Map.ofList [(format, "json")]))

--- a/tests/any2mochi/fs/match_capture.fs.error
+++ b/tests/any2mochi/fs/match_capture.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 7: exception Return_depth of int
-  6: 
-  7: exception Return_depth of int
-  8: let rec depth (t: Tree) : int =
-  9:     try
+unsupported syntax at line 12: failwith "unreachable"
+ 11:         raise (Return_depth ((match t with | Leaf -> 0 | Node(l, _, r) -> ((depth l + depth r) + 1))))
+ 12:         failwith "unreachable"
+ 13:     with Return_depth v -> v
+ 14:

--- a/tests/any2mochi/fs/nested_type.fs.error
+++ b/tests/any2mochi/fs/nested_type.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: exception Return_outer of string
-  2: 
-  3: exception Return_outer of string
-  4: let rec outer  : string =
-  5:     try
+unsupported syntax at line 12: failwith "unreachable"
+ 11:         raise (Return_outer (p.name))
+ 12:         failwith "unreachable"
+ 13:     with Return_outer v -> v
+ 14:

--- a/tests/any2mochi/fs/tpch_q2.fs.error
+++ b/tests/any2mochi/fs/tpch_q2.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 24: let rec _to_json (v: obj) : string =
- 23: let n = "n"
- 24: let rec _to_json (v: obj) : string =
- 25:   match v with
- 26:   | null -> "null"
+unsupported syntax at line 116: ignore (_json result)
+115:     |> Array.map snd
+116: ignore (_json result)
+117: let test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part() =
+118:     if not ((result = [|Map.ofList [(s_acctbal, 1000.0); (s_name, "BestSupplier"); (n_name, "FRANCE"); (p_partkey, 1000); (p_mfgr, "M1"); (s_address, "123 Rue"); (s_phone, "123"); (s_comment, "Fast and reliable"); (ps_supplycost, 10.0)]|])) then failwith "expect failed"

--- a/tests/any2mochi/fs/two_sum.fs.error
+++ b/tests/any2mochi/fs/two_sum.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: exception Return_twoSum of int[]
-  2: 
-  3: exception Return_twoSum of int[]
-  4: let rec twoSum (nums: int[]) (target: int) : int[] =
-  5:     try
+unsupported syntax at line 14: failwith "unreachable"
+ 13:         raise (Return_twoSum ([|(-1); (-1)|]))
+ 14:         failwith "unreachable"
+ 15:     with Return_twoSum v -> v
+ 16:

--- a/tests/any2mochi/fs/union_match.fs.error
+++ b/tests/any2mochi/fs/union_match.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 7: exception Return_isLeaf of bool
-  6: 
-  7: exception Return_isLeaf of bool
-  8: let rec isLeaf (t: Tree) : bool =
-  9:     try
+unsupported syntax at line 12: failwith "unreachable"
+ 11:         raise (Return_isLeaf ((match t with | Leaf -> true | _ -> false)))
+ 12:         failwith "unreachable"
+ 13:     with Return_isLeaf v -> v
+ 14:

--- a/tests/any2mochi/fs/update_statement.fs.error
+++ b/tests/any2mochi/fs/update_statement.fs.error
@@ -1,5 +1,5 @@
-unsupported syntax at line 3: let _run_test (name: string) (f: unit -> unit) : bool =
-  2: 
-  3: let _run_test (name: string) (f: unit -> unit) : bool =
-  4:   printf "%s ... " name
-  5:   try
+unsupported syntax at line 29: let test_update_adult_status() =
+ 28:     people.[i] <- item
+ 29: let test_update_adult_status() =
+ 30:     if not ((people = [|{ name = "Alice"; age = 17; status = "minor" }; { name = "Bob"; age = 26; status = "adult" }; { name = "Charlie"; age = 19; status = "adult" }; { name = "Diana"; age = 16; status = "minor" }|])) then failwith "expect failed"
+ 31:

--- a/tools/any2mochi/x/fs/convert.go
+++ b/tools/any2mochi/x/fs/convert.go
@@ -322,6 +322,31 @@ func writeStmts(out *strings.Builder, stmts []Stmt, indent int) {
 			out.WriteString(idt + "while " + v.Cond + " {\n")
 			writeStmts(out, v.Body, indent+1)
 			out.WriteString(idt + "}\n")
+		case If:
+			out.WriteString(idt + "if " + fixIndex(v.Cond) + " {\n")
+			writeStmts(out, v.Then, indent+1)
+			if len(v.Else) > 0 {
+				out.WriteString(idt + "} else {\n")
+				writeStmts(out, v.Else, indent+1)
+			}
+			out.WriteString(idt + "}\n")
+		case Return:
+			out.WriteString(idt + "return " + fixIndex(v.Expr) + "\n")
+		case Fun:
+			out.WriteString(idt + "fun " + v.Name + "(")
+			for i, p := range v.Params {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				out.WriteString(p.Name)
+			}
+			out.WriteByte(')')
+			if t := mapType(v.Ret); t != "" {
+				out.WriteString(": " + t)
+			}
+			out.WriteString(" {\n")
+			writeStmts(out, v.Body, indent+1)
+			out.WriteString(idt + "}\n")
 		case TypeDecl:
 			if len(v.Fields) > 0 {
 				out.WriteString(idt + "type " + v.Name + " {\n")


### PR DESCRIPTION
## Summary
- extend F# parser with Fun/Return/If AST nodes
- support detection of functions/return statements/if blocks
- generate new statements when converting F# code
- refresh golden .error outputs for F# language

## Testing
- `go test ./tools/any2mochi/x/fs -run TestConvertFs_Golden -tags slow -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a45c259d48320bc3af9a4156c0cef