### PR TITLE
Improve readability of C++ example programs

### DIFF
--- a/tests/human/x/cpp/README.md
+++ b/tests/human/x/cpp/README.md
@@ -1,6 +1,7 @@
 # Mochi VM Translations to C++
 
-This directory contains manual C++ versions of sample Mochi programs from `tests/vm/valid`.
+This directory contains manual C++ versions of sample Mochi programs from
+`tests/vm/valid`. A total of 97 examples have been translated by hand.
 
 ## Translated programs
 - `append_builtin`

--- a/tests/human/x/cpp/dataset_sort_take_limit.cpp
+++ b/tests/human/x/cpp/dataset_sort_take_limit.cpp
@@ -1,15 +1,27 @@
-#include <iostream>
-#include <vector>
-#include <string>
 #include <algorithm>
-struct Product{std::string name; int price;};
-int main(){
-    std::vector<Product> products={{"Laptop",1500},{"Smartphone",900},{"Tablet",600},{"Monitor",300},{"Keyboard",100},{"Mouse",50},{"Headphones",200}};
-    std::sort(products.begin(),products.end(),[](const Product&a,const Product&b){return a.price>b.price;});
-    std::cout<<"--- Top products (excluding most expensive) ---\n";
-    for(size_t i=1;i<products.size() && i<4;i++){
-        const auto&p=products[i];
-        std::cout<<p.name<<" costs $"<<p.price<<"\n";
+#include <iostream>
+#include <string>
+#include <vector>
+
+struct Product {
+    std::string name;
+    int price;
+};
+
+int main() {
+    std::vector<Product> products = {
+        {"Laptop", 1500},   {"Smartphone", 900}, {"Tablet", 600},
+        {"Monitor", 300},   {"Keyboard", 100},   {"Mouse", 50},
+        {"Headphones", 200}
+    };
+
+    std::sort(products.begin(), products.end(),
+              [](const Product& a, const Product& b) { return a.price > b.price; });
+
+    std::cout << "--- Top products (excluding most expensive) ---\n";
+    for (size_t i = 1; i < products.size() && i < 4; i++) {
+        const auto& p = products[i];
+        std::cout << p.name << " costs $" << p.price << "\n";
     }
     return 0;
 }

--- a/tests/human/x/cpp/tail_recursion.cpp
+++ b/tests/human/x/cpp/tail_recursion.cpp
@@ -1,6 +1,13 @@
 #include <iostream>
-int sum_rec(int n,int acc){return n==0?acc:sum_rec(n-1,acc+n);} 
-int main(){
-    std::cout<<sum_rec(10,0)<<std::endl;
+
+int sum_rec(int n, int acc) {
+    if (n == 0) {
+        return acc;
+    }
+    return sum_rec(n - 1, acc + n);
+}
+
+int main() {
+    std::cout << sum_rec(10, 0) << std::endl;
     return 0;
 }

--- a/tests/human/x/cpp/tree_sum.cpp
+++ b/tests/human/x/cpp/tree_sum.cpp
@@ -1,21 +1,34 @@
 #include <iostream>
 #include <memory>
-struct Tree{virtual ~Tree(){};};
-struct Leaf:Tree{};
-struct Node:Tree{std::unique_ptr<Tree> left;int value;std::unique_ptr<Tree> right;};
-int sum_tree(const Tree* t){
-    if(dynamic_cast<const Leaf*>(t)) return 0;
-    auto n=static_cast<const Node*>(t);
-    return sum_tree(n->left.get())+n->value+sum_tree(n->right.get());
+
+struct Tree {
+    virtual ~Tree() = default;
+};
+
+struct Leaf : Tree {};
+
+struct Node : Tree {
+    std::unique_ptr<Tree> left;
+    int value;
+    std::unique_ptr<Tree> right;
+};
+
+int sum_tree(const Tree* t) {
+    if (dynamic_cast<const Leaf*>(t)) {
+        return 0;
+    }
+    auto n = static_cast<const Node*>(t);
+    return sum_tree(n->left.get()) + n->value + sum_tree(n->right.get());
 }
-int main(){
-    auto t=std::make_unique<Node>();
-    t->left=std::make_unique<Leaf>();
-    t->value=1;
-    t->right=std::make_unique<Node>();
-    static_cast<Node*>(t->right.get())->left=std::make_unique<Leaf>();
-    static_cast<Node*>(t->right.get())->value=2;
-    static_cast<Node*>(t->right.get())->right=std::make_unique<Leaf>();
-    std::cout<<sum_tree(t.get())<<std::endl;
+
+int main() {
+    auto t = std::make_unique<Node>();
+    t->left = std::make_unique<Leaf>();
+    t->value = 1;
+    t->right = std::make_unique<Node>();
+    static_cast<Node*>(t->right.get())->left = std::make_unique<Leaf>();
+    static_cast<Node*>(t->right.get())->value = 2;
+    static_cast<Node*>(t->right.get())->right = std::make_unique<Leaf>();
+    std::cout << sum_tree(t.get()) << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- clarify README with total example count
- format `dataset_sort_take_limit.cpp` for readability
- expand `tail_recursion.cpp` and `tree_sum.cpp` with clearer formatting

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_686b6d9266ac8320abe612028bdfdd63