### PR TITLE
Add more Racket translations

### DIFF
--- a/tests/human/x/racket/README.md
+++ b/tests/human/x/racket/README.md
@@ -2,103 +2,101 @@
 
 This directory contains manual Racket translations of programs from `tests/vm/valid`.
 
-## Translated
-- append_builtin.mochi
-- avg_builtin.mochi
-- basic_compare.mochi
-- binary_precedence.mochi
-- bool_chain.mochi
-- break_continue.mochi
-- cast_string_to_int.mochi
-- cast_struct.mochi
-- closure.mochi
-- count_builtin.mochi
-- cross_join.mochi
-- cross_join_filter.mochi
-- cross_join_triple.mochi
-- dataset_sort_take_limit.mochi
-- dataset_where_filter.mochi
-- exists_builtin.mochi
-- for_list_collection.mochi
-- for_loop.mochi
-- for_map_collection.mochi
-- fun_call.mochi
-- fun_expr_in_let.mochi
-- fun_three_args.mochi
-- if_else.mochi
-- let_and_print.mochi
-- print_hello.mochi
-- string_concat.mochi
-- sum_builtin.mochi
-- unary_neg.mochi
-- len_builtin.mochi
-- len_map.mochi
-- len_string.mochi
-- list_assign.mochi
-- list_index.mochi
-- list_nested_assign.mochi
-- list_set_ops.mochi
-- map_assign.mochi
-- map_in_operator.mochi
-- map_index.mochi
-- map_int_key.mochi
-- map_literal_dynamic.mochi
-- map_membership.mochi
-- map_nested_assign.mochi
-- match_expr.mochi
-- match_full.mochi
-- math_ops.mochi
-- membership.mochi
-- min_max_builtin.mochi
-- nested_function.mochi
-- partial_application.mochi
-- pure_fold.mochi
-- pure_global_fold.mochi
-- query_sum_select.mochi
-- record_assign.mochi
-- short_circuit.mochi
-- slice.mochi
-- sort_stable.mochi
-- str_builtin.mochi
-- string_compare.mochi
-- string_contains.mochi
-- string_in_operator.mochi
-- string_index.mochi
-- string_prefix_slice.mochi
-- substring_builtin.mochi
-- tail_recursion.mochi
-- test_block.mochi
-- tree_sum.mochi
-- two-sum.mochi
-- typed_let.mochi
-- typed_var.mochi
-- user_type_literal.mochi
-- values_builtin.mochi
-- var_assignment.mochi
-- while_loop.mochi
-
-## Missing
-- group_by.mochi
-- group_by_conditional_sum.mochi
-- group_by_having.mochi
-- group_by_join.mochi
-- group_by_left_join.mochi
-- group_by_multi_join.mochi
-- group_by_multi_join_sort.mochi
-- group_by_sort.mochi
-- group_items_iteration.mochi
-- if_then_else.mochi
-- if_then_else_nested.mochi
-- in_operator.mochi
-- in_operator_extended.mochi
-- inner_join.mochi
-- join_multi.mochi
-- json_builtin.mochi
-- left_join.mochi
-- left_join_multi.mochi
-- load_yaml.mochi
-- order_by_map.mochi
-- outer_join.mochi
-- right_join.mochi
-- save_jsonl_stdout.mochi
-- update_stmt.mochi
+## Checklist
+- [x] append_builtin.mochi
+- [x] avg_builtin.mochi
+- [x] basic_compare.mochi
+- [x] binary_precedence.mochi
+- [x] bool_chain.mochi
+- [x] break_continue.mochi
+- [x] cast_string_to_int.mochi
+- [x] cast_struct.mochi
+- [x] closure.mochi
+- [x] count_builtin.mochi
+- [x] cross_join.mochi
+- [x] cross_join_filter.mochi
+- [x] cross_join_triple.mochi
+- [x] dataset_sort_take_limit.mochi
+- [x] dataset_where_filter.mochi
+- [x] exists_builtin.mochi
+- [x] for_list_collection.mochi
+- [x] for_loop.mochi
+- [x] for_map_collection.mochi
+- [x] fun_call.mochi
+- [x] fun_expr_in_let.mochi
+- [x] fun_three_args.mochi
+- [x] if_else.mochi
+- [x] if_then_else.mochi
+- [x] if_then_else_nested.mochi
+- [x] in_operator.mochi
+- [x] in_operator_extended.mochi
+- [x] json_builtin.mochi
+- [x] len_builtin.mochi
+- [x] len_map.mochi
+- [x] len_string.mochi
+- [x] let_and_print.mochi
+- [x] list_assign.mochi
+- [x] list_index.mochi
+- [x] list_nested_assign.mochi
+- [x] list_set_ops.mochi
+- [x] map_assign.mochi
+- [x] map_in_operator.mochi
+- [x] map_index.mochi
+- [x] map_int_key.mochi
+- [x] map_literal_dynamic.mochi
+- [x] map_membership.mochi
+- [x] map_nested_assign.mochi
+- [x] match_expr.mochi
+- [x] match_full.mochi
+- [x] math_ops.mochi
+- [x] membership.mochi
+- [x] min_max_builtin.mochi
+- [x] nested_function.mochi
+- [x] partial_application.mochi
+- [x] print_hello.mochi
+- [x] pure_fold.mochi
+- [x] pure_global_fold.mochi
+- [x] query_sum_select.mochi
+- [x] record_assign.mochi
+- [x] short_circuit.mochi
+- [x] slice.mochi
+- [x] sort_stable.mochi
+- [x] str_builtin.mochi
+- [x] string_compare.mochi
+- [x] string_concat.mochi
+- [x] string_contains.mochi
+- [x] string_in_operator.mochi
+- [x] string_index.mochi
+- [x] string_prefix_slice.mochi
+- [x] substring_builtin.mochi
+- [x] sum_builtin.mochi
+- [x] tail_recursion.mochi
+- [x] test_block.mochi
+- [x] tree_sum.mochi
+- [x] two-sum.mochi
+- [x] typed_let.mochi
+- [x] typed_var.mochi
+- [x] unary_neg.mochi
+- [x] user_type_literal.mochi
+- [x] values_builtin.mochi
+- [x] var_assignment.mochi
+- [x] while_loop.mochi
+- [ ] group_by.mochi
+- [ ] group_by_conditional_sum.mochi
+- [ ] group_by_having.mochi
+- [ ] group_by_join.mochi
+- [ ] group_by_left_join.mochi
+- [ ] group_by_multi_join.mochi
+- [ ] group_by_multi_join_sort.mochi
+- [ ] group_by_sort.mochi
+- [ ] group_items_iteration.mochi
+- [ ] inner_join.mochi
+- [ ] join_multi.mochi
+- [ ] left_join.mochi
+- [ ] left_join_multi.mochi
+- [ ] load_yaml.mochi
+- [ ] order_by_map.mochi
+- [ ] outer_join.mochi
+- [ ] right_join.mochi
+- [ ] save_jsonl_stdout.mochi
+- [ ] update_stmt.mochi

