### PR TITLE
Update hs vm roundtrip tool

### DIFF
--- a/compile/x/hs/ERRORS.md
+++ b/compile/x/hs/ERRORS.md
@@ -5,184 +5,71 @@
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/append_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/append_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/append_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/append_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/append_builtin.hs.out:183:10: error:
+    Variable not in scope: append :: [a0] -> t0 -> a1
+    Suggested fix:
+      Perhaps use one of these:
+        ‘BSL.append’ (imported from Data.ByteString.Lazy.Char8),
+        ‘T.append’ (imported from Data.Text),
+        ‘mappend’ (imported from Prelude)
+    |
+183 |   print (append a 3)
+    |          ^^^^^^
 
 ```
 
 ## tests/vm/valid/avg_builtin.mochi
 
 ```
-runhaskell error: exit status 1
-
-tests/vm/valid/avg_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/avg_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/avg_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/avg_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+output mismatch
+-- hs --
+2.0
+-- vm --
+2
 ```
 
 ## tests/vm/valid/basic_compare.mochi
 
 ```
-runhaskell error: exit status 1
-
-tests/vm/valid/basic_compare.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/basic_compare.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/basic_compare.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/basic_compare.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+output mismatch
+-- hs --
+7
+True
+True
+-- vm --
+7
+true
+true
 ```
 
 ## tests/vm/valid/binary_precedence.mochi
 
 ```
-runhaskell error: exit status 1
-
-tests/vm/valid/binary_precedence.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/binary_precedence.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/binary_precedence.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/binary_precedence.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+output mismatch
+-- hs --
+9
+9
+7
+8
+-- vm --
+7
+9
+7
+8
 ```
 
 ## tests/vm/valid/bool_chain.mochi
 
 ```
-runhaskell error: exit status 1
-
-tests/vm/valid/bool_chain.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/bool_chain.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/bool_chain.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/bool_chain.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+output mismatch
+-- hs --
+True
+False
+False
+-- vm --
+true
+false
+false
 ```
 
 ## tests/vm/valid/break_continue.mochi
@@ -190,72 +77,40 @@ tests/vm/valid/bool_chain.hs.out:15:1: error:
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/break_continue.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/break_continue.hs.out:183:26: error:
+    • Couldn't match expected type ‘IO b0’ with actual type ‘()’
+    • In the first argument of ‘fromMaybe’, namely ‘()’
+      In the expression:
+        fromMaybe
+          ()
+          (case if ((n `mod` 2) == 0) then Nothing else Nothing of
+             Just v -> Just v
+             Nothing
+               -> case if (n > 7) then Just () else Nothing of
+                    Just v -> Just v
+                    Nothing -> (let _ = ... in Nothing))
+      In the first argument of ‘mapM_’, namely
+        ‘(\ n
+            -> fromMaybe
+                 ()
+                 (case if ((n `mod` 2) == 0) then Nothing else Nothing of
+                    Just v -> Just v
+                    Nothing
+                      -> case if (n > 7) then Just () else Nothing of
+                           Just v -> Just v
+                           Nothing -> (let ... in Nothing)))’
+    |
+183 |   mapM_ (\n -> fromMaybe () (case if ((n `mod` 2) == 0) then Nothing else Nothing of Just v -> Just v; Nothing -> case if (n > 7) then Just () else Nothing of Just v -> Just v; Nothing -> (let _ = putStrLn (unwords ["odd number:", show n]) in Nothing))) numbers
+    |                          ^^
 
-tests/vm/valid/break_continue.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/break_continue.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/break_continue.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/cast_string_to_int.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/cast_string_to_int.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cast_string_to_int.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cast_string_to_int.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cast_string_to_int.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/break_continue.hs.out:183:175: error:
+    • Couldn't match expected type ‘IO b0’ with actual type ‘()’
+    • In the first argument of ‘Just’, namely ‘v’
+      In the expression: Just v
+      In a case alternative: Just v -> Just v
+    |
+183 |   mapM_ (\n -> fromMaybe () (case if ((n `mod` 2) == 0) then Nothing else Nothing of Just v -> Just v; Nothing -> case if (n > 7) then Just () else Nothing of Just v -> Just v; Nothing -> (let _ = putStrLn (unwords ["odd number:", show n]) in Nothing))) numbers
+    |                                                                                                                                                                               ^
 
 ```
 
