### PR TITLE
Add more Clojure translations for vm valid examples

### DIFF
--- a/tests/human/x/clj/README.md
+++ b/tests/human/x/clj/README.md
@@ -59,13 +59,14 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - var_assignment.mochi
 - while_loop.mochi
 
-## Missing programs
-
 - cross_join.mochi
 - cross_join_filter.mochi
 - cross_join_triple.mochi
 - dataset_sort_take_limit.mochi
 - dataset_where_filter.mochi
+
+## Missing programs
+
 - group_by.mochi
 - group_by_conditional_sum.mochi
 - group_by_having.mochi

--- a/tests/human/x/clj/cross_join.clj
+++ b/tests/human/x/clj/cross_join.clj
@@ -1,0 +1,26 @@
+(ns cross-join)
+
+(def customers
+  [{:id 1 :name "Alice"}
+   {:id 2 :name "Bob"}
+   {:id 3 :name "Charlie"}])
+
+(def orders
+  [{:id 100 :customerId 1 :total 250}
+   {:id 101 :customerId 2 :total 125}
+   {:id 102 :customerId 1 :total 300}])
+
+(def result
+  (for [o orders
+        c customers]
+    {:orderId (:id o)
+     :orderCustomerId (:customerId o)
+     :pairedCustomerName (:name c)
+     :orderTotal (:total o)}))
+
+(println "--- Cross Join: All order-customer pairs ---")
+(doseq [entry result]
+  (println "Order" (:orderId entry)
+           "(customerId:" (:orderCustomerId entry)
+           ", total: $" (:orderTotal entry)
+           ") paired with" (:pairedCustomerName entry)))

--- a/tests/human/x/clj/cross_join_filter.clj
+++ b/tests/human/x/clj/cross_join_filter.clj
@@ -1,0 +1,14 @@
+(ns cross-join-filter)
+
+(def nums [1 2 3])
+(def letters ["A" "B"])
+
+(def pairs
+  (for [n nums
+        :when (even? n)
+        l letters]
+    {:n n :l l}))
+
+(println "--- Even pairs ---")
+(doseq [p pairs]
+  (println (:n p) (:l p)))

--- a/tests/human/x/clj/cross_join_triple.clj
+++ b/tests/human/x/clj/cross_join_triple.clj
@@ -1,0 +1,15 @@
+(ns cross-join-triple)
+
+(def nums [1 2])
+(def letters ["A" "B"])
+(def bools [true false])
+
+(def combos
+  (for [n nums
+        l letters
+        b bools]
+    {:n n :l l :b b}))
+
+(println "--- Cross Join of three lists ---")
+(doseq [c combos]
+  (println (:n c) (:l c) (:b c)))

--- a/tests/human/x/clj/dataset_sort_take_limit.clj
+++ b/tests/human/x/clj/dataset_sort_take_limit.clj
@@ -1,0 +1,20 @@
+(ns dataset-sort-take-limit)
+
+(def products
+  [{:name "Laptop" :price 1500}
+   {:name "Smartphone" :price 900}
+   {:name "Tablet" :price 600}
+   {:name "Monitor" :price 300}
+   {:name "Keyboard" :price 100}
+   {:name "Mouse" :price 50}
+   {:name "Headphones" :price 200}])
+
+(def expensive
+  (->> products
+       (sort-by :price >)
+       (drop 1)
+       (take 3)))
+
+(println "--- Top products (excluding most expensive) ---")
+(doseq [item expensive]
+  (println (:name item) "costs $" (:price item)))

--- a/tests/human/x/clj/dataset_where_filter.clj
+++ b/tests/human/x/clj/dataset_where_filter.clj
@@ -1,0 +1,19 @@
+(ns dataset-where-filter)
+
+(def people
+  [{:name "Alice" :age 30}
+   {:name "Bob" :age 15}
+   {:name "Charlie" :age 65}
+   {:name "Diana" :age 45}])
+
+(def adults
+  (map (fn [p]
+         {:name (:name p)
+          :age (:age p)
+          :is_senior (>= (:age p) 60)})
+       (filter #(>= (:age %) 18) people)))
+
+(println "--- Adults ---")
+(doseq [person adults]
+  (let [suffix (if (:is_senior person) " (senior)" "")] 
+    (println (:name person) "is" (:age person) suffix)))


### PR DESCRIPTION
## Summary
- add Clojure versions of cross join and dataset query programs
- list these programs as translated in the Clojure README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b6e2a4ae483208ab080e9016c88d2