### PR TITLE
Improve F# compiler test output

### DIFF
--- a/compile/x/fs/ERRORS.md
+++ b/compile/x/fs/ERRORS.md
@@ -1,117 +1,268 @@
 === RUN   TestFSCompiler_GoldenOutput
 === RUN   TestFSCompiler_GoldenOutput/break_continue
-    compiler_test.go:146: skipping unsupported file: runtime mismatch
-        
-        --- F# ---
-        ("odd number:", 1)
-        ("odd number:", 3)
-        ("odd number:", 5)
-        ("odd number:", 7)
-        
-        --- VM ---
-        odd number: 1
-        odd number: 3
-        odd number: 5
-        odd number: 7
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/closure
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/cross_join
-    compiler_test.go:146: skipping unsupported file: runtime mismatch
-        
-        --- F# ---
-        "--- Cross Join: All order-customer pairs ---"
-        ("Order", 100, "(customerId:", 1, ", total: $", 250, ") paired with", "Alice")
-        ("Order", 100, "(customerId:", 1, ", total: $", 250, ") paired with", "Bob")
-        ("Order", 100, "(customerId:", 1, ", total: $", 250, ") paired with", "Charlie")
-        ("Order", 101, "(customerId:", 2, ", total: $", 125, ") paired with", "Alice")
-        ("Order", 101, "(customerId:", 2, ", total: $", 125, ") paired with", "Bob")
-        ("Order", 101, "(customerId:", 2, ", total: $", 125, ") paired with", "Charlie")
-        ("Order", 102, "(customerId:", 1, ", total: $", 300, ") paired with", "Alice")
-        ("Order", 102, "(customerId:", 1, ", total: $", 300, ") paired with", "Bob")
-        ("Order", 102, "(customerId:", 1, ", total: $", 300, ") paired with", "Charlie")
-        
-        --- VM ---
-        --- Cross Join: All order-customer pairs ---
-        Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
-        Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
-        Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
-        Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
-        Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
-        Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
-        Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
-        Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
-        Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/fold_pure_let
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/for_list_collection
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/for_loop
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/for_string_collection
-    compiler_test.go:146: skipping unsupported file: runtime mismatch
-        
-        --- F# ---
-        "h"
-        "i"
-        
-        --- VM ---
-        h
-        i
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/fun_call
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/fun_expr_in_let
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/generate_echo
-    compiler_test.go:146: skipping unsupported file: runtime mismatch
-        
-        --- F# ---
-        /tmp/TestFSCompiler_GoldenOutput2308848553/010/main.fsx(3,48): warning FS0046: The identifier 'params' is reserved for future use by F#
-        
-        "echo hello"
-        
-        --- VM ---
-        <nil>
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/generate_embedding
-    compiler_test.go:146: skipping unsupported file: runtime mismatch
-        
-        --- F# ---
-        /tmp/TestFSCompiler_GoldenOutput2308848553/011/main.fsx(3,47): warning FS0046: The identifier 'params' is reserved for future use by F#
-        
-        2
-        
-        --- VM ---
-        0
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/grouped_expr
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/if_else
-    compiler_test.go:146: skipping unsupported file: runtime mismatch
-        
-        --- F# ---
-        "big"
-        
-        --- VM ---
-        big
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/join
-    compiler_test.go:146: skipping unsupported file: runtime mismatch
-        
-        --- F# ---
-        "--- Orders with customer info ---"
-        ("Order", 100, "by", "Alice", "- $", 250)
-        ("Order", 101, "by", "Bob", "- $", 125)
-        ("Order", 102, "by", "Alice", "- $", 300)
-        
-        --- VM ---
-        --- Orders with customer info ---
-        Order 100 by Alice - $ 250
-        Order 101 by Bob - $ 125
-        Order 102 by Alice - $ 300
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/join_filter_pag
-    compiler_test.go:146: skipping unsupported file: ❌ fsi error: exit status 1
-        
-        
-        /tmp/TestFSCompiler_GoldenOutput2308848553/015/main.fsx(27,78): error FS0001: This expression was expected to have type
-            'string'    
-        but here has type
-            'int'    
-        
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/len_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/let_and_print
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/list_index
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/list_set
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
 === RUN   TestFSCompiler_GoldenOutput/local_recursion
