### PR TITLE
Add tree_sum Fortran example

### DIFF
--- a/tests/human/x/fortran/README.md
+++ b/tests/human/x/fortran/README.md
@@ -1,102 +1,102 @@
 # Mochi to Fortran Translations
 
 ## Translated
-- append_builtin
-- avg_builtin
-- basic_compare
-- binary_precedence
-- bool_chain
-- break_continue
-- cast_string_to_int
-- cast_struct
-- closure
-- count_builtin
-- cross_join
-- cross_join_filter
-- cross_join_triple
-- dataset_sort_take_limit
-- dataset_where_filter
-- exists_builtin
-- for_list_collection
-- for_loop
-- for_map_collection
-- fun_call
-- fun_expr_in_let
-- fun_three_args
-- group_by
-- if_else
-- if_then_else
-- if_then_else_nested
-- in_operator
-- len_builtin
-- len_map
-- len_string
-- let_and_print
-- list_assign
-- list_index
-- list_nested_assign
-- map_assign
-- map_index
-- map_int_key
-- map_nested_assign
-- match_expr
-- math_ops
-- membership
-- min_max_builtin
-- print_hello
-- record_assign
-- short_circuit
-- slice
-- str_builtin
-- string_compare
-- string_concat
-- string_contains
-- string_in_operator
-- string_index
-- string_prefix_slice
-- substring_builtin
-- sum_builtin
-- tail_recursion
-- two-sum
-- typed_let
-- typed_var
-- unary_neg
-- values_builtin
-- var_assignment
-- while_loop
+- [x] append_builtin
+- [x] avg_builtin
+- [x] basic_compare
+- [x] binary_precedence
+- [x] bool_chain
+- [x] break_continue
+- [x] cast_string_to_int
+- [x] cast_struct
+- [x] closure
+- [x] count_builtin
+- [x] cross_join
+- [x] cross_join_filter
+- [x] cross_join_triple
+- [x] dataset_sort_take_limit
+- [x] dataset_where_filter
+- [x] exists_builtin
+- [x] for_list_collection
+- [x] for_loop
+- [x] for_map_collection
+- [x] fun_call
+- [x] fun_expr_in_let
+- [x] fun_three_args
+- [x] group_by
+- [x] if_else
+- [x] if_then_else
+- [x] if_then_else_nested
+- [x] in_operator
+- [x] len_builtin
+- [x] len_map
+- [x] len_string
+- [x] let_and_print
+- [x] list_assign
+- [x] list_index
+- [x] list_nested_assign
+- [x] map_assign
+- [x] map_index
+- [x] map_int_key
+- [x] map_nested_assign
+- [x] match_expr
+- [x] math_ops
+- [x] membership
+- [x] min_max_builtin
+- [x] print_hello
+- [x] record_assign
+- [x] short_circuit
+- [x] slice
+- [x] str_builtin
+- [x] string_compare
+- [x] string_concat
+- [x] string_contains
+- [x] string_in_operator
+- [x] string_index
+- [x] string_prefix_slice
+- [x] substring_builtin
+- [x] sum_builtin
+- [x] tail_recursion
+- [x] tree_sum
+- [x] two-sum
+- [x] typed_let
+- [x] typed_var
+- [x] unary_neg
+- [x] values_builtin
+- [x] var_assignment
+- [x] while_loop
 
 ## Missing
-- group_by_conditional_sum
-- group_by_having
-- group_by_join
-- group_by_left_join
-- group_by_multi_join
-- group_by_multi_join_sort
-- group_by_sort
-- group_items_iteration
-- in_operator_extended
-- inner_join
-- join_multi
-- json_builtin
-- left_join
-- left_join_multi
-- list_set_ops
-- load_yaml
-- map_in_operator
-- map_literal_dynamic
-- map_membership
-- match_full
-- nested_function
-- order_by_map
-- outer_join
-- partial_application
-- pure_fold
-- pure_global_fold
-- query_sum_select
-- right_join
-- save_jsonl_stdout
-- sort_stable
-- test_block
-- tree_sum
-- update_stmt
-- user_type_literal
+- [ ] group_by_conditional_sum
+- [ ] group_by_having
+- [ ] group_by_join
+- [ ] group_by_left_join
+- [ ] group_by_multi_join
+- [ ] group_by_multi_join_sort
+- [ ] group_by_sort
+- [ ] group_items_iteration
+- [ ] in_operator_extended
+- [ ] inner_join
+- [ ] join_multi
+- [ ] json_builtin
+- [ ] left_join
+- [ ] left_join_multi
+- [ ] list_set_ops
+- [ ] load_yaml
+- [ ] map_in_operator
+- [ ] map_literal_dynamic
+- [ ] map_membership
+- [ ] match_full
+- [ ] nested_function
+- [ ] order_by_map
+- [ ] outer_join
+- [ ] partial_application
+- [ ] pure_fold
+- [ ] pure_global_fold
+- [ ] query_sum_select
+- [ ] right_join
+- [ ] save_jsonl_stdout
+- [ ] sort_stable
+- [ ] test_block
+- [ ] update_stmt
+- [ ] user_type_literal

--- a/tests/human/x/fortran/tree_sum.f90
+++ b/tests/human/x/fortran/tree_sum.f90
@@ -1,0 +1,36 @@
+program tree_sum
+  implicit none
+  type Tree
+     logical :: isLeaf = .true.
+     integer :: value = 0
+     type(Tree), pointer :: left => null()
+     type(Tree), pointer :: right => null()
+  end type Tree
+
+  type(Tree), target :: leaf
+  type(Tree), target :: t, nodeRight
+
+  ! Node right: Node(Leaf,2,Leaf)
+  nodeRight%isLeaf = .false.
+  nodeRight%value = 2
+  nodeRight%left => leaf
+  nodeRight%right => leaf
+
+  ! root node: Node(Leaf,1,nodeRight)
+  t%isLeaf = .false.
+  t%value = 1
+  t%left => leaf
+  t%right => nodeRight
+
+  print *, sum_tree(t)
+
+contains
+  recursive integer function sum_tree(node) result(res)
+    type(Tree), intent(in) :: node
+    if (node%isLeaf) then
+      res = 0
+    else
+      res = sum_tree(node%left) + node%value + sum_tree(node%right)
+    end if
+  end function sum_tree
+end program tree_sum


### PR DESCRIPTION
## Summary
- translate `tree_sum.mochi` into Fortran
- reformat Fortran README with checklist style and include new program

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_686b9839072083209f0ba3b418510bea