### PR TITLE
Improve Kotlin conversion features

### DIFF
--- a/tests/any2mochi/kt/string_slice.kt.mochi
+++ b/tests/any2mochi/kt/string_slice.kt.mochi
@@ -6,11 +6,21 @@ fun _sliceString(s: string, i: int, j: int): string {
   var end = j
   let arr = s.toCharArray()
   let n = arr.size
-  if start < 0) start += n {
-    if end < 0) end += n {
-      if start < 0) start = 0 {
-        if end > n) end = n {
-          if end < start) end = start {
-            return String(arr.sliceArray(start until end))
-          }
+  if start < 0 {
+    start += n
+  }
+  if end < 0 {
+    end += n
+  }
+  if start < 0 {
+    start = 0
+  }
+  if end > n {
+    end = n
+  }
+  if end < start {
+    end = start
+  }
+  return String(arr.sliceArray(start .. end))
+}
 main()

--- a/tests/any2mochi/kt/two_sum.kt.mochi
+++ b/tests/any2mochi/kt/two_sum.kt.mochi
@@ -1,8 +1,8 @@
 fun twoSum(nums: list<int>, target: int): list<int> {
   let n = nums.size
   for i in 0 .. n {
-    for j in (i + 1 {
-      if nums[i] + nums[j]) == target {
+    for j in (i + 1) .. n {
+      if (nums[i] + nums[j]) == target {
         return listOf(i, j)
       }
     }


### PR DESCRIPTION
## Summary
- extend Kotlin converter to handle nested `for` loops and single-line `if`
- expose start/end column info and snippet data in `ktast`
- regenerate golden test outputs for Kotlin

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a45c8da1c8320815ec97a0cf92e32