### PR TITLE
Update Clojure compiler golden tests

### DIFF
--- a/compile/x/clj/cmd/vm_roundtrip/main.go
+++ b/compile/x/clj/cmd/vm_roundtrip/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cljcode "mochi/compile/x/clj"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	cljconv "mochi/tools/any2mochi/x/clj"
+	"mochi/types"
+)
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+func main() {
+	files, err := filepath.Glob("tests/vm/valid/*.mochi")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "glob error:", err)
+		os.Exit(1)
+	}
+
+	var report strings.Builder
+	report.WriteString("# Clojure roundtrip VM test failures\n\n")
+	for _, src := range files {
+		if err := process(src); err != nil {
+			report.WriteString(fmt.Sprintf("## %s\n\n```\n%s\n```\n\n", src, err))
+		}
+	}
+	if report.Len() == 0 {
+		report.WriteString("All Clojure roundtrip VM tests passed.\n")
+	}
+	os.WriteFile("compile/x/clj/ERRORS.md", []byte(report.String()), 0644)
+}
+
+func process(src string) error {
+	base := strings.TrimSuffix(src, ".mochi")
+	cljPath := base + ".clj.out"
+	mochiPath := base + ".mochi.out"
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		writeErr(base+".clj.error", err)
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		writeErr(base+".clj.error", errs[0])
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := cljcode.New(env).Compile(prog)
+	if err != nil {
+		writeErr(base+".clj.error", err)
+		return fmt.Errorf("compile error: %w", err)
+	}
+	os.WriteFile(cljPath, code, 0644)
+
+	conv, err := cljconv.Convert(string(code))
+	if err != nil {
+		writeErr(base+".mochi.error", err)
+		return fmt.Errorf("clj2mochi error: %w", err)
+	}
+	os.WriteFile(mochiPath, conv, 0644)
+
+	rtProg, err := parser.ParseString(string(conv))
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("parse roundtrip error: %w", err)
+	}
+	if errs := types.Check(rtProg, env); len(errs) > 0 {
+		writeErr(base+".vm.error", errs[0])
+		return fmt.Errorf("type roundtrip error: %v", errs[0])
+	}
+	p, err := vm.CompileWithSource(rtProg, env, string(conv))
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("compile roundtrip error: %w", err)
+	}
+	var in io.Reader = os.Stdin
+	if fileExists(base + ".in") {
+		f, err := os.Open(base + ".in")
+		if err == nil {
+			defer f.Close()
+			in = f
+		}
+	}
+	var out bytes.Buffer
+	m := vm.NewWithIO(p, in, &out)
+	if err := m.Run(); err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("run error: %w", err)
+	}
+	want, err := os.ReadFile(base + ".out")
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("missing golden output: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(string(want)) {
+		writeErr(base+".vm.error", fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, strings.TrimSpace(string(want))))
+		return fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, strings.TrimSpace(string(want)))
+	}
+	os.Remove(base + ".clj.error")
+	os.Remove(base + ".mochi.error")
+	os.Remove(base + ".vm.error")
+	return nil
+}
+
+func writeErr(path string, err error) {
+	os.WriteFile(path, []byte(err.Error()), 0644)
+}

--- a/tests/any2mochi/clj/ERRORS.md
+++ b/tests/any2mochi/clj/ERRORS.md
@@ -1,151 +1,152 @@
 # Errors
 
