### PR TITLE
Add Erlang group_by translations

### DIFF
--- a/tests/human/x/erlang/README.md
+++ b/tests/human/x/erlang/README.md
@@ -52,12 +52,11 @@ This directory contains manual Erlang translations of some Mochi test programs f
 - unary_neg.mochi
 - tree_sum.mochi
 - two-sum.mochi
-
-## Missing
 - group_by.mochi
 - group_by_conditional_sum.mochi
 - group_by_having.mochi
 - group_by_join.mochi
+## Missing
 - group_by_left_join.mochi
 - group_by_multi_join.mochi
 - group_by_multi_join_sort.mochi

--- a/tests/human/x/erlang/group_by.erl
+++ b/tests/human/x/erlang/group_by.erl
@@ -1,0 +1,25 @@
+#!/usr/bin/env escript
+%% group_by.erl - manual translation of tests/vm/valid/group_by.mochi
+
+main(_) ->
+    People = [
+        #{name => "Alice", age => 30, city => "Paris"},
+        #{name => "Bob", age => 15, city => "Hanoi"},
+        #{name => "Charlie", age => 65, city => "Paris"},
+        #{name => "Diana", age => 45, city => "Hanoi"},
+        #{name => "Eve", age => 70, city => "Paris"},
+        #{name => "Frank", age => 22, city => "Hanoi"}
+    ],
+    Acc0 = #{},
+    Groups = lists:foldl(fun(P,Acc) ->
+                City = maps:get(city,P),
+                Age = maps:get(age,P),
+                {Cnt0,Sum0} = maps:get(City,Acc,{0,0}),
+                maps:put(City,{Cnt0+1,Sum0+Age},Acc)
+            end, Acc0, People),
+    Stats = [#{city => C, count => Cnt, avg_age => Sum/Cnt} || {C,{Cnt,Sum}} <- maps:to_list(Groups)],
+    io:format("--- People grouped by city ---~n"),
+    lists:foreach(fun(S) ->
+        io:format("~s: count = ~p, avg_age = ~p~n",
+                  [maps:get(city,S), maps:get(count,S), maps:get(avg_age,S)])
+    end, Stats).

--- a/tests/human/x/erlang/group_by_conditional_sum.erl
+++ b/tests/human/x/erlang/group_by_conditional_sum.erl
@@ -1,0 +1,23 @@
+#!/usr/bin/env escript
+%% group_by_conditional_sum.erl - manual translation of tests/vm/valid/group_by_conditional_sum.mochi
+
+main(_) ->
+    Items = [
+        #{cat => "a", val => 10, flag => true},
+        #{cat => "a", val => 5, flag => false},
+        #{cat => "b", val => 20, flag => true}
+    ],
+    Groups = lists:foldl(fun(Item,Acc) ->
+                Cat = maps:get(cat,Item),
+                Val = maps:get(val,Item),
+                Flag = maps:get(flag,Item),
+                {SumFlag,SumVal} = maps:get(Cat,Acc,{0,0}),
+                NewSumFlag = SumFlag + (case Flag of true -> Val; false -> 0 end),
+                maps:put(Cat,{NewSumFlag,SumVal+Val},Acc)
+            end, #{}, Items),
+    Result0 = [{Cat,{SF,SV}} || {Cat,{SF,SV}} <- maps:to_list(Groups)],
+    Result1 = lists:map(fun({Cat,{SF,SV}}) ->
+                #{cat => Cat, share => SF / SV}
+            end, Result0),
+    Sorted = lists:sort(fun(A,B) -> maps:get(cat,A) =< maps:get(cat,B) end, Result1),
+    io:format("~p~n", [Sorted]).

--- a/tests/human/x/erlang/group_by_having.erl
+++ b/tests/human/x/erlang/group_by_having.erl
@@ -1,0 +1,20 @@
+#!/usr/bin/env escript
+%% group_by_having.erl - manual translation of tests/vm/valid/group_by_having.mochi
+
+main(_) ->
+    People = [
+        #{name => "Alice", city => "Paris"},
+        #{name => "Bob", city => "Hanoi"},
+        #{name => "Charlie", city => "Paris"},
+        #{name => "Diana", city => "Hanoi"},
+        #{name => "Eve", city => "Paris"},
+        #{name => "Frank", city => "Hanoi"},
+        #{name => "George", city => "Paris"}
+    ],
+    Groups = lists:foldl(fun(P,Acc) ->
+                City = maps:get(city,P),
+                Cnt = maps:get(City,Acc,0),
+                maps:put(City,Cnt+1,Acc)
+            end, #{}, People),
+    Big = [#{city => City, num => Cnt} || {City,Cnt} <- maps:to_list(Groups), Cnt >= 4],
+    io:format("~p~n", [Big]).

--- a/tests/human/x/erlang/group_by_join.erl
+++ b/tests/human/x/erlang/group_by_join.erl
@@ -1,0 +1,24 @@
+#!/usr/bin/env escript
+%% group_by_join.erl - manual translation of tests/vm/valid/group_by_join.mochi
+
+main(_) ->
+    Customers = [
+        #{id => 1, name => "Alice"},
+        #{id => 2, name => "Bob"}
+    ],
+    Orders = [
+        #{id => 100, customerId => 1},
+        #{id => 101, customerId => 1},
+        #{id => 102, customerId => 2}
+    ],
+    Joined = [{maps:get(name,C), O} || O <- Orders, C <- Customers,
+                              maps:get(customerId,O) =:= maps:get(id,C)],
+    Counts = lists:foldl(fun({Name,_O},Acc) ->
+                Cnt = maps:get(Name,Acc,0),
+                maps:put(Name,Cnt+1,Acc)
+            end, #{}, Joined),
+    Stats = [#{name => Name, count => Cnt} || {Name,Cnt} <- maps:to_list(Counts)],
+    io:format("--- Orders per customer ---~n"),
+    lists:foreach(fun(S) ->
+        io:format("~s orders: ~p~n", [maps:get(name,S), maps:get(count,S)])
+    end, Stats).


### PR DESCRIPTION
## Summary
- add manual Erlang translations for several group_by Mochi programs
- list them as translated in Erlang README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b78da50a88320b808bb8cebf69f40