### PR TITLE
Update Haskell golden tests and runtime checks

### DIFF
--- a/compile/x/hs/job_golden_test.go
+++ b/compile/x/hs/job_golden_test.go
@@ -6,12 +6,15 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	hscode "mochi/compile/x/hs"
 	"mochi/compile/x/testutil"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -49,7 +52,30 @@ func TestHSCompiler_JOBQueries(t *testing.T) {
 			if err := os.WriteFile(file, code, 0644); err != nil {
 				t.Fatalf("write error: %v", err)
 			}
-			t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
+
+			cmd := exec.Command("runhaskell", file)
+			outHS, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("runhaskell error: %v\n%s", err, outHS)
+			}
+			hsRes := strings.TrimSpace(string(outHS))
+
+			p, err := vm.Compile(prog, env)
+			if err != nil {
+				t.Fatalf("vm compile error: %v", err)
+			}
+			var vmOut bytes.Buffer
+			m := vm.New(p, &vmOut)
+			if err := m.Run(); err != nil {
+				if ve, ok := err.(*vm.VMError); ok {
+					t.Fatalf("vm run error:\n%s", ve.Format(p))
+				}
+				t.Fatalf("vm run error: %v", err)
+			}
+			vmRes := strings.TrimSpace(vmOut.String())
+			if hsRes != vmRes {
+				t.Fatalf("output mismatch\n-- hs --\n%s\n-- vm --\n%s", hsRes, vmRes)
+			}
 		})
 	}
 }

--- a/compile/x/hs/tpcds_golden_test.go
+++ b/compile/x/hs/tpcds_golden_test.go
@@ -5,12 +5,15 @@ package hscode_test
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	hscode "mochi/compile/x/hs"
 	"mochi/compile/x/testutil"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -54,7 +57,30 @@ func TestHSCompiler_TPCDSQueries(t *testing.T) {
 			if err := os.WriteFile(file, code, 0644); err != nil {
 				t.Fatalf("write error: %v", err)
 			}
-			t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
+
+			cmd := exec.Command("runhaskell", file)
+			outHS, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("runhaskell error: %v\n%s", err, outHS)
+			}
+			hsRes := strings.TrimSpace(string(outHS))
+
+			p, err := vm.Compile(prog, env)
+			if err != nil {
+				t.Fatalf("vm compile error: %v", err)
+			}
+			var vmOut bytes.Buffer
+			m := vm.New(p, &vmOut)
+			if err := m.Run(); err != nil {
+				if ve, ok := err.(*vm.VMError); ok {
+					t.Fatalf("vm run error:\n%s", ve.Format(p))
+				}
+				t.Fatalf("vm run error: %v", err)
+			}
+			vmRes := strings.TrimSpace(vmOut.String())
+			if hsRes != vmRes {
+				t.Fatalf("output mismatch\n-- hs --\n%s\n-- vm --\n%s", hsRes, vmRes)
+			}
 		})
 	}
 }

--- a/tests/vm/valid/append_builtin.hs.out
+++ b/tests/vm/valid/append_builtin.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+a = [1, 2]
+
+main :: IO ()
+main = do
+  print (append a 3)

--- a/tests/vm/valid/avg_builtin.hs.out
+++ b/tests/vm/valid/avg_builtin.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (avg [1, 2, 3])

--- a/tests/vm/valid/basic_compare.hs.out
+++ b/tests/vm/valid/basic_compare.hs.out
@@ -1,0 +1,187 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+a = (10 - 3)
+
+b = (2 + 2)
+
+main :: IO ()
+main = do
+  print (a)
+  print ((a == 7))
+  print ((b < 5))

--- a/tests/vm/valid/binary_precedence.hs.out
+++ b/tests/vm/valid/binary_precedence.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (((1 + 2) * 3))
+  print ((((1 + 2)) * 3))
+  print (((2 * 3) + 1))
+  print ((2 * ((3 + 1))))

--- a/tests/vm/valid/bool_chain.hs.out
+++ b/tests/vm/valid/bool_chain.hs.out
@@ -1,0 +1,187 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+boom :: Bool
+boom = fromMaybe (False) $
+  case (let _ = putStrLn ("boom") in Nothing) of Just v -> Just v; Nothing -> Just (True)
+
+main :: IO ()
+main = do
+  print (((((1 < 2)) && ((2 < 3))) && ((3 < 4))))
+  print (((((1 < 2)) && ((2 > 3))) && boom))
+  print ((((((1 < 2)) && ((2 < 3))) && ((3 > 4))) && boom))

--- a/tests/vm/valid/break_continue.hs.out
+++ b/tests/vm/valid/break_continue.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+main :: IO ()
+main = do
+  mapM_ (\n -> fromMaybe () (case if ((n `mod` 2) == 0) then Nothing else Nothing of Just v -> Just v; Nothing -> case if (n > 7) then Just () else Nothing of Just v -> Just v; Nothing -> (let _ = putStrLn (unwords ["odd number:", show n]) in Nothing))) numbers

--- a/tests/vm/valid/cast_string_to_int.hs.out
+++ b/tests/vm/valid/cast_string_to_int.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  putStrLn ("1995")

--- a/tests/vm/valid/cast_struct.hs.out
+++ b/tests/vm/valid/cast_struct.hs.out
@@ -1,0 +1,191 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+data Todo = Todo
+  { title :: String
+  }
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON Todo
+
+todo = Map.fromList [("title", "hi")]
+
+main :: IO ()
+main = do
+  putStrLn (title (todo))

--- a/tests/vm/valid/closure.hs.out
+++ b/tests/vm/valid/closure.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+makeAdder :: Int -> (Int -> Int)
+makeAdder n = (\x -> (x + n))
+
+add10 = makeAdder 10
+
+main :: IO ()
+main = do
+  print (add10 7)

--- a/tests/vm/valid/count_builtin.hs.out
+++ b/tests/vm/valid/count_builtin.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (length [1, 2, 3])

