### PR TITLE
Update OCaml compiler tests and runtime reports

### DIFF
--- a/compile/x/ocaml/ERRORS.md
+++ b/compile/x/ocaml/ERRORS.md
@@ -4,22 +4,10 @@
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3180871086/prog.ml", line 2, characters 30-36:
+File "/tmp/ocamlprog3604641129/prog.ml", line 2, characters 30-36:
 2 | print_endline (string_of_int (append a 3));;
                                   ^^^^^^
 Error: Unbound value append
-
-```
-
-## tests/vm/valid/avg_builtin.mochi
-
-```
-ocamlc error: exit status 2
-File "/tmp/ocamlprog1860661286/prog.ml", line 3, characters 29-45:
-3 | print_endline (string_of_int (_avg [1; 2; 3]));;
-                                 ^^^^^^^^^^^^^^^^
-Error: This expression has type float but an expression was expected of type
-         int
 
 ```
 
@@ -27,7 +15,7 @@ Error: This expression has type float but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3355119754/prog.ml", line 4, characters 29-36:
+File "/tmp/ocamlprog3666755009/prog.ml", line 4, characters 29-36:
 4 | print_endline (string_of_int (a = 7));;
                                  ^^^^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -39,7 +27,7 @@ Error: This expression has type bool but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2895609636/prog.ml", line 6, characters 21-22:
+File "/tmp/ocamlprog1902709348/prog.ml", line 6, characters 21-22:
 6 |   with Return_0 v -> v
                          ^
 Error: This expression has type bool
@@ -51,7 +39,7 @@ Error: This expression has type bool
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog345999718/prog.ml", line 1, characters 16-22:
+File "/tmp/ocamlprog2862457879/prog.ml", line 1, characters 16-22:
 1 | print_endline (("1995" : int));;
                     ^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -63,7 +51,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog833041492/prog.ml", line 1, characters 10-11:
+File "/tmp/ocamlprog559688582/prog.ml", line 1, characters 10-11:
 1 | type Todo = {
               ^
 Error: Syntax error
@@ -74,7 +62,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3875023293/prog.ml", line 4, characters 10-37:
+File "/tmp/ocamlprog1186120676/prog.ml", line 4, characters 10-37:
 4 |     raise (Return_0 (fun x -> x + n))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The constructor Return_0 expects 0 argument(s),
@@ -86,7 +74,7 @@ Error: The constructor Return_0 expects 0 argument(s),
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog662882363/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog1317104393/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 3;Hashtbl.add tbl "name" "Charlie"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -98,7 +86,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2620521980/prog.ml", line 6, characters 55-56:
+File "/tmp/ocamlprog1396334712/prog.ml", line 6, characters 55-56:
 6 |     print_endline (String.concat " " [string_of_int (p.n); string_of_int (p.l)]);
                                                            ^
 Error: Unbound record field n
@@ -109,7 +97,7 @@ Error: Unbound record field n
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog577373963/prog.ml", line 7, characters 55-56:
+File "/tmp/ocamlprog3255249995/prog.ml", line 7, characters 55-56:
 7 |     print_endline (String.concat " " [string_of_int (c.n); string_of_int (c.l); string_of_int (c.b)]);
                                                            ^
 Error: Unbound record field n
@@ -120,7 +108,7 @@ Error: Unbound record field n
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3380832522/prog.ml", line 1, characters 103-107:
+File "/tmp/ocamlprog663919/prog.ml", line 1, characters 103-107:
 1 | let products = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Laptop";Hashtbl.add tbl "price" 1500; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Smartphone";Hashtbl.add tbl "price" 900; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Tablet";Hashtbl.add tbl "price" 600; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Monitor";Hashtbl.add tbl "price" 300; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Keyboard";Hashtbl.add tbl "price" 100; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Mouse";Hashtbl.add tbl "price" 50; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Headphones";Hashtbl.add tbl "price" 200; tbl)];;
                                                                                                            ^^^^
 Error: This expression has type int but an expression was expected of type
@@ -138,7 +126,7 @@ compile error: unsupported expression
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3958724184/prog.ml", line 2, characters 11-17:
+File "/tmp/ocamlprog2465013426/prog.ml", line 2, characters 11-17:
 2 | let flag = exists [];;
                ^^^^^^
 Error: Unbound value exists
@@ -150,7 +138,7 @@ Hint: Did you mean exit?
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog527536539/prog.ml", line 2, characters 35-37:
+File "/tmp/ocamlprog812777905/prog.ml", line 2, characters 35-37:
 2 |   print_endline (string_of_int (i));;
                                        ^^
 Error: Syntax error
@@ -161,7 +149,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1690861446/prog.ml", line 4, characters 4-6:
+File "/tmp/ocamlprog2679553566/prog.ml", line 4, characters 4-6:
 4 |   ) !m;;
         ^^
 Error: This expression has type (string, int) Hashtbl.t
@@ -173,7 +161,7 @@ Error: This expression has type (string, int) Hashtbl.t
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1519439221/prog.ml", line 5, characters 21-22:
+File "/tmp/ocamlprog2105312821/prog.ml", line 5, characters 21-22:
 5 |   with Return_0 v -> v
                          ^
 Error: This expression has type int
@@ -185,7 +173,7 @@ Error: This expression has type int
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3887128158/prog.ml", line 5, characters 21-22:
+File "/tmp/ocamlprog3465610871/prog.ml", line 5, characters 21-22:
 5 |   with Return_0 v -> v
                          ^
 Error: This expression has type int
@@ -197,7 +185,7 @@ Error: This expression has type int
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3548319183/prog.ml", line 1, characters 98-100:
+File "/tmp/ocamlprog1342130861/prog.ml", line 1, characters 98-100:
 1 | let people = [(let tbl = Hashtbl.create 3 in Hashtbl.add tbl "name" "Alice";Hashtbl.add tbl "age" 30;Hashtbl.add tbl "city" "Paris"; tbl); (let tbl = Hashtbl.create 3 in Hashtbl.add tbl "name" "Bob";Hashtbl.add tbl "age" 15;Hashtbl.add tbl "city" "Hanoi"; tbl); (let tbl = Hashtbl.create 3 in Hashtbl.add tbl "name" "Charlie";Hashtbl.add tbl "age" 65;Hashtbl.add tbl "city" "Paris"; tbl); (let tbl = Hashtbl.create 3 in Hashtbl.add tbl "name" "Diana";Hashtbl.add tbl "age" 45;Hashtbl.add tbl "city" "Hanoi"; tbl); (let tbl = Hashtbl.create 3 in Hashtbl.add tbl "name" "Eve";Hashtbl.add tbl "age" 70;Hashtbl.add tbl "city" "Paris"; tbl); (let tbl = Hashtbl.create 3 in Hashtbl.add tbl "name" "Frank";Hashtbl.add tbl "age" 22;Hashtbl.add tbl "city" "Hanoi"; tbl)];;
                                                                                                       ^^
 Error: This expression has type int but an expression was expected of type
@@ -209,7 +197,7 @@ Error: This expression has type int but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1992128688/prog.ml", line 1, characters 92-94:
+File "/tmp/ocamlprog2302373964/prog.ml", line 1, characters 92-94:
 1 | let items = [(let tbl = Hashtbl.create 3 in Hashtbl.add tbl "cat" "a";Hashtbl.add tbl "val" 10;Hashtbl.add tbl "flag" true; tbl); (let tbl = Hashtbl.create 3 in Hashtbl.add tbl "cat" "a";Hashtbl.add tbl "val" 5;Hashtbl.add tbl "flag" false; tbl); (let tbl = Hashtbl.create 3 in Hashtbl.add tbl "cat" "b";Hashtbl.add tbl "val" 20;Hashtbl.add tbl "flag" true; tbl)];;
                                                                                                 ^^
 Error: This expression has type int but an expression was expected of type
@@ -221,7 +209,7 @@ Error: This expression has type int but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3330571832/prog.ml", line 3, characters 0-4:
+File "/tmp/ocamlprog1671393486/prog.ml", line 3, characters 0-4:
 3 | json big;;
     ^^^^
 Error: Unbound value json
@@ -232,7 +220,7 @@ Error: Unbound value json
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3808741294/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog3342618601/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -244,7 +232,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1665440464/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog236923406/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 3;Hashtbl.add tbl "name" "Charlie"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -256,7 +244,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2777716938/prog.ml", line 1, characters 92-95:
+File "/tmp/ocamlprog1141164182/prog.ml", line 1, characters 92-95:
 1 | let nations = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "A"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "B"; tbl)];;
                                                                                                 ^^^
 Error: This expression has type string but an expression was expected of type
@@ -268,7 +256,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2075287824/prog.ml", line 1, characters 102-110:
+File "/tmp/ocamlprog1416433827/prog.ml", line 1, characters 102-110:
 1 | let nation = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "n_nationkey" 1;Hashtbl.add tbl "n_name" "BRAZIL"; tbl)];;
                                                                                                           ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -280,7 +268,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4025925682/prog.ml", line 1, characters 92-93:
+File "/tmp/ocamlprog2822702405/prog.ml", line 1, characters 92-93:
 1 | let items = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "cat" "a";Hashtbl.add tbl "val" 3; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "cat" "a";Hashtbl.add tbl "val" 1; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "cat" "b";Hashtbl.add tbl "val" 5; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "cat" "b";Hashtbl.add tbl "val" 2; tbl)];;
                                                                                                 ^
 Error: This expression has type int but an expression was expected of type
@@ -292,7 +280,7 @@ Error: This expression has type int but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2717732139/prog.ml", line 7, characters 28-31:
+File "/tmp/ocamlprog1331982766/prog.ml", line 7, characters 28-31:
 7 |         total := !total + x.val;
                                 ^^^
 Error: Syntax error
@@ -303,11 +291,11 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog642933684/prog.ml", line 3, characters 21-23:
+File "/tmp/ocamlprog3463356000/prog.ml", line 3, characters 21-23:
 3 |   print_endline "big";;
                          ^^
 Error: Syntax error: 'end' expected
-File "/tmp/ocamlprog642933684/prog.ml", line 2, characters 14-19:
+File "/tmp/ocamlprog3463356000/prog.ml", line 2, characters 14-19:
 2 | if x > 3 then begin
                   ^^^^^
   This 'begin' might be unmatched
@@ -330,7 +318,7 @@ compile error: unsupported expression
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4143606013/prog.ml", line 2, characters 42-44:
+File "/tmp/ocamlprog2023247919/prog.ml", line 2, characters 42-44:
 2 | print_endline (string_of_int (Hashtbl.mem xs 2));;
                                               ^^
 Error: This expression has type int list
@@ -342,7 +330,7 @@ Error: This expression has type int list
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3899268921/prog.ml", line 3, characters 42-44:
+File "/tmp/ocamlprog2990222498/prog.ml", line 3, characters 42-44:
 3 | print_endline (string_of_int (Hashtbl.mem ys 1));;
                                               ^^
 Error: This expression has type 'a list
@@ -354,7 +342,7 @@ Error: This expression has type 'a list
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1732398108/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog442086867/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 3;Hashtbl.add tbl "name" "Charlie"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -366,7 +354,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog241985603/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog1145579722/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -378,7 +366,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog827790678/prog.ml", line 2, characters 0-4:
+File "/tmp/ocamlprog3096948292/prog.ml", line 2, characters 0-4:
 2 | json m;;
     ^^^^
 Error: Unbound value json
@@ -389,7 +377,7 @@ Error: Unbound value json
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2849195356/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog2872078026/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -401,7 +389,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1377706656/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog3560305338/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -413,7 +401,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2798034794/prog.ml", line 8, characters 29-32:
+File "/tmp/ocamlprog3713863202/prog.ml", line 8, characters 29-32:
 8 | matrix := _set_nth !matrix 1 (5);;
                                  ^^^
 Error: This expression has type int but an expression was expected of type
@@ -425,7 +413,7 @@ Error: This expression has type int but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1682756847/prog.ml", line 5, characters 29-53:
+File "/tmp/ocamlprog4280404504/prog.ml", line 5, characters 29-53:
 5 | print_endline (string_of_int ((_union [1; 2] [2; 3])));;
                                  ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type int list
@@ -437,7 +425,7 @@ Error: This expression has type int list
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog656619767/prog.ml", line 30, characters 12-13:
+File "/tmp/ocamlprog2126920241/prog.ml", line 30, characters 12-13:
 30 | type Person = {
                  ^
 Error: Syntax error
@@ -448,7 +436,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2565721171/prog.ml", line 2, characters 29-46:
+File "/tmp/ocamlprog1406788474/prog.ml", line 2, characters 29-46:
 2 | print_endline (string_of_int (Hashtbl.mem m 1));;
                                  ^^^^^^^^^^^^^^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -460,7 +448,7 @@ Error: This expression has type bool but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4247366352/prog.ml", line 2, characters 29-49:
+File "/tmp/ocamlprog3439286870/prog.ml", line 2, characters 29-49:
 2 | print_endline (string_of_int ((Hashtbl.find m 1)));;
                                  ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -472,7 +460,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1797892886/prog.ml", line 2, characters 14-33:
+File "/tmp/ocamlprog519539548/prog.ml", line 2, characters 14-33:
 2 | print_endline (Hashtbl.mem m "a");;
                   ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -484,7 +472,7 @@ Error: This expression has type bool but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1606222627/prog.ml", line 2, characters 30-31:
+File "/tmp/ocamlprog584620441/prog.ml", line 2, characters 30-31:
 2 | Hashtbl.replace !data "outer" 2;;
                                   ^
 Error: This expression has type int but an expression was expected of type
@@ -496,7 +484,7 @@ Error: This expression has type int but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1959604533/prog.ml", line 16, characters 29-41:
+File "/tmp/ocamlprog4008375893/prog.ml", line 16, characters 29-41:
 16 | print_endline (string_of_int (classify 0));;
                                   ^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -507,22 +495,20 @@ Error: This expression has type string but an expression was expected of type
 ## tests/vm/valid/math_ops.mochi
 
 ```
