### PR TITLE
Add additional Smalltalk translations

### DIFF
--- a/tests/human/x/st/README.md
+++ b/tests/human/x/st/README.md
@@ -3,8 +3,22 @@
 This folder contains hand-written Smalltalk versions of programs from `tests/vm/valid`.
 
 ## Translated programs
+- append_builtin.mochi
+- avg_builtin.mochi
+- basic_compare.mochi
+- binary_precedence.mochi
+- bool_chain.mochi
+- break_continue.mochi
+- cast_string_to_int.mochi
+- cast_struct.mochi
+- closure.mochi
+- count_builtin.mochi
+- for_list_collection.mochi
 - for_loop.mochi
+- for_map_collection.mochi
 - fun_call.mochi
+- fun_expr_in_let.mochi
+- fun_three_args.mochi
 - if_else.mochi
 - len_builtin.mochi
 - print_hello.mochi
@@ -16,26 +30,12 @@ This folder contains hand-written Smalltalk versions of programs from `tests/vm/
 - while_loop.mochi
 
 ## Missing programs
-- append_builtin.mochi
-- avg_builtin.mochi
-- basic_compare.mochi
-- binary_precedence.mochi
-- bool_chain.mochi
-- break_continue.mochi
-- cast_string_to_int.mochi
-- cast_struct.mochi
-- closure.mochi
-- count_builtin.mochi
 - cross_join.mochi
 - cross_join_filter.mochi
 - cross_join_triple.mochi
 - dataset_sort_take_limit.mochi
 - dataset_where_filter.mochi
 - exists_builtin.mochi
-- for_list_collection.mochi
-- for_map_collection.mochi
-- fun_expr_in_let.mochi
-- fun_three_args.mochi
 - group_by.mochi
 - group_by_conditional_sum.mochi
 - group_by_having.mochi

--- a/tests/human/x/st/append_builtin.st
+++ b/tests/human/x/st/append_builtin.st
@@ -1,0 +1,3 @@
+| a |
+a := {1. 2} copyWith: 3.
+Transcript show: a printString; cr.

--- a/tests/human/x/st/avg_builtin.st
+++ b/tests/human/x/st/avg_builtin.st
@@ -1,0 +1,5 @@
+| list sum |
+list := #(1 2 3).
+sum := 0.
+list do: [:each | sum := sum + each].
+Transcript show: (sum / list size) printString; cr.

--- a/tests/human/x/st/basic_compare.st
+++ b/tests/human/x/st/basic_compare.st
@@ -1,0 +1,6 @@
+| a b |
+a := 10 - 3.
+b := 2 + 2.
+Transcript show: a printString; cr.
+Transcript show: (a = 7) printString; cr.
+Transcript show: (b < 5) printString; cr.

--- a/tests/human/x/st/binary_precedence.st
+++ b/tests/human/x/st/binary_precedence.st
@@ -1,0 +1,4 @@
+Transcript show: (1 + 2 * 3) printString; cr.
+Transcript show: ((1 + 2) * 3) printString; cr.
+Transcript show: (2 * 3 + 1) printString; cr.
+Transcript show: (2 * (3 + 1)) printString; cr.

--- a/tests/human/x/st/bool_chain.st
+++ b/tests/human/x/st/bool_chain.st
@@ -1,0 +1,5 @@
+| boom |
+boom := [ Transcript show: 'boom'; cr. true ].
+Transcript show: (((1 < 2) and: [ 2 < 3 ]) and: [ 3 < 4 ]) printString; cr.
+Transcript show: (((1 < 2) and: [ 2 > 3 ]) and: [ boom value ]) printString; cr.
+Transcript show: ((((1 < 2) and: [ 2 < 3 ]) and: [ 3 > 4 ]) and: [ boom value ]) printString; cr.

--- a/tests/human/x/st/break_continue.st
+++ b/tests/human/x/st/break_continue.st
@@ -1,0 +1,16 @@
+| numbers i n |
+numbers := #(1 2 3 4 5 6 7 8 9).
+i := 1.
+[i <= numbers size] whileTrue: [
+    n := numbers at: i.
+    (n even)
+        ifTrue: [ i := i + 1 ]
+        ifFalse: [
+            (n > 7)
+                ifTrue: [ i := numbers size + 1 ]
+                ifFalse: [
+                    Transcript show: 'odd number: ', n printString; cr.
+                    i := i + 1.
+                ].
+        ].
+].

--- a/tests/human/x/st/cast_string_to_int.st
+++ b/tests/human/x/st/cast_string_to_int.st
@@ -1,0 +1,1 @@
+Transcript show: ('1995' asNumber) printString; cr.

--- a/tests/human/x/st/cast_struct.st
+++ b/tests/human/x/st/cast_struct.st
@@ -1,0 +1,4 @@
+| todo |
+todo := Dictionary new.
+todo at: 'title' put: 'hi'.
+Transcript show: (todo at: 'title'); cr.

--- a/tests/human/x/st/closure.st
+++ b/tests/human/x/st/closure.st
@@ -1,0 +1,4 @@
+| makeAdder add10 |
+makeAdder := [:n | [:x | x + n] ].
+add10 := makeAdder value: 10.
+Transcript show: (add10 value: 7) printString; cr.

--- a/tests/human/x/st/count_builtin.st
+++ b/tests/human/x/st/count_builtin.st
@@ -1,0 +1,1 @@
+Transcript show: ({1. 2. 3} size) printString; cr.

--- a/tests/human/x/st/for_list_collection.st
+++ b/tests/human/x/st/for_list_collection.st
@@ -1,0 +1,1 @@
+{1. 2. 3} do: [:n | Transcript show: n printString; cr].

--- a/tests/human/x/st/for_map_collection.st
+++ b/tests/human/x/st/for_map_collection.st
@@ -1,0 +1,3 @@
+| m |
+m := Dictionary newFrom: {'a'->1. 'b'->2}.
+m keysDo: [:k | Transcript show: k; cr].

--- a/tests/human/x/st/fun_expr_in_let.st
+++ b/tests/human/x/st/fun_expr_in_let.st
@@ -1,0 +1,3 @@
+| square |
+square := [:x | x * x].
+Transcript show: (square value: 6) printString; cr.

--- a/tests/human/x/st/fun_three_args.st
+++ b/tests/human/x/st/fun_three_args.st
@@ -1,0 +1,3 @@
+| sum3 |
+sum3 := [:a :b :c | a + b + c].
+Transcript show: (sum3 value: 1 value: 2 value: 3) printString; cr.


### PR DESCRIPTION
## Summary
- expand Smalltalk examples for `tests/vm/valid` programs
- update list of translated files in README

## Testing
- `go test ./... --vet=off -run TestPlaceholder` *(fails: build errors)*


------
https://chatgpt.com/codex/tasks/task_e_686b4acc9ff08320b74e0871ea1d99b1