-- append_builtin: ok
-- avg_builtin: parse2 error: parse error: 2:56: unexpected token "+" (expected ")")
-- basic_compare: ok
-- binary_precedence: ok
-- bool_chain: parse2 error: parse error: 2:22: unexpected token "," (expected PostfixExpr)
-- break_continue: parse2 error: parse error: 3:72: unexpected token "break" (expected PostfixExpr)
-- cast_string_to_int: type2 error: error[T003]: unknown function: int
+- /workspace/mochi/tests/vm/valid/avg_builtin.mochi: reparse error: parse error: 2:56: unexpected token "+" (expected ")")
+- /workspace/mochi/tests/vm/valid/binary_precedence.mochi: output mismatch
+-- got --
+7
+7
+7
+7
+-- want --
+7
+9
+7
+8
+- /workspace/mochi/tests/vm/valid/bool_chain.mochi: reparse error: parse error: 2:22: unexpected token "," (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/break_continue.mochi: reparse error: parse error: 3:72: unexpected token "break" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/cast_string_to_int.mochi: retype error: error[T003]: unknown function: int
   --> :2:9
 
 help:
   Ensure the function is defined before it's called.
-- cast_struct: parse2 error: parse error: 2:35: lexer: invalid input text "#, get(m, %), fi..."
-- closure: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- count_builtin: ok
-- cross_join: parse2 error: parse error: 2:20: unexpected token ":" (expected "}")
-- cross_join_filter: parse2 error: parse error: 4:19: unexpected token ">" (expected ")")
-- cross_join_triple: parse2 error: parse error: 5:20: unexpected token ">" (expected ")")
-- dataset_sort_take_limit: parse2 error: parse error: 2:19: unexpected token ":" (expected "}")
-- dataset_where_filter: parse2 error: parse error: 2:17: unexpected token ":" (expected "}")
-- exists_builtin: parse2 error: parse error: 3:25: unexpected token ">" (expected ")")
-- for_list_collection: parse2 error: parse error: 2:74: unexpected token "break" (expected PostfixExpr)
-- for_loop: parse2 error: parse error: 2:46: unexpected token "break" (expected PostfixExpr)
-- for_map_collection: parse2 error: parse error: 3:66: unexpected token "break" (expected PostfixExpr)
-- fun_call: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- fun_expr_in_let: parse2 error: parse error: 2:28: unexpected token "," (expected ")")
-- fun_three_args: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- group_by: parse2 error: parse error: 9:65: lexer: invalid input text "@groups, ks), sw..."
-- group_by_conditional_sum: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
-- group_by_having: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
-- group_by_join: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
-- group_by_left_join: parse2 error: parse error: 3:65: lexer: invalid input text "@groups, ks), sw..."
-- group_by_multi_join: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
-- group_by_multi_join_sort: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
-- group_by_sort: parse2 error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
-- group_items_iteration: parse2 error: parse error: 3:65: lexer: invalid input text "@groups, ks), sw..."
-- if_else: ok
-- if_then_else: ok
-- if_then_else_nested: ok
-- in_operator: parse2 error: parse error: 3:14: lexer: invalid input text "#, 2 == %, xs))\n..."
-- in_operator_extended: parse2 error: parse error: 4:14: lexer: invalid input text "#, 1 == %, ys))\n..."
-- inner_join: parse2 error: parse error: 2:20: unexpected token ":" (expected "}")
-- join_multi: parse2 error: parse error: 2:20: unexpected token ":" (expected "}")
-- json_builtin: parse2 error: parse error: 2:3: unexpected token ">" (expected "}")
-- left_join: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
-- left_join_multi: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
-- len_builtin: ok
-- len_map: parse2 error: parse error: 2:19: unexpected token "," (expected ":" Expr)
-- len_string: type2 error: error[T037]: count() expects list or group, got string
+- /workspace/mochi/tests/vm/valid/cast_struct.mochi: reparse error: parse error: 2:35: lexer: invalid input text "#, get(m, %), fi..."
+- /workspace/mochi/tests/vm/valid/closure.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/cross_join.mochi: reparse error: parse error: 2:20: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/cross_join_filter.mochi: reparse error: parse error: 4:19: unexpected token ">" (expected ")")
+- /workspace/mochi/tests/vm/valid/cross_join_triple.mochi: reparse error: parse error: 5:20: unexpected token ">" (expected ")")
+- /workspace/mochi/tests/vm/valid/dataset_sort_take_limit.mochi: reparse error: parse error: 2:19: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/dataset_where_filter.mochi: reparse error: parse error: 2:17: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/exists_builtin.mochi: reparse error: parse error: 3:25: unexpected token ">" (expected ")")
+- /workspace/mochi/tests/vm/valid/for_list_collection.mochi: reparse error: parse error: 2:74: unexpected token "break" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/for_loop.mochi: reparse error: parse error: 2:46: unexpected token "break" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/for_map_collection.mochi: reparse error: parse error: 3:66: unexpected token "break" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/fun_call.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/fun_expr_in_let.mochi: reparse error: parse error: 2:28: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/fun_three_args.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/group_by.mochi: reparse error: parse error: 9:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_by_conditional_sum.mochi: reparse error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_by_having.mochi: reparse error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_by_join.mochi: reparse error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_by_left_join.mochi: reparse error: parse error: 3:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_by_multi_join.mochi: reparse error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_by_multi_join_sort.mochi: reparse error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_by_sort.mochi: reparse error: parse error: 6:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/group_items_iteration.mochi: reparse error: parse error: 3:65: lexer: invalid input text "@groups, ks), sw..."
+- /workspace/mochi/tests/vm/valid/if_else.mochi: output mismatch
+-- got --
+
+-- want --
+big
+- /workspace/mochi/tests/vm/valid/in_operator.mochi: reparse error: parse error: 3:14: lexer: invalid input text "#, 2 == %, xs))\n..."
+- /workspace/mochi/tests/vm/valid/in_operator_extended.mochi: reparse error: parse error: 4:14: lexer: invalid input text "#, 1 == %, ys))\n..."
+- /workspace/mochi/tests/vm/valid/inner_join.mochi: reparse error: parse error: 2:20: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/join_multi.mochi: reparse error: parse error: 2:20: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/json_builtin.mochi: reparse error: parse error: 2:3: unexpected token ">" (expected "}")
+- /workspace/mochi/tests/vm/valid/left_join.mochi: reparse error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
+- /workspace/mochi/tests/vm/valid/left_join_multi.mochi: reparse error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
+- /workspace/mochi/tests/vm/valid/len_map.mochi: reparse error: parse error: 2:19: unexpected token "," (expected ":" Expr)
+- /workspace/mochi/tests/vm/valid/len_string.mochi: retype error: error[T037]: count() expects list or group, got string
   --> :2:9
 
 help:
   Pass a list or group to count().
-- let_and_print: ok
-- list_assign: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
-- list_index: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
-- list_nested_assign: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
-- list_set_ops: type2 error: error[T005]: parameter `a` is missing a type
+- /workspace/mochi/tests/vm/valid/list_assign.mochi: reparse error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/list_index.mochi: reparse error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/list_nested_assign.mochi: reparse error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/list_set_ops.mochi: retype error: error[T005]: parameter `a` is missing a type
   --> :1:1
 
 help:
   Add a type like `x: int` to this parameter.
-- load_yaml: parse2 error: parse error: 5:352: lexer: invalid input text "#, clojure_data_..."
-- map_assign: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
-- map_in_operator: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
-- map_index: parse2 error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
-- map_int_key: parse2 error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
-- map_literal_dynamic: parse2 error: parse error: 8:1: unexpected token "<EOF>" (expected "}")
-- map_membership: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
-- map_nested_assign: parse2 error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
-- match_expr: parse2 error: parse error: 3:78: unexpected token "else" (expected PostfixExpr)
-- match_full: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- math_ops: ok
-- membership: parse2 error: parse error: 3:14: lexer: invalid input text "#, 2 == %, nums)..."
-- min_max_builtin: type2 error: error[T003]: unknown function: apply
+- /workspace/mochi/tests/vm/valid/load_yaml.mochi: reparse error: parse error: 5:351: lexer: invalid input text "#, clojure_data_..."
+- /workspace/mochi/tests/vm/valid/map_assign.mochi: reparse error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/map_in_operator.mochi: reparse error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/map_index.mochi: reparse error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/map_int_key.mochi: reparse error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/map_literal_dynamic.mochi: reparse error: parse error: 8:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/map_membership.mochi: reparse error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/map_nested_assign.mochi: reparse error: parse error: 7:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/match_expr.mochi: reparse error: parse error: 3:78: unexpected token "else" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/match_full.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/membership.mochi: reparse error: parse error: 3:14: lexer: invalid input text "#, 2 == %, nums)..."
+- /workspace/mochi/tests/vm/valid/min_max_builtin.mochi: retype error: error[T003]: unknown function: apply
   --> :3:9
 
 help:
   Ensure the function is defined before it's called.
-- nested_function: parse2 error: parse error: 2:28: unexpected token "," (expected ")")
-- order_by_map: parse2 error: parse error: 2:15: unexpected token ":" (expected "}")
-- outer_join: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
-- partial_application: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- print_hello: ok
-- pure_fold: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- pure_global_fold: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- query_sum_select: parse2 error: parse error: 2:23: unexpected token "+" (expected ")")
-- record_assign: parse2 error: parse error: 2:4: unexpected token ":" (expected "}")
-- right_join: parse2 error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
-- save_jsonl_stdout: parse2 error: parse error: 2:187: lexer: invalid input text "#, str(get(r, %,..."
-- short_circuit: parse2 error: parse error: 2:22: unexpected token "," (expected PostfixExpr)
-- slice: type2 error: error[T003]: unknown function: subvec
+- /workspace/mochi/tests/vm/valid/nested_function.mochi: reparse error: parse error: 2:28: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/order_by_map.mochi: reparse error: parse error: 2:15: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/outer_join.mochi: reparse error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
+- /workspace/mochi/tests/vm/valid/partial_application.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/pure_fold.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/pure_global_fold.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/query_sum_select.mochi: reparse error: parse error: 2:23: unexpected token "+" (expected ")")
+- /workspace/mochi/tests/vm/valid/record_assign.mochi: reparse error: parse error: 2:4: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/right_join.mochi: reparse error: parse error: 2:108: lexer: invalid input text "@items), (fun(m)..."
+- /workspace/mochi/tests/vm/valid/save_jsonl_stdout.mochi: reparse error: parse error: 2:187: lexer: invalid input text "#, str(get(r, %,..."
+- /workspace/mochi/tests/vm/valid/short_circuit.mochi: reparse error: parse error: 2:22: unexpected token "," (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/slice.mochi: retype error: error[T003]: unknown function: subvec
   --> :2:9
 
 help:
   Ensure the function is defined before it's called.
-- sort_stable: parse2 error: parse error: 2:16: unexpected token ":" (expected "}")
-- str_builtin: ok
-- string_compare: type2 error: error[T003]: unknown function: compare
+- /workspace/mochi/tests/vm/valid/sort_stable.mochi: reparse error: parse error: 2:16: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/string_compare.mochi: retype error: error[T003]: unknown function: compare
   --> :2:9
 
 help:
   Ensure the function is defined before it's called.
-- string_concat: type2 error: error[T039]: function str expects 1 arguments, got 2
+- /workspace/mochi/tests/vm/valid/string_concat.mochi: retype error: error[T039]: function str expects 1 arguments, got 2
   --> :2:9
 
 help:
   Pass exactly 1 arguments to `str`.
-- string_contains: type2 error: error[T003]: unknown function: clojure_string_includes_p
+- /workspace/mochi/tests/vm/valid/string_contains.mochi: retype error: error[T003]: unknown function: clojure_string_includes_p
   --> :3:9
 
 help:
   Ensure the function is defined before it's called.
-- string_in_operator: type2 error: error[T003]: unknown function: clojure_string_includes_p
+- /workspace/mochi/tests/vm/valid/string_in_operator.mochi: retype error: error[T003]: unknown function: clojure_string_includes_p
   --> :3:9
 
 help:
   Ensure the function is defined before it's called.
-- string_index: parse2 error: parse error: 2:43: unexpected token "}" (expected PostfixExpr)
-- string_prefix_slice: type2 error: error[T003]: unknown function: subs
+- /workspace/mochi/tests/vm/valid/string_index.mochi: reparse error: parse error: 2:43: unexpected token "}" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/string_prefix_slice.mochi: retype error: error[T003]: unknown function: subs
   --> :4:9
 
 help:
   Ensure the function is defined before it's called.
-- substring_builtin: ok
-- sum_builtin: parse2 error: parse error: 2:16: unexpected token "+" (expected ")")
-- tail_recursion: parse2 error: parse error: 2:7: unexpected token "," (expected ")")
-- test_block: type2 error: error[T003]: unknown function: assert
+- /workspace/mochi/tests/vm/valid/sum_builtin.mochi: reparse error: parse error: 2:16: unexpected token "+" (expected ")")
+- /workspace/mochi/tests/vm/valid/tail_recursion.mochi: reparse error: parse error: 2:7: unexpected token "," (expected ")")
+- /workspace/mochi/tests/vm/valid/test_block.mochi: retype error: error[T003]: unknown function: assert
   --> :3:3
 
 help:
   Ensure the function is defined before it's called.
-- tree_sum: parse2 error: parse error: 2:4: unexpected token ":" (expected "}")
-- two-sum: parse2 error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
-- typed_let: type2 error: error[T002]: undefined variable: y
+- /workspace/mochi/tests/vm/valid/tree_sum.mochi: reparse error: parse error: 2:4: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/two-sum.mochi: reparse error: parse error: 2:50: unexpected token "}" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/typed_let.mochi: retype error: error[T002]: undefined variable: y
   --> :2:9
 
 help:
   Check if the variable was declared in this scope.
-- typed_var: type2 error: error[T002]: undefined variable: nil
+- /workspace/mochi/tests/vm/valid/typed_var.mochi: retype error: error[T002]: undefined variable: nil
   --> :2:11
 
 help:
   Check if the variable was declared in this scope.
-- unary_neg: ok
-- update_stmt: parse2 error: parse error: 2:35: lexer: invalid input text "#, get(m, %), fi..."
-- user_type_literal: parse2 error: parse error: 2:4: unexpected token ":" (expected "}")
-- values_builtin: parse2 error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
-- var_assignment: ok
-- while_loop: parse2 error: parse error: 3:43: unexpected token "break" (expected PostfixExpr)
+- /workspace/mochi/tests/vm/valid/update_stmt.mochi: reparse error: parse error: 2:35: lexer: invalid input text "#, get(m, %), fi..."
+- /workspace/mochi/tests/vm/valid/user_type_literal.mochi: reparse error: parse error: 2:4: unexpected token ":" (expected "}")
+- /workspace/mochi/tests/vm/valid/values_builtin.mochi: reparse error: parse error: 6:1: unexpected token "<EOF>" (expected "}")
+- /workspace/mochi/tests/vm/valid/while_loop.mochi: reparse error: parse error: 3:8: unexpected token "," (expected ")")

--- a/tests/compiler/clj/break_continue.clj.out
+++ b/tests/compiler/clj/break_continue.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare numbers)
+
 (defn -main []
   (def numbers [1 2 3 4 5 6 7 8 9])
   (loop [_tmp0 (seq numbers)]

--- a/tests/compiler/clj/closure.clj.out
+++ b/tests/compiler/clj/closure.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare add10)
+
 (defn makeAdder [n]
   (try
     (throw (ex-info "return" {:value (fn [x]

--- a/tests/compiler/clj/dataset.clj.out
+++ b/tests/compiler/clj/dataset.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare people names)
+
 (defn Person [name age]
   {:__name "Person" :name name :age age})
 

--- a/tests/compiler/clj/dataset_sort_take_limit.clj.out
+++ b/tests/compiler/clj/dataset_sort_take_limit.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare products expensive)
+
 (defn Product [name price]
   {:__name "Product" :name name :price price})
 

--- a/tests/compiler/clj/fetch_builtin.clj.out
+++ b/tests/compiler/clj/fetch_builtin.clj.out
@@ -3,9 +3,12 @@
    [clojure.data.json :as json]))
 
 (defn _cast_struct [ctor m]
-  (let [fields (first (:arglists (meta ctor)))]
+  (let [fields (or (some->> ctor meta :arglists first (map keyword))
+                   (keys m))]
     (apply ctor (map #(get m %) fields))))
 (defn _fetch [url opts]
+  ;; Ensure IPv4 is preferred to avoid network issues in some environments
+  (System/setProperty "java.net.preferIPv4Stack" "true")
   (let [method (get opts :method "GET")
         q      (get opts :query nil)
         url     (if q
@@ -17,27 +20,42 @@
                                                      q))
                         sep (if (clojure.string/includes? url "?") "&" "?")]
                     (str url sep qs))
-                  url)
-        builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
-                  (.method method
-                           (if (contains? opts :body)
-                             (java.net.http.HttpRequest$BodyPublishers/ofString
-                              (clojure.data.json/write-str (:body opts)))
-                             (java.net.http.HttpRequest$BodyPublishers/noBody))))]
-    (when-let [hs (:headers opts)]
-      (doseq [[k v] hs]
-        (.header builder (name k) (str v))))
-    (when-let [t (:timeout opts)]
-      (.timeout builder (java.time.Duration/ofSeconds (long t))))
-    (let [client (java.net.http.HttpClient/newHttpClient)
-          resp (.send client (.build builder)
-                      (java.net.http.HttpResponse$BodyHandlers/ofString))]
-      (clojure.data.json/read-str (.body resp) :key-fn keyword))))
+                  url)]
+    (cond
+      (or (clojure.string/starts-with? url "file://")
+          (clojure.string/starts-with? url "file:"))
+      (let [path (if (clojure.string/starts-with? url "file://")
+                   (subs url 7)
+                   (subs url 5))
+            txt  (try
+                   (slurp path)
+                   (catch java.io.FileNotFoundException _
+                     (let [alt (str "../../.." "/" path)]
+                       (slurp alt))))]
+        (clojure.data.json/read-str txt :key-fn keyword))
+      :else
+      (let [builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
+                      (.method method
+                               (if (contains? opts :body)
+                                 (java.net.http.HttpRequest$BodyPublishers/ofString
+                                  (clojure.data.json/write-str (:body opts)))
+                                 (java.net.http.HttpRequest$BodyPublishers/noBody))))]
+        (when-let [hs (:headers opts)]
+          (doseq [[k v] hs]
+            (.header builder (name k) (str v))))
+        (when-let [t (:timeout opts)]
+          (.timeout builder (java.time.Duration/ofSeconds (long t))))
+        (let [client (java.net.http.HttpClient/newHttpClient)
+              resp (.send client (.build builder)
+                          (java.net.http.HttpResponse$BodyHandlers/ofString))]
+          (clojure.data.json/read-str (.body resp) :key-fn keyword))))))
+(declare data)
+
 (defn Msg [message]
   {:__name "Msg" :message message})
 
 (defn -main []
-  (def data (_cast_struct Msg (_fetch "file://tests/compiler/lua/fetch_builtin.json" nil)))
+  (def data (_cast_struct #'Msg (_fetch "file://tests/compiler/lua/fetch_builtin.json" nil)))
   (println (:message data)))
 
 (-main)

--- a/tests/compiler/clj/fetch_options.clj.out
+++ b/tests/compiler/clj/fetch_options.clj.out
@@ -3,6 +3,8 @@
    [clojure.data.json :as json]))
 
 (defn _fetch [url opts]
+  ;; Ensure IPv4 is preferred to avoid network issues in some environments
+  (System/setProperty "java.net.preferIPv4Stack" "true")
   (let [method (get opts :method "GET")
         q      (get opts :query nil)
         url     (if q
@@ -14,22 +16,37 @@
                                                      q))
                         sep (if (clojure.string/includes? url "?") "&" "?")]
                     (str url sep qs))
