### PR TITLE
Add Python translations for sample Mochi programs

### DIFF
--- a/tests/human/python/README.md
+++ b/tests/human/python/README.md
@@ -1,0 +1,106 @@
+# Python Translations of Mochi Programs
+
+This directory contains manual translations of Mochi programs from
+`tests/vm/valid` into Python. The goal is to mirror the behavior of the
+original Mochi examples without using the Mochi compiler.
+
+## Translated programs
+- append_builtin.mochi
+- avg_builtin.mochi
+- basic_compare.mochi
+- binary_precedence.mochi
+- bool_chain.mochi
+- break_continue.mochi
+- cast_string_to_int.mochi
+- cast_struct.mochi
+- closure.mochi
+- count_builtin.mochi
+- cross_join.mochi
+- cross_join_filter.mochi
+- cross_join_triple.mochi
+- dataset_sort_take_limit.mochi
+- dataset_where_filter.mochi
+- exists_builtin.mochi
+- for_list_collection.mochi
+- for_loop.mochi
+- for_map_collection.mochi
+- fun_call.mochi
+- fun_expr_in_let.mochi
+
+## Missing translations
+- fun_three_args.mochi
+- group_by.mochi
+- group_by_conditional_sum.mochi
+- group_by_having.mochi
+- group_by_join.mochi
+- group_by_left_join.mochi
+- group_by_multi_join.mochi
+- group_by_multi_join_sort.mochi
+- group_by_sort.mochi
+- group_items_iteration.mochi
+- if_else.mochi
+- if_then_else.mochi
+- if_then_else_nested.mochi
+- in_operator.mochi
+- in_operator_extended.mochi
+- inner_join.mochi
+- join_multi.mochi
+- json_builtin.mochi
+- left_join.mochi
+- left_join_multi.mochi
+- len_builtin.mochi
+- len_map.mochi
+- len_string.mochi
+- let_and_print.mochi
+- list_assign.mochi
+- list_index.mochi
+- list_nested_assign.mochi
+- list_set_ops.mochi
+- load_yaml.mochi
+- map_assign.mochi
+- map_in_operator.mochi
+- map_index.mochi
+- map_int_key.mochi
+- map_literal_dynamic.mochi
+- map_membership.mochi
+- map_nested_assign.mochi
+- match_expr.mochi
+- match_full.mochi
+- math_ops.mochi
+- membership.mochi
+- min_max_builtin.mochi
+- nested_function.mochi
+- order_by_map.mochi
+- outer_join.mochi
+- partial_application.mochi
+- print_hello.mochi
+- pure_fold.mochi
+- pure_global_fold.mochi
+- query_sum_select.mochi
+- record_assign.mochi
+- right_join.mochi
+- save_jsonl_stdout.mochi
+- short_circuit.mochi
+- slice.mochi
+- sort_stable.mochi
+- str_builtin.mochi
+- string_compare.mochi
+- string_concat.mochi
+- string_contains.mochi
+- string_in_operator.mochi
+- string_index.mochi
+- string_prefix_slice.mochi
+- substring_builtin.mochi
+- sum_builtin.mochi
+- tail_recursion.mochi
+- test_block.mochi
+- tree_sum.mochi
+- two-sum.mochi
+- typed_let.mochi
+- typed_var.mochi
+- unary_neg.mochi
+- update_stmt.mochi
+- user_type_literal.mochi
+- values_builtin.mochi
+- var_assignment.mochi
+- while_loop.mochi

--- a/tests/human/python/append_builtin.py
+++ b/tests/human/python/append_builtin.py
@@ -1,0 +1,11 @@
+# Translation of append_builtin.mochi to Python
+
+a = [1, 2]
+
+# Mochi 'append' returns a new list with the item appended
+# We'll mimic this behaviour with list concatenation
+
+def append(lst, item):
+    return lst + [item]
+
+print(append(a, 3))

--- a/tests/human/python/avg_builtin.py
+++ b/tests/human/python/avg_builtin.py
@@ -1,0 +1,4 @@
+# Translation of avg_builtin.mochi to Python
+
+nums = [1, 2, 3]
+print(sum(nums) / len(nums))

