### PR TITLE
Add F# translations for join and dataset examples

### DIFF
--- a/tests/human/x/fs/README.md
+++ b/tests/human/x/fs/README.md
@@ -14,6 +14,12 @@ This directory contains F# programs that replicate the behavior of the `.mochi` 
 - cast_struct
 - closure
 - count_builtin
+- cross_join
+- cross_join_filter
+- cross_join_triple
+- dataset_sort_take_limit
+- dataset_where_filter
+- exists_builtin
 - for_list_collection
 - for_loop
 - for_map_collection
@@ -76,12 +82,6 @@ This directory contains F# programs that replicate the behavior of the `.mochi` 
 
 ## Missing translations
 
-- cross_join
-- cross_join_filter
-- cross_join_triple
-- dataset_sort_take_limit
-- dataset_where_filter
-- exists_builtin
 - group_by
 - group_by_conditional_sum
 - group_by_having

--- a/tests/human/x/fs/cross_join.fs
+++ b/tests/human/x/fs/cross_join.fs
@@ -1,0 +1,30 @@
+open System
+
+type Customer = { id: int; name: string }
+type Order = { id: int; customerId: int; total: int }
+
+let customers = [
+    { id = 1; name = "Alice" }
+    { id = 2; name = "Bob" }
+    { id = 3; name = "Charlie" }
+]
+
+let orders = [
+    { id = 100; customerId = 1; total = 250 }
+    { id = 101; customerId = 2; total = 125 }
+    { id = 102; customerId = 1; total = 300 }
+]
+
+let result =
+    [ for o in orders do
+        for c in customers do
+            yield {| orderId = o.id
+                     orderCustomerId = o.customerId
+                     pairedCustomerName = c.name
+                     orderTotal = o.total |} ]
+
+printfn "--- Cross Join: All order-customer pairs ---"
+for entry in result do
+    printfn "Order %d (customerId: %d, total: $%d) paired with %s" \
+        entry.orderId entry.orderCustomerId entry.orderTotal entry.pairedCustomerName
+

--- a/tests/human/x/fs/cross_join_filter.fs
+++ b/tests/human/x/fs/cross_join_filter.fs
@@ -1,0 +1,13 @@
+let nums = [1; 2; 3]
+let letters = ["A"; "B"]
+
+let pairs =
+    [ for n in nums do
+        for l in letters do
+            if n % 2 = 0 then
+                yield {| n = n; l = l |} ]
+
+printfn "--- Even pairs ---"
+for p in pairs do
+    printfn "%d %s" p.n p.l
+

--- a/tests/human/x/fs/cross_join_triple.fs
+++ b/tests/human/x/fs/cross_join_triple.fs
@@ -1,0 +1,14 @@
+let nums = [1; 2]
+let letters = ["A"; "B"]
+let bools = [true; false]
+
+let combos =
+    [ for n in nums do
+        for l in letters do
+            for b in bools do
+                yield {| n = n; l = l; b = b |} ]
+
+printfn "--- Cross Join of three lists ---"
+for c in combos do
+    printfn "%d %s %b" c.n c.l c.b
+

--- a/tests/human/x/fs/dataset_sort_take_limit.fs
+++ b/tests/human/x/fs/dataset_sort_take_limit.fs
@@ -1,0 +1,24 @@
+open System
+
+type Product = { name: string; price: int }
+
+let products = [
+    { name = "Laptop"; price = 1500 }
+    { name = "Smartphone"; price = 900 }
+    { name = "Tablet"; price = 600 }
+    { name = "Monitor"; price = 300 }
+    { name = "Keyboard"; price = 100 }
+    { name = "Mouse"; price = 50 }
+    { name = "Headphones"; price = 200 }
+]
+
+let expensive =
+    products
+    |> List.sortByDescending (fun p -> p.price)
+    |> List.skip 1
+    |> List.take 3
+
+printfn "--- Top products (excluding most expensive) ---"
+for item in expensive do
+    printfn "%s costs $%d" item.name item.price
+

--- a/tests/human/x/fs/dataset_where_filter.fs
+++ b/tests/human/x/fs/dataset_where_filter.fs
@@ -1,0 +1,21 @@
+open System
+
+type Person = { name: string; age: int }
+
+let people = [
+    { name = "Alice"; age = 30 }
+    { name = "Bob"; age = 15 }
+    { name = "Charlie"; age = 65 }
+    { name = "Diana"; age = 45 }
+]
+
+let adults =
+    [ for p in people do
+        if p.age >= 18 then
+            yield {| name = p.name; age = p.age; is_senior = p.age >= 60 |} ]
+
+printfn "--- Adults ---"
+for person in adults do
+    let suffix = if person.is_senior then " (senior)" else ""
+    printfn "%s is %d%s" person.name person.age suffix
+

--- a/tests/human/x/fs/exists_builtin.fs
+++ b/tests/human/x/fs/exists_builtin.fs
@@ -1,0 +1,4 @@
+let data = [1; 2]
+let flag = data |> List.exists (fun x -> x = 1)
+printfn "%b" flag
+


### PR DESCRIPTION
## Summary
- implement additional Mochi examples in F#: cross join variants and dataset utilities
- update F# translation README with new examples and revised missing list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b69bd64e08320846ea76147f0ca5a