-                  url)
-        builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
-                  (.method method
-                           (if (contains? opts :body)
-                             (java.net.http.HttpRequest$BodyPublishers/ofString
-                              (clojure.data.json/write-str (:body opts)))
-                             (java.net.http.HttpRequest$BodyPublishers/noBody))))]
-    (when-let [hs (:headers opts)]
-      (doseq [[k v] hs]
-        (.header builder (name k) (str v))))
-    (when-let [t (:timeout opts)]
-      (.timeout builder (java.time.Duration/ofSeconds (long t))))
-    (let [client (java.net.http.HttpClient/newHttpClient)
-          resp (.send client (.build builder)
-                      (java.net.http.HttpResponse$BodyHandlers/ofString))]
-      (clojure.data.json/read-str (.body resp) :key-fn keyword))))
+                  url)]
+    (cond
+      (or (clojure.string/starts-with? url "file://")
+          (clojure.string/starts-with? url "file:"))
+      (let [path (if (clojure.string/starts-with? url "file://")
+                   (subs url 7)
+                   (subs url 5))
+            txt  (try
+                   (slurp path)
+                   (catch java.io.FileNotFoundException _
+                     (let [alt (str "../../.." "/" path)]
+                       (slurp alt))))]
+        (clojure.data.json/read-str txt :key-fn keyword))
+      :else
+      (let [builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
+                      (.method method
+                               (if (contains? opts :body)
+                                 (java.net.http.HttpRequest$BodyPublishers/ofString
+                                  (clojure.data.json/write-str (:body opts)))
+                                 (java.net.http.HttpRequest$BodyPublishers/noBody))))]
+        (when-let [hs (:headers opts)]
+          (doseq [[k v] hs]
+            (.header builder (name k) (str v))))
+        (when-let [t (:timeout opts)]
+          (.timeout builder (java.time.Duration/ofSeconds (long t))))
+        (let [client (java.net.http.HttpClient/newHttpClient)
+              resp (.send client (.build builder)
+                          (java.net.http.HttpResponse$BodyHandlers/ofString))]
+          (clojure.data.json/read-str (.body resp) :key-fn keyword))))))
+(declare resp)
+
 (defn -main []
   (def resp (_fetch "https://httpbin.org/anything" {:method "POST" :headers {"Content-Type" "application/json"} :query {:x "1"} :body {"foo" 123}}))
   (println (:foo (:json resp))))

