### PR TITLE
Update PHP golden tests and runtime

### DIFF
--- a/compile/x/php/ERRORS.md
+++ b/compile/x/php/ERRORS.md
@@ -3,12 +3,11 @@
 ## tests/vm/valid/append_builtin.mochi
 
 ```
-php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function append() in /tmp/php_run3971473010/main.php:3
-Stack trace:
-#0 {main}
-  thrown in /tmp/php_run3971473010/main.php on line 3
-
+output mismatch
+-- php --
+[1,2,3]
+-- vm --
+1 2 3
 ```
 
 ## tests/vm/valid/basic_compare.mochi
@@ -41,10 +40,10 @@ false
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Cannot use object of type Todo as array in /tmp/php_run1539923832/main.php:10
+PHP Fatal error:  Uncaught Error: Cannot use object of type Todo as array in /tmp/php_run2848440466/main.php:10
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run1539923832/main.php on line 10
+  thrown in /tmp/php_run2848440466/main.php on line 10
 
 ```
 
@@ -93,12 +92,11 @@ Diana is 45
 ## tests/vm/valid/exists_builtin.mochi
 
 ```
-php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function exists() in /tmp/php_run2254180212/main.php:3
-Stack trace:
-#0 {main}
-  thrown in /tmp/php_run2254180212/main.php on line 3
-
+output mismatch
+-- php --
+1
+-- vm --
+true
 ```
 
 ## tests/vm/valid/for_map_collection.mochi
@@ -131,34 +129,34 @@ Hanoi : count = 3 , avg_age = 27.333333333333332
 
 ```
 php run error: exit status 255
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 42
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 42
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 42
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 42
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 42
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 42
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2353961726/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 20
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 26
-PHP Warning:  Undefined variable $g in /tmp/php_run2353961726/main.php on line 26
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2353961726/main.php on line 26
-PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /tmp/php_run2353961726/main.php:18
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 42
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3233809951/main.php on line 42
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 42
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3233809951/main.php on line 42
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 42
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3233809951/main.php on line 42
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3233809951/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3233809951/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3233809951/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 20
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3233809951/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 26
+PHP Warning:  Undefined variable $g in /tmp/php_run3233809951/main.php on line 26
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3233809951/main.php on line 26
+PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /tmp/php_run3233809951/main.php:18
 Stack trace:
-#0 /tmp/php_run2353961726/main.php(18): intdiv()
-#1 /tmp/php_run2353961726/main.php(129): {closure}()
-#2 /tmp/php_run2353961726/main.php(5): _query()
-#3 /tmp/php_run2353961726/main.php(43): {closure}()
+#0 /tmp/php_run3233809951/main.php(18): intdiv()
+#1 /tmp/php_run3233809951/main.php(130): {closure}()
+#2 /tmp/php_run3233809951/main.php(5): _query()
+#3 /tmp/php_run3233809951/main.php(43): {closure}()
 #4 {main}
-  thrown in /tmp/php_run2353961726/main.php on line 18
+  thrown in /tmp/php_run3233809951/main.php on line 18
 
 ```
 
@@ -177,22 +175,22 @@ output mismatch
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run2263987481/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run2910525598/main.php on line 8
 --- Orders per customer ---
- orders: 0
- orders: 0
- orders: 0
+<nil> orders: 0
+<nil> orders: 0
+<nil> orders: 0
 -- vm --
 --- Orders per customer ---
 Alice orders: 2
@@ -204,43 +202,43 @@ Bob orders: 1
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3548755337/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 10
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  Undefined variable $g in /tmp/php_run3548755337/main.php on line 17
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3548755337/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Trying to access array offset on null in /tmp/php_run551964208/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 10
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  Undefined variable $g in /tmp/php_run551964208/main.php on line 17
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run551964208/main.php on line 17
 --- Group Left Join ---
- orders: 0
- orders: 0
- orders: 0
- orders: 0
+<nil> orders: 0
+<nil> orders: 0
+<nil> orders: 0
+<nil> orders: 0
 -- vm --
 --- Group Left Join ---
 Alice orders: 2
@@ -263,33 +261,33 @@ map[part:100 total:20] map[part:200 total:15]
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 22
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 22
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3516876976/main.php on line 22
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 16
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 16
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3516876976/main.php on line 16
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Undefined variable $g in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
-PHP Warning:  Trying to access array offset on null in /tmp/php_run3516876976/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 22
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 22
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3136869074/main.php on line 22
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 14
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 16
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 16
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3136869074/main.php on line 16
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Undefined variable $g in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
+PHP Warning:  Trying to access array offset on null in /tmp/php_run3136869074/main.php on line 20
 [{"c_custkey":null,"c_name":null,"revenue":0,"c_acctbal":null,"n_name":null,"c_address":null,"c_phone":null,"c_comment":null}]
 -- vm --
 map[c_acctbal:100 c_address:123 St c_comment:Loyal c_custkey:1 c_name:Alice c_phone:123-456 n_name:BRAZIL revenue:900]
@@ -300,38 +298,38 @@ map[c_acctbal:100 c_address:123 St c_comment:Loyal c_custkey:1 c_name:Alice c_ph
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 14
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Trying to access array offset on null in /tmp/php_run809419930/main.php on line 6
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  Undefined variable $g in /tmp/php_run809419930/main.php on line 8
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run809419930/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 14
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Trying to access array offset on null in /tmp/php_run4134217594/main.php on line 6
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  Undefined variable $g in /tmp/php_run4134217594/main.php on line 8
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run4134217594/main.php on line 8
 [{"cat":null,"total":0},{"cat":null,"total":0},{"cat":null,"total":0},{"cat":null,"total":0}]
 -- vm --
 map[cat:b total:7] map[cat:a total:4]
@@ -340,15 +338,19 @@ map[cat:b total:7] map[cat:a total:4]
 ## tests/vm/valid/group_items_iteration.mochi
 
 ```
