### PR TITLE
Add more Go translations

### DIFF
--- a/tests/human/x/go/README.md
+++ b/tests/human/x/go/README.md
@@ -1,104 +1,104 @@
 # Go Translations of Mochi Programs
 
-This directory contains manual Go translations of some Mochi test programs from `tests/vm/valid`.
+This directory contains manual Go translations of Mochi programs from `tests/vm/valid`.
 
 ## Translated
-- append_builtin.mochi
-- avg_builtin.mochi
-- basic_compare.mochi
-- binary_precedence.mochi
-- bool_chain.mochi
-- break_continue.mochi
-- cast_string_to_int.mochi
-- cast_struct.mochi
-- closure.mochi
-- count_builtin.mochi
-- cross_join.mochi
-- cross_join_filter.mochi
-- cross_join_triple.mochi
-- dataset_sort_take_limit.mochi
-- dataset_where_filter.mochi
-- exists_builtin.mochi
-- for_loop.mochi
-- for_list_collection.mochi
-- for_map_collection.mochi
-- fun_call.mochi
-- fun_expr_in_let.mochi
-- fun_three_args.mochi
-- if_else.mochi
-- if_then_else.mochi
-- if_then_else_nested.mochi
-- in_operator.mochi
-- in_operator_extended.mochi
-- print_hello.mochi
+- [x] append_builtin.mochi
+- [x] avg_builtin.mochi
+- [x] basic_compare.mochi
+- [x] binary_precedence.mochi
+- [x] bool_chain.mochi
+- [x] break_continue.mochi
+- [x] cast_string_to_int.mochi
+- [x] cast_struct.mochi
+- [x] closure.mochi
+- [x] count_builtin.mochi
+- [x] cross_join.mochi
+- [x] cross_join_filter.mochi
+- [x] cross_join_triple.mochi
+- [x] dataset_sort_take_limit.mochi
+- [x] dataset_where_filter.mochi
+- [x] exists_builtin.mochi
+- [x] for_list_collection.mochi
+- [x] for_loop.mochi
+- [x] for_map_collection.mochi
+- [x] fun_call.mochi
+- [x] fun_expr_in_let.mochi
+- [x] fun_three_args.mochi
+- [x] group_by.mochi
+- [x] group_items_iteration.mochi
+- [x] if_else.mochi
+- [x] if_then_else.mochi
+- [x] if_then_else_nested.mochi
+- [x] in_operator.mochi
+- [x] in_operator_extended.mochi
+- [x] len_builtin.mochi
+- [x] len_map.mochi
+- [x] len_string.mochi
+- [x] let_and_print.mochi
+- [x] list_assign.mochi
+- [x] list_index.mochi
+- [x] list_nested_assign.mochi
+- [x] map_assign.mochi
+- [x] map_in_operator.mochi
+- [x] map_index.mochi
+- [x] map_int_key.mochi
+- [x] map_literal_dynamic.mochi
+- [x] map_membership.mochi
+- [x] map_nested_assign.mochi
+- [x] match_expr.mochi
+- [x] match_full.mochi
+- [x] math_ops.mochi
+- [x] membership.mochi
+- [x] min_max_builtin.mochi
+- [x] nested_function.mochi
+- [x] partial_application.mochi
+- [x] print_hello.mochi
+- [x] record_assign.mochi
+- [x] short_circuit.mochi
+- [x] slice.mochi
+- [x] str_builtin.mochi
+- [x] string_compare.mochi
+- [x] string_concat.mochi
+- [x] string_contains.mochi
+- [x] string_in_operator.mochi
+- [x] string_index.mochi
+- [x] string_prefix_slice.mochi
+- [x] substring_builtin.mochi
+- [x] sum_builtin.mochi
+- [x] tail_recursion.mochi
+- [x] test_block.mochi
+- [x] tree_sum.mochi
+- [x] two-sum.mochi
+- [x] typed_let.mochi
+- [x] typed_var.mochi
+- [x] unary_neg.mochi
+- [x] user_type_literal.mochi
+- [x] values_builtin.mochi
+- [x] var_assignment.mochi
+- [x] while_loop.mochi
 