--- a/tests/compiler/clj/fetch_todo.clj.out
+++ b/tests/compiler/clj/fetch_todo.clj.out
@@ -3,9 +3,12 @@
    [clojure.data.json :as json]))
 
 (defn _cast_struct [ctor m]
-  (let [fields (first (:arglists (meta ctor)))]
+  (let [fields (or (some->> ctor meta :arglists first (map keyword))
+                   (keys m))]
     (apply ctor (map #(get m %) fields))))
 (defn _fetch [url opts]
+  ;; Ensure IPv4 is preferred to avoid network issues in some environments
+  (System/setProperty "java.net.preferIPv4Stack" "true")
   (let [method (get opts :method "GET")
         q      (get opts :query nil)
         url     (if q
@@ -17,27 +20,42 @@
                                                      q))
                         sep (if (clojure.string/includes? url "?") "&" "?")]
                     (str url sep qs))
-                  url)
-        builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
-                  (.method method
-                           (if (contains? opts :body)
-                             (java.net.http.HttpRequest$BodyPublishers/ofString
-                              (clojure.data.json/write-str (:body opts)))
-                             (java.net.http.HttpRequest$BodyPublishers/noBody))))]
-    (when-let [hs (:headers opts)]
-      (doseq [[k v] hs]
-        (.header builder (name k) (str v))))
-    (when-let [t (:timeout opts)]
-      (.timeout builder (java.time.Duration/ofSeconds (long t))))
-    (let [client (java.net.http.HttpClient/newHttpClient)
-          resp (.send client (.build builder)
-                      (java.net.http.HttpResponse$BodyHandlers/ofString))]
-      (clojure.data.json/read-str (.body resp) :key-fn keyword))))
+                  url)]
+    (cond
+      (or (clojure.string/starts-with? url "file://")
+          (clojure.string/starts-with? url "file:"))
+      (let [path (if (clojure.string/starts-with? url "file://")
+                   (subs url 7)
+                   (subs url 5))
+            txt  (try
+                   (slurp path)
+                   (catch java.io.FileNotFoundException _
+                     (let [alt (str "../../.." "/" path)]
+                       (slurp alt))))]
+        (clojure.data.json/read-str txt :key-fn keyword))
+      :else
+      (let [builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
+                      (.method method
+                               (if (contains? opts :body)
+                                 (java.net.http.HttpRequest$BodyPublishers/ofString
+                                  (clojure.data.json/write-str (:body opts)))
+                                 (java.net.http.HttpRequest$BodyPublishers/noBody))))]
+        (when-let [hs (:headers opts)]
+          (doseq [[k v] hs]
+            (.header builder (name k) (str v))))
+        (when-let [t (:timeout opts)]
+          (.timeout builder (java.time.Duration/ofSeconds (long t))))
+        (let [client (java.net.http.HttpClient/newHttpClient)
+              resp (.send client (.build builder)
+                          (java.net.http.HttpResponse$BodyHandlers/ofString))]
+          (clojure.data.json/read-str (.body resp) :key-fn keyword))))))
+(declare todo)
+
 (defn Todo [userId id title completed]
   {:__name "Todo" :userId userId :id id :title title :completed completed})
 
 (defn -main []
-  (def todo (_cast_struct Todo (_fetch "https://jsonplaceholder.typicode.com/todos/1" nil)))
+  (def todo (_cast_struct #'Todo (_fetch "https://jsonplaceholder.typicode.com/todos/1" nil)))
   (println (:title todo)))
 
 (-main)

--- a/tests/compiler/clj/field_select.clj.out
+++ b/tests/compiler/clj/field_select.clj.out
@@ -6,6 +6,8 @@
       (throw (ex-info "index out of range" {}))
       (nth xs idx))))
 