-output mismatch
--- ocaml --
-42
-3
-1
--- vm --
-42
-3.5
-1
+ocamlc error: exit status 2
+File "/tmp/ocamlprog3974743837/prog.ml", line 2, characters 29-67:
+2 | print_endline (string_of_int (float_of_int (7) /. float_of_int (2)));;
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type float but an expression was expected of type
+         int
+
 ```
 
 ## tests/vm/valid/membership.mochi
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4078275235/prog.ml", line 2, characters 42-46:
+File "/tmp/ocamlprog2645347525/prog.ml", line 2, characters 42-46:
 2 | print_endline (string_of_int (Hashtbl.mem nums 2));;
                                               ^^^^
 Error: This expression has type int list
@@ -530,28 +516,11 @@ Error: This expression has type int list
 
 ```
 
-## tests/vm/valid/min_max_builtin.mochi
-
-```
-ocamlc error: exit status 2
-File "/tmp/ocamlprog3051656125/prog.ml", line 4, characters 29-39:
-4 | print_endline (string_of_int (min nums));;
-                                 ^^^^^^^^^^
-Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
-File "/tmp/ocamlprog3051656125/prog.ml", line 4, characters 29-39:
-4 | print_endline (string_of_int (min nums));;
-                                 ^^^^^^^^^^
-Error: This expression has type int list -> int list
-       but an expression was expected of type int
-
-```
-
 ## tests/vm/valid/nested_function.mochi
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3022070565/prog.ml", line 4, characters 0-9:
+File "/tmp/ocamlprog2794896783/prog.ml", line 4, characters 0-9:
 4 | exception Return_1 of int
     ^^^^^^^^^
 Error: Syntax error