--- a/tests/vm/valid/cross_join.hs.out
+++ b/tests/vm/valid/cross_join.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))], Map.fromList [("id", VInt (3)), ("name", VString ("Charlie"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1), ("total", 250)], Map.fromList [("id", 101), ("customerId", 2), ("total", 125)], Map.fromList [("id", 102), ("customerId", 1), ("total", 300)]]
+
+result = [Map.fromList [("orderId", VInt (fromMaybe (error "missing") (Map.lookup "id" o))), ("orderCustomerId", VInt (fromMaybe (error "missing") (Map.lookup "customerId" o))), ("pairedCustomerName", VString (fromMaybe (error "missing") (Map.lookup "name" c))), ("orderTotal", VInt (fromMaybe (error "missing") (Map.lookup "total" o)))] | o <- orders, c <- customers]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Cross Join: All order-customer pairs ---")
+  mapM_ (\entry -> putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "orderId" entry), "(customerId:", show fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry), ", total: $", show fromMaybe (error "missing") (Map.lookup "orderTotal" entry), ") paired with", show fromMaybe (error "missing") (Map.lookup "pairedCustomerName" entry)])) result

--- a/tests/vm/valid/cross_join_filter.hs.out
+++ b/tests/vm/valid/cross_join_filter.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+nums = [1, 2, 3]
+
+letters = ["A", "B"]
+
+pairs = [Map.fromList [("n", VInt (n)), ("l", VString (l))] | n <- nums, l <- letters, ((n `mod` 2) == 0)]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Even pairs ---")
+  mapM_ (\p -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "n" p), show fromMaybe (error "missing") (Map.lookup "l" p)])) pairs

--- a/tests/vm/valid/cross_join_triple.hs.out
+++ b/tests/vm/valid/cross_join_triple.hs.out
@@ -1,0 +1,190 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+nums = [1, 2]
+
+letters = ["A", "B"]
+
+bools = [True, False]
+
+combos = [Map.fromList [("n", VInt (n)), ("l", VString (l)), ("b", VBool (b))] | n <- nums, l <- letters, b <- bools]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Cross Join of three lists ---")
+  mapM_ (\c -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "n" c), show fromMaybe (error "missing") (Map.lookup "l" c), show fromMaybe (error "missing") (Map.lookup "b" c)])) combos

--- a/tests/vm/valid/dataset_sort_take_limit.hs.out
+++ b/tests/vm/valid/dataset_sort_take_limit.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+products = [Map.fromList [("name", VString ("Laptop")), ("price", VInt (1500))], Map.fromList [("name", VString ("Smartphone")), ("price", VInt (900))], Map.fromList [("name", VString ("Tablet")), ("price", VInt (600))], Map.fromList [("name", VString ("Monitor")), ("price", VInt (300))], Map.fromList [("name", VString ("Keyboard")), ("price", VInt (100))], Map.fromList [("name", VString ("Mouse")), ("price", VInt (50))], Map.fromList [("name", VString ("Headphones")), ("price", VInt (200))]]
+
+expensive = take 3 drop 1 map snd (List.sortOn fst [((-fromMaybe (error "missing") (Map.lookup "price" (p))), p) | p <- products])
+
+main :: IO ()
+main = do
+  putStrLn ("--- Top products (excluding most expensive) ---")
+  mapM_ (\item -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" item), "costs $", show fromMaybe (error "missing") (Map.lookup "price" item)])) expensive

--- a/tests/vm/valid/dataset_where_filter.hs.out
+++ b/tests/vm/valid/dataset_where_filter.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+people = [Map.fromList [("name", VString ("Alice")), ("age", VInt (30))], Map.fromList [("name", VString ("Bob")), ("age", VInt (15))], Map.fromList [("name", VString ("Charlie")), ("age", VInt (65))], Map.fromList [("name", VString ("Diana")), ("age", VInt (45))]]
+
+adults = [Map.fromList [("name", VString (fromMaybe (error "missing") (Map.lookup "name" person))), ("age", VString (fromMaybe (error "missing") (Map.lookup "age" person))), ("is_senior", VBool ((fromMaybe (error "missing") (Map.lookup "age" person) >= 60)))] | person <- filter (\person -> (fromMaybe (error "missing") (Map.lookup "age" person) >= 18)) people]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Adults ---")
+  mapM_ (\person -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" person), "is", show fromMaybe (error "missing") (Map.lookup "age" person), 0])) adults

--- a/tests/vm/valid/exists_builtin.hs.out
+++ b/tests/vm/valid/exists_builtin.hs.out
@@ -1,0 +1,178 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+
+data = [1, 2]
+
+flag = exists [x | x <- filter (\x -> (x == 1)) data]
+
+main :: IO ()
+main = do
+    print (flag)

--- a/tests/vm/valid/for_list_collection.hs.out
+++ b/tests/vm/valid/for_list_collection.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  mapM_ (\n -> print (n)) [1, 2, 3]

--- a/tests/vm/valid/for_loop.hs.out
+++ b/tests/vm/valid/for_loop.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  mapM_ (\i -> print (i)) [1 .. 4 - 1]

--- a/tests/vm/valid/for_map_collection.hs.out
+++ b/tests/vm/valid/for_map_collection.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+m = Map.fromList [("a", 1), ("b", 2)]
+
+main :: IO ()
+main = do
+  mapM_ (\k -> putStrLn (k)) (Map.keys m)

--- a/tests/vm/valid/fun_call.hs.out
+++ b/tests/vm/valid/fun_call.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+add :: Int -> Int -> Int
+add a b = (a + b)
+
+main :: IO ()
+main = do
+  print (add 2 3)

--- a/tests/vm/valid/fun_expr_in_let.hs.out
+++ b/tests/vm/valid/fun_expr_in_let.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+square = (\x -> (x * x))
+
+main :: IO ()
+main = do
+  print (square 6)

--- a/tests/vm/valid/fun_three_args.hs.out
+++ b/tests/vm/valid/fun_three_args.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+sum3 :: Int -> Int -> Int -> Int
+sum3 a b c = ((a + b) + c)
+
+main :: IO ()
+main = do
+  print (sum3 1 2 3)

--- a/tests/vm/valid/group_by.hs.out
+++ b/tests/vm/valid/group_by.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+people = [Map.fromList [("name", VString ("Alice")), ("age", VInt (30)), ("city", VString ("Paris"))], Map.fromList [("name", VString ("Bob")), ("age", VInt (15)), ("city", VString ("Hanoi"))], Map.fromList [("name", VString ("Charlie")), ("age", VInt (65)), ("city", VString ("Paris"))], Map.fromList [("name", VString ("Diana")), ("age", VInt (45)), ("city", VString ("Hanoi"))], Map.fromList [("name", VString ("Eve")), ("age", VInt (70)), ("city", VString ("Paris"))], Map.fromList [("name", VString ("Frank")), ("age", VInt (22)), ("city", VString ("Hanoi"))]]
+
+stats = [Map.fromList [("city", VString (key (g))), ("count", VInt (length (items g))), ("avg_age", VDouble (avg [fromMaybe (error "missing") (Map.lookup "age" (p)) | p <- g]))] | g <- _group_by people (\person -> fromMaybe (error "missing") (Map.lookup "city" person)), let g = g]
+
+main :: IO ()
+main = do
+  putStrLn ("--- People grouped by city ---")
+  mapM_ (\s -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "city" s), ": count =", show fromMaybe (error "missing") (Map.lookup "count" s), ", avg_age =", show fromMaybe (error "missing") (Map.lookup "avg_age" s)])) stats