+(declare people)
+
 (defn Person [name age]
   {:__name "Person" :name name :age age})
 

--- a/tests/compiler/clj/generate_struct.clj.out
+++ b/tests/compiler/clj/generate_struct.clj.out
@@ -4,14 +4,16 @@
 
 (defn _gen_struct [ctor prompt model params]
   (let [m (clojure.data.json/read-str prompt :key-fn keyword)
-        fields (first (:arglists (meta ctor)))
+        fields (some->> ctor meta :arglists first (map keyword))
         args (map #(get m %) fields)]
     (apply ctor args)))
+(declare info)
+
 (defn Info [msg]
   {:__name "Info" :msg msg})
 
 (defn -main []
-  (def info (_gen_struct Info "{\"msg\": \"hello\"}" "" nil))
+  (def info (_gen_struct #'Info "{\"msg\": \"hello\"}" "" nil))
   (println (:msg info)))
 
 (-main)

--- a/tests/compiler/clj/generate_text.clj.out
+++ b/tests/compiler/clj/generate_text.clj.out
@@ -2,6 +2,8 @@
 
 (defn _gen_text [prompt model params]
   prompt)
+(declare poem)
+
 (defn -main []
   (def poem (_gen_text "echo hello" "" nil))
   (println poem))

--- a/tests/compiler/clj/group_by.clj.out
+++ b/tests/compiler/clj/group_by.clj.out
@@ -78,6 +78,8 @@
           it (if (contains? opts :skip) (vec (drop (:skip opts) it)) it)
           it (if (contains? opts :take) (vec (take (:take opts) it)) it)]
       (mapv #(apply (:select opts) %) it)))
+(declare xs groups)
+
 (defn -main []
   (def xs [1 1 2])
   (def groups (let [_src xs
@@ -85,7 +87,7 @@
 
       ] { :select (fn [x] [x]) })
       _groups (_group_by _rows (fn [x] x))
-  (vec (map (fn [g] {:k (:key g) :c (_count g)}) _groups))))
+  (vec (map (fn [g] {:k (:key g) :c (count (:Items g))}) _groups))))
   (loop [_tmp0 (seq groups)]
     (when _tmp0
       (let [g (clojure.core/first _tmp0)]

--- a/tests/compiler/clj/join_where_pushdown.clj.out
+++ b/tests/compiler/clj/join_where_pushdown.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare left right res)
+
 (defn -main []
   (def left [0 1 2 3])
   (def right [0 1 2 3])

--- a/tests/compiler/clj/load_csv.clj.out
+++ b/tests/compiler/clj/load_csv.clj.out
@@ -39,6 +39,8 @@
           :else []))
       :else [])))
 
