### PR TITLE
Add Clojure roundtrip VM test

### DIFF
--- a/compile/x/clj/roundtrip_test.go
+++ b/compile/x/clj/roundtrip_test.go
@@ -1,0 +1,133 @@
+//go:build roundtrip
+
+package cljcode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cljcode "mochi/compile/x/clj"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	cljconv "mochi/tools/any2mochi/x/clj"
+	"mochi/types"
+)
+
+// roundTrip compiles the Mochi source to Clojure, converts back to Mochi and
+// executes using the VM. Output must match the golden .out file.
+func roundTrip(src string) error {
+	prog, err := parser.Parse(src)
+	if err != nil {
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := cljcode.New(env).Compile(prog)
+	if err != nil {
+		return fmt.Errorf("compile error: %w", err)
+	}
+	mochiSrc, err := cljconv.Convert(string(code))
+	if err != nil {
+		return fmt.Errorf("convert error: %w", err)
+	}
+	prog2, err := parser.ParseString(string(mochiSrc))
+	if err != nil {
+		return fmt.Errorf("reparse error: %w", err)
+	}
+	env2 := types.NewEnv(nil)
+	if errs := types.Check(prog2, env2); len(errs) > 0 {
+		return fmt.Errorf("retype error: %v", errs[0])
+	}
+	p, err := vm.CompileWithSource(prog2, env2, string(mochiSrc))
+	if err != nil {
+		return fmt.Errorf("vm compile error: %w", err)
+	}
+	inPath := strings.TrimSuffix(src, ".mochi") + ".in"
+	var in []byte
+	if data, err := os.ReadFile(inPath); err == nil {
+		in = data
+	}
+	var out bytes.Buffer
+	m := vm.NewWithIO(p, bytes.NewReader(in), &out)
+	if err := m.Run(); err != nil {
+		if ve, ok := err.(*vm.VMError); ok {
+			return fmt.Errorf("vm run error:\n%s", ve.Format(p))
+		}
+		return fmt.Errorf("vm run error: %v", err)
+	}
+	wantPath := strings.TrimSuffix(src, ".mochi") + ".out"
+	if want, err := os.ReadFile(wantPath); err == nil {
+		got := strings.TrimSpace(out.String())
+		wantStr := strings.TrimSpace(string(want))
+		if got != wantStr {
+			return fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, wantStr)
+		}
+	}
+	return nil
+}
+
+func TestClojureRoundTripVM(t *testing.T) {
+	if err := cljcode.EnsureClojure(); err != nil {
+		t.Skipf("clojure not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	pattern := filepath.Join(root, "tests/vm/valid", "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files: %s", pattern)
+	}
+	var errs []string
+	for _, src := range files {
+		name := filepath.Base(src)
+		t.Run(name, func(t *testing.T) {
+			if e := roundTrip(src); e != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", src, e))
+				t.Logf("%v", e)
+			}
+		})
+	}
+	writeErrorsMarkdown(filepath.Join(root, "tests/any2mochi/clj"), errs)
+}
+
+func writeErrorsMarkdown(dir string, errs []string) {
+	_ = os.MkdirAll(dir, 0755)
+	path := filepath.Join(dir, "ERRORS.md")
+	var buf strings.Builder
+	buf.WriteString("# Errors\n\n")
+	if len(errs) == 0 {
+		buf.WriteString("None\n")
+	} else {
+		for _, e := range errs {
+			buf.WriteString("- " + e + "\n")
+		}
+	}
+	_ = os.WriteFile(path, []byte(buf.String()), 0644)
+}
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found (not in Go module)")
+	return ""
+}