@@ -264,109 +119,15 @@ tests/vm/valid/cast_string_to_int.hs.out:15:1: error:
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/cast_struct.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cast_struct.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cast_struct.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cast_struct.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/closure.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/closure.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/closure.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/closure.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/closure.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/count_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/count_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/count_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/count_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/count_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cast_struct.hs.out:191:20: error:
+    • Couldn't match expected type ‘Todo’
+                  with actual type ‘Map.Map String String’
+    • In the first argument of ‘title’, namely ‘(todo)’
+      In the first argument of ‘putStrLn’, namely ‘(title (todo))’
+      In a stmt of a 'do' block: putStrLn (title (todo))
+    |
+191 |   putStrLn (title (todo))
+    |                    ^^^^
 
 ```
 
@@ -375,35 +136,92 @@ tests/vm/valid/count_builtin.hs.out:15:1: error:
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/cross_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join.hs.out:183:258: error:
+    • Couldn't match type ‘AnyValue’ with ‘[Char]’
+      Expected: Map.Map String String
+        Actual: Map.Map String AnyValue
+    • In the second argument of ‘Map.lookup’, namely ‘c’
+      In the second argument of ‘fromMaybe’, namely
+        ‘(Map.lookup "name" c)’
+      In the first argument of ‘VString’, namely
+        ‘(fromMaybe (error "missing") (Map.lookup "name" c))’
+    |
+183 | result = [Map.fromList [("orderId", VInt (fromMaybe (error "missing") (Map.lookup "id" o))), ("orderCustomerId", VInt (fromMaybe (error "missing") (Map.lookup "customerId" o))), ("pairedCustomerName", VString (fromMaybe (error "missing") (Map.lookup "name" c))), ("orderTotal", VInt (fromMaybe (error "missing") (Map.lookup "total" o)))] | o <- orders, c <- customers]
+    |                                                                                                                                                                                                                                                                  ^
 
-tests/vm/valid/cross_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join.hs.out:188:48: error:
+    • Couldn't match expected type: t0 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a0 -> Maybe a0 -> a0) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "orderId" entry)
+      In the first argument of ‘unwords’, namely
+        ‘["Order",
+          show fromMaybe (error "missing") (Map.lookup "orderId" entry),
+          "(customerId:",
+          show
+            fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry),
+          ....]’
+    |
+188 |   mapM_ (\entry -> putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "orderId" entry), "(customerId:", show fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry), ", total: $", show fromMaybe (error "missing") (Map.lookup "orderTotal" entry), ") paired with", show fromMaybe (error "missing") (Map.lookup "pairedCustomerName" entry)])) result
+    |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/cross_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join.hs.out:188:127: error:
+    • Couldn't match expected type: t1 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a1 -> Maybe a1 -> a1) -> [Char]’ has only one
+      In the expression:
+        show
+          fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry)
+      In the first argument of ‘unwords’, namely
+        ‘["Order",
+          show fromMaybe (error "missing") (Map.lookup "orderId" entry),
+          "(customerId:",
+          show
+            fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry),
+          ....]’
+    |
+188 |   mapM_ (\entry -> putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "orderId" entry), "(customerId:", show fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry), ", total: $", show fromMaybe (error "missing") (Map.lookup "orderTotal" entry), ") paired with", show fromMaybe (error "missing") (Map.lookup "pairedCustomerName" entry)])) result
+    |                                                                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/cross_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join.hs.out:188:212: error:
+    • Couldn't match expected type: t2 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a2 -> Maybe a2 -> a2) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "orderTotal" entry)
+      In the first argument of ‘unwords’, namely
+        ‘["Order",
+          show fromMaybe (error "missing") (Map.lookup "orderId" entry),
+          "(customerId:",
+          show
+            fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry),
+          ....]’
+    |
+188 |   mapM_ (\entry -> putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "orderId" entry), "(customerId:", show fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry), ", total: $", show fromMaybe (error "missing") (Map.lookup "orderTotal" entry), ") paired with", show fromMaybe (error "missing") (Map.lookup "pairedCustomerName" entry)])) result
+    |                                                                                                                                                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/vm/valid/cross_join.hs.out:188:295: error:
+    • Couldn't match expected type: t3 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a3 -> Maybe a3 -> a3) -> [Char]’ has only one
+      In the expression:
+        show
+          fromMaybe (error "missing") (Map.lookup "pairedCustomerName" entry)
+      In the first argument of ‘unwords’, namely
+        ‘["Order",
+          show fromMaybe (error "missing") (Map.lookup "orderId" entry),
+          "(customerId:",
+          show
+            fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry),
+          ....]’
+    |
+188 |   mapM_ (\entry -> putStrLn (unwords ["Order", show fromMaybe (error "missing") (Map.lookup "orderId" entry), "(customerId:", show fromMaybe (error "missing") (Map.lookup "orderCustomerId" entry), ", total: $", show fromMaybe (error "missing") (Map.lookup "orderTotal" entry), ") paired with", show fromMaybe (error "missing") (Map.lookup "pairedCustomerName" entry)])) result
+    |                                                                                                                                                                                                                                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ```
 
