### PR TITLE
Add Go translations and update checklist

### DIFF
--- a/tests/human/x/go/README.md
+++ b/tests/human/x/go/README.md
@@ -1,8 +1,7 @@
 # Go Translations of Mochi Programs
 
-This directory contains manual Go translations of Mochi programs from `tests/vm/valid`.
+The following checklist tracks which programs from `tests/vm/valid` have manual Go translations.
 
-## Translated
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -26,12 +25,24 @@ This directory contains manual Go translations of Mochi programs from `tests/vm/
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
 - [x] group_by.mochi
+- [ ] group_by_conditional_sum.mochi
+- [ ] group_by_having.mochi
+- [ ] group_by_join.mochi
+- [ ] group_by_left_join.mochi
+- [ ] group_by_multi_join.mochi
+- [ ] group_by_multi_join_sort.mochi
+- [ ] group_by_sort.mochi
 - [x] group_items_iteration.mochi
 - [x] if_else.mochi
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
 - [x] in_operator.mochi
 - [x] in_operator_extended.mochi
+- [ ] inner_join.mochi
+- [ ] join_multi.mochi
+- [x] json_builtin.mochi
+- [ ] left_join.mochi
+- [ ] left_join_multi.mochi
 - [x] len_builtin.mochi
 - [x] len_map.mochi
 - [x] len_string.mochi
@@ -39,6 +50,8 @@ This directory contains manual Go translations of Mochi programs from `tests/vm/
 - [x] list_assign.mochi
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
+- [x] list_set_ops.mochi
+- [ ] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi
@@ -52,11 +65,19 @@ This directory contains manual Go translations of Mochi programs from `tests/vm/
 - [x] membership.mochi
 - [x] min_max_builtin.mochi
 - [x] nested_function.mochi
+- [ ] order_by_map.mochi
+- [ ] outer_join.mochi
 - [x] partial_application.mochi
 - [x] print_hello.mochi
+- [ ] pure_fold.mochi
+- [ ] pure_global_fold.mochi
+- [ ] query_sum_select.mochi
 - [x] record_assign.mochi
+- [ ] right_join.mochi
+- [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
 - [x] slice.mochi
+- [x] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi
@@ -73,32 +94,8 @@ This directory contains manual Go translations of Mochi programs from `tests/vm/
 - [x] typed_let.mochi
 - [x] typed_var.mochi
 - [x] unary_neg.mochi
+- [ ] update_stmt.mochi
 - [x] user_type_literal.mochi
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
-
-## Missing
-- [ ] group_by_conditional_sum.mochi
-- [ ] group_by_having.mochi
-- [ ] group_by_join.mochi
-- [ ] group_by_left_join.mochi
-- [ ] group_by_multi_join.mochi
-- [ ] group_by_multi_join_sort.mochi
-- [ ] group_by_sort.mochi
-- [ ] inner_join.mochi
-- [ ] join_multi.mochi
-- [ ] json_builtin.mochi
-- [ ] left_join.mochi
-- [ ] left_join_multi.mochi
-- [ ] list_set_ops.mochi
-- [ ] load_yaml.mochi
-- [ ] order_by_map.mochi
-- [ ] outer_join.mochi
-- [ ] pure_fold.mochi
-- [ ] pure_global_fold.mochi
-- [ ] query_sum_select.mochi
-- [ ] right_join.mochi
-- [ ] save_jsonl_stdout.mochi
-- [ ] sort_stable.mochi
-- [ ] update_stmt.mochi

--- a/tests/human/x/go/json_builtin.go
+++ b/tests/human/x/go/json_builtin.go
@@ -1,0 +1,14 @@
+//go:build ignore
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func main() {
+	m := map[string]int{"a": 1, "b": 2}
+	b, _ := json.Marshal(m)
+	fmt.Println(string(b))
+}

--- a/tests/human/x/go/list_set_ops.go
+++ b/tests/human/x/go/list_set_ops.go
@@ -1,0 +1,60 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+)
+
+func union(a, b []int) []int {
+	m := make(map[int]bool)
+	for _, v := range a {
+		m[v] = true
+	}
+	for _, v := range b {
+		if !m[v] {
+			a = append(a, v)
+			m[v] = true
+		}
+	}
+	return a
+}
+
+func except(a, b []int) []int {
+	m := make(map[int]bool)
+	for _, v := range b {
+		m[v] = true
+	}
+	var r []int
+	for _, v := range a {
+		if !m[v] {
+			r = append(r, v)
+		}
+	}
+	return r
+}
+
+func intersect(a, b []int) []int {
+	m := make(map[int]bool)
+	for _, v := range b {
+		m[v] = true
+	}
+	var r []int
+	for _, v := range a {
+		if m[v] {
+			r = append(r, v)
+		}
+	}
+	return r
+}
+
+func unionAll(a, b []int) []int {
+	return append(append([]int{}, a...), b...)
+}
+
+func main() {
+	fmt.Println(union([]int{1, 2}, []int{2, 3}))
+	fmt.Println(except([]int{1, 2, 3}, []int{2}))
+	fmt.Println(intersect([]int{1, 2, 3}, []int{2, 4}))
+	fmt.Println(len(unionAll([]int{1, 2}, []int{2, 3})))
+}

--- a/tests/human/x/go/sort_stable.go
+++ b/tests/human/x/go/sort_stable.go
@@ -1,0 +1,23 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+type item struct {
+	n int
+	v string
+}
+
+func main() {
+	items := []item{{1, "a"}, {1, "b"}, {2, "c"}}
+	sort.SliceStable(items, func(i, j int) bool { return items[i].n < items[j].n })
+	var result []string
+	for _, it := range items {
+		result = append(result, it.v)
+	}
+	fmt.Println(result)
+}


### PR DESCRIPTION
## Summary
- add missing Go translations for `json_builtin`, `list_set_ops`, and `sort_stable`
- reformat Go README as a single checklist and mark new translations

## Testing
- `gofmt -w tests/human/x/go/json_builtin.go tests/human/x/go/list_set_ops.go tests/human/x/go/sort_stable.go`

------
https://chatgpt.com/codex/tasks/task_e_686b996425dc8320ab770aba9b101ab4