+(declare people adults)
+
 (defn Person [name age]
   {:__name "Person" :name name :age age})
 

--- a/tests/compiler/clj/load_json.clj.out
+++ b/tests/compiler/clj/load_json.clj.out
@@ -39,6 +39,8 @@
           :else []))
       :else [])))
 
+(declare people adults)
+
 (defn Person [name age email]
   {:__name "Person" :name name :age age :email email})
 

--- a/tests/compiler/clj/load_save_json.clj.out
+++ b/tests/compiler/clj/load_save_json.clj.out
@@ -1,4 +1,6 @@
-(ns main)
+(ns main
+  (:require
+   [clojure.data.json :as json]))
 
 (defn _parse_csv [text header delim]
   (let [lines (->> (clojure.string/split-lines text)
@@ -76,6 +78,8 @@
           (spit path out)))
       :else
       nil)))
+
+(declare people)
 
 (defn Person [name age]
   {:__name "Person" :name name :age age})

--- a/tests/compiler/clj/membership.clj.out
+++ b/tests/compiler/clj/membership.clj.out
@@ -1,13 +1,7 @@
 (ns main)
 
-(defn _in [item col]
-  (cond
-    (and (string? col) (string? item)) (clojure.string/includes? col item)
-    (map? col) (contains? col item)
-    (sequential? col) (some #(= item %) col)
-    :else false))
 (defn -main []
-  (println (_in 2 [1 2 3]))
-  (println (_in "b" ["a" "b"])))
+  (println (some #(= 2 %) [1 2 3]))
+  (println (some #(= "b" %) ["a" "b"])))
 
 (-main)

--- a/tests/compiler/clj/method.clj.out
+++ b/tests/compiler/clj/method.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare c)
+
 (defn Circle [radius]
   {:__name "Circle" :radius radius})
 

--- a/tests/compiler/clj/save_json_stdout.clj.out
+++ b/tests/compiler/clj/save_json_stdout.clj.out
@@ -1,4 +1,6 @@
-(ns main)
+(ns main
+  (:require
+   [clojure.data.json :as json]))
 
 (defn _save [rows path opts]
   (let [fmt (get opts :format "csv")
@@ -37,6 +39,8 @@
           (spit path out)))
       :else
       nil)))
+
+(declare people)
 
 (defn -main []
   (def people [{:name "Alice" :age 30} {:name "Bob" :age 25}])

--- a/tests/compiler/clj/set_ops.clj.out
+++ b/tests/compiler/clj/set_ops.clj.out
@@ -6,6 +6,8 @@
   (vec (remove (set b) a)))
 (defn _intersect [a b]
   (vec (distinct (filter (set b) a))))
+(declare a b)
+
 (defn -main []
   (def a [1 2 3])
   (def b [3 4])

--- a/tests/compiler/clj/string_in.clj.out
+++ b/tests/compiler/clj/string_in.clj.out
@@ -1,13 +1,7 @@
 (ns main)
 
-(defn _in [item col]
-  (cond
-    (and (string? col) (string? item)) (clojure.string/includes? col item)
-    (map? col) (contains? col item)
-    (sequential? col) (some #(= item %) col)
-    :else false))
 (defn -main []
-  (println (_in "cat" "catch"))
-  (println (_in "dog" "catch")))
+  (println (clojure.string/includes? "catch" "cat"))
+  (println (clojure.string/includes? "catch" "dog")))
 
 (-main)

--- a/tests/compiler/clj/string_index.clj.out
+++ b/tests/compiler/clj/string_index.clj.out
@@ -7,6 +7,8 @@
       (throw (ex-info "index out of range" {}))
       (str (nth r i)))))
 
