### PR TITLE
Improve Kotlin converter with sealed interface support

### DIFF
--- a/tests/any2mochi/kt/underscore_for_loop.kt.mochi
+++ b/tests/any2mochi/kt/underscore_for_loop.kt.mochi
@@ -3,7 +3,7 @@ fun main() {
   for _ in 0 .. 2 {
     c = (c + 1)
   }
-  for _ in listOf(1, 2 {
+  for _ in listOf(1, 2) {
     c = (c + 1)
   }
   for _ in "ab" {

--- a/tests/any2mochi/kt/union_inorder.kt.mochi
+++ b/tests/any2mochi/kt/union_inorder.kt.mochi
@@ -1,9 +1,6 @@
-type Leaf {}
-type Node {
-  left: Tree
-  value: int
-  right: Tree
-}
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
 fun inorder(t: Tree): list<int> {
   return run {
   let _t = t

--- a/tests/any2mochi/kt/union_match.kt.mochi
+++ b/tests/any2mochi/kt/union_match.kt.mochi
@@ -1,9 +1,6 @@
-type Leaf {}
-type Node {
-  left: Tree
-  value: int
-  right: Tree
-}
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
 fun isLeaf(t: Tree): bool {
   return run {
   let _t = t

--- a/tests/any2mochi/kt/union_slice.kt.mochi
+++ b/tests/any2mochi/kt/union_slice.kt.mochi
@@ -1,7 +1,6 @@
-type Empty {}
-type Node {
-  child: Foo
-}
+type Foo =
+  Empty
+  | Node(child: Foo)
 fun listit(): list<Foo> {
   return listOf(Empty())
 }


### PR DESCRIPTION
## Summary
- enrich `ktast` AST nodes with kind, data, sealed, and extends info
- parse the new fields from Kotlin source
- generate union definitions from sealed interfaces when converting Kotlin to Mochi
- update affected golden outputs

## Testing
- `go build ./tools/ktast`
- `go build ./tools/any2mochi/x/kt`
- `go test ./tools/any2mochi/x/kt -tags slow -run TestConvertKt_Golden/while_membership.kt -update`


------
https://chatgpt.com/codex/tasks/task_e_686a4aac4ecc8320be8d75cccb2dd7dd