### PR TITLE
Improve Dart any2mochi roundtrip

### DIFF
--- a/tests/any2mochi/dart/ERRORS.md
+++ b/tests/any2mochi/dart/ERRORS.md
@@ -1,189 +1,133 @@
 # Errors
 
-- append_builtin: type2 error: error[T002]: undefined variable: a
-  --> :2:16
-
-help:
-  Check if the variable was declared in this scope.
+- append_builtin: ok
 - avg_builtin: parse2 error: parse error: 7:26: lexer: invalid input text "'items'] is List..."
-- basic_compare: type2 error: error[T002]: undefined variable: a
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
+- basic_compare: ok
 - binary_precedence: ok
 - bool_chain: ok
-- break_continue: parse2 error: parse error: 9:57: lexer: invalid input text "' '))\n  }\n}\nfun ..."
+- break_continue: parse2 error: parse error: 10:57: lexer: invalid input text "' '))\n  }\n}\nfun ..."
 - cast_string_to_int: type2 error: error[T004]: `` is not callable
   --> :2:23
 
 help:
   Use a function or closure in this position.
-- cast_struct: parse2 error: parse error: 5:18: lexer: invalid input text "'Todo'] = (m) =>..."
-- closure: parse2 error: parse error: 2:14: unexpected token "=>" (expected "}")
+- cast_struct: parse2 error: parse error: 7:18: lexer: invalid input text "'Todo'] = (m) =>..."
+- closure: parse2 error: parse error: 3:14: unexpected token "=>" (expected "}")
 - count_builtin: parse2 error: parse error: 8:41: lexer: invalid input text "; if (items is L..."
-- cross_join: parse2 error: parse error: 4:245: lexer: invalid input text "' '))\n  }\n}\n"
-- cross_join_filter: parse2 error: parse error: 4:49: lexer: invalid input text "' '))\n  }\n}\n"
-- cross_join_triple: parse2 error: parse error: 4:65: lexer: invalid input text "' '))\n  }\n}\n"
-- dataset_sort_take_limit: parse2 error: parse error: 4:86: lexer: invalid input text "' '))\n  }\n}\n"
-- dataset_where_filter: parse2 error: parse error: 4:94: lexer: invalid input text "? \" (senior)\" : ..."
-- exists_builtin: parse2 error: parse error: 8:11: lexer: invalid input text "'items'] is List..."
+- cross_join: parse2 error: parse error: 9:245: lexer: invalid input text "' '))\n  }\n}\n"
+- cross_join_filter: parse2 error: parse error: 10:49: lexer: invalid input text "' '))\n  }\n}\n"
+- cross_join_triple: parse2 error: parse error: 10:65: lexer: invalid input text "' '))\n  }\n}\n"
+- dataset_sort_take_limit: parse2 error: parse error: 6:15: lexer: invalid input text "'price']\nlet key..."
+- dataset_where_filter: parse2 error: parse error: 4:47: lexer: invalid input text "'age'] >= 18)).t..."
+- exists_builtin: parse2 error: parse error: 13:11: lexer: invalid input text "'items'] is List..."
 - for_list_collection: parse2 error: parse error: 2:7: unexpected token "(" (expected <ident> "in" Expr (".." Expr)? "{" Statement* "}")
 - for_loop: ok
-- for_map_collection: parse2 error: parse error: 3:7: unexpected token "(" (expected <ident> "in" Expr (".." Expr)? "{" Statement* "}")
+- for_map_collection: parse2 error: parse error: 4:7: unexpected token "(" (expected <ident> "in" Expr (".." Expr)? "{" Statement* "}")
 - fun_call: ok
-- fun_expr_in_let: type2 error: error[T003]: unknown function: square
-  --> :2:9
-
-help:
-  Ensure the function is defined before it's called.
+- fun_expr_in_let: parse2 error: parse error: 1:18: unexpected token "=>"
 - fun_three_args: ok