--- a/tests/vm/valid/group_by_conditional_sum.hs.out
+++ b/tests/vm/valid/group_by_conditional_sum.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+items = [Map.fromList [("cat", VString ("a")), ("val", VInt (10)), ("flag", VBool (True))], Map.fromList [("cat", VString ("a")), ("val", VInt (5)), ("flag", VBool (False))], Map.fromList [("cat", VString ("b")), ("val", VInt (20)), ("flag", VBool (True))]]
+
+result = map snd (List.sortOn fst [(key (g), Map.fromList [("cat", VString (key (g))), ("share", VDouble ((sum [0 | x <- g] / sum [fromMaybe (error "missing") (Map.lookup "val" (x)) | x <- g])))]) | g <- _group_by [(i) | i <- items] (\(i) -> fromMaybe (error "missing") (Map.lookup "cat" i))])
+
+main :: IO ()
+main = do
+  print (result)

--- a/tests/vm/valid/group_by_having.hs.out
+++ b/tests/vm/valid/group_by_having.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+people = [Map.fromList [("name", "Alice"), ("city", "Paris")], Map.fromList [("name", "Bob"), ("city", "Hanoi")], Map.fromList [("name", "Charlie"), ("city", "Paris")], Map.fromList [("name", "Diana"), ("city", "Hanoi")], Map.fromList [("name", "Eve"), ("city", "Paris")], Map.fromList [("name", "Frank"), ("city", "Hanoi")], Map.fromList [("name", "George"), ("city", "Paris")]]
+
+big = [Map.fromList [("city", VString (key (g))), ("num", VInt (length (items g)))] | g <- _group_by people (\p -> fromMaybe (error "missing") (Map.lookup "city" p)), let g = g]
+
+main :: IO ()
+main = do
+  _json big

