### PR TITLE
Add Scheme versions of several VM test programs

### DIFF
--- a/tests/human/x/scheme/README.md
+++ b/tests/human/x/scheme/README.md
@@ -1,0 +1,104 @@
+# Scheme translations of Mochi VM tests
+
+This directory contains manual Scheme implementations of selected programs from `tests/vm/valid`.
+
+## Translated
+- closure.mochi -> closure.scm
+- let_and_print.mochi -> let_and_print.scm
+- list_assign.mochi -> list_assign.scm
+- list_index.mochi -> list_index.scm
+- tree_sum.mochi -> tree_sum.scm
+- while_loop.mochi -> while_loop.scm
+
+## Missing
+append_builtin.mochi
+avg_builtin.mochi
+basic_compare.mochi
+binary_precedence.mochi
+bool_chain.mochi
+break_continue.mochi
+cast_string_to_int.mochi
+cast_struct.mochi
+count_builtin.mochi
+cross_join.mochi
+cross_join_filter.mochi
+cross_join_triple.mochi
+dataset_sort_take_limit.mochi
+dataset_where_filter.mochi
+exists_builtin.mochi
+for_list_collection.mochi
+for_loop.mochi
+for_map_collection.mochi
+fun_call.mochi
+fun_expr_in_let.mochi
+fun_three_args.mochi
+group_by.mochi
+group_by_conditional_sum.mochi
+group_by_having.mochi
+group_by_join.mochi
+group_by_left_join.mochi
+group_by_multi_join.mochi
+group_by_multi_join_sort.mochi
+group_by_sort.mochi
+group_items_iteration.mochi
+if_else.mochi
+if_then_else.mochi
+if_then_else_nested.mochi
+in_operator.mochi
+in_operator_extended.mochi
+inner_join.mochi
+join_multi.mochi
+json_builtin.mochi
+left_join.mochi
+left_join_multi.mochi
+len_builtin.mochi
+len_map.mochi
+len_string.mochi
+list_nested_assign.mochi
+list_set_ops.mochi
+load_yaml.mochi
+map_assign.mochi
+map_in_operator.mochi
+map_index.mochi
+map_int_key.mochi
+map_literal_dynamic.mochi
+map_membership.mochi
+map_nested_assign.mochi
+match_expr.mochi
+match_full.mochi
+math_ops.mochi
+membership.mochi
+min_max_builtin.mochi
+nested_function.mochi
+order_by_map.mochi
+outer_join.mochi
+partial_application.mochi
+print_hello.mochi
+pure_fold.mochi
+pure_global_fold.mochi
+query_sum_select.mochi
+record_assign.mochi
+right_join.mochi
+save_jsonl_stdout.mochi
+short_circuit.mochi
+slice.mochi
+sort_stable.mochi
+str_builtin.mochi
+string_compare.mochi
+string_concat.mochi
+string_contains.mochi
+string_in_operator.mochi
+string_index.mochi
+string_prefix_slice.mochi
+substring_builtin.mochi
+sum_builtin.mochi
+tail_recursion.mochi
+test_block.mochi
+two-sum.mochi
+typed_let.mochi
+typed_var.mochi
+unary_neg.mochi
+update_stmt.mochi
+user_type_literal.mochi
+values_builtin.mochi
+var_assignment.mochi

--- a/tests/human/x/scheme/closure.scm
+++ b/tests/human/x/scheme/closure.scm
@@ -1,0 +1,5 @@
+(define (makeAdder n)
+  (lambda (x) (+ x n)))
+
+(define add10 (makeAdder 10))
+(begin (display (add10 7)) (newline))

--- a/tests/human/x/scheme/let_and_print.scm
+++ b/tests/human/x/scheme/let_and_print.scm
@@ -1,0 +1,4 @@
+(let ((a 10)
+      (b 20))
+  (display (+ a b))
+  (newline))

--- a/tests/human/x/scheme/list_assign.scm
+++ b/tests/human/x/scheme/list_assign.scm
@@ -1,0 +1,3 @@
+(define nums (vector 1 2))
+(vector-set! nums 1 3)
+(begin (display (vector-ref nums 1)) (newline))

--- a/tests/human/x/scheme/list_index.scm
+++ b/tests/human/x/scheme/list_index.scm
@@ -1,0 +1,2 @@
+(define xs '(10 20 30))
+(begin (display (list-ref xs 1)) (newline))

--- a/tests/human/x/scheme/tree_sum.scm
+++ b/tests/human/x/scheme/tree_sum.scm
@@ -1,0 +1,17 @@
+(define Leaf 'Leaf)
+(define (Node left value right)
+  (list 'Node left value right))
+
+(define (sum-tree t)
+  (cond
+    ((eq? t Leaf) 0)
+    ((eq? (car t) 'Node)
+     (+ (sum-tree (cadr t))
+        (caddr t)
+        (sum-tree (cadddr t))))))
+
+(define t
+  (Node Leaf 1
+        (Node Leaf 2 Leaf)))
+
+(begin (display (sum-tree t)) (newline))

--- a/tests/human/x/scheme/while_loop.scm
+++ b/tests/human/x/scheme/while_loop.scm
@@ -1,0 +1,4 @@
+(let loop ((i 0))
+  (when (< i 3)
+    (begin (display i) (newline))
+    (loop (+ i 1))))


### PR DESCRIPTION
## Summary
- create `tests/human/x/scheme` for hand-written Scheme examples
- translate several Mochi VM tests into Scheme
- document which programs have been translated and which remain

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_686b19509c5c8320b07113e4674af8fa