### PR TITLE
Improve F# any2mochi roundtrip tests

### DIFF
--- a/tests/any2mochi/fs_vm/ERRORS.md
+++ b/tests/any2mochi/fs_vm/ERRORS.md
@@ -1,0 +1,227 @@
+# Errors
+
+- append_builtin: parse2 error: parse error: 2:14: unexpected token "a" (expected ")")
+- avg_builtin: parse2 error: parse error: 1:21: unexpected token "," (expected "]")
+- basic_compare: parse2 error: parse error: 4:10: unexpected token "=" (expected "(" (Expr ("," Expr)*)? ")")
+- binary_precedence: ok
+- bool_chain: unsupported syntax at line 8: failwith "unreachable"
+  7:         raise (Return_boom (true))
+  8:         failwith "unreachable"
+  9:     with Return_boom v -> v
+ 10: 
+- break_continue: unsupported syntax at line 2: exception BreakException of int
+  1: open System
+  2: exception BreakException of int
+  3: exception ContinueException of int
+  4: 
+- cast_string_to_int: parse2 error: parse error: 1:12: unexpected token "1995" (expected "(" (Expr ("," Expr)*)? ")")
+- cast_struct: parse2 error: parse error: 6:44: unexpected token "," (expected ")")
+- closure: unsupported syntax at line 8: failwith "unreachable"
+  7:         raise (Return_makeAdder ((fun (x: int) -> (x + n))))
+  8:         failwith "unreachable"
+  9:     with Return_makeAdder v -> v
+ 10: 
+- count_builtin: parse2 error: parse error: 1:20: unexpected token "," (expected "]")
+- cross_join: parse2 error: parse error: 9:33: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- cross_join_filter: type2 error: error[T000]: `let` requires a type or a value
+  --> :5:1
+
+help:
+  Use `let x = ...` or `let x: int` to declare a variable.
+- cross_join_triple: type2 error: error[T000]: `let` requires a type or a value
+  --> :7:1
+
+help:
+  Use `let x = ...` or `let x: int` to declare a variable.
+- dataset_sort_take_limit: parse2 error: parse error: 3:34: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- dataset_where_filter: parse2 error: parse error: 4:32: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- exists_builtin: parse2 error: parse error: 4:1: unexpected token "<EOF>" (expected ")")
+- for_list_collection: parse2 error: parse error: 1:13: lexer: invalid input text "; 2; 3|] {\n  pri..."
+- for_loop: ok
+- for_map_collection: parse2 error: parse error: 1:25: unexpected token "," (expected ")")
+- fun_call: unsupported syntax at line 9: failwith "unreachable"
+  8:         raise (Return_add ((a + b)))
+  9:         failwith "unreachable"
+ 10:     with Return_add v -> v
+ 11: 
+- fun_expr_in_let: parse2 error: parse error: 1:26: unexpected token ")" (expected "<" TypeRef ("," TypeRef)* ">")
+- fun_three_args: unsupported syntax at line 10: failwith "unreachable"
+  9:         raise (Return_sum3 (((a + b) + c)))
+ 10:         failwith "unreachable"
+ 11:     with Return_sum3 v -> v
+ 12: 
+- group_by: unsupported syntax at line 8: type _Group<'T>(key: obj) =
+  7: let avg_age = "avg_age"
+  8: type _Group<'T>(key: obj) =
+  9:   member val key = key with get, set
+ 10:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_by_conditional_sum: unsupported syntax at line 7: type _Group<'T>(key: obj) =
+  6: let share = "share"
+  7: type _Group<'T>(key: obj) =
+  8:   member val key = key with get, set
+  9:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_by_having: unsupported syntax at line 6: type _Group<'T>(key: obj) =
+  5: let num = "num"
+  6: type _Group<'T>(key: obj) =
+  7:   member val key = key with get, set
+  8:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_by_join: unsupported syntax at line 7: type _Group<'T>(key: obj) =
+  6: let count = "count"
+  7: type _Group<'T>(key: obj) =
+  8:   member val key = key with get, set
+  9:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_by_left_join: unsupported syntax at line 7: type _Group<'T>(key: obj) =
+  6: let count = "count"
+  7: type _Group<'T>(key: obj) =
+  8:   member val key = key with get, set
+  9:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_by_multi_join: unsupported syntax at line 12: type _Group<'T>(key: obj) =
+ 11: let total = "total"
+ 12: type _Group<'T>(key: obj) =
+ 13:   member val key = key with get, set
+ 14:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_by_multi_join_sort: unsupported syntax at line 20: type _Group<'T>(key: obj) =
+ 19: let revenue = "revenue"
+ 20: type _Group<'T>(key: obj) =
+ 21:   member val key = key with get, set
+ 22:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_by_sort: unsupported syntax at line 6: type _Group<'T>(key: obj) =
+  5: let total = "total"
+  6: type _Group<'T>(key: obj) =
+  7:   member val key = key with get, set
+  8:   member val Items = System.Collections.Generic.List<'T>() with get
+- group_items_iteration: unsupported syntax at line 6: type _Group<'T>(key: obj) =
+  5: let total = "total"
+  6: type _Group<'T>(key: obj) =
+  7:   member val key = key with get, set
+  8:   member val Items = System.Collections.Generic.List<'T>() with get
+- if_else: ok
+- if_then_else: ok
+- if_then_else_nested: ok
+- in_operator: parse2 error: parse error: 2:22: unexpected token "2" (expected ")")
+- in_operator_extended: parse2 error: parse error: 4:22: unexpected token "1" (expected ")")
+- inner_join: parse2 error: parse error: 7:33: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- join_multi: parse2 error: parse error: 6:33: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- json_builtin: unsupported syntax at line 30: ignore (_json m)
+ 29: let m = Map.ofList [(a, 1); (b, 2)]
+ 30: ignore (_json m)
+- left_join: parse2 error: parse error: 7:33: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- left_join_multi: parse2 error: parse error: 7:33: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- len_builtin: ok
+- len_map: parse2 error: parse error: 1:34: unexpected token "," (expected ")")
+- len_string: ok
+- let_and_print: ok
+- list_assign: ok
+- list_index: ok
+- list_nested_assign: parse2 error: parse error: 2:11: unexpected token "[" (expected <ident>)
+- list_set_ops: parse2 error: parse error: 5:22: unexpected token "," (expected "]")
+- load_yaml: parse2 error: parse error: 13:85: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- map_assign: parse2 error: parse error: 1:34: unexpected token "," (expected ")")
+- map_in_operator: parse2 error: parse error: 1:23: unexpected token "," (expected ")")
+- map_index: parse2 error: parse error: 1:25: unexpected token "," (expected ")")
+- map_int_key: parse2 error: parse error: 1:23: unexpected token "," (expected ")")
+- map_literal_dynamic: parse2 error: parse error: 3:25: unexpected token "," (expected ")")
+- map_membership: parse2 error: parse error: 1:25: unexpected token "," (expected ")")
+- map_nested_assign: parse2 error: parse error: 1:32: unexpected token "," (expected ")")
+- match_expr: parse2 error: parse error: 2:22: unexpected token "with" (expected "{" MatchCase* "}")
+- match_full: unsupported syntax at line 8: failwith "unreachable"
+  7:         raise (Return_classify ((match n with | 0 -> "zero" | 1 -> "one" | _ -> "many")))
+  8:         failwith "unreachable"
+  9:     with Return_classify v -> v
+ 10: 
+- math_ops: ok
+- membership: parse2 error: parse error: 2:22: unexpected token "2" (expected ")")
+- min_max_builtin: parse2 error: parse error: 2:15: unexpected token "nums" (expected ")")
+- nested_function: unsupported syntax at line 13: failwith "unreachable"
+ 12:                 raise (Return_inner ((x + y)))
+ 13:                 failwith "unreachable"
+ 14:             with Return_inner v -> v
+ 15:         raise (Return_outer (inner (5)))
+- order_by_map: parse2 error: parse error: 3:27: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- outer_join: parse2 error: parse error: 7:33: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- partial_application: unsupported syntax at line 9: failwith "unreachable"
+  8:         raise (Return_add ((a + b)))
+  9:         failwith "unreachable"
+ 10:     with Return_add v -> v
+ 11: 
+- print_hello: ok
+- pure_fold: unsupported syntax at line 8: failwith "unreachable"
+  7:         raise (Return_triple ((x * 3)))
+  8:         failwith "unreachable"
+  9:     with Return_triple v -> v
+ 10: 
+- pure_global_fold: unsupported syntax at line 8: failwith "unreachable"
+  7:         raise (Return_inc ((x + k)))
+  8:         failwith "unreachable"
+  9:     with Return_inc v -> v
+ 10: 
+- query_sum_select: type2 error: error[T000]: `let` requires a type or a value
+  --> :2:1
+
+help:
+  Use `let x = ...` or `let x: int` to declare a variable.
+- record_assign: unsupported syntax at line 13: failwith "unreachable"
+ 12:         c <- (c.n + 1)
+ 13:         failwith "unreachable"
+ 14:     with Return_inc v -> v
+ 15: 
+- right_join: parse2 error: parse error: 7:33: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- save_jsonl_stdout: unsupported syntax at line 47: ignore (_save people Some "-" Some (Map.ofList [(format, "jsonl")]))
+ 46: let people = [|Map.ofList [(name, "Alice"); (age, 30)]; Map.ofList [(name, "Bob"); (age, 25)]|]
+ 47: ignore (_save people Some "-" Some (Map.ofList [(format, "jsonl")]))
+- short_circuit: unsupported syntax at line 10: failwith "unreachable"
+  9:         raise (Return_boom (true))
+ 10:         failwith "unreachable"
+ 11:     with Return_boom v -> v
+ 12: 
+- slice: parse2 error: parse error: 1:17: unexpected token "[" (expected <ident>)
+- sort_stable: parse2 error: parse error: 3:28: unexpected token "," (expected "(" (Expr ("," Expr)*)? ")")
+- str_builtin: parse2 error: parse error: 1:15: unexpected token "123" (expected "(" (Expr ("," Expr)*)? ")")
+- string_compare: ok
+- string_concat: ok
+- string_contains: parse2 error: parse error: 2:18: unexpected token "cat" (expected ")")
+- string_in_operator: type2 error: error[T027]: string is not a struct
+  --> :2:7
+
+help:
+  Field access is only valid on struct types.
+- string_index: parse2 error: parse error: 2:15: unexpected token "s" (expected "(" (Expr ("," Expr)*)? ")")
+- string_prefix_slice: parse2 error: parse error: 3:13: unexpected token ".." (expected "]")
+- substring_builtin: type2 error: error[T039]: function substring expects 3 arguments, got 1
+  --> :1:7
+
+help:
+  Pass exactly 3 arguments to `substring`.
+- sum_builtin: parse2 error: parse error: 1:17: unexpected token "," (expected "]")
+- tail_recursion: unsupported syntax at line 11: failwith "unreachable"
+ 10:         raise (Return_sum_rec (sum_rec ((n - 1)) ((acc + n))))
+ 11:         failwith "unreachable"
+ 12:     with Return_sum_rec v -> v
+ 13: 
+- test_block: unsupported syntax at line 13: let test_addition_works() =
+ 12: 
+ 13: let test_addition_works() =
+ 14:     let x = (1 + 2)
+ 15:     if not ((x = 3)) then failwith "expect failed"
+- tree_sum: unsupported syntax at line 12: failwith "unreachable"
+ 11:         raise (Return_sum_tree ((match t with | Leaf -> 0 | Node(left, value, right) -> ((sum_tree left + value) + sum_tree right))))
+ 12:         failwith "unreachable"
+ 13:     with Return_sum_tree v -> v
+ 14: 
+- two-sum: unsupported syntax at line 14: failwith "unreachable"
+ 13:         raise (Return_twoSum ([|(-1); (-1)|]))
+ 14:         failwith "unreachable"
+ 15:     with Return_twoSum v -> v
+ 16: 
+- typed_let: panic: runtime error: invalid memory address or nil pointer dereference
+- typed_var: panic: runtime error: invalid memory address or nil pointer dereference
+- unary_neg: ok
+- update_stmt: unsupported syntax at line 29: let test_update_adult_status() =
+ 28:     people.[i] <- item
+ 29: let test_update_adult_status() =
+ 30:     if not ((people = [|{ name = "Alice"; age = 17; status = "minor" }; { name = "Bob"; age = 26; status = "adult" }; { name = "Charlie"; age = 19; status = "adult" }; { name = "Diana"; age = 16; status = "minor" }|])) then failwith "expect failed"
+ 31: 
+- user_type_literal: parse2 error: parse error: 9:26: unexpected token "," (expected PostfixExpr)
+- values_builtin: parse2 error: parse error: 1:25: unexpected token "," (expected ")")
+- var_assignment: ok
+- while_loop: ok

