### PR TITLE
Improve Rust backend type inference

### DIFF
--- a/compile/x/rust/compiler.go
+++ b/compile/x/rust/compiler.go
@@ -20,11 +20,12 @@ type Compiler struct {
 	methodFields  map[string]bool
 	externs       []string
 	externObjects []string
+	locals        map[string]types.Type
 }
 
 // New creates a new Rust compiler instance.
 func New(env *types.Env) *Compiler {
-	return &Compiler{env: env, helpers: make(map[string]bool), structs: make(map[string]bool), methodFields: nil, externs: []string{}, externObjects: []string{}}
+	return &Compiler{env: env, helpers: make(map[string]bool), structs: make(map[string]bool), methodFields: nil, externs: []string{}, externObjects: []string{}, locals: map[string]types.Type{}}
 }
 
 func (c *Compiler) writeIndent() {

--- a/compile/x/rust/expressions.go
+++ b/compile/x/rust/expressions.go
@@ -1039,7 +1039,7 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 		}
 		return fmt.Sprintf("Box::new(move |%s| %s)", strings.Join(params, ", "), expr), nil
 	}
-	sub := &Compiler{env: c.env, helpers: c.helpers, structs: c.structs}
+	sub := &Compiler{env: c.env, helpers: c.helpers, structs: c.structs, locals: map[string]types.Type{}}
 	sub.indent = 1
 	for _, s := range fn.BlockBody {
 		if err := sub.compileStmt(s); err != nil {

--- a/compile/x/rust/infer.go
+++ b/compile/x/rust/infer.go
@@ -7,12 +7,75 @@ import (
 
 // inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.ExprType(e, c.env)
+	if e == nil {
+		return types.AnyType{}
+	}
+	if len(e.Binary.Right) == 0 {
+		u := e.Binary.Left
+		if len(u.Ops) == 0 {
+			p := u.Value
+			if len(p.Ops) == 0 {
+				if p.Target.List != nil {
+					var elem types.Type = types.AnyType{}
+					for i, el := range p.Target.List.Elems {
+						t := c.inferExprType(el)
+						if i == 0 {
+							elem = t
+						} else if !equalTypes(elem, t) {
+							elem = types.AnyType{}
+							break
+						}
+					}
+					return types.ListType{Elem: elem}
+				}
+				if p.Target.Map != nil {
+					var key types.Type = types.AnyType{}
+					var val types.Type = types.AnyType{}
+					for i, it := range p.Target.Map.Items {
+						kt := c.inferExprType(it.Key)
+						if _, ok := identName(it.Key); ok {
+							kt = types.StringType{}
+						}
+						vt := c.inferExprType(it.Value)
+						if i == 0 {
+							key = kt
+							val = vt
+						} else {
+							if !equalTypes(key, kt) {
+								key = types.AnyType{}
+							}
+							if !equalTypes(val, vt) {
+								val = types.AnyType{}
+							}
+						}
+					}
+					return types.MapType{Key: key, Value: val}
+				}
+			}
+		}
+	}
+
+	env := types.NewEnv(c.env)
+	for name, tt := range c.locals {
+		env.SetVar(name, tt, true)
+	}
+	return types.CheckExprType(e, env)
 }
 
 // inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.ExprTypeHint(e, hint, c.env)
+	if e == nil {
+		return types.AnyType{}
+	}
+	if len(e.Binary.Right) == 0 {
+		u := e.Binary.Left
+		if len(u.Ops) == 0 && u.Value.Target.List != nil && len(u.Value.Target.List.Elems) == 0 {
+			if lt, ok := hint.(types.ListType); ok {
+				return types.ListType{Elem: lt.Elem}
+			}
+		}
+	}
+	return c.inferExprType(e)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {


### PR DESCRIPTION
## Summary
- enhance Rust compiler struct with local variable tracking
- extend inference for list and map literals to produce better types
- propagate local types through function and method compilation
- update anonymous function helper to include locals

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686ac6803f1083209570bd670c2a891c