### PR TITLE
Add group_by_having OCaml example

### DIFF
--- a/tests/human/x/ocaml/README.md
+++ b/tests/human/x/ocaml/README.md
@@ -28,7 +28,7 @@ The table below shows which Mochi examples have been translated (`[x]`) and whic
 - [x] fun_three_args.mochi
 - [x] group_by.mochi
 - [x] group_by_conditional_sum.mochi
-- [ ] group_by_having.mochi
+- [x] group_by_having.mochi
 - [ ] group_by_join.mochi
 - [ ] group_by_left_join.mochi
 - [ ] group_by_multi_join.mochi
@@ -65,7 +65,7 @@ The table below shows which Mochi examples have been translated (`[x]`) and whic
 - [x] match_full.mochi
 - [x] math_ops.mochi
 - [x] membership.mochi
- - [x] min_max_builtin.mochi
+- [x] min_max_builtin.mochi
 - [x] nested_function.mochi
 - [x] order_by_map.mochi
 - [ ] outer_join.mochi

--- a/tests/human/x/ocaml/group_by_having.ml
+++ b/tests/human/x/ocaml/group_by_having.ml
@@ -1,0 +1,29 @@
+let people = [
+  ("Alice", "Paris");
+  ("Bob", "Hanoi");
+  ("Charlie", "Paris");
+  ("Diana", "Hanoi");
+  ("Eve", "Paris");
+  ("Frank", "Hanoi");
+  ("George", "Paris")
+]
+
+let add map city =
+  let count = try List.assoc city map with Not_found -> 0 in
+  (city, count + 1) :: List.remove_assoc city map
+
+let grouped =
+  List.fold_left (fun m (_,city) -> add m city) [] people
+
+let big = List.filter (fun (_,count) -> count >= 4) grouped
+
+let json_of_groups lst =
+  "[" ^
+  String.concat ", " (
+    List.map (fun (city,count) ->
+      Printf.sprintf "{\"city\":\"%s\",\"num\":%d}" city count
+    ) lst)
+  ^ "]"
+
+let () =
+  print_endline (json_of_groups big)


### PR DESCRIPTION
## Summary
- add OCaml version of `group_by_having.mochi`
- update checklist in OCaml README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b984287e48320bc322ef277b83914