### PR TITLE
Regenerate PHP compiler golden tests

### DIFF
--- a/compile/x/php/ERRORS.md
+++ b/compile/x/php/ERRORS.md
@@ -4,10 +4,10 @@
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function append() in /tmp/php_run3978177478/main.php:3
+PHP Fatal error:  Uncaught Error: Call to undefined function append() in /tmp/php_run3971473010/main.php:3
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run3978177478/main.php on line 3
+  thrown in /tmp/php_run3971473010/main.php on line 3
 
 ```
 
@@ -41,10 +41,10 @@ false
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Cannot use object of type Todo as array in /tmp/php_run2241569259/main.php:10
+PHP Fatal error:  Uncaught Error: Cannot use object of type Todo as array in /tmp/php_run1539923832/main.php:10
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run2241569259/main.php on line 10
+  thrown in /tmp/php_run1539923832/main.php on line 10
 
 ```
 
@@ -94,10 +94,10 @@ Diana is 45
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function exists() in /tmp/php_run3047288028/main.php:3
+PHP Fatal error:  Uncaught Error: Call to undefined function exists() in /tmp/php_run2254180212/main.php:3
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run3047288028/main.php on line 3
+  thrown in /tmp/php_run2254180212/main.php on line 3
 
 ```
 
@@ -131,34 +131,34 @@ Hanoi : count = 3 , avg_age = 27.333333333333332
 
 ```
 php run error: exit status 255
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 42
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3200379535/main.php on line 42
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 42
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3200379535/main.php on line 42
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 42
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3200379535/main.php on line 42
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3200379535/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3200379535/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3200379535/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 20
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3200379535/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 26
-PHP Warning:  Undefined variable $g in /tmp/php_run3200379535/main.php on line 26
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3200379535/main.php on line 26
-PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /tmp/php_run3200379535/main.php:18
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 42
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 42
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 42
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 42
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 42
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 42
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 20
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 26
+PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 26
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 26
+PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /tmp/php_run2353961726/main.php:18
 Stack trace:
-#0 /tmp/php_run3200379535/main.php(18): intdiv()
-#1 /tmp/php_run3200379535/main.php(129): {closure}()
-#2 /tmp/php_run3200379535/main.php(5): _query()
-#3 /tmp/php_run3200379535/main.php(43): {closure}()
+#0 /tmp/php_run2353961726/main.php(18): intdiv()
+#1 /tmp/php_run2353961726/main.php(129): {closure}()
+#2 /tmp/php_run2353961726/main.php(5): _query()
+#3 /tmp/php_run2353961726/main.php(43): {closure}()
 #4 {main}
-  thrown in /tmp/php_run3200379535/main.php on line 18
+  thrown in /tmp/php_run2353961726/main.php on line 18
 
 ```
 
@@ -177,18 +177,18 @@ output mismatch
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run1878602274/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
 --- Orders per customer ---
  orders: 0
  orders: 0
@@ -204,38 +204,38 @@ Bob orders: 1
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3550436238/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3550436238/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3550436238/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
 --- Group Left Join ---
  orders: 0
  orders: 0
@@ -263,33 +263,33 @@ map[part:100 total:20] map[part:200 total:15]
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 22
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 22
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2507855621/main.php on line 22
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 16
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 16
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2507855621/main.php on line 16
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2507855621/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 22
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 22
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3516876976/main.php on line 22
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 16
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 16
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3516876976/main.php on line 16
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
 [{"c_custkey":null,"c_name":null,"revenue":0,"c_acctbal":null,"n_name":null,"c_address":null,"c_phone":null,"c_comment":null}]
 -- vm --
 map[c_acctbal:100 c_address:123 St c_comment:Loyal c_custkey:1 c_name:Alice c_phone:123-456 n_name:BRAZIL revenue:900]
@@ -300,38 +300,38 @@ map[c_acctbal:100 c_address:123 St c_comment:Loyal c_custkey:1 c_name:Alice c_ph
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3074559800/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3074559800/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3074559800/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
 [{"cat":null,"total":0},{"cat":null,"total":0},{"cat":null,"total":0},{"cat":null,"total":0}]
 -- vm --
 map[cat:b total:7] map[cat:a total:4]
@@ -341,13 +341,13 @@ map[cat:b total:7] map[cat:a total:4]
 
 ```
 php run error: exit status 255