--- a/tests/vm/valid/group_by_join.hs.out
+++ b/tests/vm/valid/group_by_join.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1)], Map.fromList [("id", 101), ("customerId", 1)], Map.fromList [("id", 102), ("customerId", 2)]]
+
+stats = [Map.fromList [("name", VString (key (g))), ("count", VInt (length (items g)))] | g <- _group_by [(o, c) | o <- orders, c <- customers, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c)))] (\(o, c) -> fromMaybe (error "missing") (Map.lookup "name" c)), let g = g]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Orders per customer ---")
+  mapM_ (\s -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" s), "orders:", show fromMaybe (error "missing") (Map.lookup "count" s)])) stats

--- a/tests/vm/valid/group_by_left_join.hs.out
+++ b/tests/vm/valid/group_by_left_join.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))], Map.fromList [("id", VInt (3)), ("name", VString ("Charlie"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1)], Map.fromList [("id", 101), ("customerId", 1)], Map.fromList [("id", 102), ("customerId", 2)]]
+
+stats = [Map.fromList [("name", VString (key (g))), ("count", VInt (length [r | r <- filter (\r -> fromMaybe (error "missing") (Map.lookup "o" (r))) g]))] | g <- _group_by [(c, o) | c <- customers, o <- orders, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c)))] (\(c, o) -> fromMaybe (error "missing") (Map.lookup "name" c)), let g = g]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Group Left Join ---")
+  mapM_ (\s -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" s), "orders:", show fromMaybe (error "missing") (Map.lookup "count" s)])) stats

--- a/tests/vm/valid/group_by_multi_join.hs.out
+++ b/tests/vm/valid/group_by_multi_join.hs.out
@@ -1,0 +1,191 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+nations = [Map.fromList [("id", VInt (1)), ("name", VString ("A"))], Map.fromList [("id", VInt (2)), ("name", VString ("B"))]]
+
+suppliers = [Map.fromList [("id", 1), ("nation", 1)], Map.fromList [("id", 2), ("nation", 2)]]
+
+partsupp = [Map.fromList [("part", VInt (100)), ("supplier", VInt (1)), ("cost", VDouble (10.0)), ("qty", VInt (2))], Map.fromList [("part", VInt (100)), ("supplier", VInt (2)), ("cost", VDouble (20.0)), ("qty", VInt (1))], Map.fromList [("part", VInt (200)), ("supplier", VInt (1)), ("cost", VDouble (5.0)), ("qty", VInt (3))]]
+
+filtered = [Map.fromList [("part", VString (fromMaybe (error "missing") (Map.lookup "part" ps))), ("value", VString ((fromMaybe (error "missing") (Map.lookup "cost" ps) * fromMaybe (error "missing") (Map.lookup "qty" ps))))] | ps <- partsupp, s <- suppliers, n <- nations, (fromMaybe (error "missing") (Map.lookup "id" (s)) == fromMaybe (error "missing") (Map.lookup "supplier" (ps))), (fromMaybe (error "missing") (Map.lookup "id" (n)) == fromMaybe (error "missing") (Map.lookup "nation" (s))), (fromMaybe (error "missing") (Map.lookup "name" n) == "A")]
+
+grouped = [Map.fromList [("part", VString (key (g))), ("total", VDouble (sum [fromMaybe (error "missing") (Map.lookup "value" (r)) | r <- g]))] | g <- _group_by filtered (\x -> fromMaybe (error "missing") (Map.lookup "part" x)), let g = g]
+
+main :: IO ()
+main = do
+  print (grouped)

--- a/tests/vm/valid/group_by_multi_join_sort.hs.out
+++ b/tests/vm/valid/group_by_multi_join_sort.hs.out
@@ -1,0 +1,195 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+nation = [Map.fromList [("n_nationkey", VInt (1)), ("n_name", VString ("BRAZIL"))]]
+
+customer = [Map.fromList [("c_custkey", VInt (1)), ("c_name", VString ("Alice")), ("c_acctbal", VDouble (100.0)), ("c_nationkey", VInt (1)), ("c_address", VString ("123 St")), ("c_phone", VString ("123-456")), ("c_comment", VString ("Loyal"))]]
+
+orders = [Map.fromList [("o_orderkey", VInt (1000)), ("o_custkey", VInt (1)), ("o_orderdate", VString ("1993-10-15"))], Map.fromList [("o_orderkey", VInt (2000)), ("o_custkey", VInt (1)), ("o_orderdate", VString ("1994-01-02"))]]
+
+lineitem = [Map.fromList [("l_orderkey", VInt (1000)), ("l_returnflag", VString ("R")), ("l_extendedprice", VDouble (1000.0)), ("l_discount", VDouble (0.1))], Map.fromList [("l_orderkey", VInt (2000)), ("l_returnflag", VString ("N")), ("l_extendedprice", VDouble (500.0)), ("l_discount", VDouble (0.0))]]
+
+start_date = "1993-10-01"
+
+end_date = "1994-01-01"
+
+result = map snd (List.sortOn fst [((-sum [(fromMaybe (error "missing") (Map.lookup "l_extendedprice" (fromMaybe (error "missing") (Map.lookup "l" (x)))) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (fromMaybe (error "missing") (Map.lookup "l" (x))))))) | x <- g]), Map.fromList [("c_custkey", VString (fromMaybe (error "missing") (Map.lookup "c_custkey" (key (g))))), ("c_name", VString (fromMaybe (error "missing") (Map.lookup "c_name" (key (g))))), ("revenue", VDouble (sum [(fromMaybe (error "missing") (Map.lookup "l_extendedprice" (fromMaybe (error "missing") (Map.lookup "l" (x)))) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (fromMaybe (error "missing") (Map.lookup "l" (x))))))) | x <- g])), ("c_acctbal", VString (fromMaybe (error "missing") (Map.lookup "c_acctbal" (key (g))))), ("n_name", VString (fromMaybe (error "missing") (Map.lookup "n_name" (key (g))))), ("c_address", VString (fromMaybe (error "missing") (Map.lookup "c_address" (key (g))))), ("c_phone", VString (fromMaybe (error "missing") (Map.lookup "c_phone" (key (g))))), ("c_comment", VString (fromMaybe (error "missing") (Map.lookup "c_comment" (key (g)))))]) | g <- _group_by [(c, o, l, n) | c <- customer, o <- orders, l <- lineitem, n <- nation, (fromMaybe (error "missing") (Map.lookup "o_custkey" (o)) == fromMaybe (error "missing") (Map.lookup "c_custkey" (c))), (fromMaybe (error "missing") (Map.lookup "l_orderkey" (l)) == fromMaybe (error "missing") (Map.lookup "o_orderkey" (o))), (fromMaybe (error "missing") (Map.lookup "n_nationkey" (n)) == fromMaybe (error "missing") (Map.lookup "c_nationkey" (c))), (((((fromMaybe (error "missing") (Map.lookup "o_orderdate" o) >= start_date) && fromMaybe (error "missing") (Map.lookup "o_orderdate" o)) < end_date) && fromMaybe (error "missing") (Map.lookup "l_returnflag" l)) == "R")] (\(c, o, l, n) -> Map.fromList [("c_custkey", VString (fromMaybe (error "missing") (Map.lookup "c_custkey" c))), ("c_name", VString (fromMaybe (error "missing") (Map.lookup "c_name" c))), ("c_acctbal", VString (fromMaybe (error "missing") (Map.lookup "c_acctbal" c))), ("c_address", VString (fromMaybe (error "missing") (Map.lookup "c_address" c))), ("c_phone", VString (fromMaybe (error "missing") (Map.lookup "c_phone" c))), ("c_comment", VString (fromMaybe (error "missing") (Map.lookup "c_comment" c))), ("n_name", VString (fromMaybe (error "missing") (Map.lookup "n_name" n)))])])
+
+main :: IO ()
+main = do
+  print (result)

--- a/tests/vm/valid/group_by_sort.hs.out
+++ b/tests/vm/valid/group_by_sort.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+items = [Map.fromList [("cat", VString ("a")), ("val", VInt (3))], Map.fromList [("cat", VString ("a")), ("val", VInt (1))], Map.fromList [("cat", VString ("b")), ("val", VInt (5))], Map.fromList [("cat", VString ("b")), ("val", VInt (2))]]
+
+grouped = map snd (List.sortOn fst [((-sum [fromMaybe (error "missing") (Map.lookup "val" (x)) | x <- g]), Map.fromList [("cat", VString (key (g))), ("total", VDouble (sum [fromMaybe (error "missing") (Map.lookup "val" (x)) | x <- g]))]) | g <- _group_by [(i) | i <- items] (\(i) -> fromMaybe (error "missing") (Map.lookup "cat" i))])
+
+main :: IO ()
+main = do
+  print (grouped)

--- a/tests/vm/valid/group_items_iteration.hs.out
+++ b/tests/vm/valid/group_items_iteration.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+
+data = [Map.fromList [("tag", VString ("a")), ("val", VInt (1))], Map.fromList [("tag", VString ("a")), ("val", VInt (2))], Map.fromList [("tag", VString ("b")), ("val", VInt (3))]]
+
+groups = [ g | g <- _group_by data (\d -> fromMaybe (error "missing") (Map.lookup "tag" d)), let g = g ]
+
+tmp = []
+
+result = map snd (List.sortOn fst [ ( fromMaybe (error "missing") (Map.lookup "tag" (r)), r ) | r <- tmp ])
+
+main :: IO ()
+main = do
+    mapM_ (\g -> fromMaybe () ((let total = 0 in case foldr (\x acc -> case (let total = (total + fromMaybe (error "missing") (Map.lookup "val" (x))) in Nothing) of Just v -> Just v; Nothing -> acc) Nothing items (g) of Just v -> Just v; Nothing -> (let tmp = append tmp Map.fromList [("tag", VString (key (g))), ("total", VString (total))] in Nothing)))) groups
+    print (result)