--- a/tests/human/x/racket/if_then_else.rkt
+++ b/tests/human/x/racket/if_then_else.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(define x 12)
+(define msg (if (> x 10) "yes" "no"))
+(displayln msg)

--- a/tests/human/x/racket/if_then_else_nested.rkt
+++ b/tests/human/x/racket/if_then_else_nested.rkt
@@ -1,0 +1,6 @@
+#lang racket
+(define x 8)
+(define msg (if (> x 10)
+                "big"
+                (if (> x 5) "medium" "small")))
+(displayln msg)

--- a/tests/human/x/racket/in_operator.rkt
+++ b/tests/human/x/racket/in_operator.rkt
@@ -1,0 +1,6 @@
+#lang racket
+(require racket/list)
+(define xs '(1 2 3))
+(define (in-list? x lst) (if (member x lst) #t #f))
+(displayln (in-list? 2 xs))
+(displayln (not (in-list? 5 xs)))

--- a/tests/human/x/racket/in_operator_extended.rkt
+++ b/tests/human/x/racket/in_operator_extended.rkt
@@ -1,0 +1,13 @@
+#lang racket
+(require racket/list racket/string)
+(define xs '(1 2 3))
+(define ys (filter odd? xs))
+(define (in-list? x lst) (if (member x lst) #t #f))
+(displayln (in-list? 1 ys))
+(displayln (in-list? 2 ys))
+(define m (hash 'a 1))
+(displayln (hash-has-key? m 'a))
+(displayln (hash-has-key? m 'b))
+(define s "hello")
+(displayln (string-contains? s "ell"))
+(displayln (string-contains? s "foo"))

--- a/tests/human/x/racket/json_builtin.rkt
+++ b/tests/human/x/racket/json_builtin.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(require json)
+(define m (hash 'a 1 'b 2))
+(displayln (jsexpr->string m))


### PR DESCRIPTION
## Summary
- add more manual Racket versions of Mochi programs
- update the Racket checklist

## Testing
- `grep -c '^-' tests/human/x/racket/README.md`

------
https://chatgpt.com/codex/tasks/task_e_686b984f0bec8320816e2c8bb6acce74