### PR TITLE
Add optional auto type inference to C backend

### DIFF
--- a/compile/x/c/README.md
+++ b/compile/x/c/README.md
@@ -37,6 +37,7 @@ Additional features include:
 - `if` expressions for conditional values
 - anonymous `fun` expressions (without captured variables) compiled to static functions
 - methods declared inside `type` blocks
+- variables without an explicit type use GCC `__auto_type` for inference
 - union types are translated to tagged C unions
 
 ## Building


### PR DESCRIPTION
## Summary
- expose `Compiler.autoType` flag with `NewWithAutoType`
- optionally emit `__auto_type` for variable declarations
- document auto type inference feature in C backend README

## Testing
- `go test ./compile/x/c -tags slow -run TwoSum -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ac4a3ee7483209afdd900bd1ac4c7