### PR TITLE
Improve Clojure tooling

### DIFF
--- a/tools/any2mochi/x/clj/convert.go
+++ b/tools/any2mochi/x/clj/convert.go
@@ -17,21 +17,25 @@ type Program struct {
 }
 
 type form struct {
-	Type   string   `json:"type"`
-	Name   string   `json:"name,omitempty"`
-	Params []string `json:"params,omitempty"`
-	Doc    string   `json:"doc,omitempty"`
-	Body   []node   `json:"body,omitempty"`
-	Value  node     `json:"value,omitempty"`
-	Line   int      `json:"line,omitempty"`
-	Col    int      `json:"col,omitempty"`
+	Type    string   `json:"type"`
+	Name    string   `json:"name,omitempty"`
+	Params  []string `json:"params,omitempty"`
+	Doc     string   `json:"doc,omitempty"`
+	Body    []node   `json:"body,omitempty"`
+	Value   node     `json:"value,omitempty"`
+	Line    int      `json:"line,omitempty"`
+	Col     int      `json:"col,omitempty"`
+	EndLine int      `json:"end-line,omitempty"`
+	EndCol  int      `json:"end-col,omitempty"`
 }
 
 type node struct {
-	Atom string `json:"atom,omitempty"`
-	List []node `json:"list,omitempty"`
-	Line int    `json:"line,omitempty"`
-	Col  int    `json:"col,omitempty"`
+	Atom    string `json:"atom,omitempty"`
+	List    []node `json:"list,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Col     int    `json:"col,omitempty"`
+	EndLine int    `json:"end-line,omitempty"`
+	EndCol  int    `json:"end-col,omitempty"`
 }
 
 func snippet(src string) string {

--- a/tools/any2mochi/x/clj/parse.clj
+++ b/tools/any2mochi/x/clj/parse.clj
@@ -1,6 +1,7 @@
 (ns any2mochi.parse
-  (:require [clojure.edn :as edn]
-            [clojure.data.json :as json]))
+  (:require [clojure.data.json :as json]
+            [clojure.tools.reader.edn :as edn]
+            [clojure.tools.reader.reader-types :as rt]))
 
 (defn node [expr]
   (let [m (meta expr)]
@@ -8,11 +9,15 @@
       (sequential? expr)
       {:list (mapv node expr)
        :line (:line m)
-       :col (:column m)}
+       :col (:column m)
+       :end-line (:end-line m)
+       :end-col (:end-column m)}
       :else
       {:atom (str expr)
        :line (:line m)
-       :col (:column m)})))
+       :col (:column m)
+       :end-line (:end-line m)
+       :end-col (:end-column m)})))
 
 (defn param-list [p]
   (mapv str p))
@@ -27,18 +32,28 @@
                 [doc body] (if (string? (first body))
                              [(first body) (rest body)]
                              [nil body])]
-            {:type "defn" :name (str name) :params (param-list params) :doc doc :body (mapv node body) :line (:line m) :col (:column m)})
+            {:type "defn" :name (str name) :params (param-list params) :doc doc
+             :body (mapv node body)
+             :line (:line m) :col (:column m)
+             :end-line (:end-line m) :end-col (:end-column m)})
           (= head 'def)
           (let [[name value] rest]
-            {:type "def" :name (str name) :value (node value) :line (:line m) :col (:column m)})
-          :else {:type "expr" :body [(node expr)] :line (:line m) :col (:column m)}))
-      {:type "expr" :body [(node expr)] :line (:line m) :col (:column m)}))
+            {:type "def" :name (str name) :value (node value)
+             :line (:line m) :col (:column m)
+             :end-line (:end-line m) :end-col (:end-column m)})
+          :else {:type "expr" :body [(node expr)]
+                 :line (:line m) :col (:column m)
+                 :end-line (:end-line m) :end-col (:end-column m)}))
+      {:type "expr" :body [(node expr)]
+       :line (:line m) :col (:column m)
+       :end-line (:end-line m) :end-col (:end-column m)}))
 
 (defn parse-file [f]
-  (with-open [r (java.io.PushbackReader. (java.io.FileReader. f))]
+  (with-open [r (rt/indexing-push-back-reader (java.io.FileReader. f))]
     (binding [*read-eval* false]
       (loop [forms []]
-        (let [form (read r nil nil)]
+        (let [form (edn/read {:eof nil :read-cond :allow :features #{:clj}
+                               :track-position? true} r)]
           (if (nil? form)
             {:forms forms}
             (recur (conj forms (build-form form))))))))


### PR DESCRIPTION
## Summary
- enhance any2mochi test runner to compile and run code with the VM
- record end positions when parsing Clojure with tools.reader
- expose end line/column in the Clojure converter structures

## Testing
- `go test ./tools/any2mochi/x/clj -run TestConvertClj_Golden -count=1`
- `go test ./tools/any2mochi -c >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_686a49ce925883208da1987f85328029