### PR TITLE
Improve Scala converter lambda handling

### DIFF
--- a/tools/any2mochi/x/scala/convert.go
+++ b/tools/any2mochi/x/scala/convert.go
@@ -209,6 +209,11 @@ func convertFunc(lines []string, sym any2mochi.DocumentSymbol, root string) stri
 			arg := strings.TrimSuffix(line[idx+8:], ")")
 			write("append(" + recv + ", " + convertExpr(arg) + ")")
 		case strings.Contains(line, "="):
+			if strings.Contains(line, "=>") {
+				// lambda or pattern match arrow, keep as-is
+				write(line)
+				continue
+			}
 			parts := strings.SplitN(line, "=", 2)
 			left := strings.TrimSpace(parts[0])
 			right := strings.TrimSpace(parts[1])


### PR DESCRIPTION
## Summary
- improve Scala converter in any2mochi so that lines containing `=>` are preserved instead of parsed as assignments

## Testing
- `go test ./tools/any2mochi/x/scala -run TestConvertScala_Golden -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686a45ed0b5083208dbdd6a8febff0db