### PR TITLE
Add missing OCaml translations

### DIFF
--- a/tests/human/x/ocaml/README.md
+++ b/tests/human/x/ocaml/README.md
@@ -31,8 +31,8 @@ The table below shows which Mochi examples have been translated (`[x]`) and whic
 - [x] group_by_having.mochi
 - [x] group_by_join.mochi
 - [x] group_by_left_join.mochi
-- [ ] group_by_multi_join.mochi
-- [ ] group_by_multi_join_sort.mochi
+- [x] group_by_multi_join.mochi
+- [x] group_by_multi_join_sort.mochi
 - [x] group_by_sort.mochi
 - [x] group_items_iteration.mochi
 - [x] if_else.mochi
@@ -53,7 +53,7 @@ The table below shows which Mochi examples have been translated (`[x]`) and whic
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
 - [x] list_set_ops.mochi
-- [ ] load_yaml.mochi
+- [x] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi

--- a/tests/human/x/ocaml/group_by_multi_join.ml
+++ b/tests/human/x/ocaml/group_by_multi_join.ml
@@ -1,0 +1,44 @@
+(* Hand-written OCaml version of group_by_multi_join.mochi *)
+
+type nation = { id : int; name : string }
+let nations = [
+  { id = 1; name = "A" };
+  { id = 2; name = "B" };
+]
+
+type supplier = { id : int; nation : int }
+let suppliers = [
+  { id = 1; nation = 1 };
+  { id = 2; nation = 2 };
+]
+
+type partsupp = { part : int; supplier : int; cost : float; qty : int }
+let partsupp = [
+  { part = 100; supplier = 1; cost = 10.0; qty = 2 };
+  { part = 100; supplier = 2; cost = 20.0; qty = 1 };
+  { part = 200; supplier = 1; cost = 5.0; qty = 3 };
+]
+
+(* join nations and suppliers then filter *)
+let filtered =
+  List.fold_left (fun acc ps ->
+    let s = List.find (fun s -> s.id = ps.supplier) suppliers in
+    let n = List.find (fun n -> n.id = s.nation) nations in
+    if n.name = "A" then
+      let value = ps.cost *. float_of_int ps.qty in
+      (ps.part, value) :: acc
+    else acc
+  ) [] partsupp
+  |> List.rev
+
+(* group by part and sum values *)
+let totals =
+  List.fold_left (fun map (part, value) ->
+    let cur = try List.assoc part map with Not_found -> 0.0 in
+    (part, cur +. value) :: List.remove_assoc part map
+  ) [] filtered
+
+let () =
+  List.iter (fun (part,total) ->
+    Printf.printf "{part=%d; total=%g}\n" part total
+  ) totals

