### PR TITLE
Improve Smalltalk converter

### DIFF
--- a/tests/any2mochi/st/unsupported.st.error
+++ b/tests/any2mochi/st/unsupported.st.error
@@ -1,4 +1,4 @@
-no convertible symbols found
+no convertible statements found
 
 source snippet:
   1: Object new foo.

--- a/tools/any2mochi/golden_helpers.go
+++ b/tools/any2mochi/golden_helpers.go
@@ -13,6 +13,7 @@ import (
 
 	gocode "mochi/compile/go"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -96,6 +97,16 @@ func runConvertCompileGolden(t *testing.T, dir, pattern string, convert func(str
 					} else {
 						if _, cErr := gocode.New(env).Compile(prog); cErr != nil {
 							err = fmt.Errorf("compile error: %w", cErr)
+						} else {
+							if p, vErr := vm.Compile(prog, env); vErr != nil {
+								err = fmt.Errorf("vm compile error: %w", vErr)
+							} else {
+								var buf bytes.Buffer
+								m := vm.New(p, &buf)
+								if rErr := m.Run(); rErr != nil {
+									err = fmt.Errorf("vm run error: %w", rErr)
+								}
+							}
 						}
 					}
 				}

--- a/tools/any2mochi/x/st/convert.go
+++ b/tools/any2mochi/x/st/convert.go
@@ -282,7 +282,7 @@ func convertFallback(src string) ([]byte, error) {
 		}
 	}
 	if out.Len() == 0 {
-		return nil, fmt.Errorf("no convertible symbols found\n\nsource snippet:\n%s", numberedSnippet(src))
+		return nil, fmt.Errorf("no convertible statements found\n\nsource snippet:\n%s", numberedSnippet(src))
 	}
 	return []byte(out.String()), nil
 }


### PR DESCRIPTION
## Summary
- add StartOffset/EndOffset to stast AST nodes
- allow any2mochi Smalltalk parser to use an external parser via `ST_PARSER_CMD`
- provide richer runtime validation in golden helpers with `vm` execution
- update error text for unsupported Smalltalk snippets

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a4b8dcb10832082282f0c90646ff5