### PR TITLE
Add more Racket translations

### DIFF
--- a/tests/human/x/racket/README.md
+++ b/tests/human/x/racket/README.md
@@ -25,6 +25,12 @@ This directory contains manual Racket translations of programs from `tests/vm/va
 - fun_call.mochi
 - fun_expr_in_let.mochi
 - fun_three_args.mochi
+- if_else.mochi
+- let_and_print.mochi
+- print_hello.mochi
+- string_concat.mochi
+- sum_builtin.mochi
+- unary_neg.mochi
 
 ## Missing
 - group_by.mochi
@@ -36,7 +42,6 @@ This directory contains manual Racket translations of programs from `tests/vm/va
 - group_by_multi_join_sort.mochi
 - group_by_sort.mochi
 - group_items_iteration.mochi
-- if_else.mochi
 - if_then_else.mochi
 - if_then_else_nested.mochi
 - in_operator.mochi
@@ -49,7 +54,6 @@ This directory contains manual Racket translations of programs from `tests/vm/va
 - len_builtin.mochi
 - len_map.mochi
 - len_string.mochi
-- let_and_print.mochi
 - list_assign.mochi
 - list_index.mochi
 - list_nested_assign.mochi
@@ -71,7 +75,6 @@ This directory contains manual Racket translations of programs from `tests/vm/va
 - order_by_map.mochi
 - outer_join.mochi
 - partial_application.mochi
-- print_hello.mochi
 - pure_fold.mochi
 - pure_global_fold.mochi
 - query_sum_select.mochi
@@ -83,20 +86,17 @@ This directory contains manual Racket translations of programs from `tests/vm/va
 - sort_stable.mochi
 - str_builtin.mochi
 - string_compare.mochi
-- string_concat.mochi
 - string_contains.mochi
 - string_in_operator.mochi
 - string_index.mochi
 - string_prefix_slice.mochi
 - substring_builtin.mochi
-- sum_builtin.mochi
 - tail_recursion.mochi
 - test_block.mochi
 - tree_sum.mochi
 - two-sum.mochi
 - typed_let.mochi
 - typed_var.mochi
-- unary_neg.mochi
 - update_stmt.mochi
 - user_type_literal.mochi
 - values_builtin.mochi

--- a/tests/human/x/racket/if_else.rkt
+++ b/tests/human/x/racket/if_else.rkt
@@ -1,0 +1,5 @@
+#lang racket
+(define x 5)
+(if (> x 3)
+    (displayln "big")
+    (displayln "small"))

--- a/tests/human/x/racket/let_and_print.rkt
+++ b/tests/human/x/racket/let_and_print.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(define a 10)
+(define b 20)
+(displayln (+ a b))

--- a/tests/human/x/racket/print_hello.rkt
+++ b/tests/human/x/racket/print_hello.rkt
@@ -1,0 +1,2 @@
+#lang racket
+(displayln "hello")

--- a/tests/human/x/racket/string_concat.rkt
+++ b/tests/human/x/racket/string_concat.rkt
@@ -1,0 +1,2 @@
+#lang racket
+(displayln (string-append "hello " "world"))

--- a/tests/human/x/racket/sum_builtin.rkt
+++ b/tests/human/x/racket/sum_builtin.rkt
@@ -1,0 +1,2 @@
+#lang racket
+(displayln (apply + (list 1 2 3)))

--- a/tests/human/x/racket/unary_neg.rkt
+++ b/tests/human/x/racket/unary_neg.rkt
@@ -1,0 +1,3 @@
+#lang racket
+(displayln (- 3))
+(displayln (+ 5 (- 2)))


### PR DESCRIPTION
## Summary
- add new Racket equivalents for several Mochi programs
- update translation README for Racket

## Testing
- `make fmt`
- `make test STAGE=parser`


------
https://chatgpt.com/codex/tasks/task_e_686b7148d6bc83209b8dc4b208e3ce9c