--- a/tests/human/python/basic_compare.py
+++ b/tests/human/python/basic_compare.py
@@ -1,0 +1,7 @@
+# Translation of basic_compare.mochi to Python
+
+a = 10 - 3
+b = 2 + 2
+print(a)
+print(a == 7)
+print(b < 5)

--- a/tests/human/python/binary_precedence.py
+++ b/tests/human/python/binary_precedence.py
@@ -1,0 +1,6 @@
+# Translation of binary_precedence.mochi to Python
+
+print(1 + 2 * 3)
+print((1 + 2) * 3)
+print(2 * 3 + 1)
+print(2 * (3 + 1))

--- a/tests/human/python/bool_chain.py
+++ b/tests/human/python/bool_chain.py
@@ -1,0 +1,9 @@
+# Translation of bool_chain.mochi to Python
+
+def boom():
+    print("boom")
+    return True
+
+print((1 < 2) and (2 < 3) and (3 < 4))
+print((1 < 2) and (2 > 3) and boom())
+print((1 < 2) and (2 < 3) and (3 > 4) and boom())

--- a/tests/human/python/break_continue.py
+++ b/tests/human/python/break_continue.py
@@ -1,0 +1,9 @@
+# Translation of break_continue.mochi to Python
+
+numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+for n in numbers:
+    if n % 2 == 0:
+        continue
+    if n > 7:
+        break
+    print("odd number:", n)

--- a/tests/human/python/cast_string_to_int.py
+++ b/tests/human/python/cast_string_to_int.py
@@ -1,0 +1,3 @@
+# Translation of cast_string_to_int.mochi to Python
+
+print(int("1995"))

--- a/tests/human/python/cast_struct.py
+++ b/tests/human/python/cast_struct.py
@@ -1,0 +1,10 @@
+# Translation of cast_struct.mochi to Python
+
+from dataclasses import dataclass
+
+@dataclass
+class Todo:
+    title: str
+
+todo = Todo(title="hi")
+print(todo.title)

--- a/tests/human/python/closure.py
+++ b/tests/human/python/closure.py
@@ -1,0 +1,9 @@
+# Translation of closure.mochi to Python
+
+def makeAdder(n):
+    def adder(x):
+        return x + n
+    return adder
+
+add10 = makeAdder(10)
+print(add10(7))  # 17

--- a/tests/human/python/count_builtin.py
+++ b/tests/human/python/count_builtin.py
@@ -1,0 +1,3 @@
+# Translation of count_builtin.mochi to Python
+
+print(len([1, 2, 3]))

--- a/tests/human/python/cross_join.py
+++ b/tests/human/python/cross_join.py
@@ -1,0 +1,33 @@
+# Translation of cross_join.mochi to Python
+
+customers = [
+    {"id": 1, "name": "Alice"},
+    {"id": 2, "name": "Bob"},
+    {"id": 3, "name": "Charlie"},
+]
+
+orders = [
+    {"id": 100, "customerId": 1, "total": 250},
+    {"id": 101, "customerId": 2, "total": 125},
+    {"id": 102, "customerId": 1, "total": 300},
+]
+
+result = [
+    {
+        "orderId": o["id"],
+        "orderCustomerId": o["customerId"],
+        "pairedCustomerName": c["name"],
+        "orderTotal": o["total"],
+    }
+    for o in orders
+    for c in customers
+]
+
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result:
+    print(
+        "Order", entry["orderId"],
+        "(customerId:", entry["orderCustomerId"],
+        ", total: $", entry["orderTotal"],
+        ") paired with", entry["pairedCustomerName"]
+    )

--- a/tests/human/python/cross_join_filter.py
+++ b/tests/human/python/cross_join_filter.py
@@ -1,0 +1,14 @@
+# Translation of cross_join_filter.mochi to Python
+
+nums = [1, 2, 3]
+letters = ["A", "B"]
+
+pairs = [
+    {"n": n, "l": l}
+    for n in nums if n % 2 == 0
+    for l in letters
+]
+
+print("--- Even pairs ---")
+for p in pairs:
+    print(p["n"], p["l"])

