### PR TITLE
Improve php roundtrip

### DIFF
--- a/tests/any2mochi/php_vm/ERRORS.md
+++ b/tests/any2mochi/php_vm/ERRORS.md
@@ -2,11 +2,7 @@
 
 - append_builtin: ok
 - avg_builtin: ok
-- basic_compare: type error: error[T002]: undefined variable: a
-  --> :2:7
-
-help:
-  Check if the variable was declared in this scope.
+- basic_compare: ok
 - binary_precedence: ok
 - bool_chain: ok
 - break_continue: ok

--- a/tools/any2mochi/x/php/parse.go
+++ b/tools/any2mochi/x/php/parse.go
@@ -7,6 +7,7 @@ import (
 	pnode "github.com/z7zmey/php-parser/node"
 	"github.com/z7zmey/php-parser/node/expr"
 	"github.com/z7zmey/php-parser/node/expr/assign"
+	binary "github.com/z7zmey/php-parser/node/expr/binary"
 	"github.com/z7zmey/php-parser/node/name"
 	"github.com/z7zmey/php-parser/node/scalar"
 	"github.com/z7zmey/php-parser/node/stmt"
@@ -217,6 +218,46 @@ func simpleExpr(n pnode.Node) (string, bool) {
 			return "", false
 		}
 		return "-" + val, true
+	case *binary.Plus:
+		left, ok1 := simpleExpr(v.Left)
+		if !ok1 {
+			return "", false
+		}
+		right, ok2 := simpleExpr(v.Right)
+		if !ok2 {
+			return "", false
+		}
+		return fmt.Sprintf("(%s + %s)", left, right), true
+	case *binary.Minus:
+		left, ok1 := simpleExpr(v.Left)
+		if !ok1 {
+			return "", false
+		}
+		right, ok2 := simpleExpr(v.Right)
+		if !ok2 {
+			return "", false
+		}
+		return fmt.Sprintf("(%s - %s)", left, right), true
+	case *binary.Mul:
+		left, ok1 := simpleExpr(v.Left)
+		if !ok1 {
+			return "", false
+		}
+		right, ok2 := simpleExpr(v.Right)
+		if !ok2 {
+			return "", false
+		}
+		return fmt.Sprintf("(%s * %s)", left, right), true
+	case *binary.Div:
+		left, ok1 := simpleExpr(v.Left)
+		if !ok1 {
+			return "", false
+		}
+		right, ok2 := simpleExpr(v.Right)
+		if !ok2 {
+			return "", false
+		}
+		return fmt.Sprintf("(%s / %s)", left, right), true
 	case *expr.ArrayDimFetch:
 		base, ok := simpleExpr(v.Variable)
 		if !ok {


### PR DESCRIPTION
## Summary
- enhance php roundtrip parser to handle basic arithmetic in `any2mochi`
- regenerate php VM roundtrip error report

## Testing
- `go test ./tools/any2mochi/x/php -tags slow -run TestPHP_VM_RoundTrip -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686a8defee708320b6c40ba8252807d7