### PR TITLE
Enhance Clojure round‑trip tooling

### DIFF
--- a/tests/any2mochi/clj/ERRORS.md
+++ b/tests/any2mochi/clj/ERRORS.md
@@ -1,48 +1,40 @@
 # Errors
 
-- append_builtin: type2 error: error[T003]: unknown function: _1
-  --> :2:11
-
-help:
-  Ensure the function is defined before it's called.
-- avg_builtin: parse2 error: parse error: 2:9: unexpected token "let" (expected ")")
+- append_builtin: ok
+- avg_builtin: parse2 error: parse error: 2:56: unexpected token "+" (expected ")")
 - basic_compare: ok
 - binary_precedence: ok
 - bool_chain: parse2 error: parse error: 2:22: unexpected token "," (expected PostfixExpr)
-- break_continue: parse2 error: parse error: 3:40: unexpected token "let" (expected PostfixExpr)
+- break_continue: parse2 error: parse error: 3:72: unexpected token "break" (expected PostfixExpr)
 - cast_string_to_int: type2 error: error[T003]: unknown function: int
   --> :2:9
 
 help:
   Ensure the function is defined before it's called.
-- cast_struct: parse2 error: parse error: 2:96: lexer: invalid input text "#, get(m, %), fi..."
+- cast_struct: parse2 error: parse error: 2:35: lexer: invalid input text "#, get(m, %), fi..."
 - closure: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- count_builtin: type2 error: error[T003]: unknown function: _1
-  --> :2:15
-
-help:
-  Ensure the function is defined before it's called.
+- count_builtin: ok
 - cross_join: parse2 error: parse error: 2:20: unexpected token ":" (expected "}")
 - cross_join_filter: parse2 error: parse error: 4:19: unexpected token ">" (expected ")")
 - cross_join_triple: parse2 error: parse error: 5:20: unexpected token ">" (expected ")")
 - dataset_sort_take_limit: parse2 error: parse error: 2:19: unexpected token ":" (expected "}")
 - dataset_where_filter: parse2 error: parse error: 2:17: unexpected token ":" (expected "}")
 - exists_builtin: parse2 error: parse error: 3:25: unexpected token ">" (expected ")")
-- for_list_collection: parse2 error: parse error: 2:41: unexpected token "let" (expected PostfixExpr)
-- for_loop: parse2 error: parse error: 2:25: unexpected token "let" (expected PostfixExpr)
-- for_map_collection: parse2 error: parse error: 3:34: unexpected token "let" (expected PostfixExpr)
+- for_list_collection: parse2 error: parse error: 2:74: unexpected token "break" (expected PostfixExpr)
+- for_loop: parse2 error: parse error: 2:46: unexpected token "break" (expected PostfixExpr)
+- for_map_collection: parse2 error: parse error: 3:66: unexpected token "break" (expected PostfixExpr)
 - fun_call: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
 - fun_expr_in_let: parse2 error: parse error: 2:28: unexpected token "," (expected ")")
 - fun_three_args: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- group_by: parse2 error: parse error: 9:105: lexer: invalid input text "@groups, ks), sw..."
-- group_by_conditional_sum: parse2 error: parse error: 6:105: lexer: invalid input text "@groups, ks), sw..."
-- group_by_having: parse2 error: parse error: 6:105: lexer: invalid input text "@groups, ks), sw..."
-- group_by_join: parse2 error: parse error: 6:105: lexer: invalid input text "@groups, ks), sw..."
-- group_by_left_join: parse2 error: parse error: 3:105: lexer: invalid input text "@groups, ks), sw..."
-- group_by_multi_join: parse2 error: parse error: 6:105: lexer: invalid input text "@groups, ks), sw..."
-- group_by_multi_join_sort: parse2 error: parse error: 6:105: lexer: invalid input text "@groups, ks), sw..."
-- group_by_sort: parse2 error: parse error: 6:105: lexer: invalid input text "@groups, ks), sw..."
-- group_items_iteration: parse2 error: parse error: 3:105: lexer: invalid input text "@groups, ks), sw..."
+- group_by: parse2 error: parse error: 9:65: lexer: invalid input text "@groups, ks), sw..."
+- group_by_conditional_sum: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- group_by_having: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- group_by_join: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- group_by_left_join: parse2 error: parse error: 3:65: lexer: invalid input text "@groups, ks), sw..."
+- group_by_multi_join: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- group_by_multi_join_sort: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- group_by_sort: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- group_items_iteration: parse2 error: parse error: 3:65: lexer: invalid input text "@groups, ks), sw..."
 - if_else: ok
 - if_then_else: ok
 - if_then_else_nested: ok