-php run error: exit status 255
-PHP Warning:  Undefined array key "items" in /tmp/php_run2576219068/main.php on line 15
-PHP Warning:  Undefined array key "items" in /tmp/php_run2576219068/main.php on line 15
-PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run2576219068/main.php on line 15
-PHP Fatal error:  Uncaught Error: Call to undefined function append() in /tmp/php_run2576219068/main.php:18
-Stack trace:
-#0 {main}
-  thrown in /tmp/php_run2576219068/main.php on line 18
-
+output mismatch
+-- php --
+PHP Warning:  Undefined array key "items" in /tmp/php_run3109445982/main.php on line 15
+PHP Warning:  Undefined array key "items" in /tmp/php_run3109445982/main.php on line 15
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3109445982/main.php on line 15
+PHP Warning:  Undefined array key "key" in /tmp/php_run3109445982/main.php on line 18
+PHP Warning:  Undefined array key "items" in /tmp/php_run3109445982/main.php on line 15
+PHP Warning:  Undefined array key "items" in /tmp/php_run3109445982/main.php on line 15
+PHP Warning:  foreach() argument must be of type array|object, null given in /tmp/php_run3109445982/main.php on line 15
+PHP Warning:  Undefined array key "key" in /tmp/php_run3109445982/main.php on line 18
+[{"tag":null,"total":0},{"tag":null,"total":0}]
+-- vm --
+map[tag:a total:3] map[tag:b total:3]
 ```
 
 ## tests/vm/valid/in_operator.mochi
@@ -389,7 +391,7 @@ output mismatch
 -- php --
 --- Left Join ---
 Order 100 customer {"id":1,"name":"Alice"} total 250
-Order 101 customer  total 80
+Order 101 customer <nil> total 80
 -- vm --
 --- Left Join ---
 Order 100 customer map[id:1 name:Alice] total 250
@@ -403,7 +405,7 @@ output mismatch
 -- php --
 --- Left Join Multi ---
 100 Alice {"orderId":100,"sku":"a"}
-101 Bob
+101 Bob <nil>
 -- vm --
 --- Left Join Multi ---
 100 Alice map[orderId:100 sku:a]
@@ -430,12 +432,12 @@ output mismatch
 
 ```
 php run error: exit status 255
-PHP Warning:  fopen(../interpreter/valid/people.yaml): Failed to open stream: No such file or directory in /tmp/php_run2104781621/main.php on line 27
-PHP Fatal error:  Uncaught Exception: cannot open ../interpreter/valid/people.yaml in /tmp/php_run2104781621/main.php:28
+PHP Warning:  fopen(../interpreter/valid/people.yaml): Failed to open stream: No such file or directory in /tmp/php_run3682030502/main.php on line 27
+PHP Fatal error:  Uncaught Exception: cannot open ../interpreter/valid/people.yaml in /tmp/php_run3682030502/main.php:28
 Stack trace:
-#0 /tmp/php_run2104781621/main.php(13): _load_json()
+#0 /tmp/php_run3682030502/main.php(13): _load_json()
 #1 {main}
-  thrown in /tmp/php_run2104781621/main.php on line 28
+  thrown in /tmp/php_run3682030502/main.php on line 28
 
 ```
 
@@ -503,10 +505,10 @@ false
 ```
 output mismatch
 -- php --
-PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
-PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
-PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
-PHP Warning:  Array to string conversion in /tmp/php_run694810436/main.php on line 80
+PHP Warning:  Array to string conversion in /tmp/php_run574951552/main.php on line 81
+PHP Warning:  Array to string conversion in /tmp/php_run574951552/main.php on line 81
+PHP Warning:  Array to string conversion in /tmp/php_run574951552/main.php on line 81
+PHP Warning:  Array to string conversion in /tmp/php_run574951552/main.php on line 81
 [{"a":1,"b":2},{"a":1,"b":1},{"a":0,"b":5}]
 -- vm --
 map[a:0 b:5] map[a:1 b:1] map[a:1 b:2]
@@ -516,11 +518,11 @@ map[a:0 b:5] map[a:1 b:1] map[a:1 b:2]
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function mochi_add(), 1 passed in /tmp/php_run3712342176/main.php on line 6 and exactly 2 expected in /tmp/php_run3712342176/main.php:2
+PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function mochi_add(), 1 passed in /tmp/php_run554233850/main.php on line 6 and exactly 2 expected in /tmp/php_run554233850/main.php:2
 Stack trace:
-#0 /tmp/php_run3712342176/main.php(6): mochi_add()
+#0 /tmp/php_run554233850/main.php(6): mochi_add()
 #1 {main}
