### PR TITLE
Add Kotlin VM roundtrip and runtime checks

### DIFF
--- a/compile/x/kt/ERRORS.md
+++ b/compile/x/kt/ERRORS.md
@@ -1,0 +1,12 @@
+# Kotlin roundtrip VM test failures
+
+## tests/vm/valid/append_builtin.mochi
+
+```
+type roundtrip error: error[T003]: unknown function: listOf
+  --> :2:11
+
+help:
+  Ensure the function is defined before it's called.
+```
+

--- a/compile/x/kt/cmd/vm_roundtrip/main.go
+++ b/compile/x/kt/cmd/vm_roundtrip/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	ktcode "mochi/compile/x/kt"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	converter "mochi/tools/any2mochi/x/kt"
+	"mochi/types"
+)
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+func main() {
+	files, err := filepath.Glob("tests/vm/valid/*.mochi")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "glob error:", err)
+		os.Exit(1)
+	}
+	limit := 0
+	if v := os.Getenv("LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	var report strings.Builder
+	report.WriteString("# Kotlin roundtrip VM test failures\n\n")
+	for i, src := range files {
+		if limit > 0 && i >= limit {
+			break
+		}
+		if err := process(src); err != nil {
+			report.WriteString(fmt.Sprintf("## %s\n\n```\n%s\n```\n\n", src, err))
+		}
+	}
+	if report.Len() == 0 {
+		report.WriteString("All Kotlin roundtrip VM tests passed.\n")
+	}
+	os.WriteFile("compile/x/kt/ERRORS.md", []byte(report.String()), 0644)
+}
+
+func process(src string) error {
+	base := strings.TrimSuffix(src, ".mochi")
+	ktPath := base + ".kt.out"
+	mochiPath := base + ".mochi.out"
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		writeErr(base+".kt.error", err)
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		writeErr(base+".kt.error", errs[0])
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := ktcode.New(env).Compile(prog)
+	if err != nil {
+		writeErr(base+".kt.error", err)
+		return fmt.Errorf("compile error: %w", err)
+	}
+	os.WriteFile(ktPath, code, 0644)
+
+	conv, err := converter.ConvertFile(ktPath)
+	if err != nil {
+		writeErr(base+".mochi.error", err)
+		return fmt.Errorf("kt2mochi error: %w", err)
+	}
+	os.WriteFile(mochiPath, conv, 0644)
+
+	rtProg, err := parser.ParseString(string(conv))
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("parse roundtrip error: %w", err)
+	}
+	if errs := types.Check(rtProg, env); len(errs) > 0 {
+		writeErr(base+".vm.error", errs[0])
+		return fmt.Errorf("type roundtrip error: %v", errs[0])
+	}
+	p, err := vm.Compile(rtProg, env)
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("compile roundtrip error: %w", err)
+	}
+	var in io.Reader = os.Stdin
+	if fileExists(base + ".in") {
+		if f, err := os.Open(base + ".in"); err == nil {
+			defer f.Close()
+			in = f
+		}
+	}
+	var out bytes.Buffer
+	m := vm.NewWithIO(p, in, &out)
+	if err := m.Run(); err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("run error: %w", err)
+	}
+	want, err := os.ReadFile(base + ".out")
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("missing golden output: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(string(want)) {
+		writeErr(base+".vm.error", fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, strings.TrimSpace(string(want))))
+		return fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, strings.TrimSpace(string(want)))
+	}
+	os.Remove(base + ".kt.error")
+	os.Remove(base + ".mochi.error")
+	os.Remove(base + ".vm.error")
+	return nil
+}
+
+func writeErr(path string, err error) {
+	os.WriteFile(path, []byte(err.Error()), 0644)
+}

--- a/compile/x/kt/compiler_test.go
+++ b/compile/x/kt/compiler_test.go
@@ -14,6 +14,7 @@ import (
 	ktcode "mochi/compile/x/kt"
 	"mochi/golden"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -147,6 +148,10 @@ func TestKTCompiler_SubsetPrograms(t *testing.T) {
 }
 
 func TestKTCompiler_GoldenOutput(t *testing.T) {
+	if err := ktcode.EnsureKotlin(); err != nil {
+		t.Skipf("kotlin not installed: %v", err)
+	}
+
 	golden.Run(t, "tests/compiler/kt", ".mochi", ".kt.out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
@@ -160,6 +165,55 @@ func TestKTCompiler_GoldenOutput(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("❌ compile error: %w", err)
 		}
+
+		// Write and run the generated Kotlin code.
+		dir := t.TempDir()
+		ktFile := filepath.Join(dir, "Main.kt")
+		if err := os.WriteFile(ktFile, code, 0644); err != nil {
+			return nil, fmt.Errorf("write error: %w", err)
+		}
+		jar := filepath.Join(dir, "main.jar")
+		if out, err := exec.Command("kotlinc", ktFile, "-include-runtime", "-d", jar).CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("❌ kotlinc error: %w\n%s", err, out)
+		}
+		cmd := exec.Command("java", "-jar", jar)
+		inPath := strings.TrimSuffix(src, ".mochi") + ".in"
+		var inData []byte
+		if data, err := os.ReadFile(inPath); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+			inData = data
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("❌ java run error: %w\n%s", err, out)
+		}
+		gotOut := bytes.TrimSpace(out)
+
+		// Run using the Mochi VM for comparison.
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			return nil, fmt.Errorf("❌ vm compile error: %w", err)
+		}
+		var vmBuf bytes.Buffer
+		m := vm.NewWithIO(p, bytes.NewReader(inData), &vmBuf)
+		if err := m.Run(); err != nil {
+			if ve, ok := err.(*vm.VMError); ok {
+				return nil, fmt.Errorf("❌ vm run error:\n%s", ve.Format(p))
+			}
+			return nil, fmt.Errorf("❌ vm run error: %w", err)
+		}
+		if vmOut := bytes.TrimSpace(vmBuf.Bytes()); !bytes.Equal(vmOut, gotOut) {
+			t.Errorf("runtime mismatch for %s\n\n--- VM ---\n%s\n\n--- Kotlin ---\n%s\n", filepath.Base(src), vmOut, gotOut)
+		}
+
+		// Compare Kotlin output to golden if present.
+		wantPath := strings.TrimSuffix(src, ".mochi") + ".out"
+		if wantData, err := os.ReadFile(wantPath); err == nil {
+			if want := bytes.TrimSpace(wantData); !bytes.Equal(gotOut, want) {
+				t.Errorf("output mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", filepath.Base(wantPath), gotOut, want)
+			}
+		}
+
 		return bytes.TrimSpace(code), nil
 	})
 }


### PR DESCRIPTION
## Summary
- add new vm_roundtrip command for the Kotlin backend
- store results in `compile/x/kt/ERRORS.md`
- run Kotlin golden tests via VM comparison

## Testing
- `LIMIT=1 go run compile/x/kt/cmd/vm_roundtrip/main.go`
- `go test ./compile/x/kt -run TestKTCompiler_GoldenOutput$/arithmetic -tags slow -update -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686aa02e7db88320985a284650e43f1a