-- group_by: parse2 error: parse error: 7:128: lexer: invalid input text "' '))\n  }\n}\nfun ..."
-- group_by_conditional_sum: parse2 error: parse error: 10:26: lexer: invalid input text "'items'] is List..."
-- group_by_having: parse2 error: parse error: 11:41: lexer: invalid input text "; if (items is L..."
-- group_by_join: parse2 error: parse error: 7:78: lexer: invalid input text "' '))\n  }\n}\nfun ..."
-- group_by_left_join: parse2 error: parse error: 7:78: lexer: invalid input text "' '))\n  }\n}\nfun ..."
-- group_by_multi_join: parse2 error: parse error: 10:19: lexer: invalid input text "; i < a.length; ..."
-- group_by_multi_join_sort: parse2 error: parse error: 10:19: lexer: invalid input text "; i < a.length; ..."
-- group_by_sort: parse2 error: parse error: 10:26: lexer: invalid input text "'items'] is List..."
-- group_items_iteration: parse2 error: parse error: 5:7: unexpected token "(" (expected <ident> "in" Expr (".." Expr)? "{" Statement* "}")
+- group_by: parse2 error: parse error: 2:74: lexer: invalid input text "'city']).map((g)..."
+- group_by_conditional_sum: parse2 error: parse error: 5:13: lexer: invalid input text "'cat']\nlet ks = ..."
+- group_by_having: parse2 error: parse error: 2:62: lexer: invalid input text "'city']).map((g)..."
+- group_by_join: parse2 error: parse error: 6:13: lexer: invalid input text "'name']\nlet ks =..."
+- group_by_left_join: parse2 error: parse error: 10:13: lexer: invalid input text "'name']\nlet ks =..."
+- group_by_multi_join: parse2 error: parse error: 7:68: lexer: invalid input text "'part']).map((g)..."
+- group_by_multi_join_sort: parse2 error: parse error: 10:27: lexer: invalid input text "'c_custkey'], \"c..."
+- group_by_sort: parse2 error: parse error: 5:13: lexer: invalid input text "'cat']\nlet ks = ..."
+- group_items_iteration: parse2 error: parse error: 2:53: lexer: invalid input text "'tag']).map((g) ..."
 - if_else: ok
-- if_then_else: type2 error: error[T002]: undefined variable: msg
-  --> :2:9
+- if_then_else: parse2 error: parse error: 2:29: lexer: invalid input text "? \"yes\" : \"no\")\n..."
+- if_then_else_nested: parse2 error: parse error: 2:29: lexer: invalid input text "? \"big\" : ((x > ..."
+- in_operator: type2 error: error[T027]: [int] is not a struct
+  --> :3:10
 
 help:
-  Check if the variable was declared in this scope.
-- if_then_else_nested: type2 error: error[T002]: undefined variable: msg
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
-- in_operator: type2 error: error[T002]: undefined variable: xs
-  --> :2:10
-
-help:
-  Check if the variable was declared in this scope.
-- in_operator_extended: type2 error: error[T002]: undefined variable: ys
-  --> :2:10
-
-help:
-  Check if the variable was declared in this scope.
-- inner_join: parse2 error: parse error: 4:155: lexer: invalid input text "' '))\n  }\n}\nfun ..."
-- join_multi: parse2 error: parse error: 4:80: lexer: invalid input text "' '))\n  }\n}\nfun ..."
+  Field access is only valid on struct types.
+- in_operator_extended: parse2 error: parse error: 2:23: unexpected token ")" (expected PostfixExpr)
+- inner_join: parse2 error: parse error: 9:155: lexer: invalid input text "' '))\n  }\n}\nfun ..."
+- join_multi: parse2 error: parse error: 10:80: lexer: invalid input text "' '))\n  }\n}\nfun ..."
 - json_builtin: type2 error: error[T003]: unknown function: _json
-  --> :2:3
+  --> :3:3
 
 help:
   Ensure the function is defined before it's called.
-- left_join: parse2 error: parse error: 4:157: lexer: invalid input text "' '))\n  }\n}\nfun ..."
-- left_join_multi: parse2 error: parse error: 4:77: lexer: invalid input text "' '))\n  }\n}\nfun ..."
+- left_join: parse2 error: parse error: 10:157: lexer: invalid input text "' '))\n  }\n}\nfun ..."
+- left_join_multi: parse2 error: parse error: 11:77: lexer: invalid input text "' '))\n  }\n}\nfun ..."
 - len_builtin: ok
 - len_map: ok
 - len_string: ok
-- let_and_print: type2 error: error[T002]: undefined variable: a
-  --> :2:10
+- let_and_print: ok
+- list_assign: type2 error: error[T024]: cannot assign to `nums` (immutable)
+  --> :3:3
 
 help:
-  Check if the variable was declared in this scope.
-- list_assign: type2 error: error[T001]: assignment to undeclared variable: nums
-  --> :2:3
+  Use `var` to declare mutable variables.
+- list_index: ok
+- list_nested_assign: type2 error: error[T024]: cannot assign to `matrix` (immutable)
+  --> :3:3
 
 help:
