### PR TITLE
Regenerate C++ golden tests and validate runtime output

### DIFF
--- a/compile/x/cpp/vm_roundtrip_test.go
+++ b/compile/x/cpp/vm_roundtrip_test.go
@@ -1,0 +1,45 @@
+//go:build slow
+
+package cppcode_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	cppcode "mochi/compile/x/cpp"
+	"mochi/parser"
+	any2mochi "mochi/tools/any2mochi"
+	cppconv "mochi/tools/any2mochi/x/cpp"
+	"mochi/types"
+)
+
+// compileMochiToCPP compiles a Mochi source file to C++ code.
+func compileMochiToCPP(path string) ([]byte, error) {
+	prog, err := parser.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := cppcode.New(env).Compile(prog)
+	if err != nil {
+		return nil, fmt.Errorf("compile error: %w", err)
+	}
+	return code, nil
+}
+
+func TestCPP_VM_Roundtrip(t *testing.T) {
+	root := any2mochi.FindRepoRoot(t)
+	status := any2mochi.RunCompileConvertRunStatus(
+		t,
+		filepath.Join(root, "tests/vm/valid"),
+		"*.mochi",
+		compileMochiToCPP,
+		cppconv.ConvertFile,
+		"cpp",
+	)
+	any2mochi.WriteStatusMarkdown(filepath.Join(root, "compile/x/cpp"), status)
+}