@@ -51,13 +43,9 @@ help:
 - inner_join: parse2 error: parse error: 2:20: unexpected token ":" (expected "}")
 - join_multi: parse2 error: parse error: 2:20: unexpected token ":" (expected "}")
 - json_builtin: parse2 error: parse error: 2:3: unexpected token ">" (expected "}")
-- left_join: parse2 error: parse error: 2:160: lexer: invalid input text "@items), let(m(a..."
-- left_join_multi: parse2 error: parse error: 2:160: lexer: invalid input text "@items), let(m(a..."
-- len_builtin: type2 error: error[T003]: unknown function: _1
-  --> :2:15
-
-help:
-  Ensure the function is defined before it's called.
+- left_join: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
+- left_join_multi: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
+- len_builtin: ok
 - len_map: parse2 error: parse error: 2:19: unexpected token "," (expected ":" Expr)
 - len_string: type2 error: error[T037]: count() expects list or group, got string
   --> :2:9
@@ -65,15 +53,15 @@ help:
 help:
   Pass a list or group to count().
 - let_and_print: ok
-- list_assign: parse2 error: parse error: 2:6: unexpected token "(" (expected <ident> (":" TypeRef)? ("=" Expr)?)
-- list_index: parse2 error: parse error: 2:6: unexpected token "(" (expected <ident> (":" TypeRef)? ("=" Expr)?)
-- list_nested_assign: parse2 error: parse error: 2:6: unexpected token "(" (expected <ident> (":" TypeRef)? ("=" Expr)?)
+- list_assign: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
+- list_index: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
+- list_nested_assign: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
 - list_set_ops: type2 error: error[T005]: parameter `a` is missing a type
   --> :1:1
 
 help:
   Add a type like `x: int` to this parameter.
-- load_yaml: parse2 error: parse error: 2:176: lexer: invalid input text "#, str(\"c\", %), ..."
+- load_yaml: parse2 error: parse error: 5:352: lexer: invalid input text "#, clojure_data_..."
 - map_assign: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
 - map_in_operator: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
 - map_index: parse2 error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
@@ -81,26 +69,26 @@ help:
 - map_literal_dynamic: parse2 error: parse error: 8:1: unexpected token "<EOF>" (expected "}")
 - map_membership: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
 - map_nested_assign: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
-- match_expr: parse2 error: parse error: 3:15: unexpected token "let" (expected PostfixExpr)
+- match_expr: parse2 error: parse error: 3:78: unexpected token "else" (expected PostfixExpr)
 - match_full: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
 - math_ops: ok
 - membership: parse2 error: parse error: 3:14: lexer: invalid input text "#, 2 == %, nums)..."
-- min_max_builtin: type2 error: error[T003]: unknown function: _3
-  --> :2:14
+- min_max_builtin: type2 error: error[T003]: unknown function: apply
+  --> :3:9
 
 help:
   Ensure the function is defined before it's called.
 - nested_function: parse2 error: parse error: 2:28: unexpected token "," (expected ")")
 - order_by_map: parse2 error: parse error: 2:15: unexpected token ":" (expected "}")
