### PR TITLE
Add Fortran translation for dataset_sort_take_limit

### DIFF
--- a/tests/human/x/fortran/README.md
+++ b/tests/human/x/fortran/README.md
@@ -14,6 +14,7 @@
 - cross_join
 - cross_join_filter
 - cross_join_triple
+- dataset_sort_take_limit
 - dataset_where_filter
 - exists_builtin
 - for_list_collection
@@ -64,7 +65,6 @@
 - while_loop
 
 ## Missing
-- dataset_sort_take_limit
 - group_by
 - group_by_conditional_sum
 - group_by_having

--- a/tests/human/x/fortran/dataset_sort_take_limit.f90
+++ b/tests/human/x/fortran/dataset_sort_take_limit.f90
@@ -1,0 +1,35 @@
+program dataset_sort_take_limit
+  implicit none
+  type :: Product
+    character(len=20) :: name
+    integer :: price
+  end type Product
+  type(Product) :: products(7)
+  type(Product) :: sorted(7)
+  integer :: i, j
+  type(Product) :: temp
+
+  products(1) = Product('Laptop',1500)
+  products(2) = Product('Smartphone',900)
+  products(3) = Product('Tablet',600)
+  products(4) = Product('Monitor',300)
+  products(5) = Product('Keyboard',100)
+  products(6) = Product('Mouse',50)
+  products(7) = Product('Headphones',200)
+
+  sorted = products
+  do i = 1, 6
+    do j = i+1, 7
+      if (sorted(j)%price > sorted(i)%price) then
+        temp = sorted(i)
+        sorted(i) = sorted(j)
+        sorted(j) = temp
+      end if
+    end do
+  end do
+
+  print *, '--- Top products (excluding most expensive) ---'
+  do i = 2, 4
+    print *, trim(sorted(i)%name)//' costs $', sorted(i)%price
+  end do
+end program dataset_sort_take_limit


### PR DESCRIPTION
## Summary
- add Fortran version of `dataset_sort_take_limit`
- update Fortran README

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_686b78efea60832093373bd8dca0b103