-PHP Warning:  Undefined array key "items" in /tmp/php_run858993914/main.php on line 15
-PHP Warning:  Undefined array key "items" in /tmp/php_run858993914/main.php on line 15
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run858993914/main.php on line 15
-PHP Fatal error:  Uncaught Error: Call to undefined function append() in /tmp/php_run858993914/main.php:18
+PHP Warning:  Undefined array key "items" in /tmp/php_run2576219068/main.php on line 15
+PHP Warning:  Undefined array key "items" in /tmp/php_run2576219068/main.php on line 15
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2576219068/main.php on line 15
+PHP Fatal error:  Uncaught Error: Call to undefined function append() in /tmp/php_run2576219068/main.php:18
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run858993914/main.php on line 18
+  thrown in /tmp/php_run2576219068/main.php on line 18
 
 ```
 
@@ -430,12 +430,12 @@ output mismatch
 
 ```
 php run error: exit status 255
-PHP Warning:  fopen(../interpreter/valid/people.yaml): Failed to open stream: No such file or directory in /tmp/php_run2869535954/main.php on line 27
-PHP Fatal error:  Uncaught Exception: cannot open ../interpreter/valid/people.yaml in /tmp/php_run2869535954/main.php:28
+PHP Warning:  fopen(../interpreter/valid/people.yaml): Failed to open stream: No such file or directory in /tmp/php_run2104781621/main.php on line 27
+PHP Fatal error:  Uncaught Exception: cannot open ../interpreter/valid/people.yaml in /tmp/php_run2104781621/main.php:28
 Stack trace:
-#0 /tmp/php_run2869535954/main.php(13): _load_json()
+#0 /tmp/php_run2104781621/main.php(13): _load_json()
 #1 {main}
-  thrown in /tmp/php_run2869535954/main.php on line 28
+  thrown in /tmp/php_run2104781621/main.php on line 28
 
 ```
 
@@ -503,10 +503,10 @@ false
 ```
 output mismatch
 -- php --
-PHP Warning:  Array to string conversion in /tmp/php_run1450554462/main.php on line 80
-PHP Warning:  Array to string conversion in /tmp/php_run1450554462/main.php on line 80
-PHP Warning:  Array to string conversion in /tmp/php_run1450554462/main.php on line 80
-PHP Warning:  Array to string conversion in /tmp/php_run1450554462/main.php on line 80
+PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
+PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
+PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
+PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
 [{"a":1,"b":2},{"a":1,"b":1},{"a":0,"b":5}]
 -- vm --
 map[a:0 b:5] map[a:1 b:1] map[a:1 b:2]
@@ -516,11 +516,11 @@ map[a:0 b:5] map[a:1 b:1] map[a:1 b:2]
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function mochi_add(), 1 passed in /tmp/php_run2495131883/main.php on line 6 and exactly 2 expected in /tmp/php_run2495131883/main.php:2
+PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function mochi_add(), 1 passed in /tmp/php_run3712342176/main.php on line 6 and exactly 2 expected in /tmp/php_run3712342176/main.php:2
 Stack trace:
-#0 /tmp/php_run2495131883/main.php(6): mochi_add()
+#0 /tmp/php_run3712342176/main.php(6): mochi_add()
 #1 {main}
-  thrown in /tmp/php_run2495131883/main.php on line 2
+  thrown in /tmp/php_run3712342176/main.php on line 2
 
 ```
 
@@ -529,8 +529,8 @@ Stack trace:
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $k in /tmp/php_run2091947316/main.php on line 3
-PHP Warning:  Undefined variable $k in /tmp/php_run2091947316/main.php on line 3
+PHP Warning:  Undefined variable $k in /tmp/php_run2986886998/main.php on line 3
+PHP Warning:  Undefined variable $k in /tmp/php_run2986886998/main.php on line 3
 3
 -- vm --
 5
@@ -540,12 +540,12 @@ PHP Warning:  Undefined variable $k in /tmp/php_run2091947316/main.php on line 3
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught TypeError: array_sum(): Argument #1 ($array) must be of type array, int given in /tmp/php_run2080697224/main.php:7
+PHP Fatal error:  Uncaught TypeError: array_sum(): Argument #1 ($array) must be of type array, int given in /tmp/php_run2672455735/main.php:7
 Stack trace:
-#0 /tmp/php_run2080697224/main.php(7): array_sum()
-#1 /tmp/php_run2080697224/main.php(10): {closure}()
+#0 /tmp/php_run2672455735/main.php(7): array_sum()
+#1 /tmp/php_run2672455735/main.php(10): {closure}()
 #2 {main}
-  thrown in /tmp/php_run2080697224/main.php on line 7
+  thrown in /tmp/php_run2672455735/main.php on line 7
 
 ```
 