@@ -412,35 +230,33 @@ tests/vm/valid/cross_join.hs.out:15:1: error:
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/cross_join_filter.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join_filter.hs.out:188:35: error:
+    • Couldn't match expected type: t0 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a0 -> Maybe a0 -> a0) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "n" p)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "n" p),
+          show fromMaybe (error "missing") (Map.lookup "l" p)]’
+    |
+188 |   mapM_ (\p -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "n" p), show fromMaybe (error "missing") (Map.lookup "l" p)])) pairs
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/cross_join_filter.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cross_join_filter.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cross_join_filter.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join_filter.hs.out:188:88: error:
+    • Couldn't match expected type: t1 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a1 -> Maybe a1 -> a1) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "l" p)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "n" p),
+          show fromMaybe (error "missing") (Map.lookup "l" p)]’
+    |
+188 |   mapM_ (\p -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "n" p), show fromMaybe (error "missing") (Map.lookup "l" p)])) pairs
+    |                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ```
 
@@ -449,35 +265,50 @@ tests/vm/valid/cross_join_filter.hs.out:15:1: error:
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/cross_join_triple.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join_triple.hs.out:190:35: error:
+    • Couldn't match expected type: t0 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a0 -> Maybe a0 -> a0) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "n" c)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "n" c),
+          show fromMaybe (error "missing") (Map.lookup "l" c),
+          show fromMaybe (error "missing") (Map.lookup "b" c)]’
+    |
+190 |   mapM_ (\c -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "n" c), show fromMaybe (error "missing") (Map.lookup "l" c), show fromMaybe (error "missing") (Map.lookup "b" c)])) combos
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/cross_join_triple.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join_triple.hs.out:190:88: error:
+    • Couldn't match expected type: t1 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a1 -> Maybe a1 -> a1) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "l" c)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "n" c),
+          show fromMaybe (error "missing") (Map.lookup "l" c),
+          show fromMaybe (error "missing") (Map.lookup "b" c)]’
+    |
+190 |   mapM_ (\c -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "n" c), show fromMaybe (error "missing") (Map.lookup "l" c), show fromMaybe (error "missing") (Map.lookup "b" c)])) combos
+    |                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/cross_join_triple.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/cross_join_triple.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/cross_join_triple.hs.out:190:141: error:
+    • Couldn't match expected type: t2 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a2 -> Maybe a2 -> a2) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "b" c)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "n" c),
+          show fromMaybe (error "missing") (Map.lookup "l" c),
+          show fromMaybe (error "missing") (Map.lookup "b" c)]’
+    |
+190 |   mapM_ (\c -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "n" c), show fromMaybe (error "missing") (Map.lookup "l" c), show fromMaybe (error "missing") (Map.lookup "b" c)])) combos
+    |                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ```
 
