### PR TITLE
Improve Java roundtrip coverage

### DIFF
--- a/tests/any2mochi/java_vm/ERRORS.md
+++ b/tests/any2mochi/java_vm/ERRORS.md
@@ -9,11 +9,12 @@
 
 help:
   Choose an operator that supports these operand types.
-- break_continue: line 2: unsupported line
+- break_continue: line 3: unsupported line
       1| if (((n % 2) == 0)) {
->>>   2| continue;
-      3| }
+      2| continue;
+>>>   3| }
       4| if ((n > 7)) {
+      5| break;
 
 - cast_string_to_int: line 6: unsupported line
       4| }
@@ -390,9 +391,4 @@ help:
 - user_type_literal: ok
 - values_builtin: ok
 - var_assignment: ok
-- while_loop: line 2: unsupported line
-      1| int i = 0;
->>>   2| while ((i < 3)) {
-      3| System.out.println(i);
-      4| i = (i + 1);
-
+- while_loop: ok


### PR DESCRIPTION
## Summary
- add support for `while` loops and break/continue statements in the Java any2mochi converter
- update Java roundtrip status after regenerating tests

## Testing
- `go test ./tools/any2mochi/x/java -tags slow -run TestJava_VM_RoundTrip -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686a989337d48320a974c8ad7f2e8f97