### PR TITLE
Improve TypeScript roundtrip

### DIFF
--- a/compile/ts/ERRORS.md
+++ b/compile/ts/ERRORS.md
@@ -175,11 +175,11 @@ golden mismatch:
 ## tests/vm/valid/for_map_collection.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `m` (immutable)
-  --> :3:3
+type converted error: error[T002]: undefined variable: Object
+  --> :4:12
 
 help:
-  Use `var` to declare mutable variables.
+  Check if the variable was declared in this scope.
 ```
 
 ## tests/vm/valid/fun_call.mochi
@@ -445,11 +445,7 @@ help:
 ## tests/vm/valid/list_assign.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `nums` (immutable)
-  --> :3:3
-
-help:
-  Use `var` to declare mutable variables.
+vm compile error: assignment to undeclared variable: nums
 ```
 
 ## tests/vm/valid/list_index.mochi
@@ -465,11 +461,7 @@ help:
 ## tests/vm/valid/list_nested_assign.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `matrix` (immutable)
-  --> :3:3
-
-help:
-  Use `var` to declare mutable variables.
+vm compile error: assignment to undeclared variable: matrix
 ```
 
 ## tests/vm/valid/list_set_ops.mochi
@@ -496,11 +488,7 @@ Charlie charlie@example.com
 ## tests/vm/valid/map_assign.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `scores` (immutable)
-  --> :3:3
-
-help:
-  Use `var` to declare mutable variables.
+vm compile error: assignment to undeclared variable: scores
 ```
 
 ## tests/vm/valid/map_in_operator.mochi
@@ -536,11 +524,7 @@ help:
 ## tests/vm/valid/map_literal_dynamic.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `x` (immutable)
-  --> :5:3
-
-help:
-  Use `var` to declare mutable variables.
+vm compile error: assignment to undeclared variable: x
 ```
 
 ## tests/vm/valid/map_membership.mochi
@@ -556,11 +540,7 @@ help:
 ## tests/vm/valid/map_nested_assign.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `data` (immutable)
-  --> :3:3
-
-help:
-  Use `var` to declare mutable variables.
+vm compile error: assignment to undeclared variable: data
 ```
 
 ## tests/vm/valid/match_expr.mochi
@@ -946,20 +926,12 @@ help:
 ## tests/vm/valid/var_assignment.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `x` (immutable)
-  --> :3:3
-
-help:
-  Use `var` to declare mutable variables.
+vm compile error: assignment to undeclared variable: x
 ```
 
 ## tests/vm/valid/while_loop.mochi
 
 ```