@@ -486,35 +317,96 @@ tests/vm/valid/cross_join_triple.hs.out:15:1: error:
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/dataset_sort_take_limit.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_sort_take_limit.hs.out:181:13: error:
+    • Couldn't match expected type: t3
+                                    -> ((a3 -> b0) -> [a3] -> [b0])
+                                    -> ((a4, b1) -> b1)
+                                    -> [(AnyValue, Map.Map String AnyValue)]
+                                    -> t
+                  with actual type: [a6]
+    • The function ‘take’ is applied to six value arguments,
+        but its type ‘Int -> [a6] -> [a6]’ has only two
+      In the expression:
+        take
+          3 drop 1 map snd
+          (List.sortOn
+             fst
+             [((- fromMaybe (error "missing") (Map.lookup "price" (p))), p) |
+                p <- products])
+      In an equation for ‘expensive’:
+          expensive
+            = take
+                3 drop 1 map snd
+                (List.sortOn
+                   fst
+                   [((- fromMaybe (error "missing") (Map.lookup "price" (p))), p) |
+                      p <- products])
+    • Relevant bindings include
+        expensive :: t
+          (bound at tests/vm/valid/dataset_sort_take_limit.hs.out:181:1)
+    |
+181 | expensive = take 3 drop 1 map snd (List.sortOn fst [((-fromMaybe (error "missing") (Map.lookup "price" (p))), p) | p <- products])
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/dataset_sort_take_limit.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_sort_take_limit.hs.out:181:20: error:
+    • Couldn't match expected type: [a6]
+                  with actual type: Int -> [a5] -> [a5]
+    • Probable cause: ‘drop’ is applied to too few arguments
+      In the second argument of ‘take’, namely ‘drop’
+      In the expression:
+        take
+          3 drop 1 map snd
+          (List.sortOn
+             fst
+             [((- fromMaybe (error "missing") (Map.lookup "price" (p))), p) |
+                p <- products])
+      In an equation for ‘expensive’:
+          expensive
+            = take
+                3 drop 1 map snd
+                (List.sortOn
+                   fst
+                   [((- fromMaybe (error "missing") (Map.lookup "price" (p))), p) |
+                      p <- products])
+    |
+181 | expensive = take 3 drop 1 map snd (List.sortOn fst [((-fromMaybe (error "missing") (Map.lookup "price" (p))), p) | p <- products])
+    |                    ^^^^
 
