### PR TITLE
Update cpp translation README with checklist

### DIFF
--- a/tests/human/x/cpp/README.md
+++ b/tests/human/x/cpp/README.md
@@ -1,106 +1,105 @@
 # Mochi VM Translations to C++
 
-This directory contains manual C++ versions of sample Mochi programs from
-`tests/vm/valid`. A total of 97 examples have been translated by hand.
+This directory contains manual C++ versions of sample Mochi programs from `tests/vm/valid`. A total of 97 examples have been translated by hand.
 
 ## Translated programs
-- `append_builtin`
-- `avg_builtin`
-- `basic_compare`
-- `binary_precedence`
-- `bool_chain`
-- `break_continue`
-- `cast_string_to_int`
-- `cast_struct`
-- `closure`
-- `count_builtin`
-- `cross_join`
-- `cross_join_filter`
-- `cross_join_triple`
-- `dataset_sort_take_limit`
-- `dataset_where_filter`
-- `exists_builtin`
-- `for_list_collection`
-- `for_loop`
-- `for_map_collection`
-- `fun_call`
-- `fun_expr_in_let`
-- `fun_three_args`
-- `group_by`
-- `group_by_conditional_sum`
-- `group_by_having`
-- `group_by_join`
-- `group_by_left_join`
-- `group_by_multi_join`
-- `group_by_multi_join_sort`
-- `group_by_sort`
-- `group_items_iteration`
-- `if_else`
-- `if_then_else`
-- `if_then_else_nested`
-- `in_operator`
-- `in_operator_extended`
-- `inner_join`
-- `join_multi`
-- `json_builtin`
-- `left_join`
-- `left_join_multi`
-- `len_builtin`
-- `len_map`
-- `len_string`
-- `let_and_print`
-- `list_assign`
-- `list_index`
-- `list_nested_assign`
-- `list_set_ops`
-- `load_yaml`
-- `map_assign`
-- `map_in_operator`
-- `map_index`
-- `map_int_key`
-- `map_literal_dynamic`
-- `map_membership`
-- `map_nested_assign`
-- `match_expr`
-- `match_full`
-- `math_ops`
-- `membership`
-- `min_max_builtin`
-- `nested_function`
-- `order_by_map`
-- `outer_join`
-- `partial_application`
-- `print_hello`
-- `pure_fold`
-- `pure_global_fold`
-- `query_sum_select`
-- `record_assign`
-- `right_join`
-- `save_jsonl_stdout`
-- `short_circuit`
-- `slice`
-- `sort_stable`
-- `str_builtin`
-- `string_compare`
-- `string_concat`
-- `string_contains`
-- `string_in_operator`
-- `string_index`
-- `string_prefix_slice`
-- `substring_builtin`
-- `sum_builtin`
-- `tail_recursion`
-- `test_block`
-- `tree_sum`
-- `two-sum`
-- `typed_let`
-- `typed_var`
-- `unary_neg`
-- `update_stmt`
-- `user_type_literal`
-- `values_builtin`
-- `var_assignment`
-- `while_loop`
+- [x] `append_builtin`
+- [x] `avg_builtin`
+- [x] `basic_compare`
+- [x] `binary_precedence`
+- [x] `bool_chain`
+- [x] `break_continue`
+- [x] `cast_string_to_int`
+- [x] `cast_struct`
+- [x] `closure`
+- [x] `count_builtin`
+- [x] `cross_join`
+- [x] `cross_join_filter`
+- [x] `cross_join_triple`
+- [x] `dataset_sort_take_limit`
+- [x] `dataset_where_filter`
+- [x] `exists_builtin`
+- [x] `for_list_collection`
+- [x] `for_loop`
+- [x] `for_map_collection`
+- [x] `fun_call`
+- [x] `fun_expr_in_let`
+- [x] `fun_three_args`
+- [x] `group_by`
+- [x] `group_by_conditional_sum`
+- [x] `group_by_having`
+- [x] `group_by_join`
+- [x] `group_by_left_join`
+- [x] `group_by_multi_join`
+- [x] `group_by_multi_join_sort`
+- [x] `group_by_sort`
+- [x] `group_items_iteration`
+- [x] `if_else`
+- [x] `if_then_else`
+- [x] `if_then_else_nested`
+- [x] `in_operator`
+- [x] `in_operator_extended`
+- [x] `inner_join`
+- [x] `join_multi`
+- [x] `json_builtin`
+- [x] `left_join`
+- [x] `left_join_multi`
+- [x] `len_builtin`
+- [x] `len_map`
+- [x] `len_string`
+- [x] `let_and_print`
+- [x] `list_assign`
+- [x] `list_index`
+- [x] `list_nested_assign`
+- [x] `list_set_ops`
+- [x] `load_yaml`
+- [x] `map_assign`
+- [x] `map_in_operator`
+- [x] `map_index`
+- [x] `map_int_key`
+- [x] `map_literal_dynamic`
+- [x] `map_membership`
+- [x] `map_nested_assign`
+- [x] `match_expr`
+- [x] `match_full`
+- [x] `math_ops`
+- [x] `membership`
+- [x] `min_max_builtin`
+- [x] `nested_function`
+- [x] `order_by_map`
+- [x] `outer_join`
+- [x] `partial_application`
+- [x] `print_hello`
+- [x] `pure_fold`
+- [x] `pure_global_fold`
+- [x] `query_sum_select`
+- [x] `record_assign`
+- [x] `right_join`
+- [x] `save_jsonl_stdout`
+- [x] `short_circuit`
+- [x] `slice`
+- [x] `sort_stable`
+- [x] `str_builtin`
+- [x] `string_compare`
+- [x] `string_concat`
+- [x] `string_contains`
+- [x] `string_in_operator`
+- [x] `string_index`
+- [x] `string_prefix_slice`
+- [x] `substring_builtin`
+- [x] `sum_builtin`
+- [x] `tail_recursion`
+- [x] `test_block`
+- [x] `tree_sum`
+- [x] `two-sum`
+- [x] `typed_let`
+- [x] `typed_var`
+- [x] `unary_neg`
+- [x] `update_stmt`
+- [x] `user_type_literal`
+- [x] `values_builtin`
+- [x] `var_assignment`
+- [x] `while_loop`
 
 ## Missing programs
 


### PR DESCRIPTION
## Summary
- convert `tests/human/x/cpp/README.md` program list to a Markdown checklist

## Testing
- `make lint` *(fails: unused funcs)*
- `make fmt`
- `make test STAGE=parser`
- `make test STAGE=types`


------
https://chatgpt.com/codex/tasks/task_e_686b9812e3848320901349e8accec618