### PR TITLE
Improve Smalltalk output with type annotations

### DIFF
--- a/compile/x/st/helpers.go
+++ b/compile/x/st/helpers.go
@@ -2,6 +2,7 @@ package stcode
 
 import (
 	"mochi/parser"
+	"mochi/types"
 	"strings"
 )
 
@@ -28,4 +29,21 @@ func typeName(t *parser.TypeRef) string {
 		return *t.Simple
 	}
 	return ""
+}
+
+func typeString(t types.Type) string {
+	if t == nil {
+		return ""
+	}
+	return t.String()
+}
+
+func filterEmpty(list []string) []string {
+	out := make([]string, 0, len(list))
+	for _, s := range list {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
- annotate variable declarations with their inferred types as comments
- emit parameter type comments in function headers
- add helper utilities for type strings and list filtering

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ac697f0c483209f46a90972b9bdf8