-  Declare `nums` first using `let`.
-- list_index: type2 error: error[T002]: undefined variable: xs
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
-- list_nested_assign: type2 error: error[T001]: assignment to undeclared variable: matrix
-  --> :2:3
-
-help:
-  Declare `matrix` first using `let`.
+  Use `var` to declare mutable variables.
 - list_set_ops: parse2 error: parse error: 8:13: unexpected token "<" (expected PostfixExpr)
-- load_yaml: parse2 error: parse error: 7:18: lexer: invalid input text "'Person'] = (m) ..."
-- map_assign: type2 error: error[T001]: assignment to undeclared variable: scores
-  --> :2:3
+- load_yaml: parse2 error: parse error: 13:18: lexer: invalid input text "'Person'] = (m) ..."
+- map_assign: type2 error: error[T024]: cannot assign to `scores` (immutable)
+  --> :3:3
 
 help:
-  Declare `scores` first using `let`.
-- map_in_operator: type2 error: error[T002]: undefined variable: m
-  --> :2:10
+  Use `var` to declare mutable variables.
+- map_in_operator: type2 error: error[T027]: {int: string} is not a struct
+  --> :3:10
 
 help:
-  Check if the variable was declared in this scope.
-- map_index: type2 error: error[T002]: undefined variable: m
-  --> :2:9
+  Field access is only valid on struct types.
+- map_index: ok
+- map_int_key: ok
+- map_literal_dynamic: parse2 error: parse error: 5:53: lexer: invalid input text "' '))\n}\n"
+- map_membership: type2 error: error[T004]: `` is not callable
+  --> :3:23
 
 help:
-  Check if the variable was declared in this scope.
-- map_int_key: type2 error: error[T002]: undefined variable: m
-  --> :2:9
+  Use a function or closure in this position.
+- map_nested_assign: type2 error: error[T024]: cannot assign to `data` (immutable)
+  --> :3:3
 
 help:
-  Check if the variable was declared in this scope.
-- map_literal_dynamic: parse2 error: parse error: 2:53: lexer: invalid input text "' '))\n}\n"
-- map_membership: type2 error: error[T002]: undefined variable: m
-  --> :2:10
-
-help:
-  Check if the variable was declared in this scope.
-- map_nested_assign: type2 error: error[T001]: assignment to undeclared variable: data
-  --> :2:3
-
-help:
-  Declare `data` first using `let`.
-- match_expr: type2 error: error[T002]: undefined variable: label
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
-- match_full: parse2 error: parse error: 2:12: unexpected token ")" (expected PostfixExpr)
+  Use `var` to declare mutable variables.
+- match_expr: parse2 error: parse error: 2:23: unexpected token ")" (expected PostfixExpr)
+- match_full: parse2 error: parse error: 2:23: unexpected token ")" (expected PostfixExpr)
 - math_ops: parse2 error: parse error: 3:12: lexer: invalid input text "~/ 2))\n  print((..."
-- membership: type2 error: error[T002]: undefined variable: nums
-  --> :2:10
+- membership: type2 error: error[T027]: [int] is not a struct
+  --> :3:10
 
 help:
-  Check if the variable was declared in this scope.
-- min_max_builtin: parse2 error: parse error: 8:26: lexer: invalid input text "'items'] is List..."
+  Field access is only valid on struct types.
+- min_max_builtin: parse2 error: parse error: 9:26: lexer: invalid input text "'items'] is List..."
 - nested_function: type2 error: error[T002]: undefined variable: x
   --> :4:11
 
 help:
   Check if the variable was declared in this scope.
-- order_by_map: type2 error: error[T002]: undefined variable: sorted
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
-- outer_join: parse2 error: parse error: 6:161: lexer: invalid input text "' '))\n        } ..."
-- partial_application: type2 error: error[T003]: unknown function: add5
-  --> :5:9
+- order_by_map: parse2 error: parse error: 6:20: lexer: invalid input text "'a'], \"b\": x['b'..."
+- outer_join: parse2 error: parse error: 12:161: lexer: invalid input text "' '))\n        } ..."
+- partial_application: type2 error: error[T003]: unknown function: add
+  --> :1:12
 
 help:
   Ensure the function is defined before it's called.
 - print_hello: ok
 - pure_fold: ok