--- a/tests/vm/valid/if_then_else.hs.out
+++ b/tests/vm/valid/if_then_else.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+x = 12
+
+msg = 0
+
+main :: IO ()
+main = do
+  putStrLn (msg)

--- a/tests/vm/valid/if_then_else_nested.hs.out
+++ b/tests/vm/valid/if_then_else_nested.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+x = 8
+
+msg = 0
+
+main :: IO ()
+main = do
+  putStrLn (msg)

--- a/tests/vm/valid/in_operator.hs.out
+++ b/tests/vm/valid/in_operator.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+xs = [1, 2, 3]
+
+main :: IO ()
+main = do
+  print (elem 2 xs)
+  print (not (elem 5 xs))

--- a/tests/vm/valid/in_operator_extended.hs.out
+++ b/tests/vm/valid/in_operator_extended.hs.out
@@ -1,0 +1,194 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+xs = [1, 2, 3]
+
+ys = [x | x <- filter (\x -> ((x `mod` 2) == 1)) xs]
+
+m = Map.fromList [("a", 1)]
+
+s = "hello"
+
+main :: IO ()
+main = do
+  print (elem 1 ys)
+  print (elem 2 ys)
+  print (Map.member "a" m)
+  print (Map.member "b" m)
+  print (elem "ell" s)
+  print (elem "foo" s)

--- a/tests/vm/valid/inner_join.hs.out
+++ b/tests/vm/valid/inner_join.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))], Map.fromList [("id", VInt (3)), ("name", VString ("Charlie"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1), ("total", 250)], Map.fromList [("id", 101), ("customerId", 2), ("total", 125)], Map.fromList [("id", 102), ("customerId", 1), ("total", 300)], Map.fromList [("id", 103), ("customerId", 4), ("total", 80)]]
+
+result = [Map.fromList [("orderId", VInt (fromMaybe (error "missing") (Map.lookup "id" o))), ("customerName", VString (fromMaybe (error "missing") (Map.lookup "name" c))), ("total", VInt (fromMaybe (error "missing") (Map.lookup "total" o)))] | o <- orders, c <- customers, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c)))]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Orders with customer info ---")
+  mapM_ (\entry -> putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "orderId" entry), "by", show fromMaybe (error "missing") (Map.lookup "customerName" entry), "- $", show fromMaybe (error "missing") (Map.lookup "total" entry)])) result

--- a/tests/vm/valid/join_multi.hs.out
+++ b/tests/vm/valid/join_multi.hs.out
@@ -1,0 +1,190 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1)], Map.fromList [("id", 101), ("customerId", 2)]]
+
+items = [Map.fromList [("orderId", VInt (100)), ("sku", VString ("a"))], Map.fromList [("orderId", VInt (101)), ("sku", VString ("b"))]]
+
+result = [Map.fromList [("name", VString (fromMaybe (error "missing") (Map.lookup "name" c))), ("sku", VString (fromMaybe (error "missing") (Map.lookup "sku" i)))] | o <- orders, c <- customers, i <- items, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c))), (fromMaybe (error "missing") (Map.lookup "id" (o)) == fromMaybe (error "missing") (Map.lookup "orderId" (i)))]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Multi Join ---")
+  mapM_ (\r -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" r), "bought item", show fromMaybe (error "missing") (Map.lookup "sku" r)])) result

--- a/tests/vm/valid/json_builtin.hs.out
+++ b/tests/vm/valid/json_builtin.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+m = Map.fromList [("a", 1), ("b", 2)]
+
+main :: IO ()
+main = do
+  _json m

--- a/tests/vm/valid/left_join.hs.out
+++ b/tests/vm/valid/left_join.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1), ("total", 250)], Map.fromList [("id", 101), ("customerId", 3), ("total", 80)]]
+
+result = [Map.fromList [("orderId", VInt (fromMaybe (error "missing") (Map.lookup "id" o))), ("customer", VString (c)), ("total", VInt (fromMaybe (error "missing") (Map.lookup "total" o)))] | o <- orders, c <- customers, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c)))]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Left Join ---")
+  mapM_ (\entry -> putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "orderId" entry), "customer", show fromMaybe (error "missing") (Map.lookup "customer" entry), "total", show fromMaybe (error "missing") (Map.lookup "total" entry)])) result

--- a/tests/vm/valid/left_join_multi.hs.out
+++ b/tests/vm/valid/left_join_multi.hs.out
@@ -1,0 +1,190 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1)], Map.fromList [("id", 101), ("customerId", 2)]]
+
+items = [Map.fromList [("orderId", VInt (100)), ("sku", VString ("a"))]]
+
+result = [Map.fromList [("orderId", VInt (fromMaybe (error "missing") (Map.lookup "id" o))), ("name", VString (fromMaybe (error "missing") (Map.lookup "name" c))), ("item", VString (i))] | o <- orders, c <- customers, i <- items, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c))), (fromMaybe (error "missing") (Map.lookup "id" (o)) == fromMaybe (error "missing") (Map.lookup "orderId" (i)))]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Left Join Multi ---")
+  mapM_ (\r -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "orderId" r), show fromMaybe (error "missing") (Map.lookup "name" r), show fromMaybe (error "missing") (Map.lookup "item" r)])) result

--- a/tests/vm/valid/len_builtin.hs.out
+++ b/tests/vm/valid/len_builtin.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (length [1, 2, 3])

--- a/tests/vm/valid/len_map.hs.out
+++ b/tests/vm/valid/len_map.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (length Map.fromList [("a", 1), ("b", 2)])

--- a/tests/vm/valid/len_string.hs.out
+++ b/tests/vm/valid/len_string.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (length "mochi")

--- a/tests/vm/valid/let_and_print.hs.out
+++ b/tests/vm/valid/let_and_print.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+a = 10
+
+b = 20
+
+main :: IO ()
+main = do
+  print ((a + b))

--- a/tests/vm/valid/list_index.hs.out
+++ b/tests/vm/valid/list_index.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+xs = [10, 20, 30]
+
+main :: IO ()
+main = do
+  print ((xs !! 1))

