### PR TITLE
Add more C translations for vm tests

### DIFF
--- a/tests/human/x/c/README.md
+++ b/tests/human/x/c/README.md
@@ -48,9 +48,13 @@ so far and which remain.
 - typed_let.mochi
 - typed_var.mochi
 - unary_neg.mochi
+- group_by.mochi
+- print_hello.mochi
+- tail_recursion.mochi
+- tree_sum.mochi
+- two-sum.mochi
 
 ## Missing
-- group_by.mochi
 - group_by_conditional_sum.mochi
 - group_by_having.mochi
 - group_by_join.mochi
@@ -79,7 +83,6 @@ so far and which remain.
 - order_by_map.mochi
 - outer_join.mochi
 - partial_application.mochi
-- print_hello.mochi
 - pure_fold.mochi
 - pure_global_fold.mochi
 - query_sum_select.mochi
@@ -95,10 +98,7 @@ so far and which remain.
 - string_index.mochi
 - string_prefix_slice.mochi
 - substring_builtin.mochi
-- tail_recursion.mochi
 - test_block.mochi
-- tree_sum.mochi
-- two-sum.mochi
 - update_stmt.mochi
 - user_type_literal.mochi
 - values_builtin.mochi

--- a/tests/human/x/c/group_by.c
+++ b/tests/human/x/c/group_by.c
@@ -1,0 +1,40 @@
+// group_by.c - manual translation of tests/vm/valid/group_by.mochi
+#include <stdio.h>
+#include <string.h>
+
+struct Person { const char *name; int age; const char *city; };
+struct Stats { const char *city; int count; double age_sum; };
+
+int main() {
+    struct Person people[] = {
+        {"Alice",30,"Paris"},
+        {"Bob",15,"Hanoi"},
+        {"Charlie",65,"Paris"},
+        {"Diana",45,"Hanoi"},
+        {"Eve",70,"Paris"},
+        {"Frank",22,"Hanoi"}
+    };
+    int n = sizeof(people)/sizeof(people[0]);
+    struct Stats stats[6];
+    int num_stats = 0;
+    for(int i=0;i<n;i++) {
+        int found=-1;
+        for(int j=0;j<num_stats;j++) {
+            if(strcmp(stats[j].city, people[i].city)==0) { found=j; break; }
+        }
+        if(found==-1) {
+            found = num_stats++;
+            stats[found].city = people[i].city;
+            stats[found].count=0;
+            stats[found].age_sum=0.0;
+        }
+        stats[found].count++;
+        stats[found].age_sum += people[i].age;
+    }
+    printf("--- People grouped by city ---\n");
+    for(int i=0;i<num_stats;i++) {
+        double avg_age = stats[i].age_sum / stats[i].count;
+        printf("%s : count = %d , avg_age = %.17g\n", stats[i].city, stats[i].count, avg_age);
+    }
+    return 0;
+}

--- a/tests/human/x/c/print_hello.c
+++ b/tests/human/x/c/print_hello.c
@@ -1,0 +1,7 @@
+// print_hello.c - manual translation of tests/vm/valid/print_hello.mochi
+#include <stdio.h>
+
+int main() {
+    printf("hello\n");
+    return 0;
+}

--- a/tests/human/x/c/tail_recursion.c
+++ b/tests/human/x/c/tail_recursion.c
@@ -1,0 +1,12 @@
+// tail_recursion.c - manual translation of tests/vm/valid/tail_recursion.mochi
+#include <stdio.h>
+
+int sum_rec(int n, int acc) {
+    if(n==0) return acc;
+    return sum_rec(n-1, acc + n);
+}
+
+int main() {
+    printf("%d\n", sum_rec(10,0));
+    return 0;
+}

--- a/tests/human/x/c/tree_sum.c
+++ b/tests/human/x/c/tree_sum.c
@@ -1,0 +1,24 @@
+// tree_sum.c - manual translation of tests/vm/valid/tree_sum.mochi
+#include <stdio.h>
+
+typedef enum { LEAF, NODE } Tag;
+
+typedef struct Tree {
+    Tag tag;
+    struct Tree *left;
+    int value;
+    struct Tree *right;
+} Tree;
+
+int sum_tree(const Tree *t) {
+    if(t->tag == LEAF) return 0;
+    return sum_tree(t->left) + t->value + sum_tree(t->right);
+}
+
+int main() {
+    Tree leaf = {LEAF, NULL, 0, NULL};
+    Tree nodeRight = {NODE, &leaf, 2, &leaf};
+    Tree root = {NODE, &leaf, 1, &nodeRight};
+    printf("%d\n", sum_tree(&root));
+    return 0;
+}

--- a/tests/human/x/c/two-sum.c
+++ b/tests/human/x/c/two-sum.c
@@ -1,0 +1,19 @@
+// two-sum.c - manual translation of tests/vm/valid/two-sum.mochi
+#include <stdio.h>
+
+void twoSum(const int *nums, int n, int target, int out[2]) {
+    for(int i=0;i<n;i++) {
+        for(int j=i+1;j<n;j++) {
+            if(nums[i]+nums[j]==target) { out[0]=i; out[1]=j; return; }
+        }
+    }
+    out[0]=-1; out[1]=-1;
+}
+
+int main() {
+    int nums[] = {2,7,11,15};
+    int result[2];
+    twoSum(nums,4,9,result);
+    printf("%d\n%d\n", result[0], result[1]);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- translate additional Mochi programs into C
- update C README to list new translations

## Testing
- `gcc -std=c99 -Wall -Wextra -o /tmp/group_by group_by.c && /tmp/group_by`
- `gcc -std=c99 -Wall -Wextra -o /tmp/print_hello print_hello.c && /tmp/print_hello`
- `gcc -std=c99 -Wall -Wextra -o /tmp/tail_recursion tail_recursion.c && /tmp/tail_recursion`
- `gcc -std=c99 -Wall -Wextra -o /tmp/tree_sum tree_sum.c && /tmp/tree_sum`
- `gcc -std=c99 -Wall -Wextra -o /tmp/two_sum two-sum.c && /tmp/two_sum`


------
https://chatgpt.com/codex/tasks/task_e_686b7867e73083208ce6ed204fb9ca8d