### PR TITLE
Add Kotlin roundtrip VM test

### DIFF
--- a/tests/any2mochi/kt/ERRORS.md
+++ b/tests/any2mochi/kt/ERRORS.md
@@ -1,86 +1,99 @@
 # Errors
 
-- avg_builtin.kt: type error: error[T003]: unknown function: listOf
-  --> :2:9
-
-help:
-  Ensure the function is defined before it's called.
-- break_continue.kt: parse error: parse error: 4:13: unexpected token ")" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
-- count_builtin.kt: type error: error[T003]: unknown function: listOf
-  --> :2:9
-
-help:
-  Ensure the function is defined before it's called.
-- cross_join.kt: parse error: parse error: 17:38: unexpected token "=" (expected ")")
-- cross_join_triple.kt: parse error: parse error: 7:45: unexpected token "," (expected PostfixExpr)
-- dataset.kt: parse error: parse error: 6:35: unexpected token "=" (expected ")")
-- dataset_sort_take_limit.kt: parse error: parse error: 6:38: unexpected token "=" (expected ")")
-- fetch_builtin.kt: parse error: parse error: 11:47: lexer: invalid input text "?): Any {\n  fun ..."
-- fetch_http.kt: parse error: parse error: 15:47: lexer: invalid input text "?): Any {\n  fun ..."
-- for_list_collection.kt: type error: error[T003]: unknown function: listOf
-  --> :2:12
-
-help:
-  Ensure the function is defined before it's called.
-- group_by.kt: parse error: parse error: 6:35: unexpected token ">" (expected PostfixExpr)
-- input_builtin.kt: type error: error[T003]: unknown function: readln
-  --> :3:16
-
-help:
-  Ensure the function is defined before it's called.
-- join_filter_pag.kt: parse error: parse error: 12:20: lexer: invalid input text "?>) -> Boolean) ..."
-- json_builtin.kt: parse error: parse error: 5:20: lexer: invalid input text "?): String = whe..."
-- list_concat.kt: type error: error[T003]: unknown function: _concat
-  --> :2:9
-
-help:
-  Ensure the function is defined before it's called.
-- list_index.kt: type error: error[T003]: unknown function: listOf
-  --> :2:12
-
-help:
-  Ensure the function is defined before it's called.
-- load_jsonl_stdin.kt: parse error: parse error: 19:47: lexer: invalid input text "?): List<Map<Str..."
-- load_save_json.kt: parse error: parse error: 26:47: lexer: invalid input text "?): List<Map<Str..."
-- load_yaml.kt: parse error: parse error: 28:47: lexer: invalid input text "?): List<Map<Str..."
-- local_recursion.kt: parse error: parse error: 10:20: unexpected token "=" (expected ")")
-- map_index.kt: parse error: parse error: 2:37: unexpected token "to" (expected ")")
-- map_iterate.kt: parse error: parse error: 2:53: unexpected token "," (expected "}")
-- map_literal.kt: parse error: parse error: 2:30: unexpected token "to" (expected ")")
-- match_capture.kt: parse error: parse error: 8:15: unexpected token ">" (expected PostfixExpr)
-- match_underscore.kt: parse error: parse error: 8:15: unexpected token ">" (expected PostfixExpr)
-- matrix_search.kt: type error: error[T027]: [[int]] is not a struct
-  --> :2:11
-
-help:
-  Field access is only valid on struct types.
-- now_builtin.kt: type error: error[T002]: undefined variable: System
-  --> :2:11
-
-help:
-  Check if the variable was declared in this scope.
-- str_builtin.kt: type error: error[T004]: `` is not callable
-  --> :2:21
-
-help:
-  Use a function or closure in this position.
-- string_index.kt: parse error: parse error: 9:10: unexpected token "=" (expected PostfixExpr)
-- string_negative_index.kt: parse error: parse error: 9:10: unexpected token "=" (expected PostfixExpr)
-- string_slice.kt: parse error: parse error: 10:12: unexpected token "=" (expected PostfixExpr)
-- test_block.kt: type error: error[T003]: unknown function: check
-  --> :3:3
-
-help:
-  Ensure the function is defined before it's called.
-- two_sum.kt: parse error: parse error: 5:27: unexpected token ")" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
-- type_method.kt: parse error: parse error: 4:11: unexpected token "." (expected "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}")
-- underscore_for_loop.kt: parse error: parse error: 12:28: unexpected token "to" (expected ")")
-- union_inorder.kt: parse error: parse error: 8:15: unexpected token ">" (expected PostfixExpr)
-- union_match.kt: parse error: parse error: 8:15: unexpected token ">" (expected PostfixExpr)
-- union_slice.kt: type error: error[T003]: unknown function: listOf
-  --> :5:10
-
-help:
-  Ensure the function is defined before it's called.
-- update_stmt.kt: parse error: parse error: 7:39: unexpected token "=" (expected ")")
-- while_membership.kt: parse error: parse error: 2:55: unexpected token "," (expected "}")
+- append_builtin.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- avg_builtin.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- basic_compare.mochi: ok
+- binary_precedence.mochi: ok
+- bool_chain.mochi: ok
+- break_continue.mochi: roundtrip parse error: parse error: 4:13: unexpected token ")" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
+- cast_string_to_int.mochi: roundtrip type error: error[T004]: `` is not callable
+- cast_struct.mochi: roundtrip parse error: parse error: 5:36: unexpected token "to" (expected ")")
+- closure.mochi: roundtrip parse error: parse error: 2:28: unexpected token "{" (expected "<" TypeRef ("," TypeRef)* ">")
+- count_builtin.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- cross_join.mochi: roundtrip parse error: parse error: 2:44: unexpected token "to" (expected ")")
+- cross_join_filter.mochi: roundtrip parse error: parse error: 6:45: unexpected token "," (expected PostfixExpr)
+- cross_join_triple.mochi: roundtrip parse error: parse error: 7:45: unexpected token "," (expected PostfixExpr)
+- dataset_sort_take_limit.mochi: roundtrip parse error: parse error: 2:45: unexpected token "to" (expected ")")
+- dataset_where_filter.mochi: roundtrip parse error: parse error: 2:43: unexpected token "to" (expected ")")
+- exists_builtin.mochi: roundtrip parse error: parse error: 4:3: unexpected token "var" (expected "}")
+- for_list_collection.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- for_loop.mochi: ok
+- for_map_collection.mochi: roundtrip parse error: parse error: 2:28: unexpected token "to" (expected ")")
+- fun_call.mochi: ok
+- fun_expr_in_let.mochi: roundtrip parse error: parse error: 2:34: unexpected token "{" (expected "<" TypeRef ("," TypeRef)* ">")
+- fun_three_args.mochi: ok
+- group_by.mochi: roundtrip parse error: parse error: 7:32: lexer: invalid input text "?>\n  res = res.m..."
+- group_by_conditional_sum.mochi: roundtrip parse error: parse error: 6:20: lexer: invalid input text "?>) -> Boolean) ..."
+- group_by_having.mochi: roundtrip parse error: parse error: 30:20: lexer: invalid input text "?): String = whe..."
+- group_by_join.mochi: roundtrip parse error: parse error: 6:20: lexer: invalid input text "?>) -> Boolean) ..."
+- group_by_left_join.mochi: roundtrip parse error: parse error: 6:20: lexer: invalid input text "?>) -> Boolean) ..."
+- group_by_multi_join.mochi: roundtrip parse error: parse error: 6:20: lexer: invalid input text "?>) -> Boolean) ..."
+- group_by_multi_join_sort.mochi: roundtrip parse error: parse error: 6:20: lexer: invalid input text "?>) -> Boolean) ..."
+- group_by_sort.mochi: roundtrip parse error: parse error: 6:20: lexer: invalid input text "?>) -> Boolean) ..."
+- group_items_iteration.mochi: roundtrip parse error: parse error: 7:23: lexer: invalid input text "?>()\n  for g in ..."
+- if_else.mochi: ok
+- if_then_else.mochi: roundtrip parse error: parse error: 3:27: unexpected token "yes" (expected (("{" Expr "}") | ("then" Expr)) (("else" IfExpr) | ("else" (("{" Expr "}") | Expr)))?)
+- if_then_else_nested.mochi: roundtrip parse error: parse error: 3:27: unexpected token "big" (expected (("{" Expr "}") | ("then" Expr)) (("else" IfExpr) | ("else" (("{" Expr "}") | Expr)))?)
+- in_operator.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- in_operator_extended.mochi: roundtrip parse error: parse error: 5:25: unexpected token ">" (expected PostfixExpr)
+- inner_join.mochi: roundtrip parse error: parse error: 3:20: lexer: invalid input text "?>) -> Boolean) ..."
+- join_multi.mochi: roundtrip parse error: parse error: 3:20: lexer: invalid input text "?>) -> Boolean) ..."
+- json_builtin.mochi: roundtrip parse error: parse error: 6:20: lexer: invalid input text "?): String = whe..."
+- left_join.mochi: roundtrip parse error: parse error: 3:20: lexer: invalid input text "?>) -> Boolean) ..."
+- left_join_multi.mochi: roundtrip parse error: parse error: 3:20: lexer: invalid input text "?>) -> Boolean) ..."
+- len_builtin.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- len_map.mochi: roundtrip parse error: parse error: 2:26: unexpected token "to" (expected ")")
+- len_string.mochi: ok
+- let_and_print.mochi: ok
+- list_assign.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- list_index.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- list_nested_assign.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- list_set_ops.mochi: roundtrip parse error: parse error: 8:30: unexpected token ")" (expected PostfixExpr)
+- load_yaml.mochi: roundtrip parse error: parse error: 28:47: lexer: invalid input text "?): List<Map<Str..."
+- map_assign.mochi: roundtrip parse error: parse error: 2:37: unexpected token "to" (expected ")")
+- map_in_operator.mochi: roundtrip parse error: parse error: 2:26: unexpected token "to" (expected ")")
+- map_index.mochi: roundtrip parse error: parse error: 2:28: unexpected token "to" (expected ")")
+- map_int_key.mochi: roundtrip parse error: parse error: 2:26: unexpected token "to" (expected ")")
+- map_literal_dynamic.mochi: roundtrip parse error: parse error: 4:28: unexpected token "to" (expected ")")
+- map_membership.mochi: roundtrip parse error: parse error: 2:28: unexpected token "to" (expected ")")
+- map_nested_assign.mochi: roundtrip parse error: parse error: 2:35: unexpected token "to" (expected ")")
+- match_expr.mochi: roundtrip parse error: parse error: 6:12: unexpected token ">" (expected PostfixExpr)
+- match_full.mochi: roundtrip parse error: parse error: 5:12: unexpected token ">" (expected PostfixExpr)
+- math_ops.mochi: ok
+- membership.mochi: roundtrip type error: error[T003]: unknown function: listOf
+- min_max_builtin.mochi: roundtrip parse error: parse error: 7:21: lexer: invalid input text "?>? = null\n  whe..."
+- nested_function.mochi: ok
+- order_by_map.mochi: roundtrip parse error: parse error: 2:38: unexpected token "to" (expected ")")
+- outer_join.mochi: roundtrip parse error: parse error: 3:20: lexer: invalid input text "?>) -> Boolean) ..."
+- partial_application.mochi: ok
+- print_hello.mochi: ok
+- pure_fold.mochi: ok
+- pure_global_fold.mochi: roundtrip type error: error[T002]: undefined variable: k
+- query_sum_select.mochi: roundtrip parse error: parse error: 12:21: lexer: invalid input text "?>? = null\n  whe..."
+- record_assign.mochi: roundtrip parse error: parse error: 5:5: unexpected token "=" (expected ":" TypeRef)
+- right_join.mochi: roundtrip parse error: parse error: 3:20: lexer: invalid input text "?>) -> Boolean) ..."
+- save_jsonl_stdout.mochi: roundtrip parse error: parse error: 5:57: lexer: invalid input text "?):  {\n  let row..."
+- short_circuit.mochi: ok
+- slice.mochi: roundtrip parse error: parse error: 12:12: unexpected token "=" (expected PostfixExpr)
+- sort_stable.mochi: roundtrip parse error: parse error: 2:39: unexpected token "to" (expected ")")
+- str_builtin.mochi: roundtrip type error: error[T004]: `` is not callable
+- string_compare.mochi: ok
+- string_concat.mochi: ok
+- string_contains.mochi: roundtrip type error: error[T015]: index must be an integer
+- string_in_operator.mochi: ok
+- string_index.mochi: roundtrip parse error: parse error: 9:10: unexpected token "=" (expected PostfixExpr)
+- string_prefix_slice.mochi: roundtrip parse error: parse error: 14:12: unexpected token "=" (expected PostfixExpr)
+- substring_builtin.mochi: ok
+- sum_builtin.mochi: roundtrip parse error: parse error: 5:21: lexer: invalid input text "?>? = null\n  whe..."
+- tail_recursion.mochi: ok
+- test_block.mochi: roundtrip type error: error[T003]: unknown function: check
+- tree_sum.mochi: roundtrip parse error: parse error: 8:15: unexpected token ">" (expected PostfixExpr)
+- two-sum.mochi: roundtrip parse error: parse error: 5:27: unexpected token ")" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
+- typed_let.mochi: roundtrip type error: error[T002]: undefined variable: y
+- typed_var.mochi: ok
+- unary_neg.mochi: ok
+- update_stmt.mochi: roundtrip parse error: parse error: 7:39: unexpected token "=" (expected ")")
+- user_type_literal.mochi: roundtrip parse error: parse error: 10:25: unexpected token "=" (expected ")")
+- values_builtin.mochi: roundtrip parse error: parse error: 2:28: unexpected token "to" (expected ")")
+- var_assignment.mochi: ok
+- while_loop.mochi: ok

