### PR TITLE
Improve Zig output with type inference

### DIFF
--- a/compile/x/zig/compiler.go
+++ b/compile/x/zig/compiler.go
@@ -468,7 +468,11 @@ func (c *Compiler) compileStmt(s *parser.Statement, inFun bool) error {
 				val = v
 			}
 		}
-		c.writeln(fmt.Sprintf("const %s: %s = %s;", name, zigTypeOf(typ), val))
+		if s.Let.Type == nil && canInferType(s.Let.Value, typ) {
+			c.writeln(fmt.Sprintf("const %s = %s;", name, val))
+		} else {
+			c.writeln(fmt.Sprintf("const %s: %s = %s;", name, zigTypeOf(typ), val))
+		}
 		return nil
 	case s.Var != nil:
 		return c.compileVar(s.Var, inFun)
@@ -1229,7 +1233,11 @@ func (c *Compiler) compileVar(st *parser.VarStmt, inFun bool) error {
 		}
 		val = v
 	}
-	c.writeln(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), val))
+	if st.Type == nil && st.Value != nil && canInferType(st.Value, typ) {
+		c.writeln(fmt.Sprintf("var %s = %s;", name, val))
+	} else {
+		c.writeln(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), val))
+	}
 	return nil
 }
 

--- a/compile/x/zig/helpers.go
+++ b/compile/x/zig/helpers.go
@@ -210,3 +210,16 @@ func isFloat(t types.Type) bool  { _, ok := t.(types.FloatType); return ok }
 func isBool(t types.Type) bool   { _, ok := t.(types.BoolType); return ok }
 func isString(t types.Type) bool { _, ok := t.(types.StringType); return ok }
 func isList(t types.Type) bool   { _, ok := t.(types.ListType); return ok }
+
+func canInferType(e *parser.Expr, t types.Type) bool {
+	if e == nil {
+		return false
+	}
+	if isEmptyListExpr(e) || isEmptyMapExpr(e) {
+		return false
+	}
+	if _, ok := t.(types.AnyType); ok {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- tweak Zig compiler to use type inference for local variables
- add helper to decide when type hints aren't required

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ac6b6ca2c8320af50025687ad2ef3