--- a/tests/any2mochi/clj/ERRORS.md
+++ b/tests/any2mochi/clj/ERRORS.md
@@ -1,0 +1,99 @@
+# Errors
+
+- /workspace/mochi/tests/vm/valid/append_builtin.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/avg_builtin.mochi: reparse error: parse error: 3:34: lexer: invalid input text "?(xs) { 0 } else..."
+- /workspace/mochi/tests/vm/valid/basic_compare.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/binary_precedence.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/bool_chain.mochi: reparse error: parse error: 3:22: unexpected token "," (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/break_continue.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/cast_string_to_int.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/cast_struct.mochi: reparse error: parse error: 3:95: lexer: invalid input text "#, get(m, %), fi..."
+- /workspace/mochi/tests/vm/valid/closure.mochi: reparse error: parse error: 4:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/count_builtin.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/cross_join.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/cross_join_filter.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/cross_join_triple.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/dataset_sort_take_limit.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/dataset_where_filter.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/exists_builtin.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/for_list_collection.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/for_loop.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/for_map_collection.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/fun_call.mochi: reparse error: parse error: 3:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/fun_expr_in_let.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/fun_three_args.mochi: reparse error: parse error: 3:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/group_by.mochi: reparse error: parse error: 3:18: lexer: invalid input text "?(v), count(v), ..."
+- /workspace/mochi/tests/vm/valid/group_by_conditional_sum.mochi: reparse error: parse error: 3:19: lexer: invalid input text "?(v) && contains..."
+- /workspace/mochi/tests/vm/valid/group_by_having.mochi: reparse error: parse error: 3:18: lexer: invalid input text "?(v), count(v), ..."
+- /workspace/mochi/tests/vm/valid/group_by_join.mochi: reparse error: parse error: 3:18: lexer: invalid input text "?(v), count(v), ..."
+- /workspace/mochi/tests/vm/valid/group_by_left_join.mochi: reparse error: parse error: 4:102: lexer: invalid input text "?(@groups, ks), ..."
+- /workspace/mochi/tests/vm/valid/group_by_multi_join.mochi: reparse error: parse error: 3:19: lexer: invalid input text "?(v) && contains..."
+- /workspace/mochi/tests/vm/valid/group_by_multi_join_sort.mochi: reparse error: parse error: 3:19: lexer: invalid input text "?(v) && contains..."
+- /workspace/mochi/tests/vm/valid/group_by_sort.mochi: reparse error: parse error: 3:19: lexer: invalid input text "?(v) && contains..."
+- /workspace/mochi/tests/vm/valid/group_items_iteration.mochi: reparse error: parse error: 4:102: lexer: invalid input text "?(@groups, ks), ..."
+- /workspace/mochi/tests/vm/valid/if_else.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/if_then_else.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/if_then_else_nested.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/in_operator.mochi: reparse error: parse error: 5:14: lexer: invalid input text "#, 2 == %, xs))\n..."
+- /workspace/mochi/tests/vm/valid/in_operator_extended.mochi: reparse error: parse error: 6:14: lexer: invalid input text "#, 1 == %, ys))\n..."
+- /workspace/mochi/tests/vm/valid/inner_join.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/join_multi.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/json_builtin.mochi: reparse error: parse error: 6:11: lexer: invalid input text "?(v), \"null\", st..."
+- /workspace/mochi/tests/vm/valid/left_join.mochi: reparse error: parse error: 3:160: lexer: invalid input text "@items), let(m(a..."
+- /workspace/mochi/tests/vm/valid/left_join_multi.mochi: reparse error: parse error: 3:160: lexer: invalid input text "@items), let(m(a..."
+- /workspace/mochi/tests/vm/valid/len_builtin.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/len_map.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/len_string.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/let_and_print.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/list_assign.mochi: reparse error: parse error: 3:17: lexer: invalid input text "?(i) { i + count..."
+- /workspace/mochi/tests/vm/valid/list_index.mochi: reparse error: parse error: 3:17: lexer: invalid input text "?(i) { i + count..."
+- /workspace/mochi/tests/vm/valid/list_nested_assign.mochi: reparse error: parse error: 3:17: lexer: invalid input text "?(i) { i + count..."
+- /workspace/mochi/tests/vm/valid/list_set_ops.mochi: reparse error: parse error: 14:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/load_yaml.mochi: reparse error: parse error: 3:78: lexer: invalid input text "?)), headers, if..."
+- /workspace/mochi/tests/vm/valid/map_assign.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/map_in_operator.mochi: reparse error: parse error: 5:17: lexer: invalid input text "?(m, 1))\n  print..."
+- /workspace/mochi/tests/vm/valid/map_index.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/map_int_key.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/map_literal_dynamic.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/map_membership.mochi: reparse error: parse error: 5:17: lexer: invalid input text "?(m, \"a\"))\n  pri..."
+- /workspace/mochi/tests/vm/valid/map_nested_assign.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/match_expr.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/match_full.mochi: reparse error: parse error: 4:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/math_ops.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/membership.mochi: reparse error: parse error: 5:14: lexer: invalid input text "#, 2 == %, nums)..."
+- /workspace/mochi/tests/vm/valid/min_max_builtin.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/nested_function.mochi: reparse error: parse error: 3:28: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/order_by_map.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/outer_join.mochi: reparse error: parse error: 3:160: lexer: invalid input text "@items), let(m(a..."
+- /workspace/mochi/tests/vm/valid/partial_application.mochi: reparse error: parse error: 4:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/print_hello.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/pure_fold.mochi: reparse error: parse error: 3:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/pure_global_fold.mochi: reparse error: parse error: 4:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/query_sum_select.mochi: reparse error: parse error: 3:19: lexer: invalid input text "?(v) && contains..."
+- /workspace/mochi/tests/vm/valid/record_assign.mochi: reparse error: parse error: 4:4: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/right_join.mochi: reparse error: parse error: 3:160: lexer: invalid input text "@items), let(m(a..."
+- /workspace/mochi/tests/vm/valid/save_jsonl_stdout.mochi: reparse error: parse error: 3:255: lexer: invalid input text "#, str(get(r, %,..."
+- /workspace/mochi/tests/vm/valid/short_circuit.mochi: reparse error: parse error: 3:22: unexpected token "," (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/slice.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/sort_stable.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/str_builtin.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/string_compare.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/string_concat.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/string_contains.mochi: reparse error: parse error: 5:32: lexer: invalid input text "?(s, \"cat\"))\n  p..."
+- /workspace/mochi/tests/vm/valid/string_in_operator.mochi: reparse error: parse error: 5:32: lexer: invalid input text "?(s, \"cat\"))\n  p..."
+- /workspace/mochi/tests/vm/valid/string_index.mochi: reparse error: parse error: 3:31: lexer: invalid input text "?(i) { i + count..."
+- /workspace/mochi/tests/vm/valid/string_prefix_slice.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/substring_builtin.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/sum_builtin.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/tail_recursion.mochi: reparse error: parse error: 3:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/test_block.mochi: reparse error: parse error: 6:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/tree_sum.mochi: reparse error: parse error: 4:4: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/two-sum.mochi: reparse error: parse error: 3:17: lexer: invalid input text "?(i) { i + count..."
+- /workspace/mochi/tests/vm/valid/typed_let.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/typed_var.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/unary_neg.mochi: reparse error: parse error: 2:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/update_stmt.mochi: reparse error: parse error: 3:95: lexer: invalid input text "#, get(m, %), fi..."
+- /workspace/mochi/tests/vm/valid/user_type_literal.mochi: reparse error: parse error: 4:4: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/values_builtin.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/var_assignment.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- /workspace/mochi/tests/vm/valid/while_loop.mochi: reparse error: parse error: 3:5: unexpected token "-" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")


### PR DESCRIPTION
## Summary
- add roundtrip test for compiling Mochi to Clojure, converting back, and executing via the VM
- log failing files in `tests/any2mochi/clj/ERRORS.md`

## Testing
- `go test ./compile/x/clj -tags roundtrip`

------
https://chatgpt.com/codex/tasks/task_e_686a7e01fc088320972e5c2909dc64d5