### PR TITLE
Add more Haskell translations

### DIFF
--- a/tests/human/x/hs/README.md
+++ b/tests/human/x/hs/README.md
@@ -13,6 +13,13 @@ This directory contains hand-written Haskell versions of some Mochi examples fro
 - `cast_struct.mochi`
 - `closure.mochi`
 - `count_builtin.mochi`
+- `for_list_collection.mochi`
+- `for_loop.mochi`
+- `if_else.mochi`
+- `len_builtin.mochi`
+- `print_hello.mochi`
+- `string_concat.mochi`
+- `var_assignment.mochi`
 
 ## Missing programs
 - `cross_join.mochi`
@@ -21,8 +28,6 @@ This directory contains hand-written Haskell versions of some Mochi examples fro
 - `dataset_sort_take_limit.mochi`
 - `dataset_where_filter.mochi`
 - `exists_builtin.mochi`
-- `for_list_collection.mochi`
-- `for_loop.mochi`
 - `for_map_collection.mochi`
 - `fun_call.mochi`
 - `fun_expr_in_let.mochi`
@@ -36,7 +41,6 @@ This directory contains hand-written Haskell versions of some Mochi examples fro
 - `group_by_multi_join_sort.mochi`
 - `group_by_sort.mochi`
 - `group_items_iteration.mochi`
-- `if_else.mochi`
 - `if_then_else.mochi`
 - `if_then_else_nested.mochi`
 - `in_operator.mochi`
@@ -46,7 +50,6 @@ This directory contains hand-written Haskell versions of some Mochi examples fro
 - `json_builtin.mochi`
 - `left_join.mochi`
 - `left_join_multi.mochi`
-- `len_builtin.mochi`
 - `len_map.mochi`
 - `len_string.mochi`
 - `let_and_print.mochi`
@@ -71,7 +74,6 @@ This directory contains hand-written Haskell versions of some Mochi examples fro
 - `order_by_map.mochi`
 - `outer_join.mochi`
 - `partial_application.mochi`
-- `print_hello.mochi`
 - `pure_fold.mochi`
 - `pure_global_fold.mochi`
 - `query_sum_select.mochi`
@@ -83,7 +85,6 @@ This directory contains hand-written Haskell versions of some Mochi examples fro
 - `sort_stable.mochi`
 - `str_builtin.mochi`
 - `string_compare.mochi`
-- `string_concat.mochi`
 - `string_contains.mochi`
 - `string_in_operator.mochi`
 - `string_index.mochi`
@@ -100,5 +101,4 @@ This directory contains hand-written Haskell versions of some Mochi examples fro
 - `update_stmt.mochi`
 - `user_type_literal.mochi`
 - `values_builtin.mochi`
-- `var_assignment.mochi`
 - `while_loop.mochi`

--- a/tests/human/x/hs/for_list_collection.hs
+++ b/tests/human/x/hs/for_list_collection.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = mapM_ print [1,2,3]

--- a/tests/human/x/hs/for_loop.hs
+++ b/tests/human/x/hs/for_loop.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = mapM_ print [1..3]

--- a/tests/human/x/hs/if_else.hs
+++ b/tests/human/x/hs/if_else.hs
@@ -1,0 +1,8 @@
+module Main where
+
+main :: IO ()
+main =
+  let x = 5 in
+  if x > 3
+    then putStrLn "big"
+    else putStrLn "small"

--- a/tests/human/x/hs/len_builtin.hs
+++ b/tests/human/x/hs/len_builtin.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = print (length [1,2,3])

--- a/tests/human/x/hs/print_hello.hs
+++ b/tests/human/x/hs/print_hello.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "hello"

--- a/tests/human/x/hs/string_concat.hs
+++ b/tests/human/x/hs/string_concat.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn ("hello " ++ "world")

--- a/tests/human/x/hs/var_assignment.hs
+++ b/tests/human/x/hs/var_assignment.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.IORef
+
+main :: IO ()
+main = do
+  x <- newIORef (1 :: Int)
+  writeIORef x 2
+  val <- readIORef x
+  print val


### PR DESCRIPTION
## Summary
- add Haskell versions of several Mochi examples
- record the new translations in the README for the Haskell folder

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_686b4ab4e7c083208d2560fbd72f8771