-  thrown in /tmp/php_run3712342176/main.php on line 2
+  thrown in /tmp/php_run554233850/main.php on line 2
 
 ```
 
@@ -529,8 +531,8 @@ Stack trace:
 ```
 output mismatch
 -- php --
-PHP Warning:  Undefined variable $k in /tmp/php_run2986886998/main.php on line 3
-PHP Warning:  Undefined variable $k in /tmp/php_run2986886998/main.php on line 3
+PHP Warning:  Undefined variable $k in /tmp/php_run3678698791/main.php on line 3
+PHP Warning:  Undefined variable $k in /tmp/php_run3678698791/main.php on line 3
 3
 -- vm --
 5
@@ -540,12 +542,12 @@ PHP Warning:  Undefined variable $k in /tmp/php_run2986886998/main.php on line 3
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught TypeError: array_sum(): Argument #1 ($array) must be of type array, int given in /tmp/php_run2672455735/main.php:7
+PHP Fatal error:  Uncaught TypeError: array_sum(): Argument #1 ($array) must be of type array, int given in /tmp/php_run92210235/main.php:7
 Stack trace:
-#0 /tmp/php_run2672455735/main.php(7): array_sum()
-#1 /tmp/php_run2672455735/main.php(10): {closure}()
+#0 /tmp/php_run92210235/main.php(7): array_sum()
+#1 /tmp/php_run92210235/main.php(10): {closure}()
 #2 {main}
-  thrown in /tmp/php_run2672455735/main.php on line 7
+  thrown in /tmp/php_run92210235/main.php on line 7
 
 ```
 
@@ -553,11 +555,11 @@ Stack trace:
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Cannot use object of type Counter as array in /tmp/php_run1980354977/main.php:3
+PHP Fatal error:  Uncaught Error: Cannot use object of type Counter as array in /tmp/php_run319900752/main.php:3
 Stack trace:
-#0 /tmp/php_run1980354977/main.php(14): mochi_inc()
+#0 /tmp/php_run319900752/main.php(14): mochi_inc()
 #1 {main}
-  thrown in /tmp/php_run1980354977/main.php on line 3
+  thrown in /tmp/php_run319900752/main.php on line 3
 
 ```
 
@@ -656,41 +658,10 @@ true
 false
 ```
 
-## tests/vm/valid/substring_builtin.mochi
-
-```
-php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function substring() in /tmp/php_run3467572083/main.php:2
-Stack trace:
-#0 {main}
-  thrown in /tmp/php_run3467572083/main.php on line 2
-
-```
-
 ## tests/vm/valid/tree_sum.mochi
 
 ```
 compile error: unsupported expression
-```
-
-## tests/vm/valid/typed_let.mochi
-
-```
-output mismatch
--- php --
-
--- vm --
-<nil>
-```
-
-## tests/vm/valid/typed_var.mochi
-
-```
-output mismatch
--- php --
-
--- vm --
-<nil>
 ```
 
 ## tests/vm/valid/update_stmt.mochi
@@ -709,21 +680,20 @@ stack trace:
 
 ```
 php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Cannot use object of type Book as array in /tmp/php_run3369578827/main.php:21
+PHP Fatal error:  Uncaught Error: Cannot use object of type Book as array in /tmp/php_run1572847811/main.php:21
 Stack trace:
 #0 {main}
-  thrown in /tmp/php_run3369578827/main.php on line 21
+  thrown in /tmp/php_run1572847811/main.php on line 21
 
 ```
 
 ## tests/vm/valid/values_builtin.mochi
 
 ```