--- a/tests/compiler/cpp/dataset.cpp.out
+++ b/tests/compiler/cpp/dataset.cpp.out
@@ -28,7 +28,7 @@ int main() {
   vector<Person> people =
       vector<Person>{Person{string("Alice"), 30}, Person{string("Bob"), 15},
                      Person{string("Charlie"), 65}};
-  auto names = ([&]() -> vector<string> {
+  vector<any> names = ([&]() -> vector<string> {
     vector<string> _res;
     for (auto &p : people) {
       if (p.age >= 18) {
@@ -37,7 +37,7 @@ int main() {
     }
     return _res;
   })();
-  for (const string &n : names) {
+  for (const any &n : names) {
     std::cout << (n) << std::endl;
   }
   return 0;

--- a/tests/compiler/cpp/dataset_skip_take.cpp.out
+++ b/tests/compiler/cpp/dataset_skip_take.cpp.out
@@ -4,7 +4,7 @@ using namespace std;
 
 int main() {
   vector<int> nums = vector<int>{1, 2, 3, 4, 5};
-  auto sub = ([&]() -> vector<int> {
+  vector<any> sub = ([&]() -> vector<int> {
     vector<int> _res;
     for (auto &n : nums) {
       _res.push_back(n);
@@ -19,7 +19,7 @@ int main() {
       _res.resize(_take);
     return _res;
   })();
-  for (int n : sub) {
+  for (const any &n : sub) {
     std::cout << (n) << std::endl;
   }
   return 0;

--- a/tests/compiler/cpp/dataset_sort_by.cpp.out
+++ b/tests/compiler/cpp/dataset_sort_by.cpp.out
@@ -4,7 +4,7 @@ using namespace std;
 
 int main() {
   vector<int> nums = vector<int>{5, 1, 4, 3, 2};
-  auto sorted = ([&]() -> vector<int> {
+  vector<any> sorted = ([&]() -> vector<int> {
     vector<pair<int, int>> _tmp;
     for (auto &n : nums) {
       _tmp.push_back({n, n});
@@ -17,7 +17,7 @@ int main() {
       _res.push_back(_it.second);
     return _res;
   })();
-  for (int n : sorted) {
+  for (const any &n : sorted) {
     std::cout << (n) << std::endl;
   }
   return 0;

--- a/tests/compiler/cpp/group_by.cpp.out
+++ b/tests/compiler/cpp/group_by.cpp.out
@@ -37,17 +37,18 @@ inline auto _count(const T &v) -> decltype(v.Items, int{}) {
 
 int main() {
   vector<int> xs = vector<int>{1, 1, 2};
-  auto groups = ([&]() -> vector<unordered_map<string, int>> {
-    auto _src = xs;
-    auto _groups = _group_by(_src, [&](auto &x) { return x; });
-    vector<unordered_map<string, int>> _res;
-    for (auto &g : _groups) {
-      _res.push_back(unordered_map<string, int>{{string("k"), g.key},
-                                                {string("c"), _count(g)}});
-    }
-    return _res;
-  })();
-  for (const unordered_map<string, any> &g : groups) {
+  vector<unordered_map<string, int>> groups =
+      ([&]() -> vector<unordered_map<string, int>> {
+        auto _src = xs;
+        auto _groups = _group_by(_src, [&](auto &x) { return x; });
+        vector<unordered_map<string, int>> _res;
+        for (auto &g : _groups) {
+          _res.push_back(unordered_map<string, int>{{string("k"), g.key},
+                                                    {string("c"), _count(g)}});
+        }
+        return _res;
+      })();
+  for (const unordered_map<string, int> &g : groups) {
     std::cout << (g["k"]) << " " << (g["c"]) << std::endl;
   }
   return 0;

--- a/tests/compiler/cpp/tpch_q1.cpp.out
+++ b/tests/compiler/cpp/tpch_q1.cpp.out
@@ -162,22 +162,22 @@ int main() {
               {string("l_returnflag"), any(string("N"))},
               {string("l_linestatus"), any(string("O"))},
               {string("l_shipdate"), any(string("1998-08-01"))}},
-          unordered_map<string, any>{
-              {string("l_quantity"), any(36)},
-              {string("l_extendedprice"), any(2000.0)},
-              {string("l_discount"), any(0.1)},
-              {string("l_tax"), any(0.05)},
-              {string("l_returnflag"), any(string("N"))},
-              {string("l_linestatus"), any(string("O"))},
-              {string("l_shipdate"), any(string("1998-09-01"))}},
           unordered_map<string, int>{
-              {string("l_quantity"), 25},
-              {string("l_extendedprice"), 1500.0},
-              {string("l_discount"), 0.0},
-              {string("l_tax"), 0.08},
-              {string("l_returnflag"), string("R")},
-              {string("l_linestatus"), string("F")},
-              {string("l_shipdate"), string("1998-09-03")}}};
+              {string("l_quantity"), 36},
+              {string("l_extendedprice"), 2000.0},
+              {string("l_discount"), 0.1},
+              {string("l_tax"), 0.05},
+              {string("l_returnflag"), string("N")},
+              {string("l_linestatus"), string("O")},
+              {string("l_shipdate"), string("1998-09-01")}},
+          unordered_map<string, any>{
+              {string("l_quantity"), any(25)},
+              {string("l_extendedprice"), any(1500.0)},
+              {string("l_discount"), any(0.0)},
+              {string("l_tax"), any(0.08)},
+              {string("l_returnflag"), any(string("R"))},
+              {string("l_linestatus"), any(string("F"))},
+              {string("l_shipdate"), any(string("1998-09-03"))}}};
   struct GroupKey0 {
     string returnflag;
     string linestatus;
@@ -196,96 +196,99 @@ int main() {
   };
   } // namespace std
 
-  auto result = ([&]() -> vector<unordered_map<string, double>> {
-    using ElemT = unordered_map<string, string>;
-    using KeyT = GroupKey0;
-    struct Group {
-      KeyT Key;
-      vector<ElemT> Items;
-    };
-    unordered_map<KeyT, Group> groups;
-    vector<KeyT> order;
-    for (auto &row : lineitem) {
-      if (row["l_shipdate"] <= string("1998-09-02")) {
-        KeyT _k = GroupKey0{row["l_returnflag"], row["l_linestatus"]};
-        if (!groups.count(_k)) {
-          groups[_k] = Group{_k, {}};
-          order.push_back(_k);
+  vector<unordered_map<string, double>> result =
+      ([&]() -> vector<unordered_map<string, double>> {
+        using ElemT = unordered_map<string, string>;
+        using KeyT = GroupKey0;
+        struct Group {
+          KeyT Key;
+          vector<ElemT> Items;
+        };
+        unordered_map<KeyT, Group> groups;
+        vector<KeyT> order;
+        for (auto &row : lineitem) {
+          if (row["l_shipdate"] <= string("1998-09-02")) {
+            KeyT _k = GroupKey0{row["l_returnflag"], row["l_linestatus"]};
+            if (!groups.count(_k)) {
+              groups[_k] = Group{_k, {}};
+              order.push_back(_k);
+            }
+            groups[_k].Items.push_back(row);
+          }
         }
-        groups[_k].Items.push_back(row);
-      }
-    }
-    vector<Group *> items;
-    for (auto &_k : order)
-      items.push_back(&groups[_k]);
-    vector<unordered_map<string, double>> _res;
-    for (auto *g : items) {
-      _res.push_back(unordered_map<string, double>{
-          {string("returnflag"), g.key.returnflag},
-          {string("linestatus"), g.key.linestatus},
-          {string("sum_qty"), _sum(([&]() -> vector<any> {
-             vector<any> _res;
-             for (auto &x : g) {
-               _res.push_back(
-                   _cast<unordered_map<string, any>>(x)["l_quantity"]);
-             }
-             return _res;
-           })())},
-          {string("sum_base_price"), _sum(([&]() -> vector<any> {
-             vector<any> _res;
-             for (auto &x : g) {
-               _res.push_back(
-                   _cast<unordered_map<string, any>>(x)["l_extendedprice"]);
-             }
-             return _res;
-           })())},
-          {string("sum_disc_price"), _sum(([&]() -> vector<any> {
-             vector<any> _res;
-             for (auto &x : g) {
-               _res.push_back(
-                   _cast<unordered_map<string, any>>(x)["l_extendedprice"] *
-                   (1 - _cast<unordered_map<string, any>>(x)["l_discount"]));
-             }
-             return _res;
-           })())},
-          {string("sum_charge"), _sum(([&]() -> vector<any> {
-             vector<any> _res;
-             for (auto &x : g) {
-               _res.push_back(
-                   _cast<unordered_map<string, any>>(x)["l_extendedprice"] *
-                   (1 - _cast<unordered_map<string, any>>(x)["l_discount"]) *
-                   (1 + _cast<unordered_map<string, any>>(x)["l_tax"]));
-             }
-             return _res;
-           })())},
-          {string("avg_qty"), _avg(([&]() -> vector<any> {
-             vector<any> _res;
-             for (auto &x : g) {
-               _res.push_back(
-                   _cast<unordered_map<string, any>>(x)["l_quantity"]);
-             }
-             return _res;
-           })())},
-          {string("avg_price"), _avg(([&]() -> vector<any> {
-             vector<any> _res;
-             for (auto &x : g) {
-               _res.push_back(
-                   _cast<unordered_map<string, any>>(x)["l_extendedprice"]);
-             }
-             return _res;
-           })())},
-          {string("avg_disc"), _avg(([&]() -> vector<any> {
-             vector<any> _res;
-             for (auto &x : g) {
-               _res.push_back(
-                   _cast<unordered_map<string, any>>(x)["l_discount"]);
-             }
-             return _res;
-           })())},
-          {string("count_order"), _count(g)}});
-    }
-    return _res;
-  })();
+        vector<Group *> items;
+        for (auto &_k : order)
+          items.push_back(&groups[_k]);
+        vector<unordered_map<string, double>> _res;
+        for (auto *g : items) {
+          _res.push_back(unordered_map<string, double>{
+              {string("returnflag"), g.key.returnflag},
+              {string("linestatus"), g.key.linestatus},
+              {string("sum_qty"), _sum(([&]() -> vector<any> {
+                 vector<any> _res;
+                 for (auto &x : g) {
+                   _res.push_back(
+                       _cast<unordered_map<string, any>>(x)["l_quantity"]);
+                 }
+                 return _res;
+               })())},
+              {string("sum_base_price"), _sum(([&]() -> vector<any> {
+                 vector<any> _res;
+                 for (auto &x : g) {
+                   _res.push_back(
+                       _cast<unordered_map<string, any>>(x)["l_extendedprice"]);
+                 }
+                 return _res;
+               })())},
+              {string("sum_disc_price"), _sum(([&]() -> vector<any> {
+                 vector<any> _res;
+                 for (auto &x : g) {
+                   _res.push_back(
+                       _cast<unordered_map<string, any>>(x)["l_extendedprice"] *
+                       (1 -
+                        _cast<unordered_map<string, any>>(x)["l_discount"]));
+                 }
+                 return _res;
+               })())},
+              {string("sum_charge"), _sum(([&]() -> vector<any> {
+                 vector<any> _res;
+                 for (auto &x : g) {
+                   _res.push_back(
+                       _cast<unordered_map<string, any>>(x)["l_extendedprice"] *
+                       (1 -
+                        _cast<unordered_map<string, any>>(x)["l_discount"]) *
+                       (1 + _cast<unordered_map<string, any>>(x)["l_tax"]));
+                 }
+                 return _res;
+               })())},
+              {string("avg_qty"), _avg(([&]() -> vector<any> {
+                 vector<any> _res;
+                 for (auto &x : g) {
+                   _res.push_back(
+                       _cast<unordered_map<string, any>>(x)["l_quantity"]);
+                 }
+                 return _res;
+               })())},
+              {string("avg_price"), _avg(([&]() -> vector<any> {
+                 vector<any> _res;
+                 for (auto &x : g) {
+                   _res.push_back(
+                       _cast<unordered_map<string, any>>(x)["l_extendedprice"]);
+                 }
+                 return _res;
+               })())},
+              {string("avg_disc"), _avg(([&]() -> vector<any> {
+                 vector<any> _res;
+                 for (auto &x : g) {
+                   _res.push_back(
+                       _cast<unordered_map<string, any>>(x)["l_discount"]);
+                 }
+                 return _res;
+               })())},
+              {string("count_order"), _count(g)}});
+        }
+        return _res;
+      })();
   _json(result);
   auto test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus =
       [&]() {

--- a/tests/compiler/valid/cross_join.cpp.out
+++ b/tests/compiler/valid/cross_join.cpp.out
@@ -74,7 +74,7 @@ int main() {
                        Customer{3, string("Charlie")}};
   vector<Order> orders =
       vector<Order>{Order{100, 1, 250}, Order{101, 2, 125}, Order{102, 1, 300}};
-  auto result = ([&]() -> vector<PairInfo> {
+  vector<PairInfo> result = ([&]() -> vector<PairInfo> {
     vector<PairInfo> _res;
     for (auto &o : orders) {
       for (auto &c : customers) {

--- a/tests/compiler/valid/join.cpp.out
+++ b/tests/compiler/valid/join.cpp.out
@@ -71,7 +71,7 @@ int main() {
                        Customer{3, string("Charlie")}};
   vector<Order> orders = vector<Order>{Order{100, 1, 250}, Order{101, 2, 125},
                                        Order{102, 1, 300}, Order{103, 4, 80}};
-  auto result = ([&]() -> vector<PairInfo> {
+  vector<PairInfo> result = ([&]() -> vector<PairInfo> {
     vector<PairInfo> _res;
     for (auto &o : orders) {
       for (auto &c : customers) {

--- a/tests/compiler/valid/join_filter_pag.cpp.out
+++ b/tests/compiler/valid/join_filter_pag.cpp.out
@@ -51,35 +51,38 @@ int main() {
   vector<Purchase> purchases = vector<Purchase>{
       Purchase{1, 1, 200}, Purchase{2, 1, 50}, Purchase{3, 2, 150},
       Purchase{4, 3, 100}, Purchase{5, 2, 250}};
-  auto result = ([&]() -> vector<unordered_map<string, any>> {
-    vector<pair<unordered_map<string, any>, unordered_map<string, any>>> _tmp;
-    for (auto &p : people) {
-      for (auto &o : purchases) {
-        if (!(p.id == o.personId))
-          continue;
-        if (o.total > 100) {
-          _tmp.push_back({-o.total, unordered_map<string, any>{
-                                        {string("person"), any(p.name)},
-                                        {string("spent"), any(o.total)}}});
+  vector<unordered_map<string, any>> result =
+      ([&]() -> vector<unordered_map<string, any>> {
+        vector<pair<unordered_map<string, any>, unordered_map<string, any>>>
+            _tmp;
+        for (auto &p : people) {
+          for (auto &o : purchases) {
+            if (!(p.id == o.personId))
+              continue;
+            if (o.total > 100) {
+              _tmp.push_back({-o.total, unordered_map<string, any>{
+                                            {string("person"), any(p.name)},
+                                            {string("spent"), any(o.total)}}});
+            }
+          }
         }
-      }
-    }
-    std::sort(_tmp.begin(), _tmp.end(),
-              [](const auto &a, const auto &b) { return a.first < b.first; });
-    vector<unordered_map<string, any>> _res;
-    _res.reserve(_tmp.size());
-    for (auto &_it : _tmp)
-      _res.push_back(_it.second);
-    int _skip = 1;
-    if (_skip < (int)_res.size())
-      _res.erase(_res.begin(), _res.begin() + _skip);
-    else
-      _res.clear();
-    int _take = 2;
-    if (_take < (int)_res.size())
-      _res.resize(_take);
-    return _res;
-  })();
+        std::sort(_tmp.begin(), _tmp.end(), [](const auto &a, const auto &b) {
+          return a.first < b.first;
+        });
+        vector<unordered_map<string, any>> _res;
+        _res.reserve(_tmp.size());
+        for (auto &_it : _tmp)
+          _res.push_back(_it.second);
+        int _skip = 1;
+        if (_skip < (int)_res.size())
+          _res.erase(_res.begin(), _res.begin() + _skip);
+        else
+          _res.clear();
+        int _take = 2;
+        if (_take < (int)_res.size())
+          _res.resize(_take);
+        return _res;
+      })();
   for (const unordered_map<string, any> &r : result) {
     std::cout << (r["person"]) << " " << (r["spent"]) << std::endl;
   }


### PR DESCRIPTION
## Summary
- regenerate golden `.cpp.out` for the C++ backend
- verify compiled program output matches VM execution
- add a VM round‑trip test for the C++ backend

## Testing
- `go test ./compile/x/cpp -tags slow -run TestCPPCompiler_GoldenOutput` *(fails: runtime output mismatch)*
- `GOMAXPROCS=1 go test ./compile/x/cpp -tags slow -run TestCPP_VM_Roundtrip` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f3d5430832082bb3b8a8ab3bedd