-type converted error: error[T024]: cannot assign to `i` (immutable)
-  --> :3:3
-
-help:
-  Use `var` to declare mutable variables.
+vm compile error: assignment to undeclared variable: i
 ```
 

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -147,9 +147,9 @@ func (c *Compiler) collectGlobals(stmts []*parser.Statement) {
 			}
 			ts := tsType(typ)
 			if ts != "" {
-				c.globals[name] = fmt.Sprintf("let %s: %s", name, ts)
+				c.globals[name] = fmt.Sprintf("var %s: %s", name, ts)
 			} else {
-				c.globals[name] = fmt.Sprintf("let %s", name)
+				c.globals[name] = fmt.Sprintf("var %s", name)
 			}
 		case s.Fetch != nil:
 			name := sanitizeName(s.Fetch.Target)
@@ -555,16 +555,16 @@ func (c *Compiler) compileVar(s *parser.VarStmt) error {
 	typStr := tsType(typ)
 	if c.moduleScope && c.indent == 1 {
 		if typStr != "" {
-			c.globals[name] = fmt.Sprintf("let %s: %s", name, typStr)
+			c.globals[name] = fmt.Sprintf("var %s: %s", name, typStr)
 		} else {
-			c.globals[name] = fmt.Sprintf("let %s", name)
+			c.globals[name] = fmt.Sprintf("var %s", name)
 		}
 		c.writeln(fmt.Sprintf("%s = %s", name, value))
 	} else {
 		if typStr != "" {
-			c.writeln(fmt.Sprintf("let %s: %s = %s", name, typStr, value))
+			c.writeln(fmt.Sprintf("var %s: %s = %s", name, typStr, value))
 		} else {
-			c.writeln(fmt.Sprintf("let %s = %s", name, value))
+			c.writeln(fmt.Sprintf("var %s = %s", name, value))
 		}
 	}
 	return nil
@@ -716,31 +716,31 @@ func (c *Compiler) compileUpdate(u *parser.UpdateStmt) error {
 		c.buf.WriteString(fmt.Sprintf("if (%s) {\n", cond))
 		c.indent++
 	}
-        for _, it := range u.Set.Items {
-                if key, ok := identName(it.Key); ok {
-                        val, err := c.compileExpr(it.Value)
-                        if err != nil {
-                                c.env = orig
-                                return err
-                        }
-                        c.writeIndent()
-                        c.buf.WriteString(fmt.Sprintf("_item.%s = %s;\n", sanitizeName(key), val))
-                        continue
-                }
+	for _, it := range u.Set.Items {
+		if key, ok := identName(it.Key); ok {
+			val, err := c.compileExpr(it.Value)
+			if err != nil {
+				c.env = orig
+				return err
+			}
+			c.writeIndent()
+			c.buf.WriteString(fmt.Sprintf("_item.%s = %s;\n", sanitizeName(key), val))
+			continue
+		}
 
-                keyExpr, err := c.compileExpr(it.Key)
-                if err != nil {
-                        c.env = orig
-                        return err
-                }
-                valExpr, err := c.compileExpr(it.Value)
-                if err != nil {
-                        c.env = orig
-                        return err
-                }
-                c.writeIndent()
-                c.buf.WriteString(fmt.Sprintf("_item[%s] = %s;\n", keyExpr, valExpr))
-        }
+		keyExpr, err := c.compileExpr(it.Key)
+		if err != nil {
+			c.env = orig
+			return err
+		}
+		valExpr, err := c.compileExpr(it.Value)
+		if err != nil {
+			c.env = orig
+			return err
+		}
+		c.writeIndent()
+		c.buf.WriteString(fmt.Sprintf("_item[%s] = %s;\n", keyExpr, valExpr))
+	}
 	if u.Where != nil {
 		c.indent--
 		c.writeIndent()

--- a/tools/any2mochi/ts/convert.go
+++ b/tools/any2mochi/ts/convert.go
@@ -588,14 +588,16 @@ func parseTSFallback(out *strings.Builder, src string) {
 		out.WriteString("}\n")
 	}
 
-	varRe := regexp.MustCompile(`(?m)^(?:let|const|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*([^=;]+))?`)
+	varRe := regexp.MustCompile(`(?m)^(let|const|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*([^=;]+))?`)
 	for _, m := range varRe.FindAllStringSubmatch(src, -1) {
-		name := m[1]
-		typ := tsToMochiType(strings.TrimSpace(m[2]))
+		kw := m[1]
+		name := m[2]
+		typ := tsToMochiType(strings.TrimSpace(m[3]))
 		if name == "" {
 			continue
 		}
-		out.WriteString("let ")
+		out.WriteString(map[string]string{"var": "var", "let": "let", "const": "let"}[kw])
+		out.WriteByte(' ')
 		out.WriteString(name)
 		if typ != "" {
 			out.WriteString(": ")

--- a/tools/any2mochi/ts/convert_deno.ts
+++ b/tools/any2mochi/ts/convert_deno.ts
@@ -95,8 +95,11 @@ function tsFunctionBody(src: string): string[] {
     if (/^(let|const|var) /.test(s)) {
       const end = s.indexOf(";");
       let stmt = s.slice(0, end === -1 ? undefined : end).trim();
-      stmt = stmt.replace(/^let\s+|^const\s+|^var\s+/, "");
-      lines.push(`let ${stmt.replace(/;$/, "")}`);
+      const kwMatch = stmt.match(/^(let|const|var)\s+/);
+      let kw = "let";
+      if (kwMatch && kwMatch[1] === "var") kw = "var";
+      stmt = stmt.replace(/^(let|const|var)\s+/, "");
+      lines.push(`${kw} ${stmt.replace(/;$/, "")}`);
       s = end === -1 ? "" : s.slice(end + 1);
       continue;
     }

--- a/tools/any2mochi/ts/parse_simple.go
+++ b/tools/any2mochi/ts/parse_simple.go
@@ -79,11 +79,18 @@ func tsFunctionBody(src string) []string {
 				end = len(s)
 			}
 			stmt := strings.TrimSpace(s[:end])
-			stmt = strings.TrimPrefix(stmt, "let ")
-			stmt = strings.TrimPrefix(stmt, "const ")
-			stmt = strings.TrimPrefix(stmt, "var ")
+			kw := "let"
+			switch {
+			case strings.HasPrefix(stmt, "var "):
+				kw = "var"
+				stmt = strings.TrimPrefix(stmt, "var ")
+			case strings.HasPrefix(stmt, "let "):
+				stmt = strings.TrimPrefix(stmt, "let ")
+			case strings.HasPrefix(stmt, "const "):
+				stmt = strings.TrimPrefix(stmt, "const ")
+			}
 			if eq := strings.Index(stmt, "="); eq != -1 {
-				lines = append(lines, "let "+strings.TrimSpace(stmt))
+				lines = append(lines, kw+" "+strings.TrimSpace(stmt))
 			} else {
 				uninit[strings.TrimSpace(stmt)] = true
 			}

--- a/tools/any2mochi/x/scheme/cmd/genvm/main.go
+++ b/tools/any2mochi/x/scheme/cmd/genvm/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- preserve mutable variable declarations when round-tripping via TypeScript
- fix fallback TypeScript parsers to keep `var` keyword
- adjust TypeScript runtime converter accordingly
- mark scheme VM roundtrip tool as slow only
- regenerate TypeScript roundtrip error report

## Testing
- `go test ./...`
- `go run compile/ts/cmd/vm_roundtrip/main.go`

------
https://chatgpt.com/codex/tasks/task_e_686a95cf92908320b556d75a971cb188