### PR TITLE
Improve Scala roundtrip in any2mochi

### DIFF
--- a/tests/any2mochi/scala_vm/ERRORS.md
+++ b/tests/any2mochi/scala_vm/ERRORS.md
@@ -1,0 +1,163 @@
+# Errors
+
+- append_builtin.mochi: roundtrip parse error: parse error: 1:25: unexpected token "="
+- avg_builtin.mochi: roundtrip type error: error[T002]: undefined variable: scala
+  --> :1:8
+
+help:
+  Check if the variable was declared in this scope.
+- basic_compare.mochi: ok
+- binary_precedence.mochi: ok
+- bool_chain.mochi: roundtrip type error: error[T008]: type mismatch: expected void, got bool
+  --> :3:10
+
+help:
+  Change the value to match the expected type.
+- break_continue.mochi: roundtrip parse error: parse error: 1:31: unexpected token "="
+- cast_string_to_int.mochi: roundtrip type error: error[T002]: undefined variable: _cast
+  --> :1:7
+
+help:
+  Check if the variable was declared in this scope.
+- cast_struct.mochi: roundtrip parse error: parse error: 1:68: unexpected token ">" (expected PostfixExpr)
+- closure.mochi: roundtrip parse error: parse error: 2:3: unexpected token ">" (expected "}")
+- count_builtin.mochi: roundtrip type error: error[T002]: undefined variable: scala
+  --> :1:11
+
+help:
+  Check if the variable was declared in this scope.
+- cross_join.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- cross_join_filter.mochi: roundtrip parse error: parse error: 1:28: unexpected token "="
+- cross_join_triple.mochi: roundtrip parse error: parse error: 1:28: unexpected token "="
+- dataset_sort_take_limit.mochi: roundtrip parse error: parse error: 1:31: unexpected token "]"
+- dataset_where_filter.mochi: roundtrip parse error: parse error: 1:29: unexpected token "]"
+- exists_builtin.mochi: roundtrip parse error: parse error: 1:28: unexpected token "="
+- for_list_collection.mochi: roundtrip type error: error[T002]: undefined variable: scala
+  --> :1:11
+
+help:
+  Check if the variable was declared in this scope.
+- for_loop.mochi: ok
+- for_map_collection.mochi: roundtrip parse error: parse error: 1:43: unexpected token ">" (expected PostfixExpr)
+- fun_call.mochi: roundtrip type error: error[T005]: parameter `a` is missing a type
+  --> :1:1
+
+help:
+  Add a type like `x: int` to this parameter.
+- fun_expr_in_let.mochi: roundtrip parse error: parse error: 1:13: unexpected token "(" (expected TypeRef)
+- fun_three_args.mochi: roundtrip type error: error[T005]: parameter `a` is missing a type
+  --> :1:1
+
+help:
+  Add a type like `x: int` to this parameter.
+- group_by.mochi: roundtrip parse error: parse error: 1:29: unexpected token "]"
+- group_by_conditional_sum.mochi: roundtrip parse error: parse error: 1:28: unexpected token "]"
+- group_by_having.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- group_by_join.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- group_by_left_join.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- group_by_multi_join.mochi: roundtrip parse error: parse error: 1:30: unexpected token "]"
+- group_by_multi_join_sort.mochi: roundtrip parse error: parse error: 1:29: unexpected token "]"
+- group_by_sort.mochi: roundtrip parse error: parse error: 1:28: unexpected token "]"
+- group_items_iteration.mochi: roundtrip parse error: parse error: 1:27: unexpected token "]"
+- if_else.mochi: roundtrip parse error: parse error: 4:1: unexpected token "else" (expected "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
+- if_then_else.mochi: roundtrip parse error: parse error: 2:34: unexpected token "yes" (expected (("{" Expr "}") | ("then" Expr)) (("else" IfExpr) | ("else" (("{" Expr "}") | Expr)))?)
+- if_then_else_nested.mochi: roundtrip parse error: parse error: 2:34: unexpected token "big" (expected (("{" Expr "}") | ("then" Expr)) (("else" IfExpr) | ("else" (("{" Expr "}") | Expr)))?)
+- in_operator.mochi: roundtrip parse error: parse error: 1:26: unexpected token "="
+- in_operator_extended.mochi: roundtrip parse error: parse error: 1:26: unexpected token "="
+- inner_join.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- join_multi.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- json_builtin.mochi: roundtrip parse error: parse error: 1:25: unexpected token "="
+- left_join.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- left_join_multi.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- len_builtin.mochi: roundtrip type error: error[T002]: undefined variable: scala
+  --> :1:11
+
+help:
+  Check if the variable was declared in this scope.
+- len_map.mochi: roundtrip parse error: parse error: 1:45: unexpected token ">" (expected PostfixExpr)
+- len_string.mochi: ok
+- let_and_print.mochi: ok
+- list_assign.mochi: ok
+- list_index.mochi: roundtrip parse error: parse error: 1:26: unexpected token "="
+- list_nested_assign.mochi: roundtrip type error: error[T002]: undefined variable: scala
+  --> :1:15
+
+help:
+  Check if the variable was declared in this scope.
+- list_set_ops.mochi: roundtrip parse error: parse error: 1:52: unexpected token "+" (expected PostfixExpr)
+- load_yaml.mochi: roundtrip parse error: parse error: 1:33: unexpected token "="
+- map_assign.mochi: roundtrip parse error: parse error: 1:52: unexpected token ">" (expected PostfixExpr)
+- map_in_operator.mochi: roundtrip parse error: parse error: 1:25: unexpected token "="
+- map_index.mochi: roundtrip parse error: parse error: 1:25: unexpected token "="
+- map_int_key.mochi: roundtrip parse error: parse error: 1:25: unexpected token "="
+- map_literal_dynamic.mochi: roundtrip parse error: parse error: 3:43: unexpected token ">" (expected PostfixExpr)
+- map_membership.mochi: roundtrip parse error: parse error: 1:25: unexpected token "="
+- map_nested_assign.mochi: roundtrip parse error: parse error: 1:50: unexpected token ">" (expected PostfixExpr)
+- match_expr.mochi: roundtrip parse error: parse error: 2:11: unexpected token "label" (expected "{" MatchCase* "}")
+- match_full.mochi: roundtrip parse error: parse error: 9:11: unexpected token "label" (expected "{" MatchCase* "}")
+- math_ops.mochi: ok
+- membership.mochi: roundtrip parse error: parse error: 1:28: unexpected token "="
+- min_max_builtin.mochi: roundtrip parse error: parse error: 1:28: unexpected token "="
+- nested_function.mochi: roundtrip parse error: parse error: 2:14: unexpected token ":" (expected ")")
+- order_by_map.mochi: roundtrip parse error: parse error: 1:27: unexpected token "]"
+- outer_join.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- partial_application.mochi: roundtrip type error: error[T005]: parameter `a` is missing a type
+  --> :1:1
+
+help:
+  Add a type like `x: int` to this parameter.
+- print_hello.mochi: ok
+- pure_fold.mochi: roundtrip type error: error[T005]: parameter `x` is missing a type
+  --> :1:1
+
+help:
+  Add a type like `x: int` to this parameter.
+- pure_global_fold.mochi: roundtrip type error: error[T005]: parameter `x` is missing a type
+  --> :1:1
+
+help:
+  Add a type like `x: int` to this parameter.
+- query_sum_select.mochi: roundtrip parse error: parse error: 1:28: unexpected token "="
+- record_assign.mochi: roundtrip parse error: parse error: 5:28: unexpected token "=" (expected ")")
+- right_join.mochi: roundtrip parse error: parse error: 1:32: unexpected token "]"
+- save_jsonl_stdout.mochi: roundtrip parse error: parse error: 1:29: unexpected token "]"
+- short_circuit.mochi: roundtrip type error: error[T005]: parameter `a` is missing a type
+  --> :1:1
+
+help:
+  Add a type like `x: int` to this parameter.
+- slice.mochi: roundtrip parse error: parse error: 10:18: unexpected token "start" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
+- sort_stable.mochi: roundtrip parse error: parse error: 1:28: unexpected token "]"
+- str_builtin.mochi: ok
+- string_compare.mochi: ok
+- string_concat.mochi: ok
+- string_contains.mochi: ok
+- string_in_operator.mochi: ok
+- string_index.mochi: roundtrip parse error: parse error: 7:16: unexpected token "idx" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
+- string_prefix_slice.mochi: roundtrip parse error: parse error: 12:18: unexpected token "start" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
+- substring_builtin.mochi: roundtrip parse error: parse error: 8:18: unexpected token "start" (expected "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))?)
+- sum_builtin.mochi: roundtrip type error: error[T002]: undefined variable: scala
+  --> :1:11
+
+help:
+  Check if the variable was declared in this scope.
+- tail_recursion.mochi: roundtrip type error: error[T005]: parameter `n` is missing a type
+  --> :1:1
+
+help:
+  Add a type like `x: int` to this parameter.
+- test_block.mochi: roundtrip parse error: parse error: 3:13: unexpected token "=" (expected "(" (Expr ("," Expr)*)? ")")
+- tree_sum.mochi: roundtrip parse error: parse error: 6:10: unexpected token "=>" (expected ":" Expr)
+- two-sum.mochi: roundtrip parse error: parse error: 18:30: unexpected token "="
+- typed_let.mochi: roundtrip type error: error[T002]: undefined variable: y
+  --> :1:7
+
+help:
+  Check if the variable was declared in this scope.
+- typed_var.mochi: ok
+- unary_neg.mochi: ok
+- update_stmt.mochi: roundtrip parse error: parse error: 2:18: unexpected token "=" (expected "(" (Expr ("," Expr)*)? ")")
+- user_type_literal.mochi: roundtrip parse error: parse error: 1:29: unexpected token "=" (expected ")")
+- values_builtin.mochi: roundtrip parse error: parse error: 1:25: unexpected token "="
+- var_assignment.mochi: ok
+- while_loop.mochi: ok

--- a/tools/any2mochi/x/scala/vm_roundtrip_test.go
+++ b/tools/any2mochi/x/scala/vm_roundtrip_test.go
@@ -1,0 +1,95 @@
+//go:build slow
+
+package scala
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	scalacode "mochi/compile/x/scala"
+	"mochi/parser"
+	vm "mochi/runtime/vm"
+	any2mochi "mochi/tools/any2mochi"
+	"mochi/types"
+)
+
+func TestRoundTripVM(t *testing.T) {
+	root := any2mochi.FindRepoRoot(t)
+	pattern := filepath.Join(root, "tests/vm/valid", "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files: %s", pattern)
+	}
+	var statuses []string
+	for _, src := range files {
+		name := filepath.Base(src)
+		if err := roundTripVM(src); err != nil {
+			statuses = append(statuses, fmt.Sprintf("%s: %v", name, err))
+		} else {
+			statuses = append(statuses, fmt.Sprintf("%s: ok", name))
+		}
+	}
+	writeStatusMarkdown(filepath.Join(root, "tests/any2mochi/scala_vm"), statuses)
+}
+
+func roundTripVM(path string) error {
+	prog, err := parser.Parse(path)
+	if err != nil {
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := scalacode.New(env).Compile(prog)
+	if err != nil {
+		return fmt.Errorf("compile error: %w", err)
+	}
+	mochiSrc, err := Convert(string(code))
+	if err != nil {
+		return fmt.Errorf("convert error: %w", err)
+	}
+	prog2, err := parser.ParseString(string(mochiSrc))
+	if err != nil {
+		return fmt.Errorf("roundtrip parse error: %w", err)
+	}
+	env2 := types.NewEnv(nil)
+	if errs := types.Check(prog2, env2); len(errs) > 0 {
+		return fmt.Errorf("roundtrip type error: %v", errs[0])
+	}
+	p, err := vm.Compile(prog2, env2)
+	if err != nil {
+		return fmt.Errorf("vm compile error: %w", err)
+	}
+	var buf bytes.Buffer
+	m := vm.New(p, &buf)
+	if err := m.Run(); err != nil {
+		if ve, ok := err.(*vm.VMError); ok {
+			return fmt.Errorf("vm run error:\n%s", ve.Format(p))
+		}
+		return fmt.Errorf("vm run error: %v", err)
+	}
+	return nil
+}
+
+func writeStatusMarkdown(dir string, lines []string) {
+	_ = os.MkdirAll(dir, 0755)
+	path := filepath.Join(dir, "ERRORS.md")
+	var buf strings.Builder
+	buf.WriteString("# Errors\n\n")
+	if len(lines) == 0 {
+		buf.WriteString("None\n")
+	} else {
+		for _, l := range lines {
+			buf.WriteString("- " + l + "\n")
+		}
+	}
+	_ = os.WriteFile(path, []byte(buf.String()), 0644)
+}


### PR DESCRIPTION
## Summary
- update Scala converter for lists, maps, and option types
- add VM roundtrip test for Scala and record results
- include generated `ERRORS.md` for Scala VM roundtrip

## Testing
- `go test ./tools/any2mochi/x/scala -run TestRoundTripVM -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686a89913ea0832094e5acedf086c099