### PR TITLE
Improve Zig converter with pub visibility

### DIFF
--- a/tests/any2mochi/zig/dataset_sort_take_limit.mochi
+++ b/tests/any2mochi/zig/dataset_sort_take_limit.mochi
@@ -28,6 +28,7 @@ fun _slice_list(comptime T: type, v: list<const T>, start: int, end: int, step: 
   return res.toOwnedSlice() catch unreachable
 }
 // line 29
+// pub
 fun main() {
   let products: list<const i32> = &[_]i32{Product{ .name = "Laptop", .price = 1500 }, Product{ .name = "Smartphone", .price = 900 }, Product{ .name = "Tablet", .price = 600 }, Product{ .name = "Monitor", .price = 300 }, Product{ .name = "Keyboard", .price = 100 }, Product{ .name = "Mouse", .price = 50 }, Product{ .name = "Headphones", .price = 200 }}
   let expensive: list<const i32> = blk: { var _tmp0 = std.ArrayList(struct { item: i32; key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp0.append([ .item = p, .key = -p.price ]) catch unreachable; } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch unreachable; } var _tmp2 = _tmp1.toOwnedSlice() catch unreachable; _tmp2 = _slice_list(i32, _tmp2, 1, (1 + 3), 1); break :blk _tmp2; }

--- a/tests/any2mochi/zig/simple_fn.mochi
+++ b/tests/any2mochi/zig/simple_fn.mochi
@@ -5,6 +5,7 @@ fun id(x: int): int {
   return x
 }
 // line 7
+// pub
 fun main() {
   print(id(123))
 }

--- a/tools/any2mochi/x/zig/convert.go
+++ b/tools/any2mochi/x/zig/convert.go
@@ -44,6 +44,7 @@ type variable struct {
 	Type  string `json:"type"`
 	Value string `json:"value,omitempty"`
 	Const bool   `json:"const,omitempty"`
+	Pub   bool   `json:"pub,omitempty"`
 	Line  int    `json:"line"`
 }
 
@@ -53,6 +54,7 @@ type function struct {
 	Ret     string   `json:"ret"`
 	Line    int      `json:"line"`
 	EndLine int      `json:"endLine"`
+	Pub     bool     `json:"pub,omitempty"`
 	Lines   []string `json:"lines"`
 }
 
@@ -60,6 +62,7 @@ type structDef struct {
 	Name    string  `json:"name"`
 	Line    int     `json:"line"`
 	EndLine int     `json:"endLine"`
+	Pub     bool    `json:"pub,omitempty"`
 	Fields  []field `json:"fields"`
 }
 
@@ -216,6 +219,9 @@ func convertAST(a *ast) ([]byte, error) {
 			out.WriteString(fmt.Sprint(v.Line))
 			out.WriteByte('\n')
 		}
+		if v.Pub {
+			out.WriteString("// pub\n")
+		}
 		out.WriteString("let ")
 		out.WriteString(v.Name)
 		if v.Type != "" {
@@ -234,6 +240,9 @@ func convertAST(a *ast) ([]byte, error) {
 			out.WriteString("// line ")
 			out.WriteString(fmt.Sprint(st.Line))
 			out.WriteByte('\n')
+		}
+		if st.Pub {
+			out.WriteString("// pub\n")
 		}
 		out.WriteString("type ")
 		out.WriteString(st.Name)
@@ -259,6 +268,9 @@ func convertAST(a *ast) ([]byte, error) {
 			out.WriteString("// line ")
 			out.WriteString(fmt.Sprint(fn.Line))
 			out.WriteByte('\n')
+		}
+		if fn.Pub {
+			out.WriteString("// pub\n")
 		}
 		out.WriteString("fun ")
 		out.WriteString(fn.Name)
@@ -315,6 +327,9 @@ func parseFunctionBodyLines(lines []string) []string {
 		}
 		for strings.HasPrefix(l, "}") {
 			indent--
+			if indent < 0 {
+				indent = 0
+			}
 			if len(post) > 0 {
 				p := post[len(post)-1]
 				if p != "" {
@@ -341,6 +356,9 @@ func parseFunctionBodyLines(lines []string) []string {
 		}
 		if l == "}" {
 			indent--
+			if indent < 0 {
+				indent = 0
+			}
 			if len(post) > 0 {
 				p := post[len(post)-1]
 				if p != "" {
@@ -668,6 +686,9 @@ func parseFunctionBody(src string, sym any2mochi.DocumentSymbol) []string {
 		}
 		for strings.HasPrefix(l, "}") {
 			indent--
+			if indent < 0 {
+				indent = 0
+			}
 			if len(post) > 0 {
 				p := post[len(post)-1]
 				if p != "" {
@@ -694,6 +715,9 @@ func parseFunctionBody(src string, sym any2mochi.DocumentSymbol) []string {
 		}
 		if l == "}" {
 			indent--
+			if indent < 0 {
+				indent = 0
+			}
 			if len(post) > 0 {
 				p := post[len(post)-1]
 				if p != "" {

--- a/tools/any2mochi/x/zig/convert_golden_test.go
+++ b/tools/any2mochi/x/zig/convert_golden_test.go
@@ -1,15 +1,16 @@
 //go:build slow
 
-package any2mochi
+package zig_test
 
 import (
 	"path/filepath"
 	"testing"
 
+	any2mochi "mochi/tools/any2mochi"
 	zig "mochi/tools/any2mochi/x/zig"
 )
 
 func TestConvertZig_Golden(t *testing.T) {
-	root := findRepoRoot(t)
-	runConvertGolden(t, filepath.Join(root, "tests/compiler/zig"), "*.zig.out", zig.ConvertFile, "zig", ".mochi", ".error")
+	root := any2mochi.FindRepoRoot(t)
+	any2mochi.RunConvertGolden(t, filepath.Join(root, "tests/compiler/zig"), "*.zig.out", zig.ConvertFile, "zig", ".mochi", ".error")
 }


### PR DESCRIPTION
## Summary
- enhance zig parser to capture `pub` flag for variables, structs and functions
- expose the `pub` flag in the zig any2mochi converter
- emit comments for public symbols in generated Mochi code
- avoid negative indent crashes when parsing zig code
- fix zig convert golden test package name
- update zig golden samples

## Testing
- `go test ./tools/any2mochi/x/zig -run TestConvertZig_Golden/simple_fn -tags slow -update`
- `go test ./tools/any2mochi/x/zig -run TestConvertZig_Golden/dataset_sort_take_limit -tags slow -update`


------
https://chatgpt.com/codex/tasks/task_e_686a45f61408832086581fe6cc706dc4