### PR TITLE
Update Lua golden tests to execute output

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -483,6 +483,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: FloatType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("abs", FuncType{
+		Params: []Type{AnyType{}},
+		Return: FloatType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("sum", FuncType{
 		Params: []Type{AnyType{}},
 		Return: FloatType{},
@@ -2288,6 +2293,7 @@ var builtinArity = map[string]int{
 	"avg":       1,
 	"ceil":      1,
 	"floor":     1,
+	"abs":       1,
 	"sum":       1,
 	"min":       1,
 	"max":       1,
@@ -2411,7 +2417,7 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 		default:
 			return errSumOperand(pos, a)
 		}
-	case "ceil", "floor":
+	case "ceil", "floor", "abs":
 		if len(args) != 1 {
 			return errArgCount(pos, name, 1, len(args))
 		}


### PR DESCRIPTION
## Summary
- support `abs` builtin in type checker
- run compiled Lua code in golden tests and compare output with VM

## Testing
- `go test -tags slow ./compile/x/lua -run TestLuaCompiler_GoldenOutput -timeout=60s` *(fails: runtime mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686aa673b9d883209d73661b65772fb0