--- a/tests/vm/valid/list_set_ops.hs.out
+++ b/tests/vm/valid/list_set_ops.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (List.union [1, 2] [2, 3])
+  print (([1, 2, 3] List.\ [2]))
+  print (List.intersect [1, 2, 3] [2, 4])
+  print (length ([1, 2] ++ [2, 3]))

--- a/tests/vm/valid/load_yaml.hs.out
+++ b/tests/vm/valid/load_yaml.hs.out
@@ -1,0 +1,195 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+data Person = Person
+  { name :: String,
+    age :: Int,
+    email :: String
+  }
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON Person
+
+people = _load Just "../interpreter/valid/people.yaml" Just (Map.fromList [("format", "yaml")])
+
+adults = [Map.fromList [("name", name (p)), ("email", email (p))] | p <- filter (\p -> (age (p) >= 18)) people]
+
+main :: IO ()
+main = do
+  mapM_ (\a -> putStrLn (unwords [fromMaybe (error "missing") (Map.lookup "name" a), fromMaybe (error "missing") (Map.lookup "email" a)])) adults

--- a/tests/vm/valid/map_in_operator.hs.out
+++ b/tests/vm/valid/map_in_operator.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+m = Map.fromList [(1, "a"), (2, "b")]
+
+main :: IO ()
+main = do
+  print (Map.member 1 m)
+  print (Map.member 3 m)

--- a/tests/vm/valid/map_index.hs.out
+++ b/tests/vm/valid/map_index.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+m = Map.fromList [("a", 1), ("b", 2)]
+
+main :: IO ()
+main = do
+  print (fromMaybe (error "missing") (Map.lookup "b" m))

--- a/tests/vm/valid/map_int_key.hs.out
+++ b/tests/vm/valid/map_int_key.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+m = Map.fromList [(1, "a"), (2, "b")]
+
+main :: IO ()
+main = do
+  putStrLn (fromMaybe (error "missing") (Map.lookup 1 m))

--- a/tests/vm/valid/map_literal_dynamic.hs.out
+++ b/tests/vm/valid/map_literal_dynamic.hs.out
@@ -1,0 +1,187 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+x = 3
+
+y = 4
+
+m = Map.fromList [("a", x), ("b", y)]
+
+main :: IO ()
+main = do
+  putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "a" m), show fromMaybe (error "missing") (Map.lookup "b" m)])

--- a/tests/vm/valid/map_membership.hs.out
+++ b/tests/vm/valid/map_membership.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+m = Map.fromList [("a", 1), ("b", 2)]
+
+main :: IO ()
+main = do
+  print (Map.member "a" m)
+  print (Map.member "c" m)

--- a/tests/vm/valid/match_expr.hs.out
+++ b/tests/vm/valid/match_expr.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+x = 2
+
+label = 0
+
+main :: IO ()
+main = do
+  putStrLn (label)

--- a/tests/vm/valid/match_full.hs.out
+++ b/tests/vm/valid/match_full.hs.out
@@ -1,0 +1,200 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+classify :: Int -> String
+classify n = 0
+
+x = 2
+
+label = 0
+
+day = "sun"
+
+mood = 0
+
+ok = True
+
+status = 0
+
+main :: IO ()
+main = do
+  putStrLn (label)
+  putStrLn (mood)
+  putStrLn (status)
+  putStrLn (classify 0)
+  putStrLn (classify 5)

--- a/tests/vm/valid/math_ops.hs.out
+++ b/tests/vm/valid/math_ops.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print ((6 * 7))
+  print ((div 7 2))
+  print ((7 `mod` 2))

--- a/tests/vm/valid/membership.hs.out
+++ b/tests/vm/valid/membership.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+nums = [1, 2, 3]
+
+main :: IO ()
+main = do
+  print (elem 2 nums)
+  print (elem 4 nums)

--- a/tests/vm/valid/min_max_builtin.hs.out
+++ b/tests/vm/valid/min_max_builtin.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+nums = [3, 1, 4]
+
+main :: IO ()
+main = do
+  print (min nums)
+  print (max nums)

--- a/tests/vm/valid/nested_function.hs.out
+++ b/tests/vm/valid/nested_function.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+outer :: Int -> Int
+outer x =
+  fromMaybe (0) $
+    (let inner = (\y -> fromMaybe ((x + y)) $ Nothing) in Just (inner 5))
+
+main :: IO ()
+main = do
+  print (outer 3)

--- a/tests/vm/valid/order_by_map.hs.out
+++ b/tests/vm/valid/order_by_map.hs.out
@@ -1,0 +1,178 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+
+data = [Map.fromList [("a", 1), ("b", 2)], Map.fromList [("a", 1), ("b", 1)], Map.fromList [("a", 0), ("b", 5)]]
+
+sorted = map snd (List.sortOn fst [ ( Map.fromList [("a", VString (fromMaybe (error "missing") (Map.lookup "a" (x)))), ("b", VString (fromMaybe (error "missing") (Map.lookup "b" (x))))], x ) | x <- data ])
+
+main :: IO ()
+main = do
+    print (sorted)

--- a/tests/vm/valid/outer_join.hs.out
+++ b/tests/vm/valid/outer_join.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))], Map.fromList [("id", VInt (3)), ("name", VString ("Charlie"))], Map.fromList [("id", VInt (4)), ("name", VString ("Diana"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1), ("total", 250)], Map.fromList [("id", 101), ("customerId", 2), ("total", 125)], Map.fromList [("id", 102), ("customerId", 1), ("total", 300)], Map.fromList [("id", 103), ("customerId", 5), ("total", 80)]]
+
+result = [Map.fromList [("order", VString (o)), ("customer", VString (c))] | o <- orders, c <- customers, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c)))]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Outer Join using syntax ---")
+  mapM_ (\row -> fromMaybe () (if fromMaybe (error "missing") (Map.lookup "order" row) then if fromMaybe (error "missing") (Map.lookup "customer" row) then (let _ = putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "id" fromMaybe (error "missing") (Map.lookup "order" row)), "by", show fromMaybe (error "missing") (Map.lookup "name" fromMaybe (error "missing") (Map.lookup "customer" row)), "- $", show fromMaybe (error "missing") (Map.lookup "total" fromMaybe (error "missing") (Map.lookup "order" row))]) in Nothing) else (let _ = putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "id" fromMaybe (error "missing") (Map.lookup "order" row)), "by", "Unknown", "- $", show fromMaybe (error "missing") (Map.lookup "total" fromMaybe (error "missing") (Map.lookup "order" row))]) in Nothing) else (let _ = putStrLn (unwords ["Customer", show fromMaybe (error "missing") (Map.lookup "name" fromMaybe (error "missing") (Map.lookup "customer" row)), "has no orders"]) in Nothing))) result