@@ -553,11 +553,11 @@ Stack trace:
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Cannot use object of type Counter as array in /tmp/php_run2518524990/main.php:3
+PHP Fatal error:  Uncaught Error: Cannot use object of type Counter as array in /tmp/php_run1980354977/main.php:3
 Stack trace:
-#0 /tmp/php_run2518524990/main.php(14): mochi_inc()
+#0 /tmp/php_run1980354977/main.php(14): mochi_inc()
 #1 {main}
-  thrown in /tmp/php_run2518524990/main.php on line 3
+  thrown in /tmp/php_run1980354977/main.php on line 3
 
 ```
 
@@ -660,10 +660,10 @@ false
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function substring() in /tmp/php_run832673952/main.php:2
+PHP Fatal error:  Uncaught Error: Call to undefined function substring() in /tmp/php_run3467572083/main.php:2
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run832673952/main.php on line 2
+  thrown in /tmp/php_run3467572083/main.php on line 2
 
 ```
 
@@ -709,10 +709,10 @@ stack trace:
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Cannot use object of type Book as array in /tmp/php_run977306106/main.php:21
+PHP Fatal error:  Uncaught Error: Cannot use object of type Book as array in /tmp/php_run3369578827/main.php:21
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run977306106/main.php on line 21
+  thrown in /tmp/php_run3369578827/main.php on line 21
 
 ```
 
@@ -720,10 +720,10 @@ Stack trace:
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function values() in /tmp/php_run3190654889/main.php:3
+PHP Fatal error:  Uncaught Error: Call to undefined function values() in /tmp/php_run498929793/main.php:3
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run3190654889/main.php on line 3
+  thrown in /tmp/php_run498929793/main.php on line 3
 
 ```
 