+(declare text)
+
 (defn -main []
   (def text "hello")
   (println (_indexString text 1)))

--- a/tests/compiler/clj/string_negative_index.clj.out
+++ b/tests/compiler/clj/string_negative_index.clj.out
@@ -7,6 +7,8 @@
       (throw (ex-info "index out of range" {}))
       (str (nth r i)))))
 
+(declare text)
+
 (defn -main []
   (def text "hello")
   (println (_indexString text (- 1))))

--- a/tests/compiler/clj/test_block.clj.out
+++ b/tests/compiler/clj/test_block.clj.out
@@ -6,6 +6,8 @@
       (throw (ex-info "index out of range" {}))
       (nth xs idx))))
 
+(declare xs)
+
 (defn test_values []
   (assert (= (_indexList xs 0) 1) "expect failed")
   (println "done"))

--- a/tests/compiler/clj/tpch_q1.clj.out
+++ b/tests/compiler/clj/tpch_q1.clj.out
@@ -14,6 +14,7 @@
     (if (empty? lst)
       0
       (/ (reduce + lst) (double (count lst)))))
+  )
 
 (defn _sum [v]
   (let [lst (cond
@@ -21,6 +22,7 @@
               (sequential? v) v
               :else (throw (ex-info "sum() expects list or group" {})))]
     (reduce + 0 lst))
+  )
 
 (defrecord _Group [key Items])
 