--- a/tests/vm/valid/partial_application.hs.out
+++ b/tests/vm/valid/partial_application.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+add :: Int -> Int -> Int
+add a b = (a + b)
+
+add5 = add 5
+
+main :: IO ()
+main = do
+  print (add5 3)

--- a/tests/vm/valid/print_hello.hs.out
+++ b/tests/vm/valid/print_hello.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  putStrLn ("hello")

--- a/tests/vm/valid/pure_fold.hs.out
+++ b/tests/vm/valid/pure_fold.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+triple :: Int -> Int
+triple x = (x * 3)
+
+main :: IO ()
+main = do
+  print (triple (1 + 2))

--- a/tests/vm/valid/pure_global_fold.hs.out
+++ b/tests/vm/valid/pure_global_fold.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+inc :: Int -> Int
+inc x = (x + k)
+
+k = 2
+
+main :: IO ()
+main = do
+  print (inc 3)

--- a/tests/vm/valid/query_sum_select.hs.out
+++ b/tests/vm/valid/query_sum_select.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+nums = [1, 2, 3]
+
+result = [sum n | n <- filter (\n -> (n > 1)) nums]
+
+main :: IO ()
+main = do
+  print (result)

--- a/tests/vm/valid/record_assign.hs.out
+++ b/tests/vm/valid/record_assign.hs.out
@@ -1,0 +1,197 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+data Counter = Counter
+  { n :: Int
+  }
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON Counter
+
+inc :: Counter -> ()
+inc c =
+  fromMaybe (()) $
+    (let c = (n (c) + 1) in Nothing)
+
+c = Counter {n = 0}
+
+main :: IO ()
+main = do
+  inc c
+  print (n (c))

--- a/tests/vm/valid/right_join.hs.out
+++ b/tests/vm/valid/right_join.hs.out
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.fromList [("id", VInt (2)), ("name", VString ("Bob"))], Map.fromList [("id", VInt (3)), ("name", VString ("Charlie"))], Map.fromList [("id", VInt (4)), ("name", VString ("Diana"))]]
+
+orders = [Map.fromList [("id", 100), ("customerId", 1), ("total", 250)], Map.fromList [("id", 101), ("customerId", 2), ("total", 125)], Map.fromList [("id", 102), ("customerId", 1), ("total", 300)]]
+
+result = [Map.fromList [("customerName", VString (fromMaybe (error "missing") (Map.lookup "name" c))), ("order", VString (o))] | c <- customers, o <- orders, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c)))]
+
+main :: IO ()
+main = do
+  putStrLn ("--- Right Join using syntax ---")
+  mapM_ (\entry -> fromMaybe () (if fromMaybe (error "missing") (Map.lookup "order" entry) then (let _ = putStrLn (unwords ["Customer", show fromMaybe (error "missing") (Map.lookup "customerName" entry), "has order", show fromMaybe (error "missing") (Map.lookup "id" (fromMaybe (error "missing") (Map.lookup "order" entry))), "- $", show fromMaybe (error "missing") (Map.lookup "total" (fromMaybe (error "missing") (Map.lookup "order" entry)))]) in Nothing) else (let _ = putStrLn (unwords ["Customer", show fromMaybe (error "missing") (Map.lookup "customerName" entry), "has no orders"]) in Nothing))) result

--- a/tests/vm/valid/save_jsonl_stdout.hs.out
+++ b/tests/vm/valid/save_jsonl_stdout.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+people = [Map.fromList [("name", VString ("Alice")), ("age", VInt (30))], Map.fromList [("name", VString ("Bob")), ("age", VInt (25))]]
+
+main :: IO ()
+main = do
+  _save people Just "-" Just (Map.fromList [("format", "jsonl")])

--- a/tests/vm/valid/short_circuit.hs.out
+++ b/tests/vm/valid/short_circuit.hs.out
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+boom :: Int -> Int -> Bool
+boom a b = fromMaybe (False) $
+  case (let _ = putStrLn ("boom") in Nothing) of Just v -> Just v; Nothing -> Just (True)
+
+main :: IO ()
+main = do
+  print ((False && boom 1 2))
+  print ((True || boom 1 2))

