### PR TITLE
Improve F# roundtrip test

### DIFF
--- a/tests/any2mochi/fs_vm/ERRORS.md
+++ b/tests/any2mochi/fs_vm/ERRORS.md
@@ -9,11 +9,11 @@
 
 help:
   Choose an operator that supports these operand types.
-- break_continue: unsupported syntax at line 2: exception BreakException of int
-  1: open System
-  2: exception BreakException of int
-  3: exception ContinueException of int
-  4: 
+- break_continue: unsupported syntax at line 6: try
+  5: let numbers = [|1; 2; 3; 4; 5; 6; 7; 8; 9|]
+  6: try
+  7:     for n in numbers do
+  8:         try
 - cast_string_to_int: parse2 error: parse error: 1:12: unexpected token "1995" (expected "(" (Expr ("," Expr)*)? ")")
 - cast_struct: parse2 error: parse error: 6:44: unexpected token "," (expected ")")
 - closure: parse2 error: parse error: 3:22: unexpected token ")" (expected "<" TypeRef ("," TypeRef)* ">")

--- a/tools/any2mochi/x/fs/parse.go
+++ b/tools/any2mochi/x/fs/parse.go
@@ -190,6 +190,11 @@ func Parse(src string) (*Program, error) {
 			if strings.HasPrefix(t, "member ") {
 				continue
 			}
+			if strings.HasPrefix(t, "exception BreakException") || strings.HasPrefix(t, "exception ContinueException") {
+				// Loop control helpers inserted by the F# backend
+				// are irrelevant for roundtripping back to Mochi.
+				continue
+			}
 			switch {
 			case strings.Contains(t, "failwith \"unreachable\""):
 				// Ignore code paths marked unreachable in the


### PR DESCRIPTION
## Summary
- ignore loop control exception helpers in the F# any2mochi parser
- update F# roundtrip errors

## Testing
- `go test ./tools/any2mochi/x/fs -run TestFSRoundtripVM -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686a976a70148320878bb4149b351909