### PR TITLE
Improve TS compiler inference

### DIFF
--- a/compile/ts/runtime.go
+++ b/compile/ts/runtime.go
@@ -63,6 +63,13 @@ const (
 		"  return sum / list.length;\n" +
 		"}\n"
 
+	helperReduce = "function _reduce(src: any[], fn: (a: any, b: any) => any, acc: any): any {\n" +
+		"  for (const it of src) {\n" +
+		"    acc = fn(acc, it);\n" +
+		"  }\n" +
+		"  return acc;\n" +
+		"}\n"
+
 	helperSum = "function _sum(v: any): number {\n" +
 		"  let list: any[] | null = null;\n" +
 		"  if (Array.isArray(v)) list = v;\n" +
@@ -500,6 +507,7 @@ var helperMap = map[string]string{
 	"_append":      helperAppend,
 	"_count":       helperCount,
 	"_avg":         helperAvg,
+	"_reduce":      helperReduce,
 	"_sum":         helperSum,
 	"_min":         helperMin,
 	"_max":         helperMax,


### PR DESCRIPTION
## Summary
- better local variable type inference to keep TS output concise
- add `_reduce` runtime helper and builtin support

## Testing
- `go test ./compile/ts -run TestTSCompiler_SubsetPrograms -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_686ac5125608832093549a04addddb45