### PR TITLE
Remove unused runConvertGolden

### DIFF
--- a/tools/any2mochi/x/racket/golden_test.go
+++ b/tools/any2mochi/x/racket/golden_test.go
@@ -11,5 +11,6 @@ import (
 
 func TestConvert_Golden(t *testing.T) {
 	root := any2mochi.FindRepoRoot(t)
-	any2mochi.RunConvertGolden(t, filepath.Join(root, "tests/compiler/rkt"), "*.rkt.out", ConvertFile, "rkt", ".mochi", ".error")
+	errs := any2mochi.RunConvertRunGolden(t, filepath.Join(root, "tests/compiler/rkt"), "*.rkt.out", ConvertFile, "rkt", ".mochi", ".error")
+	any2mochi.WriteErrorsMarkdown(filepath.Join(root, "tests/any2mochi/rkt"), errs)
 }


### PR DESCRIPTION
## Summary
- delete `runConvertGolden` implementation and exported wrapper
- switch Racket test to `RunConvertRunGolden`
- drop unused helpers in language-specific tests

## Testing
- `go test ./... --vet=off -v` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686a5d8c80008320a4e9686d67110f9a