--- a/tools/any2mochi/x/kt/roundtrip_vm_test.go
+++ b/tools/any2mochi/x/kt/roundtrip_vm_test.go
@@ -1,0 +1,95 @@
+//go:build slow
+
+package kt
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ktcode "mochi/compile/x/kt"
+	"mochi/parser"
+	vm "mochi/runtime/vm"
+	any2mochi "mochi/tools/any2mochi"
+	"mochi/types"
+)
+
+func TestRoundTripVM(t *testing.T) {
+	root := any2mochi.FindRepoRoot(t)
+	pattern := filepath.Join(root, "tests/vm/valid", "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files: %s", pattern)
+	}
+	var statuses []string
+	for _, src := range files {
+		name := filepath.Base(src)
+		if err := roundTripVM(src); err != nil {
+			statuses = append(statuses, fmt.Sprintf("%s: %v", name, err))
+		} else {
+			statuses = append(statuses, fmt.Sprintf("%s: ok", name))
+		}
+	}
+	writeStatusMarkdown(filepath.Join(root, "tests/any2mochi/kt"), statuses)
+}
+
+func roundTripVM(path string) error {
+	prog, err := parser.Parse(path)
+	if err != nil {
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := ktcode.New(env).Compile(prog)
+	if err != nil {
+		return fmt.Errorf("compile error: %w", err)
+	}
+	mochiSrc, err := Convert(string(code))
+	if err != nil {
+		return fmt.Errorf("convert error: %w", err)
+	}
+	prog2, err := parser.ParseString(string(mochiSrc))
+	if err != nil {
+		return fmt.Errorf("roundtrip parse error: %w", err)
+	}
+	env2 := types.NewEnv(nil)
+	if errs := types.Check(prog2, env2); len(errs) > 0 {
+		return fmt.Errorf("roundtrip type error: %v", errs[0])
+	}
+	p, err := vm.Compile(prog2, env2)
+	if err != nil {
+		return fmt.Errorf("vm compile error: %w", err)
+	}
+	var buf bytes.Buffer
+	m := vm.New(p, &buf)
+	if err := m.Run(); err != nil {
+		if ve, ok := err.(*vm.VMError); ok {
+			return fmt.Errorf("vm run error:\n%s", ve.Format(p))
+		}
+		return fmt.Errorf("vm run error: %v", err)
+	}
+	return nil
+}
+
+func writeStatusMarkdown(dir string, lines []string) {
+	_ = os.MkdirAll(dir, 0755)
+	path := filepath.Join(dir, "ERRORS.md")
+	var buf strings.Builder
+	buf.WriteString("# Errors\n\n")
+	if len(lines) == 0 {
+		buf.WriteString("None\n")
+	} else {
+		for _, l := range lines {
+			buf.WriteString("- " + l + "\n")
+		}
+	}
+	_ = os.WriteFile(path, []byte(buf.String()), 0644)
+}


### PR DESCRIPTION
## Summary
- add roundtrip VM test for Kotlin backend
- record Kotlin roundtrip results in `tests/any2mochi/kt/ERRORS.md`

## Testing
- `go test ./tools/any2mochi/x/kt -run TestRoundTripVM -tags slow -count=1` *(fails: context canceled)*

------
https://chatgpt.com/codex/tasks/task_e_686a7e99776483208f07b1dc43e55cb1