### PR TITLE
Improve Erlang backend testing

### DIFF
--- a/compile/x/erlang/cmd/vm_roundtrip/main.go
+++ b/compile/x/erlang/cmd/vm_roundtrip/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	erlcode "mochi/compile/x/erlang"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	converter "mochi/tools/any2mochi/x/erlang"
+	"mochi/types"
+)
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+func main() {
+	files, err := filepath.Glob("tests/vm/valid/*.mochi")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "glob error:", err)
+		os.Exit(1)
+	}
+
+	var report strings.Builder
+	report.WriteString("# Erlang roundtrip VM test failures\n\n")
+	for _, src := range files {
+		if err := process(src); err != nil {
+			report.WriteString(fmt.Sprintf("## %s\n\n```\n%s\n```\n\n", src, err))
+		}
+	}
+	if report.Len() == 0 {
+		report.WriteString("All Erlang roundtrip VM tests passed.\n")
+	}
+	os.WriteFile("compile/x/erlang/ERRORS.md", []byte(report.String()), 0644)
+}
+
+func process(src string) error {
+	base := strings.TrimSuffix(src, ".mochi")
+	erlPath := base + ".erl.out"
+	mochiPath := base + ".mochi.out"
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		writeErr(base+".erl.error", err)
+		return fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		writeErr(base+".erl.error", errs[0])
+		return fmt.Errorf("type error: %v", errs[0])
+	}
+	code, err := erlcode.New(env).Compile(prog)
+	if err != nil {
+		writeErr(base+".erl.error", err)
+		return fmt.Errorf("compile error: %w", err)
+	}
+	os.WriteFile(erlPath, code, 0644)
+
+	conv, err := converter.Convert(string(code))
+	if err != nil {
+		writeErr(base+".mochi.error", err)
+		return fmt.Errorf("erl2mochi error: %w", err)
+	}
+	os.WriteFile(mochiPath, conv, 0644)
+
+	rtProg, err := parser.ParseString(string(conv))
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("parse roundtrip error: %w", err)
+	}
+	if errs := types.Check(rtProg, env); len(errs) > 0 {
+		writeErr(base+".vm.error", errs[0])
+		return fmt.Errorf("type roundtrip error: %v", errs[0])
+	}
+	p, err := vm.Compile(rtProg, env)
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("compile roundtrip error: %w", err)
+	}
+	var in io.Reader = os.Stdin
+	if fileExists(base + ".in") {
+		if f, err := os.Open(base + ".in"); err == nil {
+			defer f.Close()
+			in = f
+		}
+	}
+	var out bytes.Buffer
+	m := vm.NewWithIO(p, in, &out)
+	if err := m.Run(); err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("run error: %w", err)
+	}
+	want, err := os.ReadFile(base + ".out")
+	if err != nil {
+		writeErr(base+".vm.error", err)
+		return fmt.Errorf("missing golden output: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(string(want)) {
+		writeErr(base+".vm.error", fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, strings.TrimSpace(string(want))))
+		return fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, strings.TrimSpace(string(want)))
+	}
+	os.Remove(base + ".erl.error")
+	os.Remove(base + ".mochi.error")
+	os.Remove(base + ".vm.error")
+	return nil
+}
+
+func writeErr(path string, err error) {
+	os.WriteFile(path, []byte(err.Error()), 0644)
+}

--- a/compile/x/erlang/compiler_test.go
+++ b/compile/x/erlang/compiler_test.go
@@ -5,6 +5,7 @@ package erlcode_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	erlcode "mochi/compile/x/erlang"
 	"mochi/golden"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -123,71 +125,39 @@ func TestErlangCompiler_SubsetPrograms(t *testing.T) {
 		t.Skipf("erlang not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/erl_simple", ".mochi", ".out", func(src string) ([]byte, error) {
-		prog, err := parser.Parse(src)
+		erlOut, err := runErlang(src)
 		if err != nil {
-			return nil, fmt.Errorf("❌ parse error: %w", err)
+			return nil, err
 		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			return nil, fmt.Errorf("❌ type error: %v", errs[0])
-		}
-		c := erlcode.New(env)
-		code, err := c.Compile(prog)
+		vmOut, err := runVM(src)
 		if err != nil {
-			return nil, fmt.Errorf("❌ compile error: %w", err)
+			return nil, err
 		}
-		dir := t.TempDir()
-		file := filepath.Join(dir, "main.erl")
-		if err := os.WriteFile(file, code, 0755); err != nil {
-			return nil, fmt.Errorf("write error: %w", err)
+		if !bytes.Equal(vmOut, erlOut) {
+			return nil, fmt.Errorf("output mismatch\n\n--- VM ---\n%s\n\n--- Erlang ---\n%s\n", vmOut, erlOut)
 		}
-		cmd := exec.Command("escript", file)
-		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
-			cmd.Stdin = bytes.NewReader(data)
+		if erlOut == nil {
+			erlOut = []byte{}
 		}
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return nil, fmt.Errorf("❌ escript error: %w\n%s", err, out)
-		}
-		res := bytes.TrimSpace(out)
-		if res == nil {
-			res = []byte{}
-		}
-		return res, nil
+		return erlOut, nil
 	})
 
 	golden.Run(t, "tests/compiler/erl", ".mochi", ".out", func(src string) ([]byte, error) {
-		prog, err := parser.Parse(src)
+		erlOut, err := runErlang(src)
 		if err != nil {
-			return nil, fmt.Errorf("❌ parse error: %w", err)
+			return nil, err
 		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			return nil, fmt.Errorf("❌ type error: %v", errs[0])
-		}
-		c := erlcode.New(env)
-		code, err := c.Compile(prog)
+		vmOut, err := runVM(src)
 		if err != nil {
-			return nil, fmt.Errorf("❌ compile error: %w", err)
+			return nil, err
 		}
-		dir := t.TempDir()
-		file := filepath.Join(dir, "main.erl")
-		if err := os.WriteFile(file, code, 0755); err != nil {
-			return nil, fmt.Errorf("write error: %w", err)
+		if !bytes.Equal(vmOut, erlOut) {
+			return nil, fmt.Errorf("output mismatch\n\n--- VM ---\n%s\n\n--- Erlang ---\n%s\n", vmOut, erlOut)
 		}
-		cmd := exec.Command("escript", file)
-		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
-			cmd.Stdin = bytes.NewReader(data)
+		if erlOut == nil {
+			erlOut = []byte{}
 		}
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return nil, fmt.Errorf("❌ escript error: %w\n%s", err, out)
-		}
-		res := bytes.TrimSpace(out)
-		if res == nil {
-			res = []byte{}
-		}
-		return res, nil
+		return erlOut, nil
 	})
 }
 