-php run error: exit status 255
-PHP Fatal error:  Uncaught Error: Call to undefined function values() in /tmp/php_run498929793/main.php:3
-Stack trace:
-#0 {main}
-  thrown in /tmp/php_run498929793/main.php on line 3
-
+output mismatch
+-- php --
+[1,2,3]
+-- vm --
+1 2 3
 ```
 

--- a/compile/x/php/compiler.go
+++ b/compile/x/php/compiler.go
@@ -937,6 +937,26 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("reverse expects 1 arg")
 		}
 		return fmt.Sprintf("(is_array(%[1]s) ? array_reverse(%[1]s) : (is_string(%[1]s) ? strrev(%[1]s) : null))", args[0]), nil
+	case "append":
+		if len(args) != 2 {
+			return "", fmt.Errorf("append expects 2 args")
+		}
+		return fmt.Sprintf("array_merge(%s, [%s])", args[0], args[1]), nil
+	case "values":
+		if len(args) != 1 {
+			return "", fmt.Errorf("values expects 1 arg")
+		}
+		return fmt.Sprintf("array_values(%s)", args[0]), nil
+	case "substr", "substring":
+		if len(args) != 3 {
+			return "", fmt.Errorf("substr expects 3 args")
+		}
+		return fmt.Sprintf("substr(%s, %s, %s - %s)", args[0], args[1], args[2], args[1]), nil
+	case "exists":
+		if len(args) != 1 {
+			return "", fmt.Errorf("exists expects 1 arg")
+		}
+		return fmt.Sprintf("((is_object(%[1]s) && property_exists(%[1]s, 'Items')) ? count(%[1]s->Items) : (is_array(%[1]s) ? count(%[1]s) : (is_string(%[1]s) ? strlen(%[1]s) : 0))) > 0", args[0]), nil
 	default:
 		return fmt.Sprintf("%s(%s)", name, strings.Join(args, ", ")), nil
 	}

--- a/compile/x/php/job_test.go
+++ b/compile/x/php/job_test.go
@@ -3,6 +3,7 @@
 package phpcode_test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 	phpcode "mochi/compile/x/php"
 	"mochi/compile/x/testutil"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -52,14 +54,31 @@ func TestPHPCompiler_JOB(t *testing.T) {
 			if err != nil {
 				t.Fatalf("php run error: %v\n%s", err, out)
 			}
+			phpOut := bytes.TrimSpace(out)
+
+			p, err := vm.Compile(prog, env)
+			if err != nil {
+				t.Fatalf("vm compile error: %v", err)
+			}
+			var vmBuf bytes.Buffer
+			m := vm.New(p, &vmBuf)
+			if err := m.Run(); err != nil {
+				if ve, ok := err.(*vm.VMError); ok {
+					t.Fatalf("vm run error:\n%s", ve.Format(p))
+				}
+				t.Fatalf("vm run error: %v", err)
+			}
+			vmOut := bytes.TrimSpace(vmBuf.Bytes())
+			if !bytes.Equal(phpOut, vmOut) {
+				t.Fatalf("vm mismatch\n\n--- PHP ---\n%s\n\n--- VM ---\n%s", phpOut, vmOut)
+			}
+
 			wantData, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "php", q+".out"))
 			if err != nil {
 				t.Fatalf("read golden: %v", err)
 			}
-			got := string(out)
-			want := string(wantData)
-			if got != want {
-				t.Fatalf("unexpected output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+			if string(phpOut) != string(bytes.TrimSpace(wantData)) {
+				t.Fatalf("unexpected output\n--- got ---\n%s\n--- want ---\n%s", phpOut, bytes.TrimSpace(wantData))
 			}
 		})
 	}

--- a/compile/x/php/runtime.go
+++ b/compile/x/php/runtime.go
@@ -125,7 +125,8 @@ const helperSaveJSON = "function _save_json($rows, $path) {\n" +
 const helperPrint = "function _print(...$args) {\n" +
 	"    $parts = [];\n" +
 	"    foreach ($args as $a) {\n" +
-	"        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }\n" +
+	"        if (is_null($a)) { $parts[] = '<nil>'; }\n" +
+	"        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }\n" +
 	"    }\n" +
 	"    echo implode(' ', $parts), PHP_EOL;\n" +
 	"}\n"

--- a/compile/x/php/tpch_golden_test.go
+++ b/compile/x/php/tpch_golden_test.go
@@ -13,6 +13,7 @@ import (
 	phpcode "mochi/compile/x/php"
 	"mochi/compile/x/testutil"
 	"mochi/parser"
+	"mochi/runtime/vm"
 	"mochi/types"
 )
 
@@ -55,14 +56,32 @@ func TestPHPCompiler_TPCH_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("php run error: %v\n%s", err, out)
 			}
+			phpOut := bytes.TrimSpace(out)
+
+			p, err := vm.Compile(prog, env)
+			if err != nil {
+				t.Fatalf("vm compile error: %v", err)
+			}
+			var vmBuf bytes.Buffer
+			m := vm.New(p, &vmBuf)
+			if err := m.Run(); err != nil {
+				if ve, ok := err.(*vm.VMError); ok {
+					t.Fatalf("vm run error:\n%s", ve.Format(p))
+				}
+				t.Fatalf("vm run error: %v", err)
+			}
+			vmOut := bytes.TrimSpace(vmBuf.Bytes())
+			if !bytes.Equal(phpOut, vmOut) {
+				t.Fatalf("vm mismatch\n\n--- PHP ---\n%s\n\n--- VM ---\n%s", phpOut, vmOut)
+			}
+
 			outWantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "php", q+".out")
 			wantOut, err := os.ReadFile(outWantPath)
 			if err != nil {
 				t.Fatalf("read golden: %v", err)
 			}
-			gotOut := bytes.TrimSpace(out)
-			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
-				t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", q, gotOut, bytes.TrimSpace(wantOut))
+			if !bytes.Equal(phpOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", q, phpOut, bytes.TrimSpace(wantOut))
 			}
 		})
 	}

--- a/tests/vm/valid/append_builtin.php.error
+++ b/tests/vm/valid/append_builtin.php.error
@@ -1,1 +1,1 @@
-exit status 255
+output mismatch

--- a/tests/vm/valid/append_builtin.php.out
+++ b/tests/vm/valid/append_builtin.php.out
@@ -1,11 +1,12 @@
 <?php
 $a = [1, 2];
-_print(append($a, 3));
+_print(array_merge($a, [3]));
 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/avg_builtin.php.out
+++ b/tests/vm/valid/avg_builtin.php.out
@@ -4,7 +4,8 @@ _print((count([1, 2, 3]) ? array_sum([1, 2, 3]) / count([1, 2, 3]) : 0));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/basic_compare.php.out
+++ b/tests/vm/valid/basic_compare.php.out
@@ -8,7 +8,8 @@ _print(($b < 5));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/binary_precedence.php.out
+++ b/tests/vm/valid/binary_precedence.php.out
@@ -7,7 +7,8 @@ _print((2 * (((is_array(3) && is_array(1)) ? array_merge(3, 1) : ((is_string(3) 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/bool_chain.php.out
+++ b/tests/vm/valid/bool_chain.php.out
@@ -11,7 +11,8 @@ _print((((((1 < 2)) && ((2 < 3))) && ((3 > 4))) && mochi_boom()));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/break_continue.php.out
+++ b/tests/vm/valid/break_continue.php.out
@@ -13,7 +13,8 @@ foreach ((is_string($numbers) ? str_split($numbers) : $numbers) as $n) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/cast_string_to_int.php.out
+++ b/tests/vm/valid/cast_string_to_int.php.out
@@ -4,7 +4,8 @@ _print((int)("1995"));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/cast_struct.php.out
+++ b/tests/vm/valid/cast_struct.php.out
@@ -12,7 +12,8 @@ _print($todo['title']);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/closure.php.out
+++ b/tests/vm/valid/closure.php.out
@@ -11,7 +11,8 @@ _print($add10(7));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/count_builtin.php.out
+++ b/tests/vm/valid/count_builtin.php.out
@@ -4,7 +4,8 @@ _print((is_array([1, 2, 3]) ? count([1, 2, 3]) : strlen([1, 2, 3])));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/cross_join.php.out
+++ b/tests/vm/valid/cross_join.php.out
@@ -18,7 +18,8 @@ foreach ((is_string($result) ? str_split($result) : $result) as $entry) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/cross_join_filter.php.out
+++ b/tests/vm/valid/cross_join_filter.php.out
@@ -19,7 +19,8 @@ foreach ((is_string($pairs) ? str_split($pairs) : $pairs) as $p) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/cross_join_triple.php.out
+++ b/tests/vm/valid/cross_join_triple.php.out
@@ -21,7 +21,8 @@ foreach ((is_string($combos) ? str_split($combos) : $combos) as $c) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/dataset_sort_take_limit.php.out
+++ b/tests/vm/valid/dataset_sort_take_limit.php.out
@@ -13,7 +13,8 @@ foreach ((is_string($expensive) ? str_split($expensive) : $expensive) as $item) 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/dataset_where_filter.php.out
+++ b/tests/vm/valid/dataset_where_filter.php.out
@@ -16,7 +16,8 @@ foreach ((is_string($adults) ? str_split($adults) : $adults) as $person) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/exists_builtin.php.error
+++ b/tests/vm/valid/exists_builtin.php.error
@@ -1,1 +1,1 @@
-exit status 255
+output mismatch

--- a/tests/vm/valid/exists_builtin.php.out
+++ b/tests/vm/valid/exists_builtin.php.out
@@ -1,19 +1,62 @@
 <?php
 $data = [1, 2];
-$flag = exists((function() use ($data) {
+$flag = ((is_object((function() use ($data) {
 	$res = [];
 	foreach ((is_string($data) ? str_split($data) : $data) as $x) {
 		if (!(($x == 1))) { continue; }
 		$res[] = $x;
 	}
 	return $res;
-})());
+})()) && property_exists((function() use ($data) {
+	$res = [];
+	foreach ((is_string($data) ? str_split($data) : $data) as $x) {
+		if (!(($x == 1))) { continue; }
+		$res[] = $x;
+	}
+	return $res;
+})(), 'Items')) ? count((function() use ($data) {
+	$res = [];
+	foreach ((is_string($data) ? str_split($data) : $data) as $x) {
+		if (!(($x == 1))) { continue; }
+		$res[] = $x;
+	}
+	return $res;
+})()->Items) : (is_array((function() use ($data) {
+	$res = [];
+	foreach ((is_string($data) ? str_split($data) : $data) as $x) {
+		if (!(($x == 1))) { continue; }
+		$res[] = $x;
+	}
+	return $res;
+})()) ? count((function() use ($data) {
+	$res = [];
+	foreach ((is_string($data) ? str_split($data) : $data) as $x) {
+		if (!(($x == 1))) { continue; }
+		$res[] = $x;
+	}
+	return $res;
+})()) : (is_string((function() use ($data) {
+	$res = [];
+	foreach ((is_string($data) ? str_split($data) : $data) as $x) {
+		if (!(($x == 1))) { continue; }
+		$res[] = $x;
+	}
+	return $res;
+})()) ? strlen((function() use ($data) {
+	$res = [];
+	foreach ((is_string($data) ? str_split($data) : $data) as $x) {
+		if (!(($x == 1))) { continue; }
+		$res[] = $x;
+	}
+	return $res;
+})()) : 0))) > 0;
 _print($flag);
 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/for_list_collection.php.out
+++ b/tests/vm/valid/for_list_collection.php.out
@@ -6,7 +6,8 @@ foreach ((is_string([1, 2, 3]) ? str_split([1, 2, 3]) : [1, 2, 3]) as $n) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/for_loop.php.out
+++ b/tests/vm/valid/for_loop.php.out
@@ -6,7 +6,8 @@ for ($i = 1; $i < 4; $i++) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/for_map_collection.php.out
+++ b/tests/vm/valid/for_map_collection.php.out
@@ -7,7 +7,8 @@ foreach ((is_string($m) ? str_split($m) : $m) as $k) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/fun_call.php.out
+++ b/tests/vm/valid/fun_call.php.out
@@ -8,7 +8,8 @@ _print(mochi_add(2, 3));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/fun_expr_in_let.php.out
+++ b/tests/vm/valid/fun_expr_in_let.php.out
@@ -7,7 +7,8 @@ _print($square(6));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/fun_three_args.php.out
+++ b/tests/vm/valid/fun_three_args.php.out
@@ -8,7 +8,8 @@ _print(mochi_sum3(1, 2, 3));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_by.php.out
+++ b/tests/vm/valid/group_by.php.out
@@ -57,7 +57,8 @@ function _group_by($src, $keyfn) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_by_conditional_sum.php.out
+++ b/tests/vm/valid/group_by_conditional_sum.php.out
@@ -46,7 +46,8 @@ _print($result);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_by_join.php.out
+++ b/tests/vm/valid/group_by_join.php.out
@@ -15,7 +15,8 @@ foreach ((is_string($stats) ? str_split($stats) : $stats) as $s) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_by_left_join.php.out
+++ b/tests/vm/valid/group_by_left_join.php.out
@@ -36,7 +36,8 @@ foreach ((is_string($stats) ? str_split($stats) : $stats) as $s) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_by_multi_join.php.out
+++ b/tests/vm/valid/group_by_multi_join.php.out
@@ -51,7 +51,8 @@ function _group_by($src, $keyfn) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_by_multi_join_sort.php.out
+++ b/tests/vm/valid/group_by_multi_join_sort.php.out
@@ -30,7 +30,8 @@ _print($result);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_by_sort.php.out
+++ b/tests/vm/valid/group_by_sort.php.out
@@ -22,7 +22,8 @@ _print($grouped);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/group_items_iteration.php.error
+++ b/tests/vm/valid/group_items_iteration.php.error
@@ -1,1 +1,1 @@
-exit status 255
+output mismatch

--- a/tests/vm/valid/group_items_iteration.php.out
+++ b/tests/vm/valid/group_items_iteration.php.out
@@ -15,7 +15,7 @@ foreach ((is_string($groups) ? str_split($groups) : $groups) as $g) {
 	foreach ((is_string($g['items']) ? str_split($g['items']) : $g['items']) as $x) {
 		$total = ((is_array($total) && is_array($x['val'])) ? array_merge($total, $x['val']) : ((is_string($total) || is_string($x['val'])) ? ($total . $x['val']) : ($total + $x['val'])));
 	}
-	$tmp = append($tmp, ["tag" => $g['key'], "total" => $total]);
+	$tmp = array_merge($tmp, [["tag" => $g['key'], "total" => $total]]);
 }
 $result = (function() use ($tmp) {
 	$_src = $tmp;
@@ -49,7 +49,8 @@ function _group_by($src, $keyfn) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/if_else.php.out
+++ b/tests/vm/valid/if_else.php.out
@@ -9,7 +9,8 @@ if (($x > 3)) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/if_then_else.php.out
+++ b/tests/vm/valid/if_then_else.php.out
@@ -6,7 +6,8 @@ _print($msg);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/if_then_else_nested.php.out
+++ b/tests/vm/valid/if_then_else_nested.php.out
@@ -6,7 +6,8 @@ _print($msg);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/in_operator.php.out
+++ b/tests/vm/valid/in_operator.php.out
@@ -6,7 +6,8 @@ _print(!((is_array($xs) ? (array_key_exists(5, $xs) || in_array(5, $xs, true)) :
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/in_operator_extended.php.out
+++ b/tests/vm/valid/in_operator_extended.php.out
@@ -20,7 +20,8 @@ _print((is_array($s) ? (array_key_exists("foo", $s) || in_array("foo", $s, true)
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/inner_join.php.out
+++ b/tests/vm/valid/inner_join.php.out
@@ -15,7 +15,8 @@ foreach ((is_string($result) ? str_split($result) : $result) as $entry) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/join_multi.php.out
+++ b/tests/vm/valid/join_multi.php.out
@@ -17,7 +17,8 @@ foreach ((is_string($result) ? str_split($result) : $result) as $r) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/left_join.php.out
+++ b/tests/vm/valid/left_join.php.out
@@ -15,7 +15,8 @@ foreach ((is_string($result) ? str_split($result) : $result) as $entry) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/left_join_multi.php.out
+++ b/tests/vm/valid/left_join_multi.php.out
@@ -17,7 +17,8 @@ foreach ((is_string($result) ? str_split($result) : $result) as $r) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/len_builtin.php.out
+++ b/tests/vm/valid/len_builtin.php.out
@@ -4,7 +4,8 @@ _print((is_array([1, 2, 3]) ? count([1, 2, 3]) : strlen([1, 2, 3])));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/len_map.php.out
+++ b/tests/vm/valid/len_map.php.out
@@ -4,7 +4,8 @@ _print((is_array(["a" => 1, "b" => 2]) ? count(["a" => 1, "b" => 2]) : strlen(["
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/len_string.php.out
+++ b/tests/vm/valid/len_string.php.out
@@ -4,7 +4,8 @@ _print((is_array("mochi") ? count("mochi") : strlen("mochi")));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/let_and_print.php.out
+++ b/tests/vm/valid/let_and_print.php.out
@@ -6,7 +6,8 @@ _print(((is_array($a) && is_array($b)) ? array_merge($a, $b) : ((is_string($a) |
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/list_assign.php.out
+++ b/tests/vm/valid/list_assign.php.out
@@ -6,7 +6,8 @@ _print($nums[1]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/list_index.php.out
+++ b/tests/vm/valid/list_index.php.out
@@ -5,7 +5,8 @@ _print($xs[1]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/list_nested_assign.php.out
+++ b/tests/vm/valid/list_nested_assign.php.out
@@ -6,7 +6,8 @@ _print($matrix[1][0]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/list_set_ops.php.out
+++ b/tests/vm/valid/list_set_ops.php.out
@@ -7,7 +7,8 @@ _print((is_array(array_merge([1, 2], [2, 3])) ? count(array_merge([1, 2], [2, 3]
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/load_yaml.php.out
+++ b/tests/vm/valid/load_yaml.php.out
@@ -36,7 +36,8 @@ function _load_json($path) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/map_assign.php.out
+++ b/tests/vm/valid/map_assign.php.out
@@ -6,7 +6,8 @@ _print($scores["bob"]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/map_in_operator.php.out
+++ b/tests/vm/valid/map_in_operator.php.out
@@ -6,7 +6,8 @@ _print((is_array($m) ? (array_key_exists(3, $m) || in_array(3, $m, true)) : (is_
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/map_index.php.out
+++ b/tests/vm/valid/map_index.php.out
@@ -5,7 +5,8 @@ _print($m["b"]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/map_int_key.php.out
+++ b/tests/vm/valid/map_int_key.php.out
@@ -5,7 +5,8 @@ _print($m[1]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/map_literal_dynamic.php.out
+++ b/tests/vm/valid/map_literal_dynamic.php.out
@@ -7,7 +7,8 @@ _print($m["a"], $m["b"]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/map_membership.php.out
+++ b/tests/vm/valid/map_membership.php.out
@@ -6,7 +6,8 @@ _print((is_array($m) ? (array_key_exists("c", $m) || in_array("c", $m, true)) : 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/map_nested_assign.php.out
+++ b/tests/vm/valid/map_nested_assign.php.out
@@ -6,7 +6,8 @@ _print($data["outer"]["inner"]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/math_ops.php.out
+++ b/tests/vm/valid/math_ops.php.out
@@ -6,7 +6,8 @@ _print(((is_int(7) && is_int(2)) ? (7 % 2) : fmod(7, 2)));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/membership.php.out
+++ b/tests/vm/valid/membership.php.out
@@ -6,7 +6,8 @@ _print((is_array($nums) ? (array_key_exists(4, $nums) || in_array(4, $nums, true
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/min_max_builtin.php.out
+++ b/tests/vm/valid/min_max_builtin.php.out
@@ -6,7 +6,8 @@ _print((count($nums) ? max($nums) : 0));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/nested_function.php.out
+++ b/tests/vm/valid/nested_function.php.out
@@ -12,7 +12,8 @@ _print(mochi_outer(3));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/order_by_map.php.out
+++ b/tests/vm/valid/order_by_map.php.out
@@ -10,7 +10,8 @@ _print($sorted);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/outer_join.php.out
+++ b/tests/vm/valid/outer_join.php.out
@@ -23,7 +23,8 @@ foreach ((is_string($result) ? str_split($result) : $result) as $row) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/partial_application.php.out
+++ b/tests/vm/valid/partial_application.php.out
@@ -9,7 +9,8 @@ _print($add5(3));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/print_hello.php.out
+++ b/tests/vm/valid/print_hello.php.out
@@ -4,7 +4,8 @@ _print("hello");
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/pure_fold.php.out
+++ b/tests/vm/valid/pure_fold.php.out
@@ -8,7 +8,8 @@ _print(mochi_triple(((is_array(1) && is_array(2)) ? array_merge(1, 2) : ((is_str
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/pure_global_fold.php.out
+++ b/tests/vm/valid/pure_global_fold.php.out
@@ -9,7 +9,8 @@ _print(mochi_inc(3));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/query_sum_select.php.out
+++ b/tests/vm/valid/query_sum_select.php.out
@@ -13,7 +13,8 @@ _print($result);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/record_assign.php.out
+++ b/tests/vm/valid/record_assign.php.out
@@ -17,7 +17,8 @@ _print($c['n']);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/right_join.php.out
+++ b/tests/vm/valid/right_join.php.out
@@ -19,7 +19,8 @@ foreach ((is_string($result) ? str_split($result) : $result) as $entry) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/short_circuit.php.out
+++ b/tests/vm/valid/short_circuit.php.out
@@ -10,7 +10,8 @@ _print((true || mochi_boom(1, 2)));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/slice.php.out
+++ b/tests/vm/valid/slice.php.out
@@ -6,7 +6,8 @@ _print((is_array("hello") ? array_slice("hello", 1, (4) - (1)) : substr("hello",
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/sort_stable.php.out
+++ b/tests/vm/valid/sort_stable.php.out
@@ -10,7 +10,8 @@ _print($result);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/str_builtin.php.out
+++ b/tests/vm/valid/str_builtin.php.out
@@ -4,7 +4,8 @@ _print(strval(123));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/string_compare.php.out
+++ b/tests/vm/valid/string_compare.php.out
@@ -7,7 +7,8 @@ _print(("b" >= "b"));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/string_concat.php.out
+++ b/tests/vm/valid/string_concat.php.out
@@ -4,7 +4,8 @@ _print(((is_array("hello ") && is_array("world")) ? array_merge("hello ", "world
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/string_contains.php.out
+++ b/tests/vm/valid/string_contains.php.out
@@ -6,7 +6,8 @@ _print((is_array($s) ? (array_key_exists("dog", $s) || in_array("dog", $s, true)
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/string_in_operator.php.out
+++ b/tests/vm/valid/string_in_operator.php.out
@@ -6,7 +6,8 @@ _print((is_array($s) ? (array_key_exists("dog", $s) || in_array("dog", $s, true)
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/string_index.php.out
+++ b/tests/vm/valid/string_index.php.out
@@ -5,7 +5,8 @@ _print($s[1]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/string_prefix_slice.php.out
+++ b/tests/vm/valid/string_prefix_slice.php.out
@@ -8,7 +8,8 @@ _print(((is_array($s2) ? array_slice($s2, 0, ((is_array($prefix) ? count($prefix
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/substring_builtin.php.error
+++ b/tests/vm/valid/substring_builtin.php.error
@@ -1,1 +1,0 @@
-exit status 255

--- a/tests/vm/valid/substring_builtin.php.out
+++ b/tests/vm/valid/substring_builtin.php.out
@@ -1,10 +1,11 @@
 <?php
-_print(substring("mochi", 1, 4));
+_print(substr("mochi", 1, 4 - 1));
 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/sum_builtin.php.out
+++ b/tests/vm/valid/sum_builtin.php.out
@@ -4,7 +4,8 @@ _print(array_sum([1, 2, 3]));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/tail_recursion.php.out
+++ b/tests/vm/valid/tail_recursion.php.out
@@ -11,7 +11,8 @@ _print(mochi_sum_rec(10, 0));
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/test_block.php.out
+++ b/tests/vm/valid/test_block.php.out
@@ -11,7 +11,8 @@ mochi_test_addition_works();
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/two-sum.php.out
+++ b/tests/vm/valid/two-sum.php.out
@@ -18,7 +18,8 @@ _print($result[1]);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/typed_let.php.error
+++ b/tests/vm/valid/typed_let.php.error
@@ -1,1 +1,0 @@
-output mismatch

--- a/tests/vm/valid/typed_let.php.out
+++ b/tests/vm/valid/typed_let.php.out
@@ -5,7 +5,8 @@ _print($y);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/typed_var.php.error
+++ b/tests/vm/valid/typed_var.php.error
@@ -1,1 +1,0 @@
-output mismatch

--- a/tests/vm/valid/typed_var.php.out
+++ b/tests/vm/valid/typed_var.php.out
@@ -5,7 +5,8 @@ _print($x);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/unary_neg.php.out
+++ b/tests/vm/valid/unary_neg.php.out
@@ -5,7 +5,8 @@ _print(((is_array(5) && is_array((-2))) ? array_merge(5, (-2)) : ((is_string(5) 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/update_stmt.php.out
+++ b/tests/vm/valid/update_stmt.php.out
@@ -32,7 +32,8 @@ mochi_test_update_adult_status();
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/user_type_literal.php.out
+++ b/tests/vm/valid/user_type_literal.php.out
@@ -23,7 +23,8 @@ _print($book['author']['name']);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/values_builtin.php.error
+++ b/tests/vm/valid/values_builtin.php.error
@@ -1,1 +1,1 @@
-exit status 255
+output mismatch

--- a/tests/vm/valid/values_builtin.php.out
+++ b/tests/vm/valid/values_builtin.php.out
@@ -1,11 +1,12 @@
 <?php
 $m = ["a" => 1, "b" => 2, "c" => 3];
-_print(values($m));
+_print(array_values($m));
 
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/var_assignment.php.out
+++ b/tests/vm/valid/var_assignment.php.out
@@ -6,7 +6,8 @@ _print($x);
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }

--- a/tests/vm/valid/while_loop.php.out
+++ b/tests/vm/valid/while_loop.php.out
@@ -8,7 +8,8 @@ while (($i < 3)) {
 function _print(...$args) {
     $parts = [];
     foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+        if (is_null($a)) { $parts[] = '<nil>'; }
+        elseif (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
     }
     echo implode(' ', $parts), PHP_EOL;
 }


### PR DESCRIPTION
## Summary
- regenerate golden tests for PHP backend
- add VM comparisons for PHP compiler golden tests
- implement missing builtins in PHP compiler
- improve `_print` helper for nil output

## Testing
- `go test ./compile/x/php -run print_hello -tags slow`
- `go test ./compile/x/php -run TestPHPCompiler_GoldenOutput -tags slow` *(failed: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686aaaa1e0c883209550fad6467e53ea