### PR TITLE
Update rust compiler golden tests

### DIFF
--- a/compile/x/rust/vm_roundtrip_test.go
+++ b/compile/x/rust/vm_roundtrip_test.go
@@ -1,0 +1,52 @@
+//go:build slow
+
+package rscode_test
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	rscode "mochi/compile/x/rust"
+	"mochi/parser"
+	any2mochi "mochi/tools/any2mochi"
+	rconv "mochi/tools/any2mochi/x/rust"
+	"mochi/types"
+)
+
+// compileMochiToRust compiles a Mochi file to Rust source code.
+func compileMochiToRust(path string) ([]byte, error) {
+	prog, err := parser.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := rscode.New(env).Compile(prog)
+	if err != nil {
+		return nil, fmt.Errorf("compile error: %w", err)
+	}
+	return code, nil
+}
+
+func TestVMValid_Roundtrip(t *testing.T) {
+	if err := rscode.Ensure(); err != nil {
+		t.Skipf("rust not installed: %v", err)
+	}
+	if _, err := exec.LookPath("rust-analyzer"); err != nil {
+		t.Skip("rust-analyzer not installed")
+	}
+	root := any2mochi.FindRepoRoot(t)
+	status := any2mochi.RunCompileConvertRunStatus(
+		t,
+		filepath.Join(root, "tests/vm/valid"),
+		"*.mochi",
+		compileMochiToRust,
+		rconv.ConvertFile,
+		"rust",
+	)
+	any2mochi.WriteStatusMarkdown(filepath.Join(root, "compile/x/rust"), status)
+}

--- a/tests/compiler/valid/print_hello.rs.out
+++ b/tests/compiler/valid/print_hello.rs.out
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", "hello");
+}

--- a/tests/compiler/valid/var_assignment.rs.out
+++ b/tests/compiler/valid/var_assignment.rs.out
@@ -1,0 +1,5 @@
+fn main() {
+    let mut x = 1;
+    x = 2;
+    println!("{}", x);
+}

--- a/tests/compiler/valid/while_loop.rs.out
+++ b/tests/compiler/valid/while_loop.rs.out
@@ -1,0 +1,7 @@
+fn main() {
+    let mut i = 0;
+    while i < 3 {
+        println!("{}", i);
+        i = i + 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add runVM helper and ensure golden Rust compiler tests execute generated binaries
- regenerate `.rs.out` files for supported valid Mochi programs
- add roundtrip VM test for Rust backend

## Testing
- `go test -tags slow ./compile/x/rust -run ^TestRustCompiler_GoldenOutput$ -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686aa1193c208320888273ecaf767a9b