### PR TITLE
Add dart translations for group_by mochi examples

### DIFF
--- a/tests/human/x/dart/README.md
+++ b/tests/human/x/dart/README.md
@@ -25,6 +25,10 @@ This directory contains hand-written Dart versions of the programs found in `tes
 - fun_call.mochi
 - fun_expr_in_let.mochi
 - fun_three_args.mochi
+- group_by.mochi
+- group_by_conditional_sum.mochi
+- group_by_having.mochi
+- group_by_join.mochi
 - if_else.mochi
 - if_then_else.mochi
 - if_then_else_nested.mochi
@@ -65,10 +69,6 @@ This directory contains hand-written Dart versions of the programs found in `tes
 - while_loop.mochi
 
 ## Missing translations
-- group_by.mochi
-- group_by_conditional_sum.mochi
-- group_by_having.mochi
-- group_by_join.mochi
 - group_by_left_join.mochi
 - group_by_multi_join.mochi
 - group_by_multi_join_sort.mochi

--- a/tests/human/x/dart/group_by.dart
+++ b/tests/human/x/dart/group_by.dart
@@ -1,0 +1,26 @@
+void main() {
+  var people = [
+    {'name': 'Alice', 'age': 30, 'city': 'Paris'},
+    {'name': 'Bob', 'age': 15, 'city': 'Hanoi'},
+    {'name': 'Charlie', 'age': 65, 'city': 'Paris'},
+    {'name': 'Diana', 'age': 45, 'city': 'Hanoi'},
+    {'name': 'Eve', 'age': 70, 'city': 'Paris'},
+    {'name': 'Frank', 'age': 22, 'city': 'Hanoi'},
+  ];
+
+  var groups = <String, List<Map<String, dynamic>>>{};
+  for (var p in people) {
+    groups.putIfAbsent(p['city'], () => []).add(p);
+  }
+
+  var stats = [];
+  groups.forEach((city, list) {
+    var totalAge = list.fold(0, (a, b) => a + (b['age'] as int));
+    stats.add({'city': city, 'count': list.length, 'avg_age': totalAge / list.length});
+  });
+
+  print('--- People grouped by city ---');
+  for (var s in stats) {
+    print('${s['city']}: count = ${s['count']}, avg_age = ${s['avg_age']}');
+  }
+}

--- a/tests/human/x/dart/group_by_conditional_sum.dart
+++ b/tests/human/x/dart/group_by_conditional_sum.dart
@@ -1,0 +1,23 @@
+void main() {
+  var items = [
+    {'cat': 'a', 'val': 10, 'flag': true},
+    {'cat': 'a', 'val': 5, 'flag': false},
+    {'cat': 'b', 'val': 20, 'flag': true},
+  ];
+
+  var groups = <String, List<Map<String, dynamic>>>{};
+  for (var item in items) {
+    groups.putIfAbsent(item['cat'], () => []).add(item);
+  }
+
+  var result = [];
+  var keys = groups.keys.toList()..sort();
+  for (var key in keys) {
+    var g = groups[key]!;
+    var sumFlag = g.fold(0, (a, b) => a + ((b['flag'] as bool) ? b['val'] as int : 0));
+    var sumVal = g.fold(0, (a, b) => a + (b['val'] as int));
+    result.add({'cat': key, 'share': sumFlag / sumVal});
+  }
+
+  print(result);
+}

--- a/tests/human/x/dart/group_by_having.dart
+++ b/tests/human/x/dart/group_by_having.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+void main() {
+  var people = [
+    {'name': 'Alice', 'city': 'Paris'},
+    {'name': 'Bob', 'city': 'Hanoi'},
+    {'name': 'Charlie', 'city': 'Paris'},
+    {'name': 'Diana', 'city': 'Hanoi'},
+    {'name': 'Eve', 'city': 'Paris'},
+    {'name': 'Frank', 'city': 'Hanoi'},
+    {'name': 'George', 'city': 'Paris'},
+  ];
+
+  var groups = <String, List<Map<String, dynamic>>>{};
+  for (var p in people) {
+    groups.putIfAbsent(p['city'], () => []).add(p);
+  }
+
+  var big = [];
+  groups.forEach((city, list) {
+    if (list.length >= 4) {
+      big.add({'city': city, 'num': list.length});
+    }
+  });
+
+  print(jsonEncode(big));
+}

--- a/tests/human/x/dart/group_by_join.dart
+++ b/tests/human/x/dart/group_by_join.dart
@@ -1,0 +1,32 @@
+void main() {
+  var customers = [
+    {'id': 1, 'name': 'Alice'},
+    {'id': 2, 'name': 'Bob'},
+  ];
+  var orders = [
+    {'id': 100, 'customerId': 1},
+    {'id': 101, 'customerId': 1},
+    {'id': 102, 'customerId': 2},
+  ];
+
+  var joined = [];
+  for (var o in orders) {
+    var customer = customers.firstWhere((c) => c['id'] == o['customerId']);
+    joined.add({'name': customer['name'], 'orderId': o['id']});
+  }
+
+  var groups = <String, List<Map<String, dynamic>>>{};
+  for (var j in joined) {
+    groups.putIfAbsent(j['name'], () => []).add(j);
+  }
+
+  var stats = [];
+  groups.forEach((name, list) {
+    stats.add({'name': name, 'count': list.length});
+  });
+
+  print('--- Orders per customer ---');
+  for (var s in stats) {
+    print('${s['name']} orders: ${s['count']}');
+  }
+}


### PR DESCRIPTION
## Summary
- add Dart versions of group_by* programs
- update dart README to list new translations and adjust missing list

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b6e79770c83209c3e067bc15e519e