### PR TITLE
Add Fortran VM roundtrip test

### DIFF
--- a/compile/x/fortran/compiler.go
+++ b/compile/x/fortran/compiler.go
@@ -639,18 +639,20 @@ func (c *Compiler) compileStmt(s *parser.Statement, retVar string) error {
 	case s.Expect != nil:
 		return c.compileExpect(s.Expect)
 	case s.Let != nil:
-		if _, ok := structLitName(s.Let.Value); ok {
-			val, err := c.compileExpr(s.Let.Value)
-			if err != nil {
-				return err
+		if s.Let.Value != nil {
+			if _, ok := structLitName(s.Let.Value); ok {
+				val, err := c.compileExpr(s.Let.Value)
+				if err != nil {
+					return err
+				}
+				c.writeln(fmt.Sprintf("%s = %s", sanitizeName(s.Let.Name), val))
+			} else if !types.IsEmptyListLiteral(s.Let.Value) {
+				val, err := c.compileExpr(s.Let.Value)
+				if err != nil {
+					return err
+				}
+				c.writeln(fmt.Sprintf("%s = %s", sanitizeName(s.Let.Name), val))
 			}
-			c.writeln(fmt.Sprintf("%s = %s", sanitizeName(s.Let.Name), val))
-		} else if !types.IsEmptyListLiteral(s.Let.Value) {
-			val, err := c.compileExpr(s.Let.Value)
-			if err != nil {
-				return err
-			}
-			c.writeln(fmt.Sprintf("%s = %s", sanitizeName(s.Let.Name), val))
 		}
 	case s.Var != nil:
 		if s.Var.Value != nil {

--- a/tests/any2mochi/fortran_vm/ERRORS.md
+++ b/tests/any2mochi/fortran_vm/ERRORS.md
@@ -1,0 +1,503 @@
+# Errors
+
+- append_builtin: generated code type error: error[T001]: assignment to undeclared variable: a
+  --> :2:3
+
+help:
+  Declare `a` first using `let`.
+  1: fun main() {
+  2:   a = [1, 2]
+  3:   print([a, 3])
+  4: }
+  5: 
+- avg_builtin: generated code type error: error[T003]: unknown function: merge
+  --> :2:9
+
+help:
+  Ensure the function is defined before it's called.
+  1: fun main() {
+  2:   print(merge(0.0, sum(real([1, 2, 3])) / size([1, 2, 3]), size([1, 2, 3]) == 0))
+  3: }
+  4: 
+- basic_compare: generated code type error: error[T001]: assignment to undeclared variable: a
+  --> :2:3
+
+help:
+  Declare `a` first using `let`.
+  1: fun main() {
+  2:   a = (10 - 3)
+  3:   b = (2 + 2)
+  4:   print(a)
+  5:   print(a == 7)
+  6:   print(b < 5)
+  7: }
+  8: 
+- binary_precedence: ok
+- bool_chain: generated code parse error: parse error: 7:9: lexer: invalid input text "'boom')\n  res = ..."
+  1: fun main() {
+  2:   print((((1 < 2))  &&  ((2 < 3)))  &&  ((3 < 4)))
+  3:   print((((1 < 2))  &&  ((2 > 3)))  &&  boom())
+  4:   print(((((1 < 2))  &&  ((2 < 3)))  &&  ((3 > 4)))  &&  boom())
+  5: }
+  6: fun boom()() {
+  7:   print('boom')
+  8:   res = true
+  9:   return
+ 10:   // end function boom
+- break_continue: generated code parse error: parse error: 11:11: lexer: invalid input text "'odd number:', n..."
+  1: fun main() {
+  2:   numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  3:   for i_n in 0..size(numbers) - 1 {
+  4:     n = numbers((i_n % size(numbers)) + 1)
+  5:     if ((n % 2) == 0) {
+  6:       continue
+  7:     }
+  8:     if (n > 7) {
+  9:       break
+ 10:     }
+- cast_string_to_int: generated code parse error: parse error: 2:13: lexer: invalid input text "'1995'))\n}\n"
+  1: fun main() {
+  2:   print(int('1995'))
+  3: }
+  4: 
+- cast_struct: compile error: unsupported expression
+- closure: generated code parse error: parse error: 5:17: unexpected token "(" (expected "{" Statement* "}")
+  1: fun main() {
+  2:   add10 = makeAdder(10)
+  3:   print(add10(7))
+  4: }
+  5: fun makeAdder(n)() {
+  6:   res = lambda_0
+  7:   return
+  8:   // end function makeAdder
+  9:   // function lambda_0(x) result(res)
+ 10:   res = (x + n)
+- count_builtin: generated code type error: error[T003]: unknown function: size
+  --> :2:9
+
+help:
+  Ensure the function is defined before it's called.
+  1: fun main() {
+  2:   print(size([1, 2, 3]))
+  3: }
+  4: 
+- cross_join: compile error: unsupported expression
+- cross_join_filter: compile error: unsupported query expression
+- cross_join_triple: compile error: unsupported query expression
+- dataset_sort_take_limit: compile error: unsupported expression
+- dataset_where_filter: compile error: unsupported expression
+- exists_builtin: generated code parse error: parse error: 6:19: unexpected token "(" (expected "{" Statement* "}")
+  1: fun main() {
+  2:   data = [1, 2]
+  3:   flag = exists(lambda_0(data))
+  4:   print(flag)
+  5: }
+  6: fun lambda_0(vsrc)() {
+  7:   n = 0
+  8:   for i in 1..size(vsrc) {
+  9:     x = vsrc(i)
+ 10:     if (x == 1) {
+- for_list_collection: generated code parse error: parse error: 2:15: unexpected token "," (expected "{" Statement* "}")
+  1: fun main() {
+  2:   for i_n in 0, size((/1, 2..3/)) - 1 {
+  3:     n = [1, 2, 3]((i_n % size([1, 2, 3])) + 1)
+  4:     print(n)
+  5: }
+  6: 
+- for_loop: generated code parse error: parse error: 5:1: unexpected token "<EOF>" (expected "}")
+  1: fun main() {
+  2:   for i in 1..4 - 1 {
+  3:     print(i)
+  4: }
+  5: 
+- for_map_collection: compile error: unsupported expression
+- fun_call: generated code parse error: parse error: 4:11: unexpected token "(" (expected Param)
+  1: fun main() {
+  2:   print(add(2, 3))
+  3: }
+  4: fun add(a,() {
+  5:   res = (a + b)
+  6:   return
+  7:   // end function add
+  8: }
+  9: 
+- fun_expr_in_let: generated code parse error: parse error: 5:16: unexpected token "(" (expected "{" Statement* "}")
+  1: fun main() {
+  2:   square = lambda_0
+  3:   print(square(6))
+  4: }
+  5: fun lambda_0(x)() {
+  6:   res = (x * x)
+  7:   return
+  8:   // end function lambda_0
+  9: }
+ 10: 
+- fun_three_args: generated code parse error: parse error: 4:12: unexpected token "(" (expected Param)
+  1: fun main() {
+  2:   print(sum3(1, 2, 3))
+  3: }
+  4: fun sum3(a,() {
+  5:   res = ((a + b) + c)
+  6:   return
+  7:   // end function sum3
+  8: }
+  9: 
+- group_by: compile error: unsupported expression
+- group_by_conditional_sum: compile error: unsupported expression
+- group_by_having: compile error: unsupported expression
+- group_by_join: compile error: unsupported expression
+- group_by_left_join: compile error: unsupported expression
+- group_by_multi_join: compile error: unsupported expression
+- group_by_multi_join_sort: compile error: unsupported expression
+- group_by_sort: compile error: unsupported expression
+- group_items_iteration: compile error: unsupported expression
+- if_else: generated code parse error: parse error: 4:11: lexer: invalid input text "'big')\n  else {\n..."
+  1: fun main() {
+  2:   x = 5
+  3:   if (x > 3) {
+  4:     print('big')
+  5:   else {
+  6:     print('small')
+  7: }
+  8: 
+- if_then_else: generated code parse error: parse error: 3:15: lexer: invalid input text "'yes', 'no', (x ..."
+  1: fun main() {
+  2:   x = 12
+  3:   msg = merge('yes', 'no', (x > 10))
+  4:   print(msg)
+  5: }
+  6: 
+- if_then_else_nested: generated code parse error: parse error: 3:15: lexer: invalid input text "'big', merge('me..."
+  1: fun main() {
+  2:   x = 8
+  3:   msg = merge('big', merge('medium', 'small', (x > 5)), (x > 10))
+  4:   print(msg)
+  5: }
+  6: 
+- in_operator: generated code type error: error[T001]: assignment to undeclared variable: xs
+  --> :2:3
+
+help:
+  Declare `xs` first using `let`.
+  1: fun main() {
+  2:   xs = [1, 2, 3]
+  3:   print(any(xs == 2))
+  4:   print(! (any(xs == 5)))
+  5: }
+  6: 
+- in_operator_extended: compile error: unsupported op in
+- inner_join: compile error: unsupported expression
+- join_multi: compile error: unsupported expression
+- json_builtin: compile error: unsupported expression
+- left_join: compile error: unsupported expression
+- left_join_multi: compile error: unsupported expression
+- len_builtin: generated code type error: error[T003]: unknown function: size
+  --> :2:9
+
+help:
+  Ensure the function is defined before it's called.
+  1: fun main() {
+  2:   print(size([1, 2, 3]))
+  3: }
+  4: 
+- len_map: compile error: unsupported expression
+- len_string: generated code parse error: parse error: 2:13: lexer: invalid input text "'mochi'))\n}\n"
+  1: fun main() {
+  2:   print(len('mochi'))
+  3: }
+  4: 
+- let_and_print: generated code type error: error[T001]: assignment to undeclared variable: a
+  --> :2:3
+
+help:
+  Declare `a` first using `let`.
+  1: fun main() {
+  2:   a = 10
+  3:   b = 20
+  4:   print(a + b)
+  5: }
+  6: 
+- list_assign: generated code parse error: parse error: 3:9: unexpected token "_8" (expected ")")
+  1: fun main() {
+  2:   nums = [1, 2]
+  3:   nums(1_8 + 1) = 3
+  4:   print(nums((1 % size(nums)) + 1))
+  5: }
+  6: 
+- list_index: generated code type error: error[T001]: assignment to undeclared variable: xs
+  --> :2:3
+
+help:
+  Declare `xs` first using `let`.
+  1: fun main() {
+  2:   xs = [10, 20, 30]
+  3:   print(xs((1 % size(xs)) + 1))
+  4: }
+  5: 
+- list_nested_assign: generated code parse error: parse error: 2:14: unexpected token "/" (expected PostfixExpr)
+  1: fun main() {
+  2:   matrix = [(/1, 2], [3, 4]/)
+  3:   matrix(1_8 + 1) = 5
+  4:   print(matrix((1 % size(matrix)) + 1)((0 % size(matrix)) + 1))
+  5: }
+  6: 
+- list_set_ops: generated code parse error: parse error: 5:16: unexpected token "/" (expected PostfixExpr)
+  1: fun main() {
+  2:   print(union_int([1, 2], [2, 3]))
+  3:   print(except_int([1, 2, 3], [2]))
+  4:   print(intersect_int([1, 2, 3], [2, 4]))
+  5:   print(size([(/1, 2], [2, 3] /)))
+  6: }
+  7: fun union_int(a,() {
+  8:   n = 0
+  9:   for i in 1..size(a) {
+ 10:     n = n + 1
+- load_yaml: compile error: unsupported expression
+- map_assign: compile error: unsupported expression
+- map_in_operator: compile error: unsupported expression
+- map_index: compile error: unsupported expression
+- map_int_key: compile error: unsupported expression
+- map_literal_dynamic: compile error: unsupported expression
+- map_membership: compile error: unsupported expression
+- map_nested_assign: compile error: unsupported expression
+- match_expr: compile error: unsupported expression
+- match_full: compile error: unsupported expression
+- math_ops: ok
+- membership: generated code type error: error[T001]: assignment to undeclared variable: nums
+  --> :2:3
+
+help:
+  Declare `nums` first using `let`.
+  1: fun main() {
+  2:   nums = [1, 2, 3]
+  3:   print(any(nums == 2))
+  4:   print(any(nums == 4))
+  5: }
+  6: 
+- min_max_builtin: generated code type error: error[T001]: assignment to undeclared variable: nums
+  --> :2:3
+
+help:
+  Declare `nums` first using `let`.
+  1: fun main() {
+  2:   nums = [3, 1, 4]
+  3:   print(merge(0, minval(nums), size(nums) == 0))
+  4:   print(max(nums))
+  5: }
+  6: 
+- nested_function: compile error: unsupported statement
+- order_by_map: compile error: unsupported expression
+- outer_join: compile error: unsupported expression
+- partial_application: generated code parse error: parse error: 5:11: unexpected token "(" (expected Param)
+  1: fun main() {
+  2:   add5 = add(5)
+  3:   print(add5(3))
+  4: }
+  5: fun add(a,() {
+  6:   res = (a + b)
+  7:   return
+  8:   // end function add
+  9: }
+ 10: 
+- print_hello: generated code parse error: parse error: 2:9: lexer: invalid input text "'hello')\n}\n"
+  1: fun main() {
+  2:   print('hello')
+  3: }
+  4: 
+- pure_fold: generated code parse error: parse error: 4:14: unexpected token "(" (expected "{" Statement* "}")
+  1: fun main() {
+  2:   print(triple((1 + 2)))
+  3: }
+  4: fun triple(x)() {
+  5:   res = (x * 3)
+  6:   return
+  7:   // end function triple
+  8: }
+  9: 
+- pure_global_fold: generated code parse error: parse error: 5:11: unexpected token "(" (expected "{" Statement* "}")
+  1: fun main() {
+  2:   k = 2
+  3:   print(inc(3))
+  4: }
+  5: fun inc(x)() {
+  6:   res = (x + k)
+  7:   return
+  8:   // end function inc
+  9: }
+ 10: 
+- query_sum_select: generated code parse error: parse error: 6:19: unexpected token "(" (expected "{" Statement* "}")
+  1: fun main() {
+  2:   nums = [1, 2, 3]
+  3:   result = lambda_0(nums)
+  4:   print(result)
+  5: }
+  6: fun lambda_0(vsrc)() {
+  7:   n = 0
+  8:   for i in 1..size(vsrc) {
+  9:     n = vsrc(i)
+ 10:     if (n > 1) {
+- record_assign: generated code parse error: parse error: 6:16: unexpected token "=" (expected ")")
+  1: type Counter {
+  2:   n: int
+  3: }
+  4: fun main() {
+  5:   // end type Counter
+  6:   c = Counter(n=0)
+  7:   // inc(c)
+  8:   print(c.n)
+  9: }
+ 10: fun inc(c)() {
+- right_join: compile error: unsupported expression
+- save_jsonl_stdout: compile error: unsupported expression
+- short_circuit: generated code parse error: parse error: 6:9: lexer: invalid input text "'boom')\n  res = ..."
+  1: fun main() {
+  2:   print(false  &&  boom(1, 2))
+  3:   print(true  ||  boom(1, 2))
+  4: }
+  5: fun boom(a,() {
+  6:   print('boom')
+  7:   res = true
+  8:   return
+  9:   // end function boom
+ 10: }
+- slice: generated code parse error: parse error: 4:9: lexer: invalid input text "'hello'(1 + 1:4)..."
+  1: fun main() {
+  2:   print(/1, 2, 3/)(1 + 1:3)
+  3:   print(/1, 2, 3/)(0 + 1:2)
+  4:   print('hello'(1 + 1:4))
+  5: }
+  6: 
+- sort_stable: compile error: unsupported expression
+- str_builtin: generated code parse error: parse error: 4:15: unexpected token "(" (expected "{" Statement* "}")
+  1: fun main() {
+  2:   print(str_int(123))
+  3: }
+  4: fun str_int(v)() {
+  5:   // write(buf,'(I0)') v
+  6:   r = trim(buf)
+  7:   // end function str_int
+  8: }
+  9: 
+- string_compare: generated code parse error: parse error: 2:9: lexer: invalid input text "'a' < 'b')\n  pri..."
+  1: fun main() {
+  2:   print('a' < 'b')
+  3:   print('a' <= 'a')
+  4:   print('b' > 'a')
+  5:   print('b' >= 'b')
+  6: }
+  7: 
+- string_concat: generated code parse error: parse error: 2:14: lexer: invalid input text "'hello ') // tri..."
+  1: fun main() {
+  2:   print(trim('hello ') // trim('world'))
+  3: }
+  4: 
+- string_contains: generated code parse error: parse error: 2:7: lexer: invalid input text "'catch'\n  print(..."
+  1: fun main() {
+  2:   s = 'catch'
+  3:   print(s.contains('cat'))
+  4:   print(s.contains('dog'))
+  5: }
+  6: 
+- string_in_operator: generated code parse error: parse error: 2:7: lexer: invalid input text "'catch'\n  print(..."
+  1: fun main() {
+  2:   s = 'catch'
+  3:   print(index(s, 'cat') > 0)
+  4:   print(index(s, 'dog') > 0)
+  5: }
+  6: 
+- string_index: generated code parse error: parse error: 2:7: lexer: invalid input text "'mochi'\n  print(..."
+  1: fun main() {
+  2:   s = 'mochi'
+  3:   print(s((1 % len(s)) + 1:(1 % len(s)) + 1))
+  4: }
+  5: 
+- string_prefix_slice: generated code parse error: parse error: 2:12: lexer: invalid input text "'fore'\n  s1 = 'f..."
+  1: fun main() {
+  2:   prefix = 'fore'
+  3:   s1 = 'forest'
+  4:   print(s1((0 % len(s1)) + 1:(len(prefix) % len(s1))) == prefix)
+  5:   s2 = 'desert'
+  6:   print(s2((0 % len(s2)) + 1:(len(prefix) % len(s2))) == prefix)
+  7: }
+  8: 
+- substring_builtin: generated code parse error: parse error: 2:19: lexer: invalid input text "'mochi', 1, 4))\n..."
+  1: fun main() {
+  2:   print(substring('mochi', 1, 4))
+  3: }
+  4: 
+- sum_builtin: ok
+- tail_recursion: generated code parse error: parse error: 4:15: unexpected token "(" (expected Param)
+  1: fun main() {
+  2:   print(sum_rec(10, 0))
+  3: }
+  4: fun sum_rec(n,() {
+  5:   if (n == 0) {
+  6:     res = acc
+  7:     return
+  8:   }
+  9:   res = sum_rec((n - 1), (acc + n))
+ 10:   return
+- test_block: generated code parse error: parse error: 2:9: lexer: invalid input text "'ok')\n  // call ..."
+  1: fun main() {
+  2:   print('ok')
+  3:   // call test_addition_works()
+  4: }
+  5: fun test_addition_works()() {
+  6:   x = (1 + 2)
+  7:   if ! (x == 3) {
+  8:     print('expect failed')
+  9:     // stop 1
+ 10:   }
+- tree_sum: compile error: union types not supported
+- two-sum: generated code parse error: parse error: 6:17: unexpected token "(" (expected Param)
+  1: fun main() {
+  2:   result = twoSum([2, 7, 11, 15], 9)
+  3:   print(result(0 + 1))
+  4:   print(result(1 + 1))
+  5: }
+  6: fun twoSum(nums,() {
+  7:   n = size(nums)
+  8:   for i in 0..n - 1 {
+  9:     for j in (i + 1)..n - 1 {
+ 10:       if ((nums(i + 1) + nums(j + 1)) == target) {
+- typed_let: generated code type error: error[T002]: undefined variable: y
+  --> :2:9
+
+help:
+  Check if the variable was declared in this scope.
+  1: fun main() {
+  2:   print(y)
+  3: }
+  4: 
+- typed_var: generated code type error: error[T002]: undefined variable: x
+  --> :2:9
+
+help:
+  Check if the variable was declared in this scope.
+  1: fun main() {
+  2:   print(x)
+  3: }
+  4: 
+- unary_neg: ok
+- update_stmt: compile error: unsupported statement
+- user_type_literal: ok
+- values_builtin: compile error: unsupported expression
+- var_assignment: generated code type error: error[T001]: assignment to undeclared variable: x
+  --> :2:3
+
+help:
+  Declare `x` first using `let`.
+  1: fun main() {
+  2:   x = 1
+  3:   x = 2
+  4:   print(x)
+  5: }
+  6: 
+- while_loop: generated code parse error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
+  1: fun main() {
+  2:   i = 0
+  3:   while (i < 3) {
+  4:     print(i)
+  5:     i = (i + 1)
+  6: }
+  7: 

--- a/tools/any2mochi/x/fortran/convert.go
+++ b/tools/any2mochi/x/fortran/convert.go
@@ -319,6 +319,15 @@ func cleanExpr(e string) string {
 	e = replacer.Replace(e)
 	reMod := regexp.MustCompile(`\bmod(?:ulo)?\(([^,]+),\s*([^\)]+)\)`)
 	e = reMod.ReplaceAllString(e, "($1 % $2)")
+	reList := regexp.MustCompile(`\(/\s*(.*?)\s*/\)`)
+	e = reList.ReplaceAllStringFunc(e, func(m string) string {
+		inner := strings.TrimSpace(m[2 : len(m)-2])
+		return "[" + inner + "]"
+	})
+	if strings.HasPrefix(e, "/") && strings.HasSuffix(e, "/") {
+		inner := strings.TrimSpace(e[1 : len(e)-1])
+		e = "[" + inner + "]"
+	}
 	return e
 }
 

--- a/tools/any2mochi/x/fortran/vm_roundtrip_test.go
+++ b/tools/any2mochi/x/fortran/vm_roundtrip_test.go
@@ -1,0 +1,44 @@
+//go:build slow
+
+package fortran
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	ftncode "mochi/compile/x/fortran"
+	"mochi/parser"
+	any2mochi "mochi/tools/any2mochi"
+	"mochi/types"
+)
+
+// compileMochiToFortran compiles Mochi source into Fortran code.
+func compileMochiToFortran(path string) ([]byte, error) {
+	prog, err := parser.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := ftncode.New().Compile(prog)
+	if err != nil {
+		return nil, fmt.Errorf("compile error: %w", err)
+	}
+	return code, nil
+}
+
+func TestFortran_VM_RoundTrip(t *testing.T) {
+	root := any2mochi.FindRepoRoot(t)
+	status := any2mochi.RunCompileConvertRunStatus(
+		t,
+		filepath.Join(root, "tests/vm/valid"),
+		"*.mochi",
+		compileMochiToFortran,
+		ConvertFile,
+		"fortran",
+	)
+	any2mochi.WriteStatusMarkdown(filepath.Join(root, "tests/any2mochi/fortran_vm"), status)
+}


### PR DESCRIPTION
## Summary
- handle typed let statements safely in Fortran compiler
- support Fortran list constructors when converting back to Mochi
- add VM roundtrip test for Fortran conversions
- document conversion errors in `tests/any2mochi/fortran_vm/ERRORS.md`

## Testing
- `go test ./tools/any2mochi/x/fortran -run VM_RoundTrip -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686a878e5d288320927dddc54e4c0df6