### PR TITLE
Enhance PHP conversion tooling

### DIFF
--- a/compile/x/php/compiler.go
+++ b/compile/x/php/compiler.go
@@ -927,6 +927,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("max expects 1 arg")
 		}
 		return fmt.Sprintf("(count(%[1]s) ? max(%[1]s) : 0)", args[0]), nil
+	case "min":
+		if len(args) != 1 {
+			return "", fmt.Errorf("min expects 1 arg")
+		}
+		return fmt.Sprintf("(count(%[1]s) ? min(%[1]s) : 0)", args[0]), nil
 	case "concat":
 		if len(args) == 0 {
 			return "[]", nil

--- a/tools/any2mochi/x/php/convert_golden_test.go
+++ b/tools/any2mochi/x/php/convert_golden_test.go
@@ -11,5 +11,5 @@ import (
 
 func TestConvertPhp_Golden(t *testing.T) {
 	root := any2mochi.FindRepoRoot(t)
-	any2mochi.RunConvertGolden(t, filepath.Join(root, "tests/compiler/php"), "*.php.out", ConvertFile, "php", ".mochi", ".error")
+	any2mochi.RunConvertCompileGolden(t, filepath.Join(root, "tests/compiler/php"), "*.php.out", ConvertFile, "php", ".mochi", ".error")
 }


### PR DESCRIPTION
## Summary
- extend PHP AST structs with source line data
- improve snippet formatting and column info
- run generated Mochi code when converting to ensure runnable output
- support struct literals from `new` expressions
- add `min` builtin for PHP compiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a4b1a7b3483208b87ac61b251a61a