### PR TITLE
Update Pascal compiler tests and golden outputs

### DIFF
--- a/compile/x/pas/ERRORS.md
+++ b/compile/x/pas/ERRORS.md
@@ -1,0 +1,267 @@
+# Pascal roundtrip compiler tests
+
+## tests/compiler/valid/break_continue.mochi
+
+```
+output mismatch
+-- got --
+odd number:1
+odd number:2
+odd number:3
+odd number:4
+odd number:5
+odd number:6
+odd number:7
+odd number:8
+odd number:9
+-- want --
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7
+```
+
+## tests/compiler/valid/closure.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling closure.pas.out
+closure.pas.out(9,33) Error: Type identifier expected
+closure.pas.out(9,33) Fatal: Syntax error, ";" expected but "FUNCTION" found
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/cross_join.mochi
+
+```
+output mismatch
+-- got --
+--- Cross Join: All order-customer pairs ---
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+Order0(customerId:0, total: $0) paired with
+-- want --
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie
+```
+
+## tests/compiler/valid/fold_pure_let.mochi
+
+```
+output mismatch
+-- got --
+100
+10
+-- want --
+55
+10
+```
+
+## tests/compiler/valid/fun_expr_in_let.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling fun_expr_in_let.pas.out
+fun_expr_in_let.pas.out(10,28) Fatal: Syntax error, ":" expected but ")" found
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/generate_echo.mochi
+
+```
+compile error: generative model expressions not supported
+```
+
+## tests/compiler/valid/generate_embedding.mochi
+
+```
+compile error: generative model expressions not supported
+```
+
+## tests/compiler/valid/grouped_expr.mochi
+
+```
+output mismatch
+-- got --
+7
+-- want --
+9
+```
+
+## tests/compiler/valid/join.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling join.pas.out
+join.pas.out(63,20) Warning: Variable "o" does not seem to be initialized
+join.pas.out(64,25) Error: Identifier not found "c"
+join.pas.out(69,11) Error: Identifier not found "c"
+join.pas.out(71,35) Error: Identifier not found "c"
+join.pas.out(82) Fatal: There were 3 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/join_filter_pag.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling join_filter_pag.pas.out
+join_filter_pag.pas.out(99,32) Warning: Variable "p" does not seem to be initialized
+join_filter_pag.pas.out(100,31) Error: Identifier not found "o"
+join_filter_pag.pas.out(105,11) Error: Identifier not found "o"
+join_filter_pag.pas.out(107,27) Error: Identifier not found "o"
+join_filter_pag.pas.out(108,20) Error: Identifier not found "o"
+join_filter_pag.pas.out(109,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE7D92CDE"
+join_filter_pag.pas.out(109,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+join_filter_pag.pas.out(110,38) Error: Identifier not found "o"
+join_filter_pag.pas.out(110,21) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+join_filter_pag.pas.out(119,17) Error: identifier idents no member "person"
+join_filter_pag.pas.out(119,27) Error: identifier idents no member "spent"
+join_filter_pag.pas.out(122) Fatal: There were 10 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/local_recursion.mochi
+
+```
+compile error: union types not supported
+```
+
+## tests/compiler/valid/map_iterate.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling map_iterate.pas.out
+map_iterate.pas.out(17,8) Error: Incompatible types: got "TFPGMap<System.ShortString,System.LongInt>" expected "TFPGMap<System.LongInt,System.Boolean>"
+map_iterate.pas.out(23,18) Error: Operator is not overloaded: "LongInt" + "TFPGMap$2$crc50650EB1"
+map_iterate.pas.out(21,12) Error: Cannot find an enumerator for the type "TFPGMap$2$crc50650EB1"
+map_iterate.pas.out(27) Fatal: There were 3 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/map_ops.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling map_ops.pas.out
+map_ops.pas.out(15,8) Error: Incompatible types: got "TFPGMap<System.ShortString,System.LongInt>" expected "TFPGMap<System.LongInt,System.LongInt>"
+map_ops.pas.out(21) Fatal: There were 1 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/match_expr.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling match_expr.pas.out
+match_expr.pas.out(21,7) Fatal: Syntax error, ";" expected but "ELSE" found
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/reduce.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling reduce.pas.out
+reduce.pas.out(11,10) Error: Illegal expression
+reduce.pas.out(19,11) Error: Identifier not found "reduce"
+reduce.pas.out(19,24) Error: Wrong number of parameters specified for call to "add"
+reduce.pas.out(9,10) Error: Found declaration: add(LongInt;LongInt):LongInt;
+reduce.pas.out(21) Fatal: There were 4 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/stream_on_emit.mochi
+
+```
+compile error: agents and streams not supported
+```
+
+## tests/compiler/valid/two_sum.mochi
+
+```
+fpc error: exit status 1
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling two_sum.pas.out
+two_sum.pas.out(19,11) Error: Ordinal expression expected
+two_sum.pas.out(21,26) Error: Identifier not found "_indexList"
+two_sum.pas.out(21,50) Fatal: Syntax error, ")" expected but "," found
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode
+
+```
+
+## tests/compiler/valid/union_inorder.mochi
+
+```
+compile error: union types not supported
+```
+
+## tests/compiler/valid/union_match.mochi
+
+```
+compile error: union types not supported
+```
+
+## tests/compiler/valid/union_slice.mochi
+
+```
+compile error: union types not supported
+```
+

--- a/compile/x/pas/cmd/vm_roundtrip/main.go
+++ b/compile/x/pas/cmd/vm_roundtrip/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	pascode "mochi/compile/x/pas"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+func main() {
+	files, err := filepath.Glob("tests/compiler/valid/*.mochi")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "glob error:", err)
+		os.Exit(1)
+	}
+
+	var report strings.Builder
+	report.WriteString("# Pascal roundtrip compiler tests\n\n")
+	for _, src := range files {
+		if err := process(src); err != nil {
+			report.WriteString(fmt.Sprintf("## %s\n\n```\n%s\n```\n\n", src, err))
+		}
+	}
+	if report.Len() == 0 {
+		report.WriteString("All Pascal compiler tests passed.\n")
+	}
+	os.WriteFile("compile/x/pas/ERRORS.md", []byte(report.String()), 0644)
+}
+
+func process(src string) error {
+	base := strings.TrimSuffix(src, ".mochi")
+	pasPath := base + ".pas.out"
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		writeErr(base+".pas.error", err)
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		writeErr(base+".pas.error", errs[0])
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := pascode.New(env).Compile(prog)
+	if err != nil {
+		writeErr(base+".pas.error", err)
+		return fmt.Errorf("compile error: %w", err)
+	}
+	if err := os.WriteFile(pasPath, code, 0644); err != nil {
+		return err
+	}
+
+	fpc, err := pascode.EnsureFPC()
+	if err != nil {
+		writeErr(base+".pas.error", err)
+		return fmt.Errorf("fpc not installed: %v", err)
+	}
+	exe := filepath.Join(filepath.Dir(pasPath), filepath.Base(base))
+	build := exec.Command(fpc, "-o"+filepath.Base(exe), filepath.Base(pasPath))
+	build.Dir = filepath.Dir(pasPath)
+	if out, err := build.CombinedOutput(); err != nil {
+		writeErr(base+".pas.error", fmt.Errorf("fpc error: %w\n%s", err, out))
+		return fmt.Errorf("fpc error: %w\n%s", err, out)
+	}
+
+	run := exec.Command(exe)
+	if data, err := os.ReadFile(base + ".in"); err == nil {
+		run.Stdin = bytes.NewReader(data)
+	}
+	var runOut bytes.Buffer
+	run.Stdout = &runOut
+	run.Stderr = &runOut
+	if err := run.Run(); err != nil {
+		writeErr(base+".pas.error", fmt.Errorf("run error: %w\n%s", err, runOut.Bytes()))
+		return fmt.Errorf("run error: %w\n%s", err, runOut.Bytes())
+	}
+	got := strings.TrimSpace(runOut.String())
+
+	// Run with VM for expected output
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		writeErr(base+".pas.error", err)
+		return fmt.Errorf("vm compile error: %w", err)
+	}
+	var in io.Reader = nil
+	if fileExists(base + ".in") {
+		f, err := os.Open(base + ".in")
+		if err == nil {
+			defer f.Close()
+			in = f
+		}
+	}
+	var vmOut bytes.Buffer
+	m := vm.NewWithIO(p, in, &vmOut)
+	if err := m.Run(); err != nil {
+		writeErr(base+".pas.error", err)
+		return fmt.Errorf("vm run error: %w", err)
+	}
+	want := strings.TrimSpace(vmOut.String())
+
+	if got != want {
+		writeErr(base+".pas.error", fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, want))
+		return fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, want)
+	}
+
+	// Clean up previous error
+	os.Remove(base + ".pas.error")
+	return nil
+}
+
+func writeErr(path string, err error) {
+	os.WriteFile(path, []byte(err.Error()), 0644)
+}