-- outer_join: parse2 error: parse error: 2:160: lexer: invalid input text "@items), let(m(a..."
+- outer_join: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
 - partial_application: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
 - print_hello: ok
 - pure_fold: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
 - pure_global_fold: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- query_sum_select: parse2 error: parse error: 2:6: unexpected token "(" (expected <ident> (":" TypeRef)? ("=" Expr)?)
+- query_sum_select: parse2 error: parse error: 2:23: unexpected token "+" (expected ")")
 - record_assign: parse2 error: parse error: 2:4: unexpected token ":" (expected "}")
-- right_join: parse2 error: parse error: 2:160: lexer: invalid input text "@items), let(m(a..."
-- save_jsonl_stdout: parse2 error: parse error: 2:252: lexer: invalid input text "#, str(get(r, %,..."
+- right_join: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
+- save_jsonl_stdout: parse2 error: parse error: 2:187: lexer: invalid input text "#, str(get(r, %,..."
 - short_circuit: parse2 error: parse error: 2:22: unexpected token "," (expected PostfixExpr)
 - slice: type2 error: error[T003]: unknown function: subvec
   --> :2:9
@@ -129,7 +117,7 @@ help:
 
 help:
   Ensure the function is defined before it's called.
-- string_index: parse2 error: parse error: 2:6: unexpected token "(" (expected <ident> (":" TypeRef)? ("=" Expr)?)
+- string_index: parse2 error: parse error: 2:43: unexpected token "}" (expected PostfixExpr)
 - string_prefix_slice: type2 error: error[T003]: unknown function: subs
   --> :4:9
 
@@ -144,7 +132,7 @@ help:
 help:
   Ensure the function is defined before it's called.
 - tree_sum: parse2 error: parse error: 2:4: unexpected token ":" (expected "}")
-- two-sum: parse2 error: parse error: 2:6: unexpected token "(" (expected <ident> (":" TypeRef)? ("=" Expr)?)
+- two-sum: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
 - typed_let: type2 error: error[T002]: undefined variable: y
   --> :2:9
 
@@ -156,8 +144,8 @@ help:
 help:
   Check if the variable was declared in this scope.
 - unary_neg: ok
-- update_stmt: parse2 error: parse error: 2:96: lexer: invalid input text "#, get(m, %), fi..."
+- update_stmt: parse2 error: parse error: 2:35: lexer: invalid input text "#, get(m, %), fi..."
 - user_type_literal: parse2 error: parse error: 2:4: unexpected token ":" (expected "}")
 - values_builtin: parse2 error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
 - var_assignment: ok
-- while_loop: parse2 error: parse error: 3:8: unexpected token "," (expected ")")
+- while_loop: parse2 error: parse error: 3:43: unexpected token "break" (expected PostfixExpr)