@@ -562,7 +531,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3526450025/prog.ml", line 3, characters 29-37:
+File "/tmp/ocamlprog44292138/prog.ml", line 3, characters 29-37:
 3 | print_endline (string_of_int (sorted));;
                                  ^^^^^^^^
 Error: This expression has type 'a list
@@ -574,7 +543,7 @@ Error: This expression has type 'a list
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2329908270/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog3773608709/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 3;Hashtbl.add tbl "name" "Charlie"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 4;Hashtbl.add tbl "name" "Diana"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -586,7 +555,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2492830083/prog.ml", line 5, characters 21-22:
+File "/tmp/ocamlprog1401427737/prog.ml", line 5, characters 21-22:
 5 |   with Return_0 v -> v
                          ^
 Error: This expression has type int
@@ -598,7 +567,7 @@ Error: This expression has type int
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2094856409/prog.ml", line 4, characters 25-26:
+File "/tmp/ocamlprog683984307/prog.ml", line 4, characters 25-26:
 4 |     raise (Return_0 (x + k))
                              ^
 Error: Unbound value k
@@ -609,7 +578,7 @@ Error: Unbound value k
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1167280846/prog.ml", line 3, characters 31-39:
+File "/tmp/ocamlprog958396122/prog.ml", line 3, characters 31-39:
 3 | print_endline (string_of_float (result));;
                                    ^^^^^^^^
 Error: This expression has type 'a list
