### PR TITLE
Enhance Prolog converter

### DIFF
--- a/tools/any2mochi/golden_helpers.go
+++ b/tools/any2mochi/golden_helpers.go
@@ -13,6 +13,7 @@ import (
 
 	gocode "mochi/compile/go"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -96,6 +97,17 @@ func runConvertCompileGolden(t *testing.T, dir, pattern string, convert func(str
 					} else {
 						if _, cErr := gocode.New(env).Compile(prog); cErr != nil {
 							err = fmt.Errorf("compile error: %w", cErr)
+						} else {
+							p, vmErr := vm.Compile(prog, env)
+							if vmErr != nil {
+								err = fmt.Errorf("vm compile error: %w", vmErr)
+							} else {
+								var buf bytes.Buffer
+								m := vm.New(p, &buf)
+								if runErr := m.Run(); runErr != nil {
+									err = fmt.Errorf("vm run error: %w", runErr)
+								}
+							}
 						}
 					}
 				}

--- a/tools/any2mochi/x/prolog/convert.go
+++ b/tools/any2mochi/x/prolog/convert.go
@@ -261,6 +261,9 @@ func convertFallback(src string) ([]byte, error) {
 	if prog, err := parseAST(src); err == nil {
 		var out strings.Builder
 		for _, c := range prog.Clauses {
+			if c.Name == ":-" {
+				continue
+			}
 			if c.Name == "main" {
 				out.WriteString("fun main() {\n")
 				for _, line := range parseBody(c.Body) {
@@ -412,6 +415,17 @@ func parseBody(body string) []string {
 					}
 				}
 				out = append(out, "  let "+varName+" = "+strings.Title(typ)+" { "+strings.Join(parts, ", ")+" }")
+			} else {
+				out = append(out, "  // "+c)
+			}
+		case strings.HasPrefix(c, "get_dict("):
+			re := regexp.MustCompile(`get_dict\(([^,]+),\s*([^,]+),\s*([^\)]+)\)`)
+			m := re.FindStringSubmatch(c)
+			if len(m) == 4 {
+				field := strings.TrimSpace(m[1])
+				obj := strings.TrimSpace(m[2])
+				dest := strings.TrimSpace(m[3])
+				out = append(out, fmt.Sprintf("  let %s = %s.%s", dest, obj, field))
 			} else {
 				out = append(out, "  // "+c)
 			}


### PR DESCRIPTION
## Summary
- extend Prolog AST structures with comment capture
- handle `get_dict/3` expressions when converting bodies
- skip directives when converting without LSP
- run generated Mochi code through the VM in golden tests

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a4b2ea4c8832094afcc5e3fec047c