### PR TITLE
Add runtime checks to C compiler golden tests

### DIFF
--- a/compile/x/c/compiler_test.go
+++ b/compile/x/c/compiler_test.go
@@ -23,7 +23,7 @@ func TestCCompiler_TwoSum(t *testing.T) {
 	if err != nil {
 		t.Skipf("C compiler not installed: %v", err)
 	}
-       src := filepath.Join("..", "..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	src := filepath.Join("..", "..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
@@ -37,7 +37,7 @@ func TestCCompiler_TwoSum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}
-       goldenPath := filepath.Join("..", "..", "..", "tests", "compiler", "valid", "two_sum.c.out")
+	goldenPath := filepath.Join("..", "..", "..", "tests", "compiler", "valid", "two_sum.c.out")
 	golden, err := os.ReadFile(goldenPath)
 	if err != nil {
 		t.Fatalf("read golden: %v", err)
@@ -141,27 +141,12 @@ func TestCCompiler_SubsetPrograms(t *testing.T) {
 }
 
 func TestCCompiler_GoldenOutput(t *testing.T) {
-	if _, err := ccode.EnsureCC(); err != nil {
+	cc, err := ccode.EnsureCC()
+	if err != nil {
 		t.Skipf("C compiler not installed: %v", err)
 	}
-	golden.Run(t, "tests/compiler/valid", ".mochi", ".c.out", func(src string) ([]byte, error) {
-		prog, err := parser.Parse(src)
-		if err != nil {
-			return nil, fmt.Errorf("\u274c parse error: %w", err)
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			return nil, fmt.Errorf("\u274c type error: %v", errs[0])
-		}
-		c := ccode.New(env)
-		code, err := c.Compile(prog)
-		if err != nil {
-			return nil, fmt.Errorf("\u274c compile error: %w", err)
-		}
-		return bytes.TrimSpace(code), nil
-	})
 
-	golden.Run(t, "tests/compiler/c", ".mochi", ".c.out", func(src string) ([]byte, error) {
+	run := func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
 			return nil, fmt.Errorf("\u274c parse error: %w", err)
@@ -175,6 +160,40 @@ func TestCCompiler_GoldenOutput(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("\u274c compile error: %w", err)
 		}
+
+		// write C source to temp dir
+		dir := t.TempDir()
+		cfile := filepath.Join(dir, "prog.c")
+		if err := os.WriteFile(cfile, code, 0644); err != nil {
+			return nil, fmt.Errorf("write error: %w", err)
+		}
+		bin := filepath.Join(dir, "prog")
+		if out, err := exec.Command(cc, cfile, "-o", bin).CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("\u274c cc error: %w\n%s", err, out)
+		}
+
+		cmd := exec.Command(bin)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("\u274c run error: %w\n%s", err, out)
+		}
+
+		wantPath := strings.TrimSuffix(src, ".mochi") + ".out"
+		want, err := os.ReadFile(wantPath)
+		if err != nil {
+			return nil, fmt.Errorf("read golden output: %w", err)
+		}
+		got := bytes.TrimSpace(out)
+		if !bytes.Equal(got, bytes.TrimSpace(want)) {
+			return nil, fmt.Errorf("output mismatch\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(want))
+		}
+
 		return bytes.TrimSpace(code), nil
-	})
+	}
+
+	golden.Run(t, "tests/compiler/valid", ".mochi", ".c.out", run)
+	golden.Run(t, "tests/compiler/c", ".mochi", ".c.out", run)
 }


### PR DESCRIPTION
## Summary
- in `TestCCompiler_GoldenOutput`, compile generated C code, run it and compare
  against the `.out` golden files

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a9abe53f883208f90cb4eb7cf7ea4