### PR TITLE
Update Scala compiler golden tests

### DIFF
--- a/compile/x/scala/ERRORS.md
+++ b/compile/x/scala/ERRORS.md
@@ -5,7 +5,7 @@
 ```
 output mismatch
 -- scala --
-()
+ArrayBuffer(1, 2, 3)
 -- vm --
 1 2 3
 ```

--- a/compile/x/scala/compiler.go
+++ b/compile/x/scala/compiler.go
@@ -1154,6 +1154,9 @@ func (c *Compiler) compileCall(call *parser.CallExpr, recv string) (string, erro
 	}
 	switch call.Func {
 	case "print":
+		if len(args) == 1 && isListExpr(call.Args[0], c.env) {
+			return fmt.Sprintf("println(%s.mkString(\" \"))", args[0]), nil
+		}
 		return fmt.Sprintf("println(%s)", argStr), nil
 	case "len":
 		if len(args) != 1 {
@@ -1229,7 +1232,7 @@ func (c *Compiler) compileCall(call *parser.CallExpr, recv string) (string, erro
 		if len(args) != 2 {
 			return "", fmt.Errorf("append expects 2 args")
 		}
-		return fmt.Sprintf("%s.append(%s)", args[0], args[1]), nil
+		return fmt.Sprintf("%s :+ %s", args[0], args[1]), nil
 	case "concat":
 		if len(args) == 0 {
 			return "scala.collection.mutable.ArrayBuffer()", nil

--- a/compile/x/scala/compiler_test.go
+++ b/compile/x/scala/compiler_test.go
@@ -132,6 +132,56 @@ func TestScalaCompiler_SubsetPrograms(t *testing.T) {
 }
 
 func TestScalaCompiler_GoldenOutput(t *testing.T) {
+	run := func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("❌ parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("❌ type error: %v", errs[0])
+		}
+		code, err := scalacode.New(env).Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("❌ compile error: %w", err)
+		}
+		dir := t.TempDir()
+		file := filepath.Join(dir, "Main.scala")
+		if err := os.WriteFile(file, code, 0644); err != nil {
+			return nil, fmt.Errorf("write error: %w", err)
+		}
+		if out, err := exec.Command("scalac", file).CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("❌ scalac error: %w\n%s", err, out)
+		}
+		scalaCmd := "scala"
+		args := []string{"Main"}
+		if _, err := exec.LookPath("scala-cli"); err == nil {
+			scalaCmd = "scala-cli"
+			args = []string{"run", file}
+		} else if out, err := exec.Command("scala", "-version").CombinedOutput(); err == nil && bytes.Contains(out, []byte("Scala CLI")) {
+			args = []string{"run", file}
+		}
+		cmd := exec.Command(scalaCmd, args...)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("❌ scala run error: %w\n%s", err, out)
+		}
+		vmOut, err := runWithVM(prog, env, src)
+		if err != nil {
+			return nil, err
+		}
+		scalaOut := bytes.TrimSpace(out)
+		if !bytes.Equal(scalaOut, vmOut) {
+			return nil, fmt.Errorf("❌ output mismatch\n-- scala --\n%s\n-- vm --\n%s", scalaOut, vmOut)
+		}
+		return scalaOut, nil
+	}
+
+	golden.Run(t, "tests/compiler/valid_scala", ".mochi", ".out", run)
+	golden.Run(t, "tests/compiler/scala", ".mochi", ".out", run)
 	golden.Run(t, "tests/compiler/valid_scala", ".mochi", ".scala.out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {

--- a/tests/compiler/scala/append_builtin.scala.out
+++ b/tests/compiler/scala/append_builtin.scala.out
@@ -1,7 +1,7 @@
 object Main {
     def main(args: Array[String]): Unit = {
         var xs = scala.collection.mutable.ArrayBuffer(1)
-        xs.append(2)
-        println(xs)
+        xs :+ 2
+        println(xs.mkString(" "))
     }
 }


### PR DESCRIPTION
## Summary
- improve Scala backend builtins to match list semantics
- support list printing in Scala backend
- update compiler golden test to run Scala code and compare with VM
- regenerate golden file
- refresh Scala VM error report

## Testing
- `go vet ./...`
- `go test ./compile/x/scala -tags slow -run TestScalaCompiler_GoldenOutput -count=1` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686aa7e53f2c8320ae1cd04cea53bedc