-- pure_global_fold: type2 error: error[T002]: undefined variable: k
-  --> :2:15
-
-help:
-  Check if the variable was declared in this scope.
-- query_sum_select: parse2 error: parse error: 7:26: lexer: invalid input text "'items'] is List..."
-- record_assign: parse2 error: parse error: 8:18: lexer: invalid input text "'Counter'] = (m)..."
-- right_join: parse2 error: parse error: 5:174: lexer: invalid input text "' '))\n      } el..."
-- save_jsonl_stdout: parse2 error: parse error: 5:21: lexer: invalid input text "?['format'] ?? '..."
+- pure_global_fold: ok
+- query_sum_select: parse2 error: parse error: 12:26: lexer: invalid input text "'items'] is List..."
+- record_assign: parse2 error: parse error: 10:18: lexer: invalid input text "'Counter'] = (m)..."
+- right_join: parse2 error: parse error: 11:174: lexer: invalid input text "' '))\n      } el..."
+- save_jsonl_stdout: parse2 error: parse error: 6:21: lexer: invalid input text "?['format'] ?? '..."
 - short_circuit: ok
 - slice: type2 error: error[T004]: `` is not callable
   --> :2:26
 
 help:
   Use a function or closure in this position.
-- sort_stable: type2 error: error[T002]: undefined variable: result
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
+- sort_stable: parse2 error: parse error: 6:14: lexer: invalid input text "'n']\nlet keyB = ..."
 - str_builtin: type2 error: error[T004]: `` is not callable
   --> :2:21
 
@@ -195,53 +139,33 @@ help:
 help:
   Use a function or closure in this position.
 - string_concat: ok
-- string_contains: type2 error: error[T002]: undefined variable: s
-  --> :2:9
+- string_contains: ok
+- string_in_operator: ok
+- string_index: parse2 error: parse error: 11:22: lexer: invalid input text "'index out of ra..."
+- string_prefix_slice: type2 error: error[T027]: string is not a struct
+  --> :5:10
 
 help:
-  Check if the variable was declared in this scope.
-- string_in_operator: type2 error: error[T002]: undefined variable: s
-  --> :2:10
-
-help:
-  Check if the variable was declared in this scope.
-- string_index: parse2 error: parse error: 10:22: lexer: invalid input text "'index out of ra..."
-- string_prefix_slice: type2 error: error[T002]: undefined variable: s1
-  --> :2:10
-
-help:
-  Check if the variable was declared in this scope.
+  Field access is only valid on struct types.
 - substring_builtin: ok
 - sum_builtin: parse2 error: parse error: 7:26: lexer: invalid input text "'items'] is List..."
 - tail_recursion: ok
-- test_block: parse2 error: parse error: 3:38: lexer: invalid input text "'expect failed')..."
-- tree_sum: parse2 error: parse error: 4:29: lexer: invalid input text "; }\n  if (_t is ..."
-- two-sum: type2 error: error[T002]: undefined variable: result
-  --> :13:9
+- test_block: parse2 error: parse error: 8:38: lexer: invalid input text "'expect failed')..."
+- tree_sum: parse2 error: parse error: 9:29: lexer: invalid input text "; }\n  if (_t is ..."
+- two-sum: type2 error: error[T003]: unknown function: twoSum
+  --> :1:25
 
 help:
-  Check if the variable was declared in this scope.
-- typed_let: type2 error: error[T002]: undefined variable: y
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
-- typed_var: type2 error: error[T002]: undefined variable: x
-  --> :2:9
-
-help:
-  Check if the variable was declared in this scope.
+  Ensure the function is defined before it's called.
+- typed_let: ok
+- typed_var: ok
 - unary_neg: ok
-- update_stmt: parse2 error: parse error: 7:242: lexer: invalid input text "'expect failed')..."
-- user_type_literal: parse2 error: parse error: 10:18: lexer: invalid input text "'Person'] = (m) ..."
-- values_builtin: type2 error: error[T002]: undefined variable: m
-  --> :2:16
+- update_stmt: parse2 error: parse error: 14:242: lexer: invalid input text "'expect failed')..."
+- user_type_literal: parse2 error: parse error: 12:18: lexer: invalid input text "'Person'] = (m) ..."
+- values_builtin: ok
+- var_assignment: type2 error: error[T024]: cannot assign to `x` (immutable)
+  --> :3:3
 
 help:
-  Check if the variable was declared in this scope.
-- var_assignment: type2 error: error[T001]: assignment to undeclared variable: x
-  --> :2:3
-
-help:
-  Declare `x` first using `let`.
+  Use `var` to declare mutable variables.
 - while_loop: vm compile error: assignment to undeclared variable: i


### PR DESCRIPTION
## Summary
- support top-level variable conversion in `any2mochi` Dart converter
- update roundtrip VM statuses for Dart

## Testing
- `go test ./tools/any2mochi/x/dart -run TestDartRoundtripVM -tags=slow -v`

------
https://chatgpt.com/codex/tasks/task_e_686a86d05aec8320bee62a68faa99e21