@@ -621,7 +590,7 @@ Error: This expression has type 'a list
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4172110667/prog.ml", line 1, characters 13-14:
+File "/tmp/ocamlprog4042423355/prog.ml", line 1, characters 13-14:
 1 | type Counter = {
                  ^
 Error: Syntax error
@@ -632,7 +601,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog490143340/prog.ml", line 1, characters 94-101:
+File "/tmp/ocamlprog103855821/prog.ml", line 1, characters 94-101:
 1 | let customers = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 1;Hashtbl.add tbl "name" "Alice"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 2;Hashtbl.add tbl "name" "Bob"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 3;Hashtbl.add tbl "name" "Charlie"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "id" 4;Hashtbl.add tbl "name" "Diana"; tbl)];;
                                                                                                   ^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -644,7 +613,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2106826540/prog.ml", line 30, characters 98-100:
+File "/tmp/ocamlprog2822811834/prog.ml", line 30, characters 98-100:
 30 | let people = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Alice";Hashtbl.add tbl "age" 30; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "name" "Bob";Hashtbl.add tbl "age" 25; tbl)];;
                                                                                                        ^^
 Error: This expression has type int but an expression was expected of type
@@ -656,7 +625,7 @@ Error: This expression has type int but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1284870153/prog.ml", line 6, characters 21-22:
+File "/tmp/ocamlprog284158102/prog.ml", line 6, characters 21-22:
 6 |   with Return_0 v -> v
                          ^
 Error: This expression has type bool
