### PR TITLE
Improve Haskell any2mochi conversion

### DIFF
--- a/compile/x/hs/compiler.go
+++ b/compile/x/hs/compiler.go
@@ -884,6 +884,10 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		if p.Call.Func == "print" {
 			return c.compilePrint(callArgs{args: args, exprs: p.Call.Args})
 		}
+		if p.Call.Func == "reverse" && len(args) == 1 {
+			c.usesList = true
+			return fmt.Sprintf("reverse %s", args[0]), nil
+		}
 		return fmt.Sprintf("%s %s", sanitizeName(p.Call.Func), strings.Join(args, " ")), nil
 	case p.Selector != nil:
 		expr := sanitizeName(p.Selector.Root)

--- a/tests/any2mochi/hs/arithmetic.hs.error
+++ b/tests/any2mochi/hs/arithmetic.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/avg_builtin.hs.error
+++ b/tests/any2mochi/hs/avg_builtin.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/bool_ops.hs.error
+++ b/tests/any2mochi/hs/bool_ops.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/closure.hs.error
+++ b/tests/any2mochi/hs/closure.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/count_builtin.hs.error
+++ b/tests/any2mochi/hs/count_builtin.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/dataset.hs.error
+++ b/tests/any2mochi/hs/dataset.hs.error
@@ -1,4 +1,4 @@
-line 14: unsupported syntax
-    13 | 
-->  14 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 16: unsupported syntax: where
     15 | forLoop start end f = go start
+->  16 |   where
+    17 |     go i

--- a/tests/any2mochi/hs/float_literal_precision.hs.error
+++ b/tests/any2mochi/hs/float_literal_precision.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/float_ops.hs.error
+++ b/tests/any2mochi/hs/float_ops.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/for_loop.hs.error
+++ b/tests/any2mochi/hs/for_loop.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/fun_call.hs.error
+++ b/tests/any2mochi/hs/fun_call.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/fun_expr_in_let.hs.error
+++ b/tests/any2mochi/hs/fun_expr_in_let.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/grouped_expr.hs.error
+++ b/tests/any2mochi/hs/grouped_expr.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/hello_world.hs.error
+++ b/tests/any2mochi/hs/hello_world.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/if_else.hs.error
+++ b/tests/any2mochi/hs/if_else.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/input_builtin.hs.error
+++ b/tests/any2mochi/hs/input_builtin.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/len_builtin.hs.error
+++ b/tests/any2mochi/hs/len_builtin.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/list_for_loop.hs.error
+++ b/tests/any2mochi/hs/list_for_loop.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/list_push.hs.error
+++ b/tests/any2mochi/hs/list_push.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/load_json_stdin.hs.error
+++ b/tests/any2mochi/hs/load_json_stdin.hs.error
@@ -1,4 +1,4 @@
-line 20: unsupported syntax
+line 20: unsupported syntax: instance Aeson.ToJSON AnyValue where
     19 | 
 ->  20 | instance Aeson.ToJSON AnyValue where
     21 |   toJSON (VInt n) = Aeson.toJSON n

--- a/tests/any2mochi/hs/map_for_loop.hs.error
+++ b/tests/any2mochi/hs/map_for_loop.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/map_index.hs.error
+++ b/tests/any2mochi/hs/map_index.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/map_keys_builtin.hs.error
+++ b/tests/any2mochi/hs/map_keys_builtin.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/map_lookup.hs.error
+++ b/tests/any2mochi/hs/map_lookup.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/reserved_keyword_var.hs.error
+++ b/tests/any2mochi/hs/reserved_keyword_var.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/save_json_stdout.hs.error
+++ b/tests/any2mochi/hs/save_json_stdout.hs.error
@@ -1,4 +1,4 @@
-line 20: unsupported syntax
+line 20: unsupported syntax: instance Aeson.ToJSON AnyValue where
     19 | 
 ->  20 | instance Aeson.ToJSON AnyValue where
     21 |   toJSON (VInt n) = Aeson.toJSON n

--- a/tests/any2mochi/hs/str_builtin.hs.error
+++ b/tests/any2mochi/hs/str_builtin.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/string_concat.hs.error
+++ b/tests/any2mochi/hs/string_concat.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/string_for_loop.hs.error
+++ b/tests/any2mochi/hs/string_for_loop.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/string_index.hs.error
+++ b/tests/any2mochi/hs/string_index.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/string_negative_index.hs.error
+++ b/tests/any2mochi/hs/string_negative_index.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/string_slice.hs.error
+++ b/tests/any2mochi/hs/string_slice.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/struct_literal.hs.error
+++ b/tests/any2mochi/hs/struct_literal.hs.error
@@ -1,4 +1,4 @@
-line 14: unsupported syntax
-    13 | 
-->  14 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 16: unsupported syntax: where
     15 | forLoop start end f = go start
+->  16 |   where
+    17 |     go i

--- a/tests/any2mochi/hs/test_block.hs.error
+++ b/tests/any2mochi/hs/test_block.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/tpc_h_q1.hs.error
+++ b/tests/any2mochi/hs/tpc_h_q1.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i

--- a/tests/any2mochi/hs/two_sum.hs.error
+++ b/tests/any2mochi/hs/two_sum.hs.error
@@ -1,4 +1,4 @@
-line 13: unsupported syntax
-    12 | 
-->  13 | forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+line 15: unsupported syntax: where
     14 | forLoop start end f = go start
+->  15 |   where
+    16 |     go i


### PR DESCRIPTION
## Summary
- extend `any2mochi` Haskell parser with signature support and detailed errors
- emit parameter/return types when converting to Mochi
- allow `reverse` in the Haskell backend
- update golden `.error` files for the converter

## Testing
- `go test ./...`
- `go test -tags slow ./tools/any2mochi/x/hs -update`

------
https://chatgpt.com/codex/tasks/task_e_686a45c537ec8320b6e948baaf3df964