### PR TITLE
Update OCaml roundtrip

### DIFF
--- a/tests/any2mochi/ocaml_vm/ERRORS.md
+++ b/tests/any2mochi/ocaml_vm/ERRORS.md
@@ -49,9 +49,9 @@ help:
 - len_map: parse error: parse error: 1:26: unexpected token "let" (expected ")")
 - len_string: parse error: parse error: 1:24: unexpected token "mochi" (expected ")")
 - let_and_print: ok
-- list_assign: parse error: parse error: 3:18: unexpected token ")" (expected "]")
+- list_assign: parse error: parse error: 3:17: unexpected token ")" (expected "]")
 - list_index: parse error: parse error: 2:15: unexpected token ")" (expected "]")
-- list_nested_assign: parse error: parse error: 3:30: unexpected token "1" (expected ")")
+- list_nested_assign: parse error: parse error: 3:29: unexpected token "1" (expected ")")
 - list_set_ops: parse error: parse error: 1:20: unexpected token "," (expected "]")
 - load_yaml: parse error: parse error: 1:21: unexpected token "with" (expected "{" MatchCase* "}")
 - map_assign: parse error: parse error: 1:15: unexpected token "let" (expected PostfixExpr)
@@ -104,4 +104,4 @@ help:
 - user_type_literal: parse error: parse error: 1:26: unexpected token "," (expected PostfixExpr)
 - values_builtin: parse error: parse error: 1:10: unexpected token "let" (expected PostfixExpr)
 - var_assignment: ok
-- while_loop: parse error: parse error: 3:15: unexpected token ")" (expected PostfixExpr)
+- while_loop: parse error: parse error: 3:14: unexpected token ")" (expected PostfixExpr)

--- a/tools/any2mochi/x/ocaml/convert.go
+++ b/tools/any2mochi/x/ocaml/convert.go
@@ -438,6 +438,12 @@ func cleanExpr(expr string, reNth *regexp.Regexp) string {
 	expr = strings.ReplaceAll(expr, "string_of_bool", "")
 	expr = strings.ReplaceAll(expr, "List.length", "len")
 	expr = reNth.ReplaceAllString(expr, "$1[$2]")
+	// Dereference operators in the generated OCaml code correspond to plain
+	// variable reads in Mochi. Drop the leading '!' so that expressions like
+	// `!x` become just `x` and `!(xs)` turns into `(xs)`.
+	expr = strings.ReplaceAll(expr, "!(", "(")
+	reDeref := regexp.MustCompile(`!([a-zA-Z_][a-zA-Z0-9_]*)`)
+	expr = reDeref.ReplaceAllString(expr, "$1")
 	expr = strings.ReplaceAll(expr, "not ", "!")
 	expr = strings.ReplaceAll(expr, "^", "+")
 	return strings.TrimSpace(expr)


### PR DESCRIPTION
## Summary
- improve OCaml fallback converter by stripping dereference operator
- regenerate OCaml VM roundtrip status

## Testing
- `go test ./tools/any2mochi/x/ocaml -run TestOCaml_VM_RoundTrip -tags slow`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a8d91c1fc8320bf3b0ee0a413c556