### PR TITLE
Add Ruby roundtrip VM test

### DIFF
--- a/tests/any2mochi/ruby_vm/ERRORS.md
+++ b/tests/any2mochi/ruby_vm/ERRORS.md
@@ -1,0 +1,3 @@
+# Errors
+None
+

--- a/tools/any2mochi/x/ruby/convert.go
+++ b/tools/any2mochi/x/ruby/convert.go
@@ -173,7 +173,7 @@ func exprString(n Node) string {
 	for _, r := range reps {
 		s = strings.ReplaceAll(s, r.old, r.new)
 	}
-	return s
+	return strings.TrimSpace(s)
 }
 
 func params(n Node) string {

--- a/tools/any2mochi/x/ruby/vm_roundtrip_test.go
+++ b/tools/any2mochi/x/ruby/vm_roundtrip_test.go
@@ -1,0 +1,46 @@
+//go:build slow
+
+package ruby
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	rbcode "mochi/compile/x/rb"
+	"mochi/parser"
+	any2mochi "mochi/tools/any2mochi"
+	"mochi/types"
+)
+
+func compileMochiToRB(path string) ([]byte, error) {
+	prog, err := parser.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := rbcode.New(env).Compile(prog)
+	if err != nil {
+		return nil, fmt.Errorf("compile error: %w", err)
+	}
+	return code, nil
+}
+
+func TestRuby_VM_RoundTrip(t *testing.T) {
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
+	}
+	root := any2mochi.FindRepoRoot(t)
+	status := any2mochi.RunCompileConvertRunStatus(
+		t,
+		filepath.Join(root, "tests/vm/valid"),
+		"*.mochi",
+		compileMochiToRB,
+		ConvertFile,
+		"rb",
+	)
+	any2mochi.WriteStatusMarkdown(filepath.Join(root, "tests/any2mochi/ruby_vm"), status)
+}


### PR DESCRIPTION
## Summary
- add VM roundtrip test for Ruby backend
- improve Ruby converter to trim expression whitespace
- include ERRORS.md placeholder for ruby VM tests

## Testing
- `go test ./tools/any2mochi/x/ruby -run TestRuby_VM_RoundTrip -tags slow -count=1` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686a895991d48320923dcdeb69dfedfc