### PR TITLE
Add Go VM roundtrip test

### DIFF
--- a/tests/any2mochi/go_vm/ERRORS.md
+++ b/tests/any2mochi/go_vm/ERRORS.md
@@ -1,0 +1,99 @@
+# Errors
+
+- append_builtin: ok
+- avg_builtin: ok
+- basic_compare: ok
+- binary_precedence: ok
+- bool_chain: ok
+- break_continue: ok
+- cast_string_to_int: parse error: parse error: 3:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- cast_struct: parse error: parse error: 6:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- closure: parse error: parse error: 2:28: unexpected token "(" (expected "{" Statement* "}")
+- count_builtin: ok
+- cross_join: ok
+- cross_join_filter: ok
+- cross_join_triple: ok
+- dataset_sort_take_limit: parse error: parse error: 3:3: unexpected token "on" (expected "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- dataset_where_filter: ok
+- exists_builtin: ok
+- for_list_collection: ok
+- for_loop: ok
+- for_map_collection: ok
+- fun_call: ok
+- fun_expr_in_let: ok
+- fun_three_args: ok
+- group_by: parse error: parse error: 4:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- group_by_conditional_sum: parse error: parse error: 3:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- group_by_having: ok
+- group_by_join: ok
+- group_by_left_join: parse error: parse error: 3:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- group_by_multi_join: parse error: parse error: 3:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- group_by_multi_join_sort: parse error: parse error: 3:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- group_by_sort: parse error: parse error: 3:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- group_items_iteration: go compile error: cannot iterate over type any
+- if_else: ok
+- if_then_else: ok
+- if_then_else_nested: ok
+- in_operator: ok
+- in_operator_extended: ok
+- inner_join: ok
+- join_multi: ok
+- json_builtin: ok
+- left_join: parse error: parse error: 3:3: unexpected token "on" (expected "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- left_join_multi: parse error: parse error: 3:3: unexpected token "on" (expected "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- len_builtin: ok
+- len_map: ok
+- len_string: ok
+- let_and_print: ok
+- list_assign: ok
+- list_index: ok
+- list_nested_assign: ok
+- list_set_ops: ok
+- load_yaml: parse error: parse error: 8:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- map_assign: ok
+- map_in_operator: ok
+- map_index: ok
+- map_int_key: ok
+- map_literal_dynamic: ok
+- map_membership: ok
+- map_nested_assign: ok
+- match_expr: ok
+- match_full: ok
+- math_ops: ok
+- membership: ok
+- min_max_builtin: ok
+- nested_function: ok
+- order_by_map: parse error: parse error: 3:3: unexpected token "on" (expected "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- outer_join: parse error: parse error: 3:3: unexpected token "on" (expected "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- partial_application: ok
+- print_hello: ok
+- pure_fold: ok
+- pure_global_fold: ok
+- query_sum_select: ok
+- record_assign: parse error: parse error: 8:26: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- right_join: parse error: parse error: 3:3: unexpected token "on" (expected "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- save_jsonl_stdout: parse error: parse error: 2:44: unexpected token "[" (expected ")" (":" TypeRef)? "{" Statement* "}")
+- short_circuit: ok
+- slice: ok
+- sort_stable: parse error: parse error: 3:3: unexpected token "on" (expected "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- str_builtin: ok
+- string_compare: ok
+- string_concat: ok
+- string_contains: ok
+- string_in_operator: ok
+- string_index: ok
+- string_prefix_slice: ok
+- substring_builtin: ok
+- sum_builtin: ok
+- tail_recursion: ok
+- test_block: parse error: parse error: 1:5: unexpected token "expect" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- tree_sum: parse error: parse error: 3:1: unexpected token "}" (expected "{" Statement* "}")
+- two-sum: ok
+- typed_let: ok
+- typed_var: ok
+- unary_neg: ok
+- update_stmt: parse error: parse error: 7:5: unexpected token "expect" (expected <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
+- user_type_literal: ok
+- values_builtin: ok
+- var_assignment: ok
+- while_loop: ok

--- a/tools/any2mochi/go/golden_helpers_test.go
+++ b/tools/any2mochi/go/golden_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,8 +14,21 @@ import (
 
 	gocode "mochi/compile/go"
 	"mochi/parser"
+	vm "mochi/runtime/vm"
 	"mochi/types"
 )
+
+func snippetFromFile(path string) string {
+	data, _ := os.ReadFile(path)
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > 10 {
+		lines = lines[:10]
+	}
+	for i, l := range lines {
+		lines[i] = fmt.Sprintf("%3d| %s", i+1, l)
+	}
+	return strings.Join(lines, "\n")
+}
 
 var update = flag.Bool("update", false, "update golden files")
 

--- a/tools/any2mochi/go/vm_roundtrip_test.go
+++ b/tools/any2mochi/go/vm_roundtrip_test.go
@@ -1,0 +1,134 @@
+//go:build go_vm
+
+package golang
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	gocode "mochi/compile/go"
+	"mochi/parser"
+	vm "mochi/runtime/vm"
+	"mochi/types"
+)
+
+// convertRoundTrip compiles the given Mochi file to Go, then converts
+// the generated Go code back to Mochi source using the Go any2mochi converter.
+func convertRoundTrip(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	prog, err := parser.ParseString(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	goSrc, err := gocode.New(env).Compile(prog)
+	if err != nil {
+		return nil, fmt.Errorf("go compile error: %w", err)
+	}
+	out, err := Convert(string(goSrc))
+	if err != nil {
+		return nil, fmt.Errorf("go convert error: %w", err)
+	}
+	return out, nil
+}
+
+// compileAndRun parses, type-checks and executes Mochi source using the VM.
+func compileAndRun(src []byte) error {
+	prog, err := parser.ParseString(string(src))
+	if err != nil {
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	p, err := vm.CompileWithSource(prog, env, string(src))
+	if err != nil {
+		return fmt.Errorf("vm compile error: %w", err)
+	}
+	var buf bytes.Buffer
+	m := vm.New(p, &buf)
+	if err := m.Run(); err != nil {
+		if ve, ok := err.(*vm.VMError); ok {
+			return fmt.Errorf("vm run error:\n%s", ve.Format(p))
+		}
+		return fmt.Errorf("vm run error: %v", err)
+	}
+	return nil
+}
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found (not in Go module)")
+	return ""
+}
+
+func writeStatusMarkdown(dir string, status map[string]string) {
+	_ = os.MkdirAll(dir, 0755)
+	path := filepath.Join(dir, "ERRORS.md")
+	var sb strings.Builder
+	sb.WriteString("# Errors\n\n")
+	names := make([]string, 0, len(status))
+	for n := range status {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if msg := status[n]; msg != "" {
+			sb.WriteString("- " + n + ": " + msg + "\n")
+		} else {
+			sb.WriteString("- " + n + ": ok\n")
+		}
+	}
+	_ = os.WriteFile(path, []byte(sb.String()), 0644)
+}
+
+func TestGoRoundTripVM(t *testing.T) {
+	root := findRepoRoot(t)
+	pattern := filepath.Join(root, "tests/vm/valid", "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files: %s", pattern)
+	}
+	status := make(map[string]string)
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		out, err := convertRoundTrip(src)
+		if err == nil {
+			err = compileAndRun(out)
+		}
+		if err != nil {
+			status[name] = err.Error()
+		} else {
+			status[name] = ""
+		}
+	}
+	writeStatusMarkdown(filepath.Join(root, "tests/any2mochi/go_vm"), status)
+}


### PR DESCRIPTION
## Summary
- add Go roundtrip test that compiles VM golden tests to Go, converts back and runs
- capture error status for each program in `tests/any2mochi/go_vm/ERRORS.md`
- fix `golden_helpers_test.go` with missing helper and import

## Testing
- `go test ./tools/any2mochi/go -run TestGoRoundTripVM -tags go_vm`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a7f59f9688320b1c1ab2f04d26be9