### PR TITLE
Add more Clojure translations

### DIFF
--- a/tests/human/x/clj/README.md
+++ b/tests/human/x/clj/README.md
@@ -32,12 +32,19 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - list_assign.mochi
 - list_index.mochi
 - map_assign.mochi
+- map_in_operator.mochi
 - membership.mochi
+- min_max_builtin.mochi
 - print_hello.mochi
 - pure_fold.mochi
 - short_circuit.mochi
 - str_builtin.mochi
+- string_compare.mochi
+- string_contains.mochi
 - string_concat.mochi
+- string_in_operator.mochi
+- string_index.mochi
+- string_prefix_slice.mochi
 - substring_builtin.mochi
 - var_assignment.mochi
 - while_loop.mochi
@@ -67,7 +74,6 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - list_nested_assign.mochi
 - list_set_ops.mochi
 - load_yaml.mochi
-- map_in_operator.mochi
 - map_index.mochi
 - map_int_key.mochi
 - map_literal_dynamic.mochi
@@ -76,7 +82,6 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - match_expr.mochi
 - match_full.mochi
 - math_ops.mochi
-- min_max_builtin.mochi
 - nested_function.mochi
 - order_by_map.mochi
 - outer_join.mochi
@@ -88,11 +93,6 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - save_jsonl_stdout.mochi
 - slice.mochi
 - sort_stable.mochi
-- string_compare.mochi
-- string_contains.mochi
-- string_in_operator.mochi
-- string_index.mochi
-- string_prefix_slice.mochi
 - sum_builtin.mochi
 - tail_recursion.mochi
 - test_block.mochi

--- a/tests/human/x/clj/map_in_operator.clj
+++ b/tests/human/x/clj/map_in_operator.clj
@@ -1,0 +1,5 @@
+(ns map-in-operator)
+
+(def m {1 "a" 2 "b"})
+(println (contains? m 1))
+(println (contains? m 3))

--- a/tests/human/x/clj/min_max_builtin.clj
+++ b/tests/human/x/clj/min_max_builtin.clj
@@ -1,0 +1,5 @@
+(ns min-max-builtin)
+
+(def nums [3 1 4])
+(println (apply min nums))
+(println (apply max nums))

--- a/tests/human/x/clj/string_compare.clj
+++ b/tests/human/x/clj/string_compare.clj
@@ -1,0 +1,6 @@
+(ns string-compare)
+
+(println (neg? (compare "a" "b")))
+(println (<= (compare "a" "a") 0))
+(println (pos? (compare "b" "a")))
+(println (>= (compare "b" "b") 0))

--- a/tests/human/x/clj/string_contains.clj
+++ b/tests/human/x/clj/string_contains.clj
@@ -1,0 +1,6 @@
+(ns string-contains
+  (:require [clojure.string :as str]))
+
+(def s "catch")
+(println (str/includes? s "cat"))
+(println (str/includes? s "dog"))

--- a/tests/human/x/clj/string_in_operator.clj
+++ b/tests/human/x/clj/string_in_operator.clj
@@ -1,0 +1,6 @@
+(ns string-in-operator
+  (:require [clojure.string :as str]))
+
+(def s "catch")
+(println (str/includes? s "cat"))
+(println (str/includes? s "dog"))

--- a/tests/human/x/clj/string_index.clj
+++ b/tests/human/x/clj/string_index.clj
@@ -1,0 +1,4 @@
+(ns string-index)
+
+(def s "mochi")
+(println (nth s 1))

--- a/tests/human/x/clj/string_prefix_slice.clj
+++ b/tests/human/x/clj/string_prefix_slice.clj
@@ -1,0 +1,8 @@
+(ns string-prefix-slice
+  (:require [clojure.string :as str]))
+
+(def prefix "fore")
+(def s1 "forest")
+(println (str/starts-with? s1 prefix))
+(def s2 "desert")
+(println (str/starts-with? s2 prefix))


### PR DESCRIPTION
## Summary
- add more Clojure ports for Mochi examples
- update README with translated and missing program lists

## Testing
- `clojure` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_686b4a8f918883208d1fb7dadc2e6d52