--- a/tests/human/x/ocaml/group_by_multi_join_sort.ml
+++ b/tests/human/x/ocaml/group_by_multi_join_sort.ml
@@ -1,0 +1,80 @@
+(* Hand-written OCaml version of group_by_multi_join_sort.mochi *)
+
+type nation = { n_nationkey:int; n_name:string }
+let nation = [ { n_nationkey=1; n_name="BRAZIL" } ]
+
+type customer = {
+  c_custkey:int; c_name:string; c_acctbal:float; c_nationkey:int;
+  c_address:string; c_phone:string; c_comment:string }
+let customer = [
+  { c_custkey=1; c_name="Alice"; c_acctbal=100.0; c_nationkey=1;
+    c_address="123 St"; c_phone="123-456"; c_comment="Loyal" }
+]
+
+type order = { o_orderkey:int; o_custkey:int; o_orderdate:string }
+let orders = [
+  { o_orderkey=1000; o_custkey=1; o_orderdate="1993-10-15" };
+  { o_orderkey=2000; o_custkey=1; o_orderdate="1994-01-02" };
+]
+
+type lineitem = {
+  l_orderkey:int; l_returnflag:string; l_extendedprice:float; l_discount:float }
+let lineitem = [
+  { l_orderkey=1000; l_returnflag="R"; l_extendedprice=1000.0; l_discount=0.1 };
+  { l_orderkey=2000; l_returnflag="N"; l_extendedprice=500.0; l_discount=0.0 };
+]
+
+let start_date = "1993-10-01"
+let end_date   = "1994-01-01"
+
+(* collect all joined rows that satisfy filters *)
+type row = { c:customer; o:order; l:lineitem; n:nation }
+
+let rows =
+  List.fold_left (fun acc c ->
+    let os = List.filter (fun o -> o.o_custkey = c.c_custkey) orders in
+    List.fold_left (fun acc o ->
+      let ls = List.filter (fun l -> l.l_orderkey = o.o_orderkey) lineitem in
+      List.fold_left (fun acc l ->
+        let ns = List.filter (fun n -> n.n_nationkey = c.c_nationkey) nation in
+        List.fold_left (fun acc n ->
+          if o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag = "R" then
+            {c;c_address=c.c_address;o;l;n} :: acc
+          else acc
+        ) acc ns
+      ) acc ls
+    ) acc os
+  ) [] customer
+  |> List.rev
+
+(* group by customer/nation info *)
+let add_group map row =
+  let key = (row.c.c_custkey, row.c.c_name, row.c.c_acctbal,
+             row.c.c_address, row.c.c_phone, row.c.c_comment,
+             row.n.n_name) in
+  let lst = try List.assoc key map with Not_found -> [] in
+  (key, row :: lst) :: List.remove_assoc key map
+
+let groups = List.fold_left add_group [] rows
+
+(* compute revenue and build result records *)
+type result = {
+  c_custkey:int; c_name:string; revenue:float; c_acctbal:float;
+  n_name:string; c_address:string; c_phone:string; c_comment:string }
+
+let results =
+  groups
+  |> List.map (fun (key, lst) ->
+       let revenue =
+         List.fold_left (fun s r -> s +.
+           r.l.l_extendedprice *. (1. -. r.l.l_discount)) 0.0 lst in
+       let (ck,cn,cb,ca,cp,cc,nn) = key in
+       { c_custkey=ck; c_name=cn; revenue; c_acctbal=cb;
+         n_name=nn; c_address=ca; c_phone=cp; c_comment=cc })
+  |> List.sort (fun a b -> compare b.revenue a.revenue)
+
+let () =
+  List.iter (fun r ->
+    Printf.printf "{c_custkey=%d; c_name=%s; revenue=%g; c_acctbal=%g; n_name=%s; c_address=%s; c_phone=%s; c_comment=%s}\n"
+      r.c_custkey r.c_name r.revenue r.c_acctbal r.n_name r.c_address r.c_phone r.c_comment
+  ) results

--- a/tests/human/x/ocaml/load_yaml.ml
+++ b/tests/human/x/ocaml/load_yaml.ml
@@ -1,0 +1,45 @@
+(* Hand-written OCaml version of load_yaml.mochi *)
+
+(* simple parser for the YAML file used in the example *)
+
+type person = { name:string; age:int; email:string }
+
+let parse_people path =
+  let ic = open_in path in
+  let rec loop acc current =
+    match input_line ic with
+    | line ->
+        let line = String.trim line in
+        if line = "" then loop acc current
+        else
+          let idx = try String.index line ':' with Not_found -> -1 in
+          if idx < 0 then loop acc current else
+          let key = String.sub line 0 idx |> String.trim in
+          let value = String.sub line (idx+1) (String.length line - idx - 1) |> String.trim in
+          if key = "- name" then
+            let acc = (match current with None -> acc | Some p -> p :: acc) in
+            let p = { name=value; age=0; email="" } in
+            loop acc (Some p)
+          else if key = "age" then
+            let current = match current with
+              | None -> { name=""; age=int_of_string value; email="" }
+              | Some p -> { p with age=int_of_string value } in
+            loop acc (Some current)
+          else if key = "email" then
+            let current = match current with
+              | None -> { name=""; age=0; email=value }
+              | Some p -> { p with email=value } in
+            loop acc (Some current)
+          else loop acc current
+    | exception End_of_file ->
+        close_in ic;
+        let acc = match current with None -> acc | Some p -> p :: acc in
+        List.rev acc
+  in
+  loop [] None
+
+let () =
+  let people = parse_people "tests/interpreter/valid/people.yaml" in
+  List.iter (fun p ->
+    if p.age >= 18 then Printf.printf "%s %s\n" p.name p.email
+  ) people


### PR DESCRIPTION
## Summary
- add OCaml versions of `group_by_multi_join`, `group_by_multi_join_sort` and `load_yaml`
- update OCaml README checklist

## Testing
- `make fmt`
- `make lint` *(fails: unused functions and other issues)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b9cc5451483208fecdc303b178535