### PR TITLE
Add more OCaml translations

### DIFF
--- a/tests/human/x/ocaml/README.md
+++ b/tests/human/x/ocaml/README.md
@@ -27,17 +27,17 @@ The table below shows which Mochi examples have been translated (`[x]`) and whic
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
 - [x] group_by.mochi
-- [ ] group_by_conditional_sum.mochi
+- [x] group_by_conditional_sum.mochi
 - [ ] group_by_having.mochi
 - [ ] group_by_join.mochi
 - [ ] group_by_left_join.mochi
 - [ ] group_by_multi_join.mochi
 - [ ] group_by_multi_join_sort.mochi
-- [ ] group_by_sort.mochi
-- [ ] group_items_iteration.mochi
+- [x] group_by_sort.mochi
+- [x] group_items_iteration.mochi
 - [x] if_else.mochi
 - [x] if_then_else.mochi
-- [ ] if_then_else_nested.mochi
+- [x] if_then_else_nested.mochi
 - [x] in_operator.mochi
 - [x] in_operator_extended.mochi
 - [ ] inner_join.mochi
@@ -76,7 +76,7 @@ The table below shows which Mochi examples have been translated (`[x]`) and whic
 - [x] query_sum_select.mochi
 - [x] record_assign.mochi
 - [ ] right_join.mochi
-- [ ] save_jsonl_stdout.mochi
+- [x] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
 - [x] slice.mochi
 - [x] sort_stable.mochi

--- a/tests/human/x/ocaml/group_by_conditional_sum.ml
+++ b/tests/human/x/ocaml/group_by_conditional_sum.ml
@@ -1,0 +1,21 @@
+
+let items = [
+  ("a", 10, true);
+  ("a", 5, false);
+  ("b", 20, true);
+]
+
+let add map (cat, value, flag) =
+  let (sum_true,sum_all) = try List.assoc cat map with Not_found -> (0,0) in
+  (cat, (sum_true + (if flag then value else 0), sum_all + value)) :: List.remove_assoc cat map
+
+let grouped = List.fold_left add [] items
+
+let sorted = List.sort (fun (c1,_) (c2,_) -> compare c1 c2) grouped
+
+let () =
+  List.iter (fun (cat,(t,a)) ->
+    let share = float_of_int t /. float_of_int a in
+    Printf.printf "{cat=%S; share=%g}\n" cat share
+  ) sorted
+

--- a/tests/human/x/ocaml/group_by_sort.ml
+++ b/tests/human/x/ocaml/group_by_sort.ml
@@ -1,0 +1,19 @@
+let items = [
+  ("a", 3);
+  ("a", 1);
+  ("b", 5);
+  ("b", 2);
+]
+
+let add map (cat,value) =
+  let sum = try List.assoc cat map with Not_found -> 0 in
+  (cat, sum + value) :: List.remove_assoc cat map
+
+let grouped = List.fold_left add [] items
+
+let sorted = List.sort (fun (_,s1) (_,s2) -> compare s2 s1) grouped
+
+let () =
+  List.iter (fun (cat,total) ->
+    Printf.printf "{cat=%S; total=%d}\n" cat total
+  ) sorted

--- a/tests/human/x/ocaml/group_items_iteration.ml
+++ b/tests/human/x/ocaml/group_items_iteration.ml
@@ -1,0 +1,22 @@
+let data = [
+  ("a", 1);
+  ("a", 2);
+  ("b", 3);
+]
+
+let add map (tag,value) =
+  let lst = try List.assoc tag map with Not_found -> [] in
+  (tag, value :: lst) :: List.remove_assoc tag map
+
+let groups = List.fold_left add [] data
+
+let totals =
+  List.map (fun (tag,values) ->
+    (tag, List.fold_left (+) 0 values)
+  ) groups
+  |> List.sort (fun (a,_) (b,_) -> compare a b)
+
+let () =
+  List.iter (fun (tag,total) ->
+    Printf.printf "{tag=%S; total=%d}\n" tag total
+  ) totals

--- a/tests/human/x/ocaml/if_then_else_nested.ml
+++ b/tests/human/x/ocaml/if_then_else_nested.ml
@@ -1,0 +1,3 @@
+let x = 8
+let msg = if x > 10 then "big" else if x > 5 then "medium" else "small"
+let () = print_endline msg

--- a/tests/human/x/ocaml/save_jsonl_stdout.ml
+++ b/tests/human/x/ocaml/save_jsonl_stdout.ml
@@ -1,0 +1,9 @@
+let people = [
+  ("Alice", 30);
+  ("Bob", 25);
+]
+
+let () =
+  List.iter (fun (name, age) ->
+    Printf.printf "{\"name\": \"%s\", \"age\": %d}\n" name age
+  ) people


### PR DESCRIPTION
## Summary
- add OCaml versions for several missing Mochi examples
  - group_by_conditional_sum
  - group_by_sort
  - group_items_iteration
  - if_then_else_nested
  - save_jsonl_stdout
- mark these examples as translated in README

## Testing
- `go test ./...` *(fails: network or environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686b7d865d308320b0409499f7eab080