-tests/vm/valid/dataset_sort_take_limit.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_sort_take_limit.hs.out:186:38: error:
+    • Couldn't match expected type: t0 -> Maybe a0 -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a1 -> Maybe a1 -> a1) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "name" item)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "name" item),
+          "costs $",
+          show fromMaybe (error "missing") (Map.lookup "price" item)]’
+    • Relevant bindings include
+        item :: Map.Map String a0
+          (bound at tests/vm/valid/dataset_sort_take_limit.hs.out:186:11)
+    |
+186 |   mapM_ (\item -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" item), "costs $", show fromMaybe (error "missing") (Map.lookup "price" item)])) expensive
+    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/dataset_sort_take_limit.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_sort_take_limit.hs.out:186:108: error:
+    • Couldn't match expected type: t1 -> Maybe a0 -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a2 -> Maybe a2 -> a2) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "price" item)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "name" item),
+          "costs $",
+          show fromMaybe (error "missing") (Map.lookup "price" item)]’
+    • Relevant bindings include
+        item :: Map.Map String a0
+          (bound at tests/vm/valid/dataset_sort_take_limit.hs.out:186:11)
+    |
+186 |   mapM_ (\item -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" item), "costs $", show fromMaybe (error "missing") (Map.lookup "price" item)])) expensive
+    |                                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ```
 
@@ -523,35 +415,61 @@ tests/vm/valid/dataset_sort_take_limit.hs.out:15:1: error:
 ```
 runhaskell error: exit status 1
 
-tests/vm/valid/dataset_where_filter.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_where_filter.hs.out:181:90: error:
+    • Couldn't match type ‘AnyValue’ with ‘[Char]’
+      Expected: Map.Map String String
+        Actual: Map.Map String AnyValue
+    • In the second argument of ‘Map.lookup’, namely ‘person’
+      In the second argument of ‘fromMaybe’, namely
+        ‘(Map.lookup "name" person)’
+      In the first argument of ‘VString’, namely
+        ‘(fromMaybe (error "missing") (Map.lookup "name" person))’
+    |
+181 | adults = [Map.fromList [("name", VString (fromMaybe (error "missing") (Map.lookup "name" person))), ("age", VString (fromMaybe (error "missing") (Map.lookup "age" person))), ("is_senior", VBool ((fromMaybe (error "missing") (Map.lookup "age" person) >= 60)))] | person <- filter (\person -> (fromMaybe (error "missing") (Map.lookup "age" person) >= 18)) people]
+    |                                                                                          ^^^^^^
 
-tests/vm/valid/dataset_where_filter.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_where_filter.hs.out:181:164: error:
+    • Couldn't match type ‘AnyValue’ with ‘[Char]’
+      Expected: Map.Map String String
+        Actual: Map.Map String AnyValue
+    • In the second argument of ‘Map.lookup’, namely ‘person’
+      In the second argument of ‘fromMaybe’, namely
+        ‘(Map.lookup "age" person)’
+      In the first argument of ‘VString’, namely
+        ‘(fromMaybe (error "missing") (Map.lookup "age" person))’
+    |
+181 | adults = [Map.fromList [("name", VString (fromMaybe (error "missing") (Map.lookup "name" person))), ("age", VString (fromMaybe (error "missing") (Map.lookup "age" person))), ("is_senior", VBool ((fromMaybe (error "missing") (Map.lookup "age" person) >= 60)))] | person <- filter (\person -> (fromMaybe (error "missing") (Map.lookup "age" person) >= 18)) people]
+    |                                                                                                                                                                    ^^^^^^
 
-tests/vm/valid/dataset_where_filter.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_where_filter.hs.out:186:40: error:
+    • Couldn't match expected type: t0 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a0 -> Maybe a0 -> a0) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "name" person)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "name" person),
+          "is", show fromMaybe (error "missing") (Map.lookup "age" person),
+          0]’
+    |
+186 |   mapM_ (\person -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" person), "is", show fromMaybe (error "missing") (Map.lookup "age" person), 0])) adults
+    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/vm/valid/dataset_where_filter.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/vm/valid/dataset_where_filter.hs.out:186:107: error:
+    • Couldn't match expected type: t1 -> Maybe AnyValue -> String
+                  with actual type: [Char]
+    • The function ‘show’ is applied to three value arguments,
+        but its type ‘(a1 -> Maybe a1 -> a1) -> [Char]’ has only one
+      In the expression:
+        show fromMaybe (error "missing") (Map.lookup "age" person)
+      In the first argument of ‘unwords’, namely
+        ‘[show fromMaybe (error "missing") (Map.lookup "name" person),
+          "is", show fromMaybe (error "missing") (Map.lookup "age" person),
+          0]’
+    |
+186 |   mapM_ (\person -> putStrLn (unwords [show fromMaybe (error "missing") (Map.lookup "name" person), "is", show fromMaybe (error "missing") (Map.lookup "age" person), 0])) adults
+    |                                                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ```
 
@@ -565,2714 +483,6 @@ tests/vm/valid/exists_builtin.hs.out:172:6: error:
     |
 172 | data = [1, 2]
     |      ^
-
-```
-
-## tests/vm/valid/for_list_collection.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/for_list_collection.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_list_collection.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_list_collection.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_list_collection.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/for_loop.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/for_loop.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_loop.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_loop.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_loop.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/for_map_collection.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/for_map_collection.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_map_collection.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_map_collection.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/for_map_collection.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/fun_call.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/fun_call.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_call.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_call.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_call.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/fun_expr_in_let.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/fun_expr_in_let.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_expr_in_let.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_expr_in_let.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_expr_in_let.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/fun_three_args.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/fun_three_args.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_three_args.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_three_args.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/fun_three_args.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by_conditional_sum.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by_conditional_sum.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_conditional_sum.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_conditional_sum.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_conditional_sum.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by_having.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by_having.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_having.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_having.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_having.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by_join.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by_left_join.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by_left_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_left_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_left_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_left_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by_multi_join.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by_multi_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_multi_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_multi_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_multi_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by_multi_join_sort.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by_multi_join_sort.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_multi_join_sort.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_multi_join_sort.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_multi_join_sort.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_by_sort.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_by_sort.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_sort.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_sort.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/group_by_sort.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/group_items_iteration.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/group_items_iteration.hs.out:172:6: error:
-    parse error on input ‘=’
-    |
-172 | data = [Map.fromList [("tag", VString ("a")), ("val", VInt (1))], Map.fromList [("tag", VString ("a")), ("val", VInt (2))], Map.fromList [("tag", VString ("b")), ("val", VInt (3))]]
-    |      ^
-
-```
-
-## tests/vm/valid/if_else.mochi
-
-```
-compile error: unsupported statement in main
-```
-
-## tests/vm/valid/if_then_else.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/if_then_else.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/if_then_else.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/if_then_else.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/if_then_else.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/if_then_else_nested.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/if_then_else_nested.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/if_then_else_nested.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/if_then_else_nested.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/if_then_else_nested.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/in_operator.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/in_operator.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/in_operator.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/in_operator.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/in_operator.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/in_operator_extended.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/in_operator_extended.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/in_operator_extended.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/in_operator_extended.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/in_operator_extended.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/inner_join.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/inner_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/inner_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/inner_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/inner_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/join_multi.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/join_multi.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/join_multi.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/join_multi.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/join_multi.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/json_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/json_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/json_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/json_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/json_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/left_join.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/left_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/left_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/left_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/left_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/left_join_multi.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/left_join_multi.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/left_join_multi.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/left_join_multi.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/left_join_multi.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/len_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/len_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/len_map.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/len_map.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_map.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_map.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_map.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/len_string.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/len_string.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_string.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_string.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/len_string.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/let_and_print.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/let_and_print.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/let_and_print.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/let_and_print.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/let_and_print.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/list_assign.mochi
-
-```
-compile error: unsupported statement in main
-```
-
-## tests/vm/valid/list_index.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/list_index.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/list_index.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/list_index.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/list_index.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/list_nested_assign.mochi
-
-```
-compile error: unsupported statement in main
-```
-
-## tests/vm/valid/list_set_ops.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/list_set_ops.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/list_set_ops.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/list_set_ops.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/list_set_ops.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/load_yaml.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/load_yaml.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/load_yaml.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/load_yaml.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/load_yaml.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/map_assign.mochi
-
-```
-compile error: unsupported statement in main
-```
-
-## tests/vm/valid/map_in_operator.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/map_in_operator.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_in_operator.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_in_operator.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_in_operator.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/map_index.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/map_index.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_index.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_index.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_index.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/map_int_key.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/map_int_key.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_int_key.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_int_key.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_int_key.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/map_literal_dynamic.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/map_literal_dynamic.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_literal_dynamic.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_literal_dynamic.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_literal_dynamic.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/map_membership.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/map_membership.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_membership.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_membership.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/map_membership.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/map_nested_assign.mochi
-
-```
-compile error: unsupported statement in main
-```
-
-## tests/vm/valid/match_expr.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/match_expr.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/match_expr.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/match_expr.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/match_expr.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/match_full.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/match_full.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/match_full.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/match_full.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/match_full.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/math_ops.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/math_ops.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/math_ops.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/math_ops.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/math_ops.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/membership.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/membership.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/membership.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/membership.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/membership.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/min_max_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/min_max_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/min_max_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/min_max_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/min_max_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/nested_function.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/nested_function.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/nested_function.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/nested_function.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/nested_function.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/order_by_map.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/order_by_map.hs.out:172:6: error:
-    parse error on input ‘=’
-    |
-172 | data = [Map.fromList [("a", 1), ("b", 2)], Map.fromList [("a", 1), ("b", 1)], Map.fromList [("a", 0), ("b", 5)]]
-    |      ^
-
-```
-
-## tests/vm/valid/outer_join.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/outer_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/outer_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/outer_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/outer_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/partial_application.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/partial_application.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/partial_application.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/partial_application.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/partial_application.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/print_hello.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/print_hello.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/print_hello.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/print_hello.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/print_hello.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/pure_fold.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/pure_fold.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/pure_fold.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/pure_fold.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/pure_fold.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/pure_global_fold.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/pure_global_fold.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/pure_global_fold.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/pure_global_fold.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/pure_global_fold.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/query_sum_select.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/query_sum_select.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/query_sum_select.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/query_sum_select.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/query_sum_select.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/record_assign.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/record_assign.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/record_assign.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/record_assign.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/record_assign.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/right_join.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/right_join.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/right_join.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/right_join.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/right_join.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/save_jsonl_stdout.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/save_jsonl_stdout.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/save_jsonl_stdout.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/save_jsonl_stdout.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/save_jsonl_stdout.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/short_circuit.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/short_circuit.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/short_circuit.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/short_circuit.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/short_circuit.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/slice.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/slice.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/slice.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/slice.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/slice.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/sort_stable.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/sort_stable.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/sort_stable.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/sort_stable.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/sort_stable.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/str_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/str_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/str_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/str_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/str_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/string_compare.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/string_compare.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_compare.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_compare.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_compare.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/string_concat.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/string_concat.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_concat.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_concat.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_concat.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/string_contains.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/string_contains.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_contains.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_contains.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_contains.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/string_in_operator.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/string_in_operator.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_in_operator.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_in_operator.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_in_operator.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/string_index.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/string_index.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_index.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_index.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_index.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/string_prefix_slice.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/string_prefix_slice.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_prefix_slice.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_prefix_slice.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/string_prefix_slice.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/substring_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/substring_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/substring_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/substring_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/substring_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/sum_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/sum_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/sum_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/sum_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/sum_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/tail_recursion.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/tail_recursion.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/tail_recursion.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/tail_recursion.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/tail_recursion.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/test_block.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/test_block.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/test_block.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/test_block.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/test_block.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/tree_sum.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/tree_sum.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/tree_sum.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/tree_sum.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/tree_sum.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/two-sum.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/two-sum.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/two-sum.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/two-sum.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/two-sum.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/typed_let.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/typed_let.hs.out:174:1: error:
-    parse error (possibly incorrect indentation or mismatched brackets)
-    |
-174 | main :: IO ()
-    | ^
-
-```
-
-## tests/vm/valid/typed_var.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/typed_var.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/typed_var.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/typed_var.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/typed_var.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/unary_neg.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/unary_neg.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/unary_neg.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/unary_neg.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/unary_neg.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/update_stmt.mochi
-
-```
-compile error: unsupported statement in main
-```
-
-## tests/vm/valid/user_type_literal.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/user_type_literal.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/user_type_literal.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/user_type_literal.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/user_type_literal.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/values_builtin.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/values_builtin.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/values_builtin.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/values_builtin.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/values_builtin.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-```
-
-## tests/vm/valid/var_assignment.mochi
-
-```
-compile error: unsupported statement in main
-```
-
-## tests/vm/valid/while_loop.mochi
-
-```
-runhaskell error: exit status 1
-
-tests/vm/valid/while_loop.hs.out:5:1: error:
-    Could not find module ‘Data.Aeson’
-    Perhaps you meant Data.Version (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-5 | import qualified Data.Aeson as Aeson
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/while_loop.hs.out:6:1: error:
-    Could not find module ‘Data.Aeson.Key’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-6 | import qualified Data.Aeson.Key as Key
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/while_loop.hs.out:7:1: error:
-    Could not find module ‘Data.Aeson.KeyMap’
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-  |
-7 | import qualified Data.Aeson.KeyMap as KeyMap
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-tests/vm/valid/while_loop.hs.out:15:1: error:
-    Could not find module ‘Data.Vector’
-    Perhaps you meant Data.Functor (from base-4.17.2.0)
-    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-   |
-15 | import qualified Data.Vector as V
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ```
 

--- a/compile/x/hs/cmd/vm_roundtrip/main.go
+++ b/compile/x/hs/cmd/vm_roundtrip/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	hscode "mochi/compile/x/hs"
@@ -27,6 +28,11 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "glob error:", err)
 		os.Exit(1)
+	}
+	if limitStr := os.Getenv("LIMIT"); limitStr != "" {
+		if n, err := strconv.Atoi(limitStr); err == nil && n < len(files) {
+			files = files[:n]
+		}
 	}
 
 	var report strings.Builder


### PR DESCRIPTION
## Summary
- limit vm roundtrip checks with a LIMIT env var so they can run quicker
- regenerate `compile/x/hs/ERRORS.md` via the updated tool

## Testing
- `go test ./compile/x/hs -run TestHSCompiler_GoldenOutput -tags slow -update`
- `go test ./compile/x/hs -run TestHSCompiler_GoldenSubset -tags slow -update` *(fails: couldn't match type `AnyValue` with `[Char]`)*

------
https://chatgpt.com/codex/tasks/task_e_686aa8215ed08320b2b6a20ee13c3bb5