--- a/tests/compiler/valid/break_continue.pas.out
+++ b/tests/compiler/valid/break_continue.pas.out
@@ -1,0 +1,21 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  n: integer;
+  numbers: specialize TArray<integer>;
+
+begin
+  numbers := specialize TArray<integer>([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  for n in numbers do
+    begin
+      if (n mod 2 = 0) then ;
+      if (n > 7) then ;
+      writeln('odd number:', n);
+    end;
+end.

--- a/tests/compiler/valid/closure.pas.out
+++ b/tests/compiler/valid/closure.pas.out
@@ -1,0 +1,27 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+function makeAdder(n: integer): function (integer): integer;
+begin
+  result := _lambda0;
+  exit;
+end;
+
+function _lambda0(x: integer): integer;
+begin
+  result := x + n;
+  exit;
+end;
+
+var
+  add10: function (integer): integer;
+
+begin
+  add10 := makeAdder(10);
+  writeln(add10(7));
+end.

--- a/tests/compiler/valid/cross_join.pas.out
+++ b/tests/compiler/valid/cross_join.pas.out
@@ -1,0 +1,80 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+type Customer = record
+  id: integer;
+  name: string;
+end;
+
+type Order = record
+  id: integer;
+  customerId: integer;
+  total: integer;
+end;
+
+type PairInfo = record
+  orderId: integer;
+  orderCustomerId: integer;
+  pairedCustomerName: string;
+  orderTotal: integer;
+end;
+
+var
+  _tmp0: Customer;
+  _tmp1: Customer;
+  _tmp2: Customer;
+  _tmp3: Order;
+  _tmp4: Order;
+  _tmp5: Order;
+  _tmp6: PairInfo;
+  _tmp7: specialize TArray<PairInfo>;
+  c: Customer;
+  customers: specialize TArray<Customer>;
+  entry: PairInfo;
+  o: Order;
+  orders: specialize TArray<Order>;
+  _result: specialize TArray<PairInfo>;
+
+begin
+  _tmp0.id := 1;
+  _tmp0.name := 'Alice';
+  _tmp1.id := 2;
+  _tmp1.name := 'Bob';
+  _tmp2.id := 3;
+  _tmp2.name := 'Charlie';
+  customers := specialize TArray<Customer>([_tmp0, _tmp1, _tmp2]);
+  _tmp3.id := 100;
+  _tmp3.customerId := 1;
+  _tmp3.total := 250;
+  _tmp4.id := 101;
+  _tmp4.customerId := 2;
+  _tmp4.total := 125;
+  _tmp5.id := 102;
+  _tmp5.customerId := 1;
+  _tmp5.total := 300;
+  orders := specialize TArray<Order>([_tmp3, _tmp4, _tmp5]);
+  _tmp6.orderId := o.id;
+  _tmp6.orderCustomerId := o.customerId;
+  _tmp6.pairedCustomerName := c.name;
+  _tmp6.orderTotal := o.total;
+  SetLength(_tmp7, 0);
+  for o in orders do
+    begin
+      for c in customers do
+        begin
+          _tmp7 := Concat(_tmp7, [_tmp6]);
+        end;
+    end;
+  _result := _tmp7;
+  writeln('--- Cross Join: All order-customer pairs ---');
+  for entry in _result do
+    begin
+      writeln('Order', entry.orderId, '(customerId:', entry.orderCustomerId, ', total: $', entry.
+              orderTotal, ') paired with', entry.pairedCustomerName);
+    end;
+end.

--- a/tests/compiler/valid/fold_pure_let.pas.out
+++ b/tests/compiler/valid/fold_pure_let.pas.out
@@ -1,0 +1,22 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+function sumN(n: integer): integer;
+begin
+  result := n * n + 1 div 2;
+  exit;
+end;
+
+var
+  n: integer;
+
+begin
+  n := 10;
+  writeln(sumN(n));
+  writeln(n);
+end.

--- a/tests/compiler/valid/for_list_collection.pas.out
+++ b/tests/compiler/valid/for_list_collection.pas.out
@@ -1,0 +1,17 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  n: integer;
+
+begin
+  for n in specialize TArray<integer>([1, 2, 3]) do
+    begin
+      writeln(n);
+    end;
+end.

--- a/tests/compiler/valid/for_loop.pas.out
+++ b/tests/compiler/valid/for_loop.pas.out
@@ -1,0 +1,17 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  i: integer;
+
+begin
+  for i := 1 to 4 - 1 do
+    begin
+      writeln(i);
+    end;
+end.

--- a/tests/compiler/valid/for_string_collection.pas.out
+++ b/tests/compiler/valid/for_string_collection.pas.out
@@ -1,0 +1,19 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  _tmp0: integer;
+  ch: char;
+
+begin
+  for _tmp0 := 1 to Length('hi') do
+    begin
+      ch := 'hi'[_tmp0];
+      writeln(ch);
+    end;
+end.

--- a/tests/compiler/valid/fun_call.pas.out
+++ b/tests/compiler/valid/fun_call.pas.out
@@ -1,0 +1,17 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+function add(a: integer; b: integer): integer;
+begin
+  result := a + b;
+  exit;
+end;
+
+begin
+  writeln(add(2, 3));
+end.

--- a/tests/compiler/valid/fun_expr_in_let.pas.out
+++ b/tests/compiler/valid/fun_expr_in_let.pas.out
@@ -1,0 +1,15 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  square: function (integer): integer;
+
+begin
+  square := @_lambda0;
+  writeln(square(6));
+end.

--- a/tests/compiler/valid/grouped_expr.pas.out
+++ b/tests/compiler/valid/grouped_expr.pas.out
@@ -1,0 +1,15 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  value: integer;
+
+begin
+  value := 1 + 2 * 3;
+  writeln(value);
+end.

--- a/tests/compiler/valid/if_else.pas.out
+++ b/tests/compiler/valid/if_else.pas.out
@@ -1,0 +1,22 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  x: integer;
+
+begin
+  x := 5;
+  if (x > 3) then
+    begin
+      writeln('big');
+    end
+  else
+    begin
+      writeln('small');
+    end;
+end.

--- a/tests/compiler/valid/join.pas.out
+++ b/tests/compiler/valid/join.pas.out
@@ -1,0 +1,81 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+type Customer = record
+  id: integer;
+  name: string;
+end;
+
+type Order = record
+  id: integer;
+  customerId: integer;
+  total: integer;
+end;
+
+type PairInfo = record
+  orderId: integer;
+  customerName: string;
+  total: integer;
+end;
+
+var
+  _tmp0: Customer;
+  _tmp1: Customer;
+  _tmp2: Customer;
+  _tmp3: Order;
+  _tmp4: Order;
+  _tmp5: Order;
+  _tmp6: Order;
+  _tmp7: PairInfo;
+  _tmp8: specialize TArray<PairInfo>;
+  customers: specialize TArray<Customer>;
+  entry: PairInfo;
+  o: Order;
+  orders: specialize TArray<Order>;
+  _result: specialize TArray<PairInfo>;
+
+begin
+  _tmp0.id := 1;
+  _tmp0.name := 'Alice';
+  _tmp1.id := 2;
+  _tmp1.name := 'Bob';
+  _tmp2.id := 3;
+  _tmp2.name := 'Charlie';
+  customers := specialize TArray<Customer>([_tmp0, _tmp1, _tmp2]);
+  _tmp3.id := 100;
+  _tmp3.customerId := 1;
+  _tmp3.total := 250;
+  _tmp4.id := 101;
+  _tmp4.customerId := 2;
+  _tmp4.total := 125;
+  _tmp5.id := 102;
+  _tmp5.customerId := 1;
+  _tmp5.total := 300;
+  _tmp6.id := 103;
+  _tmp6.customerId := 4;
+  _tmp6.total := 80;
+  orders := specialize TArray<Order>([_tmp3, _tmp4, _tmp5, _tmp6]);
+  _tmp7.orderId := o.id;
+  _tmp7.customerName := c.name;
+  _tmp7.total := o.total;
+  SetLength(_tmp8, 0);
+  for o in orders do
+    begin
+      for c in customers do
+        begin
+          if not ((o.customerId = c.id)) then continue;
+          _tmp8 := Concat(_tmp8, [_tmp7]);
+        end;
+    end;
+  _result := _tmp8;
+  writeln('--- Orders with customer info ---');
+  for entry in _result do
+    begin
+      writeln('Order', entry.orderId, 'by', entry.customerName, '- $', entry.total);
+    end;
+end.

--- a/tests/compiler/valid/join_filter_pag.pas.out
+++ b/tests/compiler/valid/join_filter_pag.pas.out
@@ -1,0 +1,121 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+type Person = record
+  id: integer;
+  name: string;
+end;
+
+type Purchase = record
+  id: integer;
+  personId: integer;
+  total: integer;
+end;
+
+generic function _sliceList<T>(arr: specialize TArray<T>; i, j: integer): specialize TArray<T>;
+
+var start_, end_, n: integer;
+begin
+  start_ := i;
+  end_ := j;
+  n := Length(arr);
+  if start_ < 0 then start_ := n + start_;
+  if end_ < 0 then end_ := n + end_;
+  if start_ < 0 then start_ := 0;
+  if end_ > n then end_ := n;
+  if end_ < start_ then end_ := start_;
+  Result := Copy(arr, start_ + 1, end_ - start_);
+end;
+
+generic procedure _sortBy<T>(var arr: specialize TArray<T>; keys: specialize TArray<Variant>);
+
+var i,j: integer;
+  tmp: T;
+  k: Variant;
+begin
+  for i := 0 to High(arr) - 1 do
+    for j := i + 1 to High(arr) do
+      if keys[i] > keys[j] then
+        begin
+          tmp := arr[i];
+          arr[i] := arr[j];
+          arr[j] := tmp;
+          k := keys[i];
+          keys[i] := keys[j];
+          keys[j] := k;
+        end;
+end;
+
+var
+  _tmp0: Person;
+  _tmp1: Person;
+  _tmp10: specialize TArray<Variant>;
+  _tmp11: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp12: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp2: Person;
+  _tmp3: Purchase;
+  _tmp4: Purchase;
+  _tmp5: Purchase;
+  _tmp6: Purchase;
+  _tmp7: Purchase;
+  _tmp8: specialize TFPGMap<Variant, Variant>;
+  _tmp9: specialize TArray<specialize TFPGMap<string, Variant>>;
+  p: Person;
+  people: specialize TArray<Person>;
+  purchases: specialize TArray<Purchase>;
+  r: specialize TFPGMap<string, Variant>;
+  _result: specialize TArray<specialize TFPGMap<string, Variant>>;
+
+begin
+  _tmp0.id := 1;
+  _tmp0.name := 'Alice';
+  _tmp1.id := 2;
+  _tmp1.name := 'Bob';
+  _tmp2.id := 3;
+  _tmp2.name := 'Charlie';
+  people := specialize TArray<Person>([_tmp0, _tmp1, _tmp2]);
+  _tmp3.id := 1;
+  _tmp3.personId := 1;
+  _tmp3.total := 200;
+  _tmp4.id := 2;
+  _tmp4.personId := 1;
+  _tmp4.total := 50;
+  _tmp5.id := 3;
+  _tmp5.personId := 2;
+  _tmp5.total := 150;
+  _tmp6.id := 4;
+  _tmp6.personId := 3;
+  _tmp6.total := 100;
+  _tmp7.id := 5;
+  _tmp7.personId := 2;
+  _tmp7.total := 250;
+  purchases := specialize TArray<Purchase>([_tmp3, _tmp4, _tmp5, _tmp6, _tmp7]);
+  _tmp8 := specialize TFPGMap<Variant, Variant>.Create;
+  _tmp8.AddOrSetData('person', p.name);
+  _tmp8.AddOrSetData('spent', o.total);
+  SetLength(_tmp9, 0);
+  SetLength(_tmp10, 0);
+  for p in people do
+    begin
+      for o in purchases do
+        begin
+          if not ((p.id = o.personId)) then continue;
+          if not ((o.total > 100)) then continue;
+          _tmp9 := Concat(_tmp9, [_tmp8]);
+          _tmp10 := Concat(_tmp10, [-o.total]);
+        end;
+    end;
+  specialize _sortBy<specialize TFPGMap<string, Variant>>(_tmp9, _tmp10);
+  _tmp11 := specialize _sliceList<specialize TFPGMap<string, Variant>>(_tmp9, 1, Length(_tmp9));
+  _tmp12 := specialize _sliceList<specialize TFPGMap<string, Variant>>(_tmp11, 0, 2);
+  _result := _tmp12;
+  for r in _result do
+    begin
+      writeln(r.person, r.spent);
+    end;
+end.

--- a/tests/compiler/valid/len_builtin.pas.out
+++ b/tests/compiler/valid/len_builtin.pas.out
@@ -1,0 +1,11 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+begin
+  writeln(Length(specialize TArray<integer>([1, 2, 3])));
+end.

--- a/tests/compiler/valid/let_and_print.pas.out
+++ b/tests/compiler/valid/let_and_print.pas.out
@@ -1,0 +1,17 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  a: integer;
+  b: integer;
+
+begin
+  a := 10;
+  b := 20;
+  writeln(a + b);
+end.

--- a/tests/compiler/valid/list_index.pas.out
+++ b/tests/compiler/valid/list_index.pas.out
@@ -1,0 +1,23 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+  generic function _indexList<T>(arr: specialize TArray<T>; i: integer): T;
+begin
+  if i < 0 then i := Length(arr) + i;
+  if (i < 0) or (i >= Length(arr)) then
+    raise Exception.Create('index out of range');
+  Result := arr[i];
+end;
+
+var
+  xs: specialize TArray<integer>;
+
+begin
+  xs := specialize TArray<integer>([10, 20, 30]);
+  writeln(specialize _indexList<integer>(xs, 1));
+end.

--- a/tests/compiler/valid/list_set.pas.out
+++ b/tests/compiler/valid/list_set.pas.out
@@ -1,0 +1,24 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+  generic function _indexList<T>(arr: specialize TArray<T>; i: integer): T;
+begin
+  if i < 0 then i := Length(arr) + i;
+  if (i < 0) or (i >= Length(arr)) then
+    raise Exception.Create('index out of range');
+  Result := arr[i];
+end;
+
+var
+  nums: specialize TArray<integer>;
+
+begin
+  nums := specialize TArray<integer>([1, 2]);
+  nums[1] := 3;
+  writeln(specialize _indexList<integer>(nums, 1));
+end.

--- a/tests/compiler/valid/map_index.pas.out
+++ b/tests/compiler/valid/map_index.pas.out
@@ -1,0 +1,19 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  _tmp0: specialize TFPGMap<string, integer>;
+  scores: specialize TFPGMap<string, integer>;
+
+begin
+  _tmp0 := specialize TFPGMap<string, integer>.Create;
+  _tmp0.AddOrSetData('Alice', 10);
+  _tmp0.AddOrSetData('Bob', 15);
+  scores := _tmp0;
+  writeln(scores.KeyData['Bob']);
+end.

--- a/tests/compiler/valid/map_iterate.pas.out
+++ b/tests/compiler/valid/map_iterate.pas.out
@@ -1,0 +1,26 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  _tmp0: specialize TFPGMap<string, integer>;
+  k: specialize TFPGMap<integer, boolean>;
+  m: specialize TFPGMap<integer, boolean>;
+  sum: integer;
+
+begin
+  _tmp0 := specialize TFPGMap<string, integer>.Create;
+  m := _tmp0;
+  m.KeyData[1] := True;
+  m.KeyData[2] := True;
+  sum := 0;
+  for k in m do
+    begin
+      sum := sum + k;
+    end;
+  writeln(sum);
+end.

--- a/tests/compiler/valid/map_ops.pas.out
+++ b/tests/compiler/valid/map_ops.pas.out
@@ -1,0 +1,20 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  _tmp0: specialize TFPGMap<string, integer>;
+  m: specialize TFPGMap<integer, integer>;
+
+begin
+  _tmp0 := specialize TFPGMap<string, integer>.Create;
+  m := _tmp0;
+  m.KeyData[1] := 10;
+  m.KeyData[2] := 20;
+  if (m.IndexOf(1) >= 0) then ;
+  writeln(m.KeyData[2]);
+end.

--- a/tests/compiler/valid/map_set.pas.out
+++ b/tests/compiler/valid/map_set.pas.out
@@ -1,0 +1,19 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  _tmp0: specialize TFPGMap<string, integer>;
+  scores: specialize TFPGMap<string, integer>;
+
+begin
+  _tmp0 := specialize TFPGMap<string, integer>.Create;
+  _tmp0.AddOrSetData('a', 1);
+  scores := _tmp0;
+  scores.KeyData['b'] := 2;
+  writeln(scores.KeyData['b']);
+end.

--- a/tests/compiler/valid/match_expr.pas.out
+++ b/tests/compiler/valid/match_expr.pas.out
@@ -1,0 +1,33 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  _tmp0: string;
+  _tmp1: integer;
+  _label: string;
+  x: integer;
+
+begin
+  x := 2;
+  _tmp1 := x;
+  if _tmp1 = 1 then
+    begin
+      _tmp0 := 'one';
+      else if _tmp1 = 2 then
+             begin
+               _tmp0 := 'two';
+               else if _tmp1 = 3 then
+                      begin
+                        _tmp0 := 'three';
+                        else
+                          begin
+                            _tmp0 := 'unknown';
+                          end;
+                        _label := _tmp0;
+                        writeln(_label);
+                      end.

--- a/tests/compiler/valid/print_hello.pas.out
+++ b/tests/compiler/valid/print_hello.pas.out
@@ -1,0 +1,11 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+begin
+  writeln('hello');
+end.

--- a/tests/compiler/valid/reduce.pas.out
+++ b/tests/compiler/valid/reduce.pas.out
@@ -1,0 +1,20 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+function add(acc: integer; v: integer): integer;
+begin
+  acc + v;
+end;
+
+var
+  nums: specialize TArray<integer>;
+
+begin
+  nums := specialize TArray<integer>([1, 2, 3, 4, 5]);
+  writeln(reduce(nums, add, 0));
+end.

--- a/tests/compiler/valid/string_index.pas.out
+++ b/tests/compiler/valid/string_index.pas.out
@@ -1,0 +1,23 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+function _indexString(s: string; i: integer): string;
+begin
+  if i < 0 then i := Length(s) + i;
+  if (i < 0) or (i >= Length(s)) then
+    raise Exception.Create('index out of range');
+  Result := s[i + 1];
+end;
+
+var
+  text: string;
+
+begin
+  text := 'hello';
+  writeln(_indexString(text, 1));
+end.

--- a/tests/compiler/valid/test_block.pas.out
+++ b/tests/compiler/valid/test_block.pas.out
@@ -1,0 +1,21 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+procedure test_addition_works;
+
+var
+  x: integer;
+begin
+  x := 1 + 2;
+  if not ((x = 3)) then raise Exception.Create('expect failed');
+end;
+
+begin
+  writeln('ok');
+  test_addition_works;
+end.

--- a/tests/compiler/valid/two_sum.pas.out
+++ b/tests/compiler/valid/two_sum.pas.out
@@ -1,0 +1,44 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+function twoSum(nums: specialize TArray<integer>; target: integer): specialize TArray<integer>;
+
+var
+  i: integer;
+  j: Variant;
+  n: integer;
+begin
+  n := Length(nums);
+  for i := 0 to n - 1 do
+    begin
+      for j := i + 1 to n - 1 do
+        begin
+          if (specialize _indexList<integer>(nums, i) + specialize _indexList<integer>(nums, j) =
+             target) then ;
+        end;
+    end;
+  result := specialize TArray<integer>([-1, -1]);
+  exit;
+end;
+
+generic function _indexList<T>(arr: specialize TArray<T>; i: integer): T;
+begin
+  if i < 0 then i := Length(arr) + i;
+  if (i < 0) or (i >= Length(arr)) then
+    raise Exception.Create('index out of range');
+  Result := arr[i];
+end;
+
+var
+  _result: specialize TArray<integer>;
+
+begin
+  _result := twoSum(specialize TArray<integer>([2, 7, 11, 15]), 9);
+  writeln(specialize _indexList<integer>(_result, 0));
+  writeln(specialize _indexList<integer>(_result, 1));
+end.

--- a/tests/compiler/valid/var_assignment.pas.out
+++ b/tests/compiler/valid/var_assignment.pas.out
@@ -1,0 +1,16 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  x: integer;
+
+begin
+  x := 1;
+  x := 2;
+  writeln(x);
+end.

--- a/tests/compiler/valid/while_loop.pas.out
+++ b/tests/compiler/valid/while_loop.pas.out
@@ -1,0 +1,19 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+var
+  i: integer;
+
+begin
+  i := 0;
+  while (i < 3) do
+    begin
+      writeln(i);
+      i := i + 1;
+    end;
+end.


### PR DESCRIPTION
## Summary
- regenerate golden outputs for Pascal from valid programs using new vm_roundtrip tool
- add vm_roundtrip command for Pascal
- run generated Pascal programs in tests and compare output with VM execution
- capture compiler run results in `compile/x/pas/ERRORS.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686aa0e16bc48320a913516e0bad57b8