--- a/tools/any2mochi/x/fs/convert.go
+++ b/tools/any2mochi/x/fs/convert.go
@@ -202,8 +202,14 @@ func mapType(t string) string {
 
 var indexRe = regexp.MustCompile(`(\w+)\.\[(.+)\]`)
 
+// fixIndex normalizes F# specific syntax like array indexing and array literals
+// to Mochi equivalents.
 func fixIndex(expr string) string {
-	return indexRe.ReplaceAllString(expr, `$1[$2]`)
+	expr = indexRe.ReplaceAllString(expr, `$1[$2]`)
+	expr = strings.ReplaceAll(expr, "[|", "[")
+	expr = strings.ReplaceAll(expr, "|]", "]")
+	expr = strings.ReplaceAll(expr, ";", ",")
+	return expr
 }
 
 func functionBody(src string, sym parent.DocumentSymbol) []string {

--- a/tools/any2mochi/x/fs/roundtrip_vm_test.go
+++ b/tools/any2mochi/x/fs/roundtrip_vm_test.go
@@ -1,0 +1,99 @@
+//go:build slow
+
+package fs
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	fscode "mochi/compile/x/fs"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	any2mochi "mochi/tools/any2mochi"
+	"mochi/types"
+)
+
+func compileMochiToFS(path string) (out []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	prog, perr := parser.Parse(path)
+	if perr != nil {
+		return nil, fmt.Errorf("parse error: %w", perr)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	out, err = fscode.New(env).Compile(prog)
+	if err != nil {
+		return nil, fmt.Errorf("compile error: %w", err)
+	}
+	return out, nil
+}
+
+func TestFSRoundtripVM(t *testing.T) {
+	root := any2mochi.FindRepoRoot(t)
+	pattern := filepath.Join(root, "tests", "vm", "valid", "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files: %s", pattern)
+	}
+	status := make(map[string]string)
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		t.Run(name, func(t *testing.T) {
+			fsSrc, err := compileMochiToFS(src)
+			if err != nil {
+				status[name] = err.Error()
+				return
+			}
+			dir := t.TempDir()
+			fsFile := filepath.Join(dir, name+".fs")
+			if err := os.WriteFile(fsFile, fsSrc, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			mochiSrc, err := ConvertFile(fsFile)
+			if err != nil {
+				status[name] = err.Error()
+				return
+			}
+			prog2, err := parser.ParseString(string(mochiSrc))
+			if err != nil {
+				status[name] = fmt.Sprintf("parse2 error: %v", err)
+				return
+			}
+			env2 := types.NewEnv(nil)
+			if errs := types.Check(prog2, env2); len(errs) > 0 {
+				status[name] = fmt.Sprintf("type2 error: %v", errs[0])
+				return
+			}
+			p2, err := vm.CompileWithSource(prog2, env2, string(mochiSrc))
+			if err != nil {
+				status[name] = fmt.Sprintf("vm compile error: %v", err)
+				return
+			}
+			var buf bytes.Buffer
+			m := vm.New(p2, &buf)
+			if err := m.Run(); err != nil {
+				if ve, ok := err.(*vm.VMError); ok {
+					status[name] = fmt.Sprintf("vm run error:\n%s", ve.Format(p2))
+				} else {
+					status[name] = fmt.Sprintf("vm run error: %v", err)
+				}
+				return
+			}
+			status[name] = ""
+		})
+	}
+	any2mochi.WriteStatusMarkdown(filepath.Join(root, "tests", "any2mochi", "fs_vm"), status)
+}


### PR DESCRIPTION
## Summary
- handle F# array syntax in converter
- add VM roundtrip tests for the F# backend
- record current status in `tests/any2mochi/fs_vm/ERRORS.md`

## Testing
- `go test ./... -run TestNonexistent`
- `go test -tags slow ./tools/any2mochi/x/fs -run TestFSRoundtripVM -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686a878250588320bed7ac9a8cbe83d3