### PR TITLE
Add new Scheme translations

### DIFF
--- a/tests/human/x/scheme/README.md
+++ b/tests/human/x/scheme/README.md
@@ -3,7 +3,7 @@
 This directory contains manual Scheme implementations of the programs found in
 `tests/vm/valid`.
 
-## Checklist (47/97 translated)
+## Checklist (49/97 translated)
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -39,7 +39,7 @@ This directory contains manual Scheme implementations of the programs found in
 - [x] if_else.mochi
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
-- [ ] in_operator.mochi
+- [x] in_operator.mochi
 - [ ] in_operator_extended.mochi
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi
@@ -82,7 +82,7 @@ This directory contains manual Scheme implementations of the programs found in
 - [ ] slice.mochi
 - [ ] sort_stable.mochi
 - [ ] str_builtin.mochi
-- [ ] string_compare.mochi
+- [x] string_compare.mochi
 - [x] string_concat.mochi
 - [x] string_contains.mochi
 - [x] string_in_operator.mochi

--- a/tests/human/x/scheme/in_operator.scm
+++ b/tests/human/x/scheme/in_operator.scm
@@ -1,0 +1,5 @@
+(define xs '(1 2 3))
+(display (if (member 2 xs) "true" "false"))
+(newline)
+(display (if (not (member 5 xs)) "true" "false"))
+(newline)

--- a/tests/human/x/scheme/string_compare.scm
+++ b/tests/human/x/scheme/string_compare.scm
@@ -1,0 +1,8 @@
+(display (if (string<? "a" "b") "true" "false"))
+(newline)
+(display (if (string<=? "a" "a") "true" "false"))
+(newline)
+(display (if (string>? "b" "a") "true" "false"))
+(newline)
+(display (if (string>=? "b" "b") "true" "false"))
+(newline)


### PR DESCRIPTION
## Summary
- add manual Scheme versions of `in_operator` and `string_compare`
- mark them in the Scheme README and update translation count

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ba27829648320bd16c8c94335bd55