--- a/tools/any2mochi/x/clj/cmd/genvm/main.go
+++ b/tools/any2mochi/x/clj/cmd/genvm/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	cljcode "mochi/compile/x/clj"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	cljconv "mochi/tools/any2mochi/x/clj"
+	"mochi/types"
+)
+
+func main() {
+	root, _ := filepath.Abs(".")
+	pattern := filepath.Join(root, "tests", "vm", "valid", "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		panic(err)
+	}
+	if len(files) == 0 {
+		panic("no files")
+	}
+	status := make(map[string]string)
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		errMsg := ""
+		prog, err := parser.Parse(src)
+		if err != nil {
+			errMsg = fmt.Sprintf("parse error: %v", err)
+		} else {
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				errMsg = fmt.Sprintf("type error: %v", errs[0])
+			} else if cljSrc, err := cljcode.New(env).Compile(prog); err != nil {
+				errMsg = fmt.Sprintf("compile error: %v", err)
+			} else {
+				dir, _ := os.MkdirTemp("", "cljrt")
+				cljFile := filepath.Join(dir, name+".clj")
+				if wErr := os.WriteFile(cljFile, cljSrc, 0644); wErr != nil {
+					errMsg = fmt.Sprintf("write error: %v", wErr)
+				} else if mochiSrc, err := cljconv.ConvertFile(cljFile); err != nil {
+					errMsg = fmt.Sprintf("convert error: %v", err)
+				} else if prog2, err := parser.ParseString(string(mochiSrc)); err != nil {
+					errMsg = fmt.Sprintf("parse2 error: %v", err)
+				} else {
+					env2 := types.NewEnv(nil)
+					if errs := types.Check(prog2, env2); len(errs) > 0 {
+						errMsg = fmt.Sprintf("type2 error: %v", errs[0])
+					} else if p2, err := vm.CompileWithSource(prog2, env2, string(mochiSrc)); err != nil {
+						errMsg = fmt.Sprintf("vm compile error: %v", err)
+					} else {
+						var buf bytes.Buffer
+						m := vm.New(p2, &buf)
+						if err := m.Run(); err != nil {
+							if ve, ok := err.(*vm.VMError); ok {
+								errMsg = fmt.Sprintf("vm run error:\n%s", ve.Format(p2))
+							} else {
+								errMsg = fmt.Sprintf("vm run error: %v", err)
+							}
+						}
+					}
+				}
+			}
+		}
+		status[name] = errMsg
+	}
+	outDir := filepath.Join(root, "tests", "any2mochi", "clj")
+	writeStatusMarkdown(outDir, status)
+}
+
+func writeStatusMarkdown(dir string, status map[string]string) {
+	os.MkdirAll(dir, 0755)
+	path := filepath.Join(dir, "ERRORS.md")
+	var buf strings.Builder
+	buf.WriteString("# Errors\n\n")
+	if len(status) == 0 {
+		buf.WriteString("None\n")
+	} else {
+		names := make([]string, 0, len(status))
+		for n := range status {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			if msg := status[n]; msg != "" {
+				buf.WriteString("- " + n + ": " + msg + "\n")
+			} else {
+				buf.WriteString("- " + n + ": ok\n")
+			}
+		}
+	}
+	os.WriteFile(path, []byte(buf.String()), 0644)
+}

--- a/tools/any2mochi/x/clj/convert.go
+++ b/tools/any2mochi/x/clj/convert.go
@@ -770,6 +770,15 @@ func cljToMochi(n sexprNode) string {
 				sb.WriteString("}")
 				return sb.String()
 			}
+		case "let":
+			if len(v) >= 3 {
+				if bind, ok := v[1].([]sexprNode); ok && len(bind) >= 2 {
+					name := cljToMochi(bind[0])
+					val := cljToMochi(bind[1])
+					body := cljToMochi(v[2])
+					return fmt.Sprintf("(fun(%s) => %s)(%s)", name, body, val)
+				}
+			}
 		case "def":
 			if len(v) >= 3 {
 				return fmt.Sprintf("let %s = %s", cljToMochi(v[1]), cljToMochi(v[2]))
@@ -830,6 +839,13 @@ func cljToMochi(n sexprNode) string {
 				}
 			}
 		default:
+			if isNumber(head) || strings.HasPrefix(head, "\"") || strings.HasPrefix(head, ":") {
+				elems := make([]string, 0, len(v))
+				for _, e := range v {
+					elems = append(elems, cljToMochi(e))
+				}
+				return "[" + strings.Join(elems, ", ") + "]"
+			}
 			var args []string
 			for _, a := range v[1:] {
 				args = append(args, cljToMochi(a))


### PR DESCRIPTION
## Summary
- improve Clojure any2mochi converter to handle `let` and vector forms
- add a helper command to generate round‑trip VM status for Clojure
- update Clojure round‑trip error report

## Testing
- `go build ./tools/any2mochi/x/clj/cmd/genvm`
- `go run ./tools/any2mochi/x/clj/cmd/genvm > /tmp/genvm.log`

------
https://chatgpt.com/codex/tasks/task_e_686a961399648320878811c5ce526c93