### PR TITLE
Add missing Clojure translations

### DIFF
--- a/tests/human/x/clj/README.md
+++ b/tests/human/x/clj/README.md
@@ -64,10 +64,12 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - cross_join_triple.mochi
 - dataset_sort_take_limit.mochi
 - dataset_where_filter.mochi
+- group_by.mochi
+- map_index.mochi
+- slice.mochi
 
 ## Missing programs
 
-- group_by.mochi
 - group_by_conditional_sum.mochi
 - group_by_having.mochi
 - group_by_join.mochi
@@ -85,7 +87,6 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - list_nested_assign.mochi
 - list_set_ops.mochi
 - load_yaml.mochi
-- map_index.mochi
 - map_int_key.mochi
 - map_literal_dynamic.mochi
 - map_membership.mochi
@@ -102,6 +103,5 @@ This directory contains hand-written Clojure versions of the Mochi examples foun
 - record_assign.mochi
 - right_join.mochi
 - save_jsonl_stdout.mochi
-- slice.mochi
 - sort_stable.mochi
 - update_stmt.mochi

--- a/tests/human/x/clj/group_by.clj
+++ b/tests/human/x/clj/group_by.clj
@@ -1,0 +1,22 @@
+(ns group-by-example)
+
+(def people
+  [{:name "Alice" :age 30 :city "Paris"}
+   {:name "Bob" :age 15 :city "Hanoi"}
+   {:name "Charlie" :age 65 :city "Paris"}
+   {:name "Diana" :age 45 :city "Hanoi"}
+   {:name "Eve" :age 70 :city "Paris"}
+   {:name "Frank" :age 22 :city "Hanoi"}])
+
+(def stats
+  (->> people
+       (group-by :city)
+       (map (fn [[city group]]
+              {:city city
+               :count (count group)
+               :avg_age (/ (reduce + (map :age group))
+                           (count group))}))))
+
+(println "--- People grouped by city ---")
+(doseq [s stats]
+  (println (:city s) ": count =" (:count s) ", avg_age =" (:avg_age s)))

--- a/tests/human/x/clj/map_index.clj
+++ b/tests/human/x/clj/map_index.clj
@@ -1,0 +1,4 @@
+(ns map-index)
+
+(def m {"a" 1 "b" 2})
+(println (get m "b"))

--- a/tests/human/x/clj/slice.clj
+++ b/tests/human/x/clj/slice.clj
@@ -1,0 +1,5 @@
+(ns slice)
+
+(println (subvec [1 2 3] 1 3))
+(println (subvec [1 2 3] 0 2))
+(println (subs "hello" 1 4))


### PR DESCRIPTION
## Summary
- add translations for `group_by.mochi`, `map_index.mochi`, `slice.mochi`
- list these programs under translated section in the README

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_686b78a2ad788320aed7a6afd9671c77