### PR TITLE
Add rust loop examples

### DIFF
--- a/tests/human/x/rust/README.md
+++ b/tests/human/x/rust/README.md
@@ -15,6 +15,9 @@ This directory contains hand-written Rust versions of some programs from `tests/
 - count_builtin.mochi
 - print_hello.mochi
 - while_loop.mochi
+- for_list_collection.mochi
+- for_loop.mochi
+- for_map_collection.mochi
 
 ## Missing
 - cross_join.mochi
@@ -23,9 +26,6 @@ This directory contains hand-written Rust versions of some programs from `tests/
 - dataset_sort_take_limit.mochi
 - dataset_where_filter.mochi
 - exists_builtin.mochi
-- for_list_collection.mochi
-- for_loop.mochi
-- for_map_collection.mochi
 - fun_call.mochi
 - fun_expr_in_let.mochi
 - fun_three_args.mochi

--- a/tests/human/x/rust/for_list_collection.rs
+++ b/tests/human/x/rust/for_list_collection.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let nums = [1, 2, 3];
+    for n in nums.iter() {
+        println!("{}", n);
+    }
+}

--- a/tests/human/x/rust/for_loop.rs
+++ b/tests/human/x/rust/for_loop.rs
@@ -1,0 +1,5 @@
+fn main() {
+    for i in 1..4 {
+        println!("{}", i);
+    }
+}

--- a/tests/human/x/rust/for_map_collection.rs
+++ b/tests/human/x/rust/for_map_collection.rs
@@ -1,0 +1,10 @@
+use std::collections::BTreeMap;
+
+fn main() {
+    let mut m = BTreeMap::new();
+    m.insert("a", 1);
+    m.insert("b", 2);
+    for k in m.keys() {
+        println!("{}", k);
+    }
+}


### PR DESCRIPTION
## Summary
- add new Rust examples translating Mochi loops
- list the new examples in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b69f254408320bc66f8a40b2f15ed