### PR TITLE
Enhance fs converter

### DIFF
--- a/tools/any2mochi/x/fs/convert.go
+++ b/tools/any2mochi/x/fs/convert.go
@@ -14,6 +14,19 @@ import (
 // available. It falls back to a very small regex based parser when the server
 // is unavailable.
 func Convert(src string) ([]byte, error) {
+	if parent.UseLSP {
+		if ls, ok := parent.Servers["fs"]; ok && ls.Command != "" {
+			syms, diags, err := parent.EnsureAndParse(ls.Command, ls.Args, ls.LangID, src)
+			if err == nil && len(diags) == 0 {
+				var out strings.Builder
+				writeFsSymbols(&out, nil, syms, src, ls)
+				if out.Len() > 0 {
+					return []byte(out.String()), nil
+				}
+			}
+		}
+	}
+
 	ast, err := Parse(src)
 	if err != nil {
 		return nil, err

--- a/tools/any2mochi/x/fs/parse.go
+++ b/tools/any2mochi/x/fs/parse.go
@@ -192,12 +192,7 @@ func Parse(src string) (*Program, error) {
 			}
 			switch {
 			case strings.Contains(t, "failwith \"unreachable\""):
-				if parseErr == nil {
-					errLine = lineNum
-					linesCopy = append([]line(nil), lines...)
-					snippet := l.raw
-					parseErr = fmt.Errorf("unsupported syntax at line %d: %s", lineNum, strings.TrimSpace(snippet))
-				}
+				// Ignore failwith markers inserted by the compiler
 				continue
 			case printRe.MatchString(t):
 				m := printRe.FindStringSubmatch(t)


### PR DESCRIPTION
## Summary
- use fsautocomplete via the LSP helpers when available
- ignore compiler-inserted `failwith "unreachable"` lines in the F# parser

## Testing
- `go test ./tools/any2mochi/x/fs -run TestConvertFs_Golden/bool_ops.fs -tags slow -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a7b61362883209525c10c38d9e041