-- len_builtin.mochi
-- len_map.mochi
-- len_string.mochi
-- let_and_print.mochi
-- list_assign.mochi
-- list_index.mochi
-- list_nested_assign.mochi
-- map_assign.mochi
-- map_in_operator.mochi
-- map_index.mochi
-- map_int_key.mochi
-- map_literal_dynamic.mochi
-- map_membership.mochi
-- map_nested_assign.mochi
-- string_compare.mochi
-- string_concat.mochi
-- string_contains.mochi
-- string_in_operator.mochi
-- string_index.mochi
-- string_prefix_slice.mochi
-- substring_builtin.mochi
-- sum_builtin.mochi
-- tail_recursion.mochi
-- typed_let.mochi
-- typed_var.mochi
-- unary_neg.mochi
-- values_builtin.mochi
-- var_assignment.mochi
-- while_loop.mochi
-- group_by.mochi
-- match_expr.mochi
-- match_full.mochi
-- short_circuit.mochi
-- slice.mochi
-- tree_sum.mochi
-- two-sum.mochi
-- group_items_iteration.mochi
-- membership.mochi
-- min_max_builtin.mochi
-- nested_function.mochi
-- partial_application.mochi
-- record_assign.mochi
-- str_builtin.mochi
 ## Missing
-- group_by_conditional_sum.mochi
-- group_by_having.mochi
-- group_by_join.mochi
-- group_by_left_join.mochi
-- group_by_multi_join.mochi
-- group_by_multi_join_sort.mochi
-- group_by_sort.mochi
-- inner_join.mochi
-- join_multi.mochi
-- json_builtin.mochi
-- left_join.mochi
-- left_join_multi.mochi
-- list_set_ops.mochi
-- load_yaml.mochi
-- math_ops.mochi
-- order_by_map.mochi
-- outer_join.mochi
-- pure_fold.mochi
-- pure_global_fold.mochi
-- query_sum_select.mochi
-- right_join.mochi
-- save_jsonl_stdout.mochi
-- sort_stable.mochi
-- test_block.mochi
-- update_stmt.mochi
-- user_type_literal.mochi
+- [ ] group_by_conditional_sum.mochi
+- [ ] group_by_having.mochi
+- [ ] group_by_join.mochi
+- [ ] group_by_left_join.mochi
+- [ ] group_by_multi_join.mochi
+- [ ] group_by_multi_join_sort.mochi
+- [ ] group_by_sort.mochi
+- [ ] inner_join.mochi
+- [ ] join_multi.mochi
+- [ ] json_builtin.mochi
+- [ ] left_join.mochi
+- [ ] left_join_multi.mochi
+- [ ] list_set_ops.mochi
+- [ ] load_yaml.mochi
+- [ ] order_by_map.mochi
+- [ ] outer_join.mochi
+- [ ] pure_fold.mochi
+- [ ] pure_global_fold.mochi
+- [ ] query_sum_select.mochi
+- [ ] right_join.mochi
+- [ ] save_jsonl_stdout.mochi
+- [ ] sort_stable.mochi
+- [ ] update_stmt.mochi

--- a/tests/human/x/go/math_ops.go
+++ b/tests/human/x/go/math_ops.go
@@ -1,0 +1,11 @@
+//go:build ignore
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(6 * 7)
+	fmt.Println(7 / 2)
+	fmt.Println(7 % 2)
+}

--- a/tests/human/x/go/test_block.go
+++ b/tests/human/x/go/test_block.go
@@ -1,0 +1,13 @@
+//go:build ignore
+
+package main
+
+import "fmt"
+
+func main() {
+	x := 1 + 2
+	if x != 3 {
+		panic(fmt.Sprintf("expected 3, got %d", x))
+	}
+	fmt.Println("ok")
+}

--- a/tests/human/x/go/user_type_literal.go
+++ b/tests/human/x/go/user_type_literal.go
@@ -1,0 +1,23 @@
+//go:build ignore
+
+package main
+
+import "fmt"
+
+type Person struct {
+	Name string
+	Age  int
+}
+
+type Book struct {
+	Title  string
+	Author Person
+}
+
+func main() {
+	book := Book{
+		Title:  "Go",
+		Author: Person{Name: "Bob", Age: 42},
+	}
+	fmt.Println(book.Author.Name)
+}


### PR DESCRIPTION
## Summary
- add Go versions of `math_ops`, `test_block`, and `user_type_literal`
- refresh README with checklist format and update translated list

## Testing
- `gofmt -w tests/human/x/go/*.go`


------
https://chatgpt.com/codex/tasks/task_e_686b97ee16488320af8ff13c0e24e2f2