### PR TITLE
Add Zig translations for dataset and cross join examples

### DIFF
--- a/tests/human/x/zig/README.md
+++ b/tests/human/x/zig/README.md
@@ -13,6 +13,11 @@ This directory contains hand-written Zig translations of examples from `tests/vm
 - cast_struct.mochi
 - closure.mochi
 - count_builtin.mochi
+- cross_join.mochi
+- cross_join_filter.mochi
+- cross_join_triple.mochi
+- dataset_sort_take_limit.mochi
+- dataset_where_filter.mochi
 - for_list_collection.mochi
 - for_loop.mochi
 - for_map_collection.mochi
@@ -53,11 +58,6 @@ This directory contains hand-written Zig translations of examples from `tests/vm
 - while_loop.mochi
 
 ## Missing
-- cross_join.mochi
-- cross_join_filter.mochi
-- cross_join_triple.mochi
-- dataset_sort_take_limit.mochi
-- dataset_where_filter.mochi
 - exists_builtin.mochi
 - fun_expr_in_let.mochi
 - group_by.mochi

--- a/tests/human/x/zig/cross_join.zig
+++ b/tests/human/x/zig/cross_join.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+const Customer = struct {
+    id: i32,
+    name: []const u8,
+};
+
+const Order = struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+};
+
+const Entry = struct {
+    orderId: i32,
+    orderCustomerId: i32,
+    pairedCustomerName: []const u8,
+    orderTotal: i32,
+};
+
+pub fn main() !void {
+    var customers = [_]Customer{
+        .{ .id = 1, .name = "Alice" },
+        .{ .id = 2, .name = "Bob" },
+        .{ .id = 3, .name = "Charlie" },
+    };
+
+    var orders = [_]Order{
+        .{ .id = 100, .customerId = 1, .total = 250 },
+        .{ .id = 101, .customerId = 2, .total = 125 },
+        .{ .id = 102, .customerId = 1, .total = 300 },
+    };
+
+    var result = std.ArrayList(Entry).init(std.heap.page_allocator);
+    defer result.deinit();
+
+    for (orders) |o| {
+        for (customers) |c| {
+            try result.append(.{
+                .orderId = o.id,
+                .orderCustomerId = o.customerId,
+                .pairedCustomerName = c.name,
+                .orderTotal = o.total,
+            });
+        }
+    }
+
+    std.debug.print("--- Cross Join: All order-customer pairs ---\n", .{});
+    for (result.items) |entry| {
+        std.debug.print(
+            "Order {d} (customerId: {d}, total: ${d}) paired with {s}\n",
+            .{ entry.orderId, entry.orderCustomerId, entry.orderTotal, entry.pairedCustomerName },
+        );
+    }
+}
+

--- a/tests/human/x/zig/cross_join_filter.zig
+++ b/tests/human/x/zig/cross_join_filter.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+const Pair = struct {
+    n: i32,
+    l: []const u8,
+};
+
+pub fn main() !void {
+    const nums = [_]i32{1, 2, 3};
+    const letters = [_][]const u8{"A", "B"};
+
+    var pairs = std.ArrayList(Pair).init(std.heap.page_allocator);
+    defer pairs.deinit();
+
+    for (nums) |n| {
+        if (n % 2 == 0) {
+            for (letters) |l| {
+                try pairs.append(.{ .n = n, .l = l });
+            }
+        }
+    }
+
+    std.debug.print("--- Even pairs ---\n", .{});
+    for (pairs.items) |p| {
+        std.debug.print("{d} {s}\n", .{ p.n, p.l });
+    }
+}
+

--- a/tests/human/x/zig/cross_join_triple.zig
+++ b/tests/human/x/zig/cross_join_triple.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+
+const Combo = struct {
+    n: i32,
+    l: []const u8,
+    b: bool,
+};
+
+pub fn main() !void {
+    const nums = [_]i32{1, 2};
+    const letters = [_][]const u8{"A", "B"};
+    const bools = [_]bool{ true, false };
+
+    var combos = std.ArrayList(Combo).init(std.heap.page_allocator);
+    defer combos.deinit();
+
+    for (nums) |n| {
+        for (letters) |l| {
+            for (bools) |b| {
+                try combos.append(.{ .n = n, .l = l, .b = b });
+            }
+        }
+    }
+
+    std.debug.print("--- Cross Join of three lists ---\n", .{});
+    for (combos.items) |c| {
+        std.debug.print("{d} {s} {}\n", .{ c.n, c.l, c.b });
+    }
+}
+

--- a/tests/human/x/zig/dataset_sort_take_limit.zig
+++ b/tests/human/x/zig/dataset_sort_take_limit.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+const Product = struct {
+    name: []const u8,
+    price: i32,
+};
+
+pub fn main() !void {
+    var products = [_]Product{
+        .{ .name = "Laptop", .price = 1500 },
+        .{ .name = "Smartphone", .price = 900 },
+        .{ .name = "Tablet", .price = 600 },
+        .{ .name = "Monitor", .price = 300 },
+        .{ .name = "Keyboard", .price = 100 },
+        .{ .name = "Mouse", .price = 50 },
+        .{ .name = "Headphones", .price = 200 },
+    };
+
+    var slice = products[0..];
+    std.sort.sort(Product, slice, {},
+        comptime fn (ctx: void, a: Product, b: Product) bool {
+            _ = ctx;
+            return a.price > b.price; // descending
+        });
+
+    const expensive = slice[1..4];
+
+    std.debug.print("--- Top products (excluding most expensive) ---\n", .{});
+    for (expensive) |item| {
+        std.debug.print("{s} costs ${d}\n", .{ item.name, item.price });
+    }
+}
+

--- a/tests/human/x/zig/dataset_where_filter.zig
+++ b/tests/human/x/zig/dataset_where_filter.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+const Person = struct {
+    name: []const u8,
+    age: i32,
+};
+
+const Adult = struct {
+    name: []const u8,
+    age: i32,
+    is_senior: bool,
+};
+
+pub fn main() !void {
+    const people = [_]Person{
+        .{ .name = "Alice", .age = 30 },
+        .{ .name = "Bob", .age = 15 },
+        .{ .name = "Charlie", .age = 65 },
+        .{ .name = "Diana", .age = 45 },
+    };
+
+    var adults = std.ArrayList(Adult).init(std.heap.page_allocator);
+    defer adults.deinit();
+
+    for (people) |p| {
+        if (p.age >= 18) {
+            try adults.append(.{ .name = p.name, .age = p.age, .is_senior = p.age >= 60 });
+        }
+    }
+
+    std.debug.print("--- Adults ---\n", .{});
+    for (adults.items) |person| {
+        const note = if (person.is_senior) " (senior)" else "";
+        std.debug.print("{s} is {d}{s}\n", .{ person.name, person.age, note });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Zig implementations for cross join examples and dataset query examples
- update the Zig README to mark them as translated

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b69fc9da483208d5e7e7a32c4f388