--- a/tests/human/python/cross_join_triple.py
+++ b/tests/human/python/cross_join_triple.py
@@ -1,0 +1,16 @@
+# Translation of cross_join_triple.mochi to Python
+
+nums = [1, 2]
+letters = ["A", "B"]
+bools = [True, False]
+
+combos = [
+    {"n": n, "l": l, "b": b}
+    for n in nums
+    for l in letters
+    for b in bools
+]
+
+print("--- Cross Join of three lists ---")
+for c in combos:
+    print(c["n"], c["l"], c["b"])

--- a/tests/human/python/dataset_sort_take_limit.py
+++ b/tests/human/python/dataset_sort_take_limit.py
@@ -1,0 +1,18 @@
+# Translation of dataset_sort_take_limit.mochi to Python
+
+products = [
+    {"name": "Laptop", "price": 1500},
+    {"name": "Smartphone", "price": 900},
+    {"name": "Tablet", "price": 600},
+    {"name": "Monitor", "price": 300},
+    {"name": "Keyboard", "price": 100},
+    {"name": "Mouse", "price": 50},
+    {"name": "Headphones", "price": 200},
+]
+
+# Sort by descending price, skip 1, take 3
+expensive = sorted(products, key=lambda p: -p["price"])[1:4]
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive:
+    print(f"{item['name']} costs ${item['price']}")

--- a/tests/human/python/dataset_where_filter.py
+++ b/tests/human/python/dataset_where_filter.py
@@ -1,0 +1,23 @@
+# Translation of dataset_where_filter.mochi to Python
+
+people = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 15},
+    {"name": "Charlie", "age": 65},
+    {"name": "Diana", "age": 45},
+]
+
+adults = [
+    {
+        "name": person["name"],
+        "age": person["age"],
+        "is_senior": person["age"] >= 60,
+    }
+    for person in people
+    if person["age"] >= 18
+]
+
+print("--- Adults ---")
+for person in adults:
+    suffix = " (senior)" if person["is_senior"] else ""
+    print(f"{person['name']} is {person['age']}{suffix}")

--- a/tests/human/python/exists_builtin.py
+++ b/tests/human/python/exists_builtin.py
@@ -1,0 +1,5 @@
+# Translation of exists_builtin.mochi to Python
+
+data = [1, 2]
+flag = any(x == 1 for x in data)
+print(flag)

--- a/tests/human/python/for_list_collection.py
+++ b/tests/human/python/for_list_collection.py
@@ -1,0 +1,4 @@
+# Translation of for_list_collection.mochi to Python
+
+for n in [1, 2, 3]:
+    print(n)

--- a/tests/human/python/for_loop.py
+++ b/tests/human/python/for_loop.py
@@ -1,0 +1,4 @@
+# Translation of for_loop.mochi to Python
+
+for i in range(1, 5):
+    print(i)

--- a/tests/human/python/for_map_collection.py
+++ b/tests/human/python/for_map_collection.py
@@ -1,0 +1,5 @@
+# Translation of for_map_collection.mochi to Python
+
+m = {"a": 1, "b": 2}
+for k in m:
+    print(k)

--- a/tests/human/python/fun_call.py
+++ b/tests/human/python/fun_call.py
@@ -1,0 +1,6 @@
+# Translation of fun_call.mochi to Python
+
+def add(a: int, b: int) -> int:
+    return a + b
+
+print(add(2, 3))  # 5

--- a/tests/human/python/fun_expr_in_let.py
+++ b/tests/human/python/fun_expr_in_let.py
@@ -1,0 +1,4 @@
+# Translation of fun_expr_in_let.mochi to Python
+
+square = lambda x: x * x
+print(square(6))  # 36


### PR DESCRIPTION
## Summary
- create `tests/human/python` with manual translations of several `.mochi` programs
- list translated and missing files in a README

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_686b69a1029c8320ba87024fcf911a5f