@@ -668,7 +637,7 @@ Error: This expression has type bool
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1737624391/prog.ml", line 7, characters 14-20:
+File "/tmp/ocamlprog277593956/prog.ml", line 7, characters 14-20:
 7 |     else x :: _slice xs 0 (len - 1)
                   ^^^^^^
 Error: This function has type 'a list -> int -> int -> 'a list
@@ -680,7 +649,7 @@ Error: This function has type 'a list -> int -> int -> 'a list
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog642918100/prog.ml", line 1, characters 86-89:
+File "/tmp/ocamlprog2752268016/prog.ml", line 1, characters 86-89:
 1 | let items = [(let tbl = Hashtbl.create 2 in Hashtbl.add tbl "n" 1;Hashtbl.add tbl "v" "a"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "n" 1;Hashtbl.add tbl "v" "b"; tbl); (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "n" 2;Hashtbl.add tbl "v" "c"; tbl)];;
                                                                                           ^^^
 Error: This expression has type string but an expression was expected of type
@@ -692,7 +661,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog506975423/prog.ml", line 1, characters 29-50:
+File "/tmp/ocamlprog2188876504/prog.ml", line 1, characters 29-50:
 1 | print_endline (string_of_int (string_of_int (123)));;
                                  ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
@@ -704,7 +673,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1412759243/prog.ml", line 1, characters 14-25:
+File "/tmp/ocamlprog4249183021/prog.ml", line 1, characters 14-25:
 1 | print_endline ("a" < "b");;
                   ^^^^^^^^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -716,7 +685,7 @@ Error: This expression has type bool but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2163157074/prog.ml", line 2, characters 18-26:
