### PR TITLE
Add release notes for v0.10.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 📦 CHANGELOG.md
 
+## [0.10.18] – 2025-07-07T08:14:56+07:00
+
+### Added
+
+* Manual translations for example programs across languages such as Haskell, C, Zig, Swift, Smalltalk, Scheme, Scala, Prolog, PHP, Pascal, OCaml, Kotlin, Lua, F#, Fortran, Elixir, Clojure, Dart, C#, C++, TypeScript and Python
+* VM roundtrip tools compare compiler outputs with the Mochi VM
+
+### Changed
+
+* Improved type inference across C, Rust, Zig and Pascal compilers with extra hints
+* Golden tests regenerated and validated via the VM
+
+### Fixed
+
+* Minor translation and dataset comparison issues
+
 ## [0.10.17] – 2025-07-06T14:31:29+07:00
 
 ### Added

--- a/releases/v0.10.18.md
+++ b/releases/v0.10.18.md
@@ -1,0 +1,19 @@
+# Jul 2025 (v0.10.18)
+
+Released on Mon Jul 7 08:14:56 2025 +0700.
+
+Mochi v0.10.18 expands manual language translations and improves type inference across compilers with VM-based golden tests.
+
+## Examples
+
+- Added translations for core programs in Haskell, C, Zig, Swift, Smalltalk, Scheme, Scala, Prolog, PHP, Pascal, OCaml, Kotlin, Lua, F#, Fortran, Elixir, Clojure, Dart, C#, C++, TypeScript, Python and more.
+
+## Compilers
+
+- Improved type inference across C, Rust, Zig, Pascal and other backends with additional hints and annotations.
+
+## Tooling
+
+- VM roundtrip scripts compare compiler outputs against the Mochi VM.
+- Regenerated golden tests across languages with runtime validation.
+


### PR DESCRIPTION
## Summary
- document release v0.10.18
- update CHANGELOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b20575e2c8320aaf41ff69e900b9e