### PR TITLE
Add more Racket translations

### DIFF
--- a/tests/human/x/racket/README.md
+++ b/tests/human/x/racket/README.md
@@ -13,8 +13,6 @@ This directory contains manual Racket translations of programs from `tests/vm/va
 - cast_struct.mochi
 - closure.mochi
 - count_builtin.mochi
-
-## Missing
 - cross_join.mochi
 - cross_join_filter.mochi
 - cross_join_triple.mochi
@@ -27,6 +25,8 @@ This directory contains manual Racket translations of programs from `tests/vm/va
 - fun_call.mochi
 - fun_expr_in_let.mochi
 - fun_three_args.mochi
+
+## Missing
 - group_by.mochi
 - group_by_conditional_sum.mochi
 - group_by_having.mochi

--- a/tests/human/x/racket/cross_join.rkt
+++ b/tests/human/x/racket/cross_join.rkt
@@ -1,0 +1,24 @@
+#lang racket
+(define customers
+  (list (hash 'id 1 'name "Alice")
+        (hash 'id 2 'name "Bob")
+        (hash 'id 3 'name "Charlie")))
+(define orders
+  (list (hash 'id 100 'customerId 1 'total 250)
+        (hash 'id 101 'customerId 2 'total 125)
+        (hash 'id 102 'customerId 1 'total 300)))
+(define result
+  (for*/list ([o orders]
+              [c customers])
+    (hash 'orderId (hash-ref o 'id)
+          'orderCustomerId (hash-ref o 'customerId)
+          'pairedCustomerName (hash-ref c 'name)
+          'orderTotal (hash-ref o 'total))) )
+(displayln "--- Cross Join: All order-customer pairs ---")
+(for ([entry result])
+  (displayln
+   (string-append
+    "Order " (number->string (hash-ref entry 'orderId))
+    " (customerId:" (number->string (hash-ref entry 'orderCustomerId))
+    ", total: $" (number->string (hash-ref entry 'orderTotal))
+    ") paired with " (hash-ref entry 'pairedCustomerName))))

--- a/tests/human/x/racket/cross_join_filter.rkt
+++ b/tests/human/x/racket/cross_join_filter.rkt
@@ -1,0 +1,11 @@
+#lang racket
+(define nums '(1 2 3))
+(define letters '("A" "B"))
+(define pairs
+  (for*/list ([n nums]
+              [l letters]
+              #:when (even? n))
+    (hash 'n n 'l l)) )
+(displayln "--- Even pairs ---")
+(for ([p pairs])
+  (displayln (string-append (number->string (hash-ref p 'n)) " " (hash-ref p 'l))))

--- a/tests/human/x/racket/cross_join_triple.rkt
+++ b/tests/human/x/racket/cross_join_triple.rkt
@@ -1,0 +1,14 @@
+#lang racket
+(define nums '(1 2))
+(define letters '("A" "B"))
+(define bools '(#t #f))
+(define combos
+  (for*/list ([n nums]
+              [l letters]
+              [b bools])
+    (hash 'n n 'l l 'b b)) )
+(displayln "--- Cross Join of three lists ---")
+(for ([c combos])
+  (displayln (string-append (number->string (hash-ref c 'n)) " "
+                            (hash-ref c 'l) " "
+                            (if (hash-ref c 'b) "#t" "#f"))))

--- a/tests/human/x/racket/dataset_sort_take_limit.rkt
+++ b/tests/human/x/racket/dataset_sort_take_limit.rkt
@@ -1,0 +1,17 @@
+#lang racket
+(define products
+  (list (hash 'name "Laptop" 'price 1500)
+        (hash 'name "Smartphone" 'price 900)
+        (hash 'name "Tablet" 'price 600)
+        (hash 'name "Monitor" 'price 300)
+        (hash 'name "Keyboard" 'price 100)
+        (hash 'name "Mouse" 'price 50)
+        (hash 'name "Headphones" 'price 200)))
+(define sorted
+  (sort products (lambda (a b) (> (hash-ref a 'price) (hash-ref b 'price)))))
+(define expensive (take (rest sorted) 3))
+(displayln "--- Top products (excluding most expensive) ---")
+(for ([item expensive])
+  (displayln (string-append (hash-ref item 'name)
+                            " costs $"
+                            (number->string (hash-ref item 'price)))))

--- a/tests/human/x/racket/dataset_where_filter.rkt
+++ b/tests/human/x/racket/dataset_where_filter.rkt
@@ -1,0 +1,18 @@
+#lang racket
+(define people
+  (list (hash 'name "Alice" 'age 30)
+        (hash 'name "Bob" 'age 15)
+        (hash 'name "Charlie" 'age 65)
+        (hash 'name "Diana" 'age 45)))
+(define adults
+  (for/list ([p people] #:when (>= (hash-ref p 'age) 18))
+    (hash 'name (hash-ref p 'name)
+          'age (hash-ref p 'age)
+          'is_senior (>= (hash-ref p 'age) 60))))
+(displayln "--- Adults ---")
+(for ([person adults])
+  (define suffix (if (hash-ref person 'is_senior) " (senior)" ""))
+  (displayln (string-append (hash-ref person 'name)
+                            " is "
+                            (number->string (hash-ref person 'age))
+                            suffix)))

--- a/tests/human/x/racket/exists_builtin.rkt
+++ b/tests/human/x/racket/exists_builtin.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(define data '(1 2))
+(define flag (ormap (lambda (x) (= x 1)) data))
+(displayln flag)

--- a/tests/human/x/racket/for_list_collection.rkt
+++ b/tests/human/x/racket/for_list_collection.rkt
@@ -1,0 +1,3 @@
+#lang racket
+(for ([n '(1 2 3)])
+  (displayln n))

--- a/tests/human/x/racket/for_loop.rkt
+++ b/tests/human/x/racket/for_loop.rkt
@@ -1,0 +1,3 @@
+#lang racket
+(for ([i (in-range 1 4)])
+  (displayln i))

--- a/tests/human/x/racket/for_map_collection.rkt
+++ b/tests/human/x/racket/for_map_collection.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(define m (hash "a" 1 "b" 2))
+(for ([k (hash-keys m)])
+  (displayln k))

--- a/tests/human/x/racket/fun_call.rkt
+++ b/tests/human/x/racket/fun_call.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(define (add a b)
+  (+ a b))
+(displayln (add 2 3))

--- a/tests/human/x/racket/fun_expr_in_let.rkt
+++ b/tests/human/x/racket/fun_expr_in_let.rkt
@@ -1,0 +1,3 @@
+#lang racket
+(define square (lambda (x) (* x x)))
+(displayln (square 6))

--- a/tests/human/x/racket/fun_three_args.rkt
+++ b/tests/human/x/racket/fun_three_args.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(define (sum3 a b c)
+  (+ a b c))
+(displayln (sum3 1 2 3))


### PR DESCRIPTION
## Summary
- add manual Racket translations for several vm programs
- update README listing translated and missing programs

## Testing
- `make lint` *(fails: unused funcs)*
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_686b69f0ece88320936b65f3784173a6