+File "/tmp/ocamlprog217891480/prog.ml", line 2, characters 18-26:
 2 | print_endline ((s.contains "cat"));;
                       ^^^^^^^^
 Error: Unbound record field contains
@@ -728,7 +697,7 @@ Hint: Did you mean contents?
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4214967222/prog.ml", line 2, characters 27-28:
+File "/tmp/ocamlprog3883790105/prog.ml", line 2, characters 27-28:
 2 | print_endline (Hashtbl.mem s "cat");;
                                ^
 Error: This expression has type string but an expression was expected of type
@@ -740,7 +709,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog2878413539/prog.ml", line 2, characters 14-32:
+File "/tmp/ocamlprog1309885490/prog.ml", line 2, characters 14-32:
 2 | print_endline ((String.get s 1));;
                   ^^^^^^^^^^^^^^^^^^
 Error: This expression has type char but an expression was expected of type
@@ -752,7 +721,7 @@ Error: This expression has type char but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog107897801/prog.ml", line 3, characters 14-69:
+File "/tmp/ocamlprog1725812253/prog.ml", line 3, characters 14-69:
 3 | print_endline ((String.sub s1 0 (String.length prefix - 0)) = prefix);;
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -764,22 +733,10 @@ Error: This expression has type bool but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog315315617/prog.ml", line 1, characters 30-39:
+File "/tmp/ocamlprog1282654454/prog.ml", line 1, characters 30-39:
 1 | print_endline (string_of_int (substring "mochi" 1 4));;
                                   ^^^^^^^^^
 Error: Unbound value substring
-
-```
-
-## tests/vm/valid/sum_builtin.mochi
-
-```
-ocamlc error: exit status 2
-File "/tmp/ocamlprog327457146/prog.ml", line 3, characters 29-45:
-3 | print_endline (string_of_int (_sum [1; 2; 3]));;
-                                 ^^^^^^^^^^^^^^^^
-Error: This expression has type float but an expression was expected of type
-         int
 
 ```
 
@@ -787,12 +744,12 @@ Error: This expression has type float but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4094972177/prog.ml", line 7, characters 21-30:
+File "/tmp/ocamlprog3938444155/prog.ml", line 7, characters 21-30:
 7 |     raise (Return_0 (sum_rec n - 1 acc + n))
                          ^^^^^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
 maybe some arguments are missing.
-File "/tmp/ocamlprog4094972177/prog.ml", line 7, characters 21-30:
+File "/tmp/ocamlprog3938444155/prog.ml", line 7, characters 21-30:
 7 |     raise (Return_0 (sum_rec n - 1 acc + n))
                          ^^^^^^^^^
 Error: This expression has type int -> 'a
@@ -804,7 +761,7 @@ Error: This expression has type int -> 'a
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1114521895/prog.ml", line 4, characters 57-62:
+File "/tmp/ocamlprog264579308/prog.ml", line 4, characters 57-62:
 4 |     raise (Return_0 ((match t with Leaf -> 0 | Node left value right -> sum_tree left + value + sum_tree right)))
                                                              ^^^^^
 Error: Syntax error
@@ -815,7 +772,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog4111715406/prog.ml", line 2, characters 29-32:
+File "/tmp/ocamlprog2851720015/prog.ml", line 2, characters 29-32:
 2 | print_endline (string_of_int (y));;
                                  ^^^
 Error: This expression has type unit but an expression was expected of type
@@ -827,7 +784,7 @@ Error: This expression has type unit but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog589688151/prog.ml", line 2, characters 29-33:
+File "/tmp/ocamlprog1197071898/prog.ml", line 2, characters 29-33:
 2 | print_endline (string_of_int (!x));;
                                  ^^^^
 Error: This expression has type unit but an expression was expected of type
@@ -839,7 +796,7 @@ Error: This expression has type unit but an expression was expected of type
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1414177755/prog.ml", line 1, characters 12-13:
+File "/tmp/ocamlprog1960154418/prog.ml", line 1, characters 12-13:
 1 | type Person = {
                 ^
 Error: Syntax error
@@ -850,7 +807,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog3156042164/prog.ml", line 1, characters 12-13:
+File "/tmp/ocamlprog3078695572/prog.ml", line 1, characters 12-13:
 1 | type Person = {
                 ^
 Error: Syntax error
@@ -861,7 +818,7 @@ Error: Syntax error
 
 ```
 ocamlc error: exit status 2
