### PR TITLE
Improve Java converter DX

### DIFF
--- a/tests/any2mochi/java/dataset.error
+++ b/tests/any2mochi/java/dataset.error
@@ -1,7 +1,7 @@
-line 3: unsupported line: public java.util.List<Object> get() {
-  1| Object[] people = new Object[]{new java.util.HashMap<>(java.util.Map.of("name", "Alice", "age", 30)), new java.util.HashMap<>(java.util.Map.of("name", "Bob", "age", 15)), new java.util.HashMap<>(java.util.Map.of("name", "Charlie", "age", 65)), new java.util.HashMap<>(java.util.Map.of("name", "Diana", "age", 45))};
-  2| Object[] adults = (new java.util.function.Supplier<java.util.List<Object>>() {
-  3| public java.util.List<Object> get() {
-  4| java.util.List<Object> _src = _toList(people);
-  5| _src = _filter(_src, (Object person) -> { return (person.age >= 18); });
+line 3: unsupported line
+      1| Object[] people = new Object[]{new java.util.HashMap<>(java.util.Map.of("name", "Alice", "age", 30)), new java.util.HashMap<>(java.util.Map.of("name", "Bob", "age", 15)), new java.util.HashMap<>(java.util.Map.of("name", "Charlie", "age", 65)), new java.util.HashMap<>(java.util.Map.of("name", "Diana", "age", 45))};
+      2| Object[] adults = (new java.util.function.Supplier<java.util.List<Object>>() {
+>>>   3| public java.util.List<Object> get() {
+      4| java.util.List<Object> _src = _toList(people);
+      5| _src = _filter(_src, (Object person) -> { return (person.age >= 18); });
 

--- a/tests/any2mochi/java/dataset_sort_take_limit.error
+++ b/tests/any2mochi/java/dataset_sort_take_limit.error
@@ -1,7 +1,7 @@
-line 3: unsupported line: public java.util.List<Object> get() {
-  1| Object[] products = new Product[]{new Product("Laptop", 1500), new Product("Smartphone", 900), new Product("Tablet", 600), new Product("Monitor", 300), new Product("Keyboard", 100), new Product("Mouse", 50), new Product("Headphones", 200)};
-  2| Object[] expensive = (new java.util.function.Supplier<java.util.List<Object>>() {
-  3| public java.util.List<Object> get() {
-  4| java.util.List<Object> _src = _toList(products);
-  5| java.util.List<_JoinSpec> _joins = java.util.List.of(
+line 3: unsupported line
+      1| Object[] products = new Product[]{new Product("Laptop", 1500), new Product("Smartphone", 900), new Product("Tablet", 600), new Product("Monitor", 300), new Product("Keyboard", 100), new Product("Mouse", 50), new Product("Headphones", 200)};
+      2| Object[] expensive = (new java.util.function.Supplier<java.util.List<Object>>() {
+>>>   3| public java.util.List<Object> get() {
+      4| java.util.List<Object> _src = _toList(products);
+      5| java.util.List<_JoinSpec> _joins = java.util.List.of(
 

--- a/tests/any2mochi/java/tpch_q1.error
+++ b/tests/any2mochi/java/tpch_q1.error
@@ -1,8 +1,7 @@
-line 6: unsupported line: static Object[] lineitem = new Object[]{new java.util.HashMap<>(java.util.Map.of("l_quantity", 17, "l_extendedprice", 1000, "l_discount", 0.05, "l_tax", 0.07, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-08-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 36, "l_extendedprice", 2000, "l_discount", 0.1, "l_tax", 0.05, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-09-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 25, "l_extendedprice", 1500, "l_discount", 0, "l_tax", 0.08, "l_returnflag", "R", "l_linestatus", "F", "l_shipdate", "1998-09-03"))};
-  4| }
-  5| 
-  6| static Object[] lineitem = new Object[]{new java.util.HashMap<>(java.util.Map.of("l_quantity", 17, "l_extendedprice", 1000, "l_discount", 0.05, "l_tax", 0.07, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-08-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 36, "l_extendedprice", 2000, "l_discount", 0.1, "l_tax", 0.05, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-09-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 25, "l_extendedprice", 1500, "l_discount", 0, "l_tax", 0.08, "l_returnflag", "R", "l_linestatus", "F", "l_shipdate", "1998-09-03"))};
-  7| 
-  8| static Object[] result = (new java.util.function.Supplier<java.util.List<Object>>() {
-
+line 8: unsupported line
+      6| static Object[] lineitem = new Object[]{new java.util.HashMap<>(java.util.Map.of("l_quantity", 17, "l_extendedprice", 1000, "l_discount", 0.05, "l_tax", 0.07, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-08-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 36, "l_extendedprice", 2000, "l_discount", 0.1, "l_tax", 0.05, "l_returnflag", "N", "l_linestatus", "O", "l_shipdate", "1998-09-01")), new java.util.HashMap<>(java.util.Map.of("l_quantity", 25, "l_extendedprice", 1500, "l_discount", 0, "l_tax", 0.08, "l_returnflag", "R", "l_linestatus", "F", "l_shipdate", "1998-09-03"))};
+      7| 
+>>>   8| static Object[] result = (new java.util.function.Supplier<java.util.List<Object>>() {
+      9| public java.util.List<Object> get() {
+     10| java.util.List<Object> _src = _toList(lineitem);
 

--- a/tests/any2mochi/java/update_stmt.error
+++ b/tests/any2mochi/java/update_stmt.error
@@ -1,8 +1,7 @@
-line 13: unsupported line: Person() {}
- 11| }
- 12| 
- 13| Person() {}
- 14| }
- 15| 
-
+line 27: unsupported line
+     25| }
+     26| 
+>>>  27| static Object[] people =
+     28| new Person[] {
+     29| new Person("Alice", 17, "minor"),
 

--- a/tools/any2mochi/golden_helpers.go
+++ b/tools/any2mochi/golden_helpers.go
@@ -69,6 +69,8 @@ func runConvertCompileGolden(t *testing.T, dir, pattern string, convert func(str
 			name = strings.TrimSuffix(filepath.Base(src), ".f90.out")
 		case strings.HasSuffix(src, ".pas.out"):
 			name = strings.TrimSuffix(filepath.Base(src), ".pas.out")
+		case strings.HasSuffix(src, ".java.out"):
+			name = strings.TrimSuffix(filepath.Base(src), ".java.out")
 		default:
 			name = strings.TrimSuffix(filepath.Base(src), filepath.Ext(src))
 		}
@@ -151,6 +153,8 @@ func runConvertGolden(t *testing.T, dir, pattern string, convert func(string) ([
 			name = strings.TrimSuffix(filepath.Base(src), ".f90.out")
 		case strings.HasSuffix(src, ".pas.out"):
 			name = strings.TrimSuffix(filepath.Base(src), ".pas.out")
+		case strings.HasSuffix(src, ".java.out"):
+			name = strings.TrimSuffix(filepath.Base(src), ".java.out")
 		default:
 			name = strings.TrimSuffix(filepath.Base(src), filepath.Ext(src))
 		}


### PR DESCRIPTION
## Summary
- handle `.java.out` filenames in golden helper
- expand Java AST structs with variable definitions
- skip helper functions and highlight lines around parse errors
- update Java golden error fixtures

## Testing
- `go test -run TestConvertJava_Golden/dataset -tags slow ./tools/any2mochi/x/java`
- `go test -run TestConvertJava_Golden/dataset_sort_take_limit -tags slow ./tools/any2mochi/x/java`
- `go test -run TestConvertJava_Golden/tpch_q1 -tags slow ./tools/any2mochi/x/java`
- `go test -run TestConvertJava_Golden/update_stmt -tags slow ./tools/any2mochi/x/java`

------
https://chatgpt.com/codex/tasks/task_e_686a45cf21ac832084be7c99512fb0d9