--- a/tests/compiler/php/update_statement.php.out
+++ b/tests/compiler/php/update_statement.php.out
@@ -19,8 +19,8 @@ function mochi_test_update_adult_status() {
 $people = [new Person(['name' => "Alice", 'age' => 17, 'status' => "minor"]), new Person(['name' => "Bob", 'age' => 25, 'status' => "unknown"]), new Person(['name' => "Charlie", 'age' => 18, 'status' => "unknown"]), new Person(['name' => "Diana", 'age' => 16, 'status' => "minor"])];
 for ($_i = 0; $_i < count($people); $_i++) {
 	$_item = $people[$_i];
-	$status = is_array($_item) ? ($_item['status'] ?? null) : $_item->status;
 	$age = is_array($_item) ? ($_item['age'] ?? null) : $_item->age;
+	$status = is_array($_item) ? ($_item['status'] ?? null) : $_item->status;
 	if (($age >= 18)) {
 		if (is_array($_item)) { $_item['status'] = "adult"; } else { $_item->status = "adult"; }
 		if (is_array($_item)) { $_item['age'] = ((is_array($age) && is_array(1)) ? array_merge($age, 1) : ((is_string($age) || is_string(1)) ? ($age . 1) : ($age + 1))); } else { $_item->age = ((is_array($age) && is_array(1)) ? array_merge($age, 1) : ((is_string($age) || is_string(1)) ? ($age . 1) : ($age + 1))); }

--- a/tests/compiler/valid/break_continue.php.out
+++ b/tests/compiler/valid/break_continue.php.out
@@ -1,0 +1,19 @@
+<?php
+$numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+foreach ((is_string($numbers) ? str_split($numbers) : $numbers) as $n) {
+	if ((((is_int($n) && is_int(2)) ? ($n % 2) : fmod($n, 2)) == 0)) {
+		continue;
+	}
+	if (($n > 7)) {
+		break;
+	}
+	_print("odd number:", $n);
+}
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/closure.php.out
+++ b/tests/compiler/valid/closure.php.out
@@ -1,0 +1,17 @@
+<?php
+function mochi_makeAdder($n) {
+	return function ($x) use ($n) {
+	return ((is_array($x) && is_array($n)) ? array_merge($x, $n) : ((is_string($x) || is_string($n)) ? ($x . $n) : ($x + $n)));
+};
+}
+
+$add10 = mochi_makeAdder(10);
+_print($add10(7));
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/fold_pure_let.php.out
+++ b/tests/compiler/valid/fold_pure_let.php.out
@@ -1,0 +1,16 @@
+<?php
+function mochi_sumN($n) {
+	return ((is_int(($n * (((is_array($n) && is_array(1)) ? array_merge($n, 1) : ((is_string($n) || is_string(1)) ? ($n . 1) : ($n + 1)))))) && is_int(2)) ? intdiv(($n * (((is_array($n) && is_array(1)) ? array_merge($n, 1) : ((is_string($n) || is_string(1)) ? ($n . 1) : ($n + 1))))), 2) : (($n * (((is_array($n) && is_array(1)) ? array_merge($n, 1) : ((is_string($n) || is_string(1)) ? ($n . 1) : ($n + 1))))) / 2));
+}
+
+$n = 10;
+_print(mochi_sumN($n));
+_print($n);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/for_list_collection.php.out
+++ b/tests/compiler/valid/for_list_collection.php.out
@@ -1,0 +1,12 @@
+<?php
+foreach ((is_string([1, 2, 3]) ? str_split([1, 2, 3]) : [1, 2, 3]) as $n) {
+	_print($n);
+}
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/for_loop.php.out
+++ b/tests/compiler/valid/for_loop.php.out
@@ -1,0 +1,12 @@
+<?php
+for ($i = 1; $i < 4; $i++) {
+	_print($i);
+}
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/for_string_collection.php.out
+++ b/tests/compiler/valid/for_string_collection.php.out
@@ -1,0 +1,12 @@
+<?php
+foreach ((is_string("hi") ? str_split("hi") : "hi") as $ch) {
+	_print($ch);
+}
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/fun_call.php.out
+++ b/tests/compiler/valid/fun_call.php.out
@@ -1,0 +1,14 @@
+<?php
+function mochi_add($a, $b) {
+	return ((is_array($a) && is_array($b)) ? array_merge($a, $b) : ((is_string($a) || is_string($b)) ? ($a . $b) : ($a + $b)));
+}
+
+_print(mochi_add(2, 3));
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/fun_expr_in_let.php.out
+++ b/tests/compiler/valid/fun_expr_in_let.php.out
@@ -1,0 +1,13 @@
+<?php
+$square = function ($x) {
+	return ($x * $x);
+};
+_print($square(6));
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/generate_echo.php.out
+++ b/tests/compiler/valid/generate_echo.php.out
@@ -1,0 +1,14 @@
+<?php
+$poem = _gen_text("echo hello", null, null);
+_print($poem);
+
+function _gen_text($prompt, $model, $params) {
+    return $prompt;
+}
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/generate_embedding.php.out
+++ b/tests/compiler/valid/generate_embedding.php.out
@@ -1,0 +1,16 @@
+<?php
+$vec = _gen_embed("hi", null, null);
+_print((is_array($vec) ? count($vec) : strlen($vec)));
+
+function _gen_embed($text, $model, $params) {
+    $out = [];
+    for ($i = 0; $i < strlen($text); $i++) { $out[] = ord($text[$i]); }
+    return $out;
+}
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/grouped_expr.php.out
+++ b/tests/compiler/valid/grouped_expr.php.out
@@ -1,0 +1,11 @@
+<?php
+$value = ((((is_array(1) && is_array(2)) ? array_merge(1, 2) : ((is_string(1) || is_string(2)) ? (1 . 2) : (1 + 2)))) * 3);
+_print($value);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/if_else.php.out
+++ b/tests/compiler/valid/if_else.php.out
@@ -1,0 +1,15 @@
+<?php
+$x = 5;
+if (($x > 3)) {
+	_print("big");
+} else {
+	_print("small");
+}
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/len_builtin.php.out
+++ b/tests/compiler/valid/len_builtin.php.out
@@ -1,0 +1,10 @@
+<?php
+_print((is_array([1, 2, 3]) ? count([1, 2, 3]) : strlen([1, 2, 3])));
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/let_and_print.php.out
+++ b/tests/compiler/valid/let_and_print.php.out
@@ -1,0 +1,12 @@
+<?php
+$a = 10;
+$b = 20;
+_print(((is_array($a) && is_array($b)) ? array_merge($a, $b) : ((is_string($a) || is_string($b)) ? ($a . $b) : ($a + $b))));
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/list_index.php.out
+++ b/tests/compiler/valid/list_index.php.out
@@ -1,0 +1,11 @@
+<?php
+$xs = [10, 20, 30];
+_print($xs[1]);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/list_set.php.out
+++ b/tests/compiler/valid/list_set.php.out
@@ -1,0 +1,12 @@
+<?php
+$nums = [1, 2];
+$nums[1] = 3;
+_print($nums[1]);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/map_index.php.out
+++ b/tests/compiler/valid/map_index.php.out
@@ -1,0 +1,11 @@
+<?php
+$scores = ["Alice" => 10, "Bob" => 15];
+_print($scores["Bob"]);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/map_ops.php.out
+++ b/tests/compiler/valid/map_ops.php.out
@@ -1,0 +1,16 @@
+<?php
+$m = [];
+$m[1] = 10;
+$m[2] = 20;
+if ((is_array($m) ? (array_key_exists(1, $m) || in_array(1, $m, true)) : (is_string($m) ? strpos($m, strval(1)) !== false : false))) {
+	_print($m[1]);
+}
+_print($m[2]);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/map_set.php.out
+++ b/tests/compiler/valid/map_set.php.out
@@ -1,0 +1,12 @@
+<?php
+$scores = ["a" => 1];
+$scores["b"] = 2;
+_print($scores["b"]);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/print_hello.php.out
+++ b/tests/compiler/valid/print_hello.php.out
@@ -1,0 +1,10 @@
+<?php
+_print("hello");
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/string_index.php.out
+++ b/tests/compiler/valid/string_index.php.out
@@ -1,0 +1,11 @@
+<?php
+$text = "hello";
+_print($text[1]);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/test_block.php.out
+++ b/tests/compiler/valid/test_block.php.out
@@ -1,0 +1,17 @@
+<?php
+function mochi_test_addition_works() {
+	global $x;
+	$x = ((is_array(1) && is_array(2)) ? array_merge(1, 2) : ((is_string(1) || is_string(2)) ? (1 . 2) : (1 + 2)));
+	if (!(($x == 3))) { throw new Exception("expect failed: ($x == 3)"); }
+}
+
+_print("ok");
+mochi_test_addition_works();
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/two_sum.php.out
+++ b/tests/compiler/valid/two_sum.php.out
@@ -1,0 +1,24 @@
+<?php
+function mochi_twoSum($nums, $target) {
+	$n = (is_array($nums) ? count($nums) : strlen($nums));
+	for ($i = 0; $i < $n; $i++) {
+		for ($j = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))); $j < $n; $j++) {
+			if ((((is_array($nums[$i]) && is_array($nums[$j])) ? array_merge($nums[$i], $nums[$j]) : ((is_string($nums[$i]) || is_string($nums[$j])) ? ($nums[$i] . $nums[$j]) : ($nums[$i] + $nums[$j]))) == $target)) {
+				return [$i, $j];
+			}
+		}
+	}
+	return [-1, -1];
+}
+
+$result = mochi_twoSum([2, 7, 11, 15], 9);
+_print($result[0]);
+_print($result[1]);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/var_assignment.php.out
+++ b/tests/compiler/valid/var_assignment.php.out
@@ -1,0 +1,12 @@
+<?php
+$x = 1;
+$x = 2;
+_print($x);
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/compiler/valid/while_loop.php.out
+++ b/tests/compiler/valid/while_loop.php.out
@@ -1,0 +1,14 @@
+<?php
+$i = 0;
+while (($i < 3)) {
+	_print($i);
+	$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+}
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}

--- a/tests/vm/valid/update_stmt.vm.error
+++ b/tests/vm/valid/update_stmt.vm.error
@@ -1,0 +1,1 @@
+expect condition failed at tests/vm/valid/update_stmt.mochi:22: expect people == [


### PR DESCRIPTION
## Summary
- regenerate PHP golden tests and update roundtrip error logs
- extend `TestPHPCompiler_GoldenOutput` to run the generated code and verify runtime output via the VM

## Testing
- `go test ./compile/x/php -run TestPHPCompiler_GoldenOutput -update -tags slow` *(fails: runtime output mismatch etc.)*
- `go run ./compile/x/php/cmd/vm_roundtrip`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686aa60764408320839b22bdc8df60d6