-File "/tmp/ocamlprog1723431723/prog.ml", line 2, characters 30-36:
+File "/tmp/ocamlprog403511333/prog.ml", line 2, characters 30-36:
 2 | print_endline (string_of_int (values m));;
                                   ^^^^^^
 Error: Unbound value values

--- a/compile/x/ocaml/compiler_test.go
+++ b/compile/x/ocaml/compiler_test.go
@@ -52,8 +52,9 @@ func TestOCamlCompiler_TwoSum(t *testing.T) {
 	if out, err := exec.Command(cmdName, args...).CombinedOutput(); err != nil {
 		t.Fatalf("ocamlc error: %v\n%s", err, out)
 	}
+	rootDir := findRepoRoot(t)
 	cmd := exec.Command(exe)
-	cmd.Dir = findRepoRoot(t)
+	cmd.Dir = rootDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("run error: %v\n%s", err, out)
@@ -106,8 +107,9 @@ func TestOCamlCompiler_SubsetPrograms(t *testing.T) {
 			if out, err := exec.Command(cmdName, args...).CombinedOutput(); err != nil {
 				return nil, fmt.Errorf("\u274c ocamlc error: %w\n%s", err, out)
 			}
+			rootDir := findRepoRoot(t)
 			cmd := exec.Command(exe)
-			cmd.Dir = findRepoRoot(t)
+			cmd.Dir = rootDir
 			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 				cmd.Stdin = bytes.NewReader(data)
 			}
@@ -131,7 +133,11 @@ func TestOCamlCompiler_SubsetPrograms(t *testing.T) {
 			}
 			var buf bytes.Buffer
 			m := vm.NewWithIO(p, bytes.NewReader(vmIn), &buf)
-			if err := m.Run(); err != nil {
+			cwd, _ := os.Getwd()
+			_ = os.Chdir(rootDir)
+			err = m.Run()
+			_ = os.Chdir(cwd)
+			if err != nil {
 				if ve, ok := err.(*vm.VMError); ok {
 					return nil, fmt.Errorf("\u274c vm run error:\n%s", ve.Format(p))
 				}
@@ -183,8 +189,9 @@ func TestOCamlCompiler_GoldenOutput(t *testing.T) {
 			if out, err := exec.Command(cmdName, args...).CombinedOutput(); err != nil {
 				return nil, fmt.Errorf("\u274c ocamlc error: %w\n%s", err, out)
 			}
+			rootDir := findRepoRoot(t)
 			cmd := exec.Command(exe)
-			cmd.Dir = findRepoRoot(t)
+			cmd.Dir = rootDir
 			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 				cmd.Stdin = bytes.NewReader(data)
 			}
@@ -207,7 +214,11 @@ func TestOCamlCompiler_GoldenOutput(t *testing.T) {
 			}
 			var buf bytes.Buffer
 			m := vm.NewWithIO(p, bytes.NewReader(vmIn), &buf)
-			if err := m.Run(); err != nil {
+			cwd, _ := os.Getwd()
+			_ = os.Chdir(rootDir)
+			err = m.Run()
+			_ = os.Chdir(cwd)
+			if err != nil {
 				if ve, ok := err.(*vm.VMError); ok {
 					return nil, fmt.Errorf("\u274c vm run error:\n%s", ve.Format(p))
 				}


### PR DESCRIPTION
## Summary
- implement list helpers `_sum`, `_avg`, `_max`, `_min`
- perform float division for `/` in OCaml backend
- run VM in tests from repo root
- regenerate OCaml roundtrip error report

## Testing
- `go test ./compile/x/ocaml -tags slow -run TestOCamlCompiler_SubsetPrograms -update` *(fails: output mismatch with VM)*
- `go run ./compile/x/ocaml/cmd/vm_roundtrip`


------
https://chatgpt.com/codex/tasks/task_e_686aa8cfee6883208d0b1988c223f76f