--- a/tests/vm/valid/slice.hs.out
+++ b/tests/vm/valid/slice.hs.out
@@ -1,0 +1,203 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+   in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+   in take (end' - start) (drop start s)
+
+main :: IO ()
+main = do
+  print (_slice [1, 2, 3] 1 3)
+  print (_slice [1, 2, 3] 0 2)
+  putStrLn (_sliceString "hello" 1 4)

--- a/tests/vm/valid/sort_stable.hs.out
+++ b/tests/vm/valid/sort_stable.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+items = [Map.fromList [("n", VInt (1)), ("v", VString ("a"))], Map.fromList [("n", VInt (1)), ("v", VString ("b"))], Map.fromList [("n", VInt (2)), ("v", VString ("c"))]]
+
+result = map snd (List.sortOn fst [(fromMaybe (error "missing") (Map.lookup "n" (i)), fromMaybe (error "missing") (Map.lookup "v" i)) | i <- items])
+
+main :: IO ()
+main = do
+  print (result)

--- a/tests/vm/valid/str_builtin.hs.out
+++ b/tests/vm/valid/str_builtin.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  putStrLn (show 123)

--- a/tests/vm/valid/string_compare.hs.out
+++ b/tests/vm/valid/string_compare.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (("a" < "b"))
+  print (("a" <= "a"))
+  print (("b" > "a"))
+  print (("b" >= "b"))

--- a/tests/vm/valid/string_concat.hs.out
+++ b/tests/vm/valid/string_concat.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  putStrLn (("hello " ++ "world"))

--- a/tests/vm/valid/string_contains.hs.out
+++ b/tests/vm/valid/string_contains.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+s = "catch"
+
+main :: IO ()
+main = do
+  print (fromMaybe (error "missing") (Map.lookup "contains" (s)) "cat")
+  print (fromMaybe (error "missing") (Map.lookup "contains" (s)) "dog")

--- a/tests/vm/valid/string_in_operator.hs.out
+++ b/tests/vm/valid/string_in_operator.hs.out
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+s = "catch"
+
+main :: IO ()
+main = do
+  print (elem "cat" s)
+  print (elem "dog" s)

--- a/tests/vm/valid/string_index.hs.out
+++ b/tests/vm/valid/string_index.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+s = "mochi"
+
+main :: IO ()
+main = do
+  putStrLn (_indexString s 1)

--- a/tests/vm/valid/string_prefix_slice.hs.out
+++ b/tests/vm/valid/string_prefix_slice.hs.out
@@ -1,0 +1,208 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+   in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+   in take (end' - start) (drop start s)
+
+prefix = "fore"
+
+s1 = "forest"
+
+s2 = "desert"
+
+main :: IO ()
+main = do
+  print ((_sliceString s1 0 length prefix == prefix))
+  print ((_sliceString s2 0 length prefix == prefix))

--- a/tests/vm/valid/substring_builtin.hs.out
+++ b/tests/vm/valid/substring_builtin.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  putStrLn (substring "mochi" 1 4)

--- a/tests/vm/valid/sum_builtin.hs.out
+++ b/tests/vm/valid/sum_builtin.hs.out
@@ -1,0 +1,181 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print (sum [1, 2, 3])

--- a/tests/vm/valid/tail_recursion.hs.out
+++ b/tests/vm/valid/tail_recursion.hs.out
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+sum_rec :: Int -> Int -> Int
+sum_rec n acc = fromMaybe (0) $
+  case if (n == 0) then Just (acc) else Nothing of Just v -> Just v; Nothing -> Just (sum_rec (n - 1) (acc + n))
+
+main :: IO ()
+main = do
+  print (sum_rec 10 0)

--- a/tests/vm/valid/test_block.hs.out
+++ b/tests/vm/valid/test_block.hs.out
@@ -1,0 +1,191 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+test_addition_works :: IO ()
+test_addition_works = do
+  let x = (1 + 2)
+  expect ((x == 3))
+
+main :: IO ()
+main = do
+  putStrLn ("ok")
+  test_addition_works

--- a/tests/vm/valid/tree_sum.hs.out
+++ b/tests/vm/valid/tree_sum.hs.out
@@ -1,0 +1,194 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+data Tree
+  = Leaf
+  | Node {left :: (), value :: Int, right :: ()}
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON Tree
+
+sum_tree :: () -> Int
+sum_tree t = 0
+
+t = Node {left = Leaf, value = 1, right = Node {left = Leaf, value = 2, right = Leaf}}
+
+main :: IO ()
+main = do
+  print (sum_tree t)

--- a/tests/vm/valid/two-sum.hs.out
+++ b/tests/vm/valid/two-sum.hs.out
@@ -1,0 +1,191 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+twoSum :: [Int] -> Int -> [Int]
+twoSum nums target =
+  fromMaybe ([]) $
+    (let n = length nums in case forLoop 0 n (\i -> forLoop (i + 1) n (\j -> if (((nums !! i) + (nums !! j)) == target) then Just ([i, j]) else Nothing)) of Just v -> Just v; Nothing -> Just ([(-1), (-1)]))
+  where
+    n = length nums
+
+result = twoSum [2, 7, 11, 15] 9
+
+main :: IO ()
+main = do
+  print ((result !! 0))
+  print ((result !! 1))

--- a/tests/vm/valid/typed_let.hs.out
+++ b/tests/vm/valid/typed_let.hs.out
@@ -1,0 +1,176 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main where
+
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  in case fmt of
+    "json" ->
+      let objs = map _mapToValue rows
+          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+      in _writeOutput path (BSL.unpack (Aeson.encode val))
+    _ ->
+      let headers = if null rows then [] else Map.keys (head rows)
+          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+      in _writeOutput path text
+
+
+y = 
+
+main :: IO ()
+main = do
+    print (y)

--- a/tests/vm/valid/typed_var.hs.out
+++ b/tests/vm/valid/typed_var.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+x = ()
+
+main :: IO ()
+main = do
+  print (x)

--- a/tests/vm/valid/unary_neg.hs.out
+++ b/tests/vm/valid/unary_neg.hs.out
@@ -1,0 +1,182 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+main :: IO ()
+main = do
+  print ((-3))
+  print ((5 + ((-2))))

--- a/tests/vm/valid/user_type_literal.hs.out
+++ b/tests/vm/valid/user_type_literal.hs.out
@@ -1,0 +1,200 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+data Person = Person
+  { name :: String,
+    age :: Int
+  }
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON Person
+
+data Book = Book
+  { title :: String,
+    author :: Person
+  }
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON Book
+
+book = Book {title = "Go", author = Person {name = "Bob", age = 42}}
+
+main :: IO ()
+main = do
+  putStrLn (name (author (book)))

--- a/tests/vm/valid/values_builtin.hs.out
+++ b/tests/vm/valid/values_builtin.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+m = Map.fromList [("a", 1), ("b", 2), ("c", 3)]
+
+main :: IO ()
+main = do
+  print (values m)

--- a/tests/vm/valid/while_loop.hs.out
+++ b/tests/vm/valid/while_loop.hs.out
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
+
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
+
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x : xs) m order =
+        let k = keyfn x
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: (Aeson.ToJSON a) => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+i = 0
+
+main :: IO ()
+main = do
+  let _ = whileLoop (\() -> (i < 3)) (\() -> Nothing <$ (fromMaybe () (case (let _ = print (i) in Nothing) of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing)))) in return ()


### PR DESCRIPTION
## Summary
- regenerate golden outputs for the Haskell backend using `vm_roundtrip`
- execute generated code in JOB/TPCH/TPCDS tests and compare with VM

## Testing
- `go test -tags=slow ./compile/x/hs -run HSCompiler_JOBQueries -count=1` *(fails: could not find `Data.Aeson` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686aa52e5d8c8320b5db7be563a0dc83