@@ -113,6 +115,8 @@
           it (if (contains? opts :skip) (vec (drop (:skip opts) it)) it)
           it (if (contains? opts :take) (vec (take (:take opts) it)) it)]
       (mapv #(apply (:select opts) %) it)))
+(declare lineitem result)
+
 (defn test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus []
   (assert (= result [{:returnflag "N" :linestatus "O" :sum_qty 53 :sum_base_price 3000 :sum_disc_price (+ 950.0 1800.0) :sum_charge (+ (* 950.0 1.07) (* 1800.0 1.05)) :avg_qty 26.5 :avg_price 1500 :avg_disc 0.07500000000000001 :count_order 2}]) "expect failed")
 )
@@ -122,9 +126,9 @@
   (def result (let [_src lineitem
       _rows (_query _src [
 
-      ] { :select (fn [row] [row]) :where (fn [row] (<= (:l_shipdate row) "1998-09-02")) })
+      ] { :select (fn [row] [row]) :where (fn [row] (<= (compare (:l_shipdate row) "1998-09-02") 0)) })
       _groups (_group_by _rows (fn [row] {:returnflag (:l_returnflag row) :linestatus (:l_linestatus row)}))
-  (vec (map (fn [g] {:returnflag (:returnflag (:key g)) :linestatus (:linestatus (:key g)) :sum_qty (_sum (vec (->> (for [x g] (:l_quantity x))))) :sum_base_price (_sum (vec (->> (for [x g] (:l_extendedprice x))))) :sum_disc_price (_sum (vec (->> (for [x g] (* (:l_extendedprice x) (- 1 (:l_discount x))))))) :sum_charge (_sum (vec (->> (for [x g] (* (* (:l_extendedprice x) (- 1 (:l_discount x))) (+ 1 (:l_tax x))))))) :avg_qty (_avg (vec (->> (for [x g] (:l_quantity x))))) :avg_price (_avg (vec (->> (for [x g] (:l_extendedprice x))))) :avg_disc (_avg (vec (->> (for [x g] (:l_discount x))))) :count_order (_count g)}) _groups))))
+  (vec (map (fn [g] {:returnflag (:returnflag (:key g)) :linestatus (:linestatus (:key g)) :sum_qty (_sum (vec (->> (for [x g] (:l_quantity x))))) :sum_base_price (_sum (vec (->> (for [x g] (:l_extendedprice x))))) :sum_disc_price (_sum (vec (->> (for [x g] (* (:l_extendedprice x) (- 1 (:l_discount x))))))) :sum_charge (_sum (vec (->> (for [x g] (* (* (:l_extendedprice x) (- 1 (:l_discount x))) (+ 1 (:l_tax x))))))) :avg_qty (_avg (vec (->> (for [x g] (:l_quantity x))))) :avg_price (_avg (vec (->> (for [x g] (:l_extendedprice x))))) :avg_disc (_avg (vec (->> (for [x g] (:l_discount x))))) :count_order (count (:Items g))}) _groups))))
   (_json result)
   (test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus)
 )

--- a/tests/compiler/clj/update_stmt.clj.out
+++ b/tests/compiler/clj/update_stmt.clj.out
@@ -1,5 +1,9 @@
 (ns main)
 
+(defn _cast_struct [ctor m]
+  (let [fields (or (some->> ctor meta :arglists first (map keyword))
+                   (keys m))]
+    (apply ctor (map #(get m %) fields))))
 (defn _cast_struct_list [ctor xs]
   (mapv #(_cast_struct ctor %) xs))
 (declare people)
@@ -11,7 +15,7 @@
   (assert (= people [{:__name "Person" :name "Alice" :age 17 :status "minor"} {:__name "Person" :name "Bob" :age 26 :status "adult"} {:__name "Person" :name "Charlie" :age 19 :status "adult"} {:__name "Person" :name "Diana" :age 16 :status "minor"}]) "expect failed"))
 
 (defn -main []
-  (def people (_cast_struct_list Person [{:__name "Person" :name "Alice" :age 17 :status "minor"} {:__name "Person" :name "Bob" :age 25 :status "unknown"} {:__name "Person" :name "Charlie" :age 18 :status "unknown"} {:__name "Person" :name "Diana" :age 16 :status "minor"}]))
+  (def people (_cast_struct_list #'Person [{:__name "Person" :name "Alice" :age 17 :status "minor"} {:__name "Person" :name "Bob" :age 25 :status "unknown"} {:__name "Person" :name "Charlie" :age 18 :status "unknown"} {:__name "Person" :name "Diana" :age 16 :status "minor"}]))
   (def people
     (vec (map (fn [_tmp0]
                 (let [name (:name _tmp0) age (:age _tmp0) status (:status _tmp0)]

--- a/tests/compiler/clj/var_assignment.clj.out
+++ b/tests/compiler/clj/var_assignment.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare x)
+
 (defn -main []
   (def x 1)
   (def x 2)

--- a/tests/compiler/clj/while_loop.clj.out
+++ b/tests/compiler/clj/while_loop.clj.out
@@ -1,5 +1,7 @@
 (ns main)
 
+(declare i)
+
 (defn -main []
   (def i 0)
   (loop []


### PR DESCRIPTION
## Summary
- capture VM output when running clj compiler tests
- add vm_roundtrip helper command for Clojure backend
- regenerate golden output for clj

## Testing
- `go test ./compile/x/clj -tags slow -run TestClojureCompiler_GoldenOutput -update`
- `go test ./compile/x/clj -tags slow -run TestClojureCompiler_SubsetPrograms -update` *(fails: clojure run error)*
- `go test ./compile/x/clj -tags roundtrip -run TestClojureRoundTripVM -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686a9f5a63208320b8a87661e7e4f47f