-signal: interrupt
-FAIL	mochi/compile/x/fs	57.723s
-FAIL
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_index
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_iterate
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_ops
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_set
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/match_expr
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/print_hello
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/reduce
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/stream_on_emit
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/string_index
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/test_block
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/two_sum
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/union_inorder
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/union_match
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/union_slice
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/var_assignment
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/while_loop
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/avg_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/bool_ops
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/break_continue#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/ceil_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/closure#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/count_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/dataset
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/dataset_sort_take_limit
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/expect_simple
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/fetch_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/fetch_cast
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/fetch_http
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/float_literal_precision
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/floor_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/fold_pure_let#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/for_list_collection#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/for_loop#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/for_string_collection#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/fun_call#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/group_by
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/if_else#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/len_builtin#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/list_concat
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/list_index#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/list_prepend
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/list_set#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/list_slice
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/load_save_json
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_index#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_iterate#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_len
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_set#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/map_typed_var
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/match_capture
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/nested_type
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/pow_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/set_ops
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/simple_struct
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/str_builtin
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/string_concat
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/string_in
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/string_index#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/string_negative_index
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/string_slice
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/string_slice_negative
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/tpch_q1
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/tpch_q2
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/two_sum#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/union_match#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/update_statement
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/var_assignment#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+=== RUN   TestFSCompiler_GoldenOutput/while_loop#01
+    compiler_test.go:146: skipping unsupported file: dotnet not installed
+--- PASS: TestFSCompiler_GoldenOutput (0.01s)
+    --- SKIP: TestFSCompiler_GoldenOutput/break_continue (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/closure (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/cross_join (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fold_pure_let (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/for_list_collection (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/for_loop (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/for_string_collection (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fun_call (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fun_expr_in_let (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/generate_echo (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/generate_embedding (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/grouped_expr (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/if_else (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/join (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/join_filter_pag (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/len_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/let_and_print (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/list_index (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/list_set (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/local_recursion (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_index (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_iterate (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_ops (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_set (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/match_expr (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/print_hello (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/reduce (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/stream_on_emit (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/string_index (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/test_block (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/two_sum (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/union_inorder (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/union_match (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/union_slice (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/var_assignment (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/while_loop (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/avg_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/bool_ops (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/break_continue#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/ceil_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/closure#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/count_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/dataset (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/dataset_sort_take_limit (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/expect_simple (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fetch_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fetch_cast (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fetch_http (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/float_literal_precision (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/floor_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fold_pure_let#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/for_list_collection#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/for_loop#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/for_string_collection#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/fun_call#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/group_by (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/if_else#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/len_builtin#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/list_concat (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/list_index#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/list_prepend (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/list_set#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/list_slice (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/load_save_json (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_index#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_iterate#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_len (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_set#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/map_typed_var (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/match_capture (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/nested_type (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/pow_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/set_ops (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/simple_struct (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/str_builtin (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/string_concat (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/string_in (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/string_index#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/string_negative_index (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/string_slice (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/string_slice_negative (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/tpch_q1 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/tpch_q2 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/two_sum#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/union_match#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/update_statement (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/var_assignment#01 (0.00s)
+    --- SKIP: TestFSCompiler_GoldenOutput/while_loop#01 (0.00s)
+PASS
+ok  	mochi/compile/x/fs	0.025s

--- a/compile/x/fs/compiler.go
+++ b/compile/x/fs/compiler.go
@@ -1763,10 +1763,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.use("_input")
 		return "_input()", nil
 	case "print":
+		c.use("_print")
 		if len(args) == 1 {
-			return fmt.Sprintf("printfn \"%%A\" (%s)", args[0]), nil
+			return fmt.Sprintf("_print %s", args[0]), nil
 		}
-		return fmt.Sprintf("printfn \"%%A\" (%s)", strings.Join(args, ", ")), nil
+		return fmt.Sprintf("_print %s", strings.Join(args, " ")), nil
 	default:
 		for i, a := range args {
 			if !isSimpleIdent(a) {

--- a/compile/x/fs/runtime.go
+++ b/compile/x/fs/runtime.go
@@ -99,6 +99,17 @@ const (
     printfn "FAIL (%s)" e.Message
     false`
 
+	helperPrint = `let _print([<System.ParamArray>] args: obj[]) : unit =
+  let sb = System.Text.StringBuilder()
+  let add (s:string) = if sb.Length > 0 then sb.Append(' ') |> ignore; sb.Append(s) |> ignore
+  for v in args do
+    match v with
+    | :? (obj[]) as arr ->
+        for i = 0 to arr.Length - 1 do
+          add (string arr.[i])
+    | _ -> add (string v)
+  printfn "%s" (sb.ToString())`
+
 	helperInput = `let _input () : string =
   match System.Console.ReadLine() with
   | null -> ""
@@ -302,6 +313,7 @@ var helperMap = map[string]string{
 	"_load":           helperLoad,
 	"_save":           helperSave,
 	"_run_test":       helperRunTest,
+	"_print":          helperPrint,
 	"_input":          helperInput,
 	"_fetch":          helperFetch,
 	"_fetch_json":     helperFetchTyped,


### PR DESCRIPTION
## Summary
- enhance the F# runtime with a `_print` helper and expose it to the compiler
- emit `_print` calls for `print` builtin
- regenerate error log for F# compiler tests (all skipped when dotnet is missing)

## Testing
- `go test ./compile/x/fs -run TestFSCompiler_GoldenOutput -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_686aaf1483b883208fa175ae73d3dc32