@@ -211,4 +181,140 @@ func TestErlangCompiler_GoldenOutput(t *testing.T) {
 
 	golden.Run(t, "tests/compiler/erl_simple", ".mochi", ".erl.out", run)
 	golden.Run(t, "tests/compiler/erl", ".mochi", ".erl.out", run)
+}
+
+func TestErlangCompiler_ValidVM(t *testing.T) {
+	if err := erlcode.EnsureErlang(); err != nil {
+		t.Skipf("erlang not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	files, err := filepath.Glob(filepath.Join(root, "tests", "compiler", "valid", "*.mochi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var errs []string
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		t.Run(name, func(t *testing.T) {
+			erlOut, err := runErlang(src)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+				t.Error(err)
+				return
+			}
+			vmOut, err := runVM(src)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+				t.Error(err)
+				return
+			}
+			if !bytes.Equal(vmOut, erlOut) {
+				errs = append(errs, fmt.Sprintf("%s: output mismatch", name))
+				t.Errorf("output mismatch\n--- VM ---\n%s\n--- ERL ---\n%s\n", vmOut, erlOut)
+			}
+		})
+	}
+	writeErrors(filepath.Join(root, "compile", "x", "erlang"), errs)
+}
+
+// runVM executes src using the runtime VM and returns trimmed stdout.
+func runVM(src string) ([]byte, error) {
+	prog, err := parser.Parse(src)
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	p, err := vm.CompileWithSource(prog, env, string(mustRead(src)))
+	if err != nil {
+		return nil, fmt.Errorf("vm compile error: %w", err)
+	}
+	var in io.Reader = os.Stdin
+	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+		in = bytes.NewReader(data)
+	}
+	var out bytes.Buffer
+	m := vm.NewWithIO(p, in, &out)
+	if err := m.Run(); err != nil {
+		if ve, ok := err.(*vm.VMError); ok {
+			return nil, fmt.Errorf("vm run error:\n%s", ve.Format(p))
+		}
+		return nil, fmt.Errorf("vm run error: %v", err)
+	}
+	return bytes.TrimSpace(out.Bytes()), nil
+}
+
+// runErlang compiles src to Erlang, runs it with escript and returns stdout.
+func runErlang(src string) ([]byte, error) {
+	prog, err := parser.Parse(src)
+	if err != nil {
+		return nil, fmt.Errorf("❌ parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("❌ type error: %v", errs[0])
+	}
+	code, err := erlcode.New(env).Compile(prog)
+	if err != nil {
+		return nil, fmt.Errorf("❌ compile error: %w", err)
+	}
+	dir, err := os.MkdirTemp("", "erl")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+	file := filepath.Join(dir, "main.erl")
+	if err := os.WriteFile(file, code, 0755); err != nil {
+		return nil, fmt.Errorf("write error: %w", err)
+	}
+	cmd := exec.Command("escript", file)
+	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+		cmd.Stdin = bytes.NewReader(data)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("❌ escript error: %w\n%s", err, out)
+	}
+	return bytes.TrimSpace(out), nil
+}
+
+func writeErrors(dir string, errs []string) {
+	_ = os.MkdirAll(dir, 0755)
+	path := filepath.Join(dir, "ERRORS.md")
+	var b bytes.Buffer
+	b.WriteString("# Errors\n\n")
+	if len(errs) == 0 {
+		b.WriteString("None\n")
+	} else {
+		for _, e := range errs {
+			b.WriteString("- " + e + "\n")
+		}
+	}
+	_ = os.WriteFile(path, b.Bytes(), 0644)
+}
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found (not in Go module)")
+	return ""
+}
+
+func mustRead(path string) []byte {
+	b, _ := os.ReadFile(path)
+	return b
 }


### PR DESCRIPTION
## Summary
- add VM comparison checks in Erlang compiler tests
- implement `TestErlangCompiler_ValidVM` to run valid samples
- provide helper functions for running via VM or escript
- create `cmd/vm_roundtrip` tool for Erlang backend

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686aa4d1f2188320a8077b33afb870cf