### PR TITLE
Add Scheme translations for some Mochi programs

### DIFF
--- a/tests/human/scheme/README.md
+++ b/tests/human/scheme/README.md
@@ -1,0 +1,105 @@
+# Scheme translations for Mochi programs
+
+The following checklist tracks which `tests/vm/valid/*.mochi` programs have been
+manually rewritten in Scheme. Checked items have a corresponding `.scm` file in
+this directory.
+
+## Status
+
+- [x] append_builtin.mochi
+- [x] avg_builtin.mochi
+- [x] basic_compare.mochi
+- [x] binary_precedence.mochi
+- [x] bool_chain.mochi
+- [x] cast_string_to_int.mochi
+- [x] closure.mochi
+- [x] count_builtin.mochi
+- [x] for_list_collection.mochi
+- [x] for_loop.mochi
+- [x] fun_call.mochi
+- [x] print_hello.mochi
+- [x] str_builtin.mochi
+- [x] string_concat.mochi
+- [x] string_contains.mochi
+- [x] string_index.mochi
+- [x] substring_builtin.mochi
+- [x] sum_builtin.mochi
+- [x] tail_recursion.mochi
+- [x] typed_let.mochi
+- [x] typed_var.mochi
+- [x] unary_neg.mochi
+- [x] var_assignment.mochi
+- [x] while_loop.mochi
+- [ ] break_continue.mochi
+- [ ] cast_struct.mochi
+- [ ] cross_join.mochi
+- [ ] cross_join_filter.mochi
+- [ ] cross_join_triple.mochi
+- [ ] dataset_sort_take_limit.mochi
+- [ ] dataset_where_filter.mochi
+- [ ] exists_builtin.mochi
+- [ ] for_map_collection.mochi
+- [ ] fun_expr_in_let.mochi
+- [ ] fun_three_args.mochi
+- [ ] group_by.mochi
+- [ ] group_by_conditional_sum.mochi
+- [ ] group_by_having.mochi
+- [ ] group_by_join.mochi
+- [ ] group_by_left_join.mochi
+- [ ] group_by_multi_join.mochi
+- [ ] group_by_multi_join_sort.mochi
+- [ ] group_by_sort.mochi
+- [ ] group_items_iteration.mochi
+- [ ] if_else.mochi
+- [ ] if_then_else.mochi
+- [ ] if_then_else_nested.mochi
+- [ ] in_operator.mochi
+- [ ] in_operator_extended.mochi
+- [ ] inner_join.mochi
+- [ ] join_multi.mochi
+- [ ] json_builtin.mochi
+- [ ] left_join.mochi
+- [ ] left_join_multi.mochi
+- [ ] len_builtin.mochi
+- [ ] len_map.mochi
+- [ ] len_string.mochi
+- [ ] let_and_print.mochi
+- [ ] list_assign.mochi
+- [ ] list_index.mochi
+- [ ] list_nested_assign.mochi
+- [ ] list_set_ops.mochi
+- [ ] load_yaml.mochi
+- [ ] map_assign.mochi
+- [ ] map_in_operator.mochi
+- [ ] map_index.mochi
+- [ ] map_int_key.mochi
+- [ ] map_literal_dynamic.mochi
+- [ ] map_membership.mochi
+- [ ] map_nested_assign.mochi
+- [ ] match_expr.mochi
+- [ ] match_full.mochi
+- [ ] math_ops.mochi
+- [ ] membership.mochi
+- [ ] min_max_builtin.mochi
+- [ ] nested_function.mochi
+- [ ] order_by_map.mochi
+- [ ] outer_join.mochi
+- [ ] partial_application.mochi
+- [ ] pure_fold.mochi
+- [ ] pure_global_fold.mochi
+- [ ] query_sum_select.mochi
+- [ ] record_assign.mochi
+- [ ] right_join.mochi
+- [ ] save_jsonl_stdout.mochi
+- [ ] short_circuit.mochi
+- [ ] slice.mochi
+- [ ] sort_stable.mochi
+- [ ] string_compare.mochi
+- [ ] string_in_operator.mochi
+- [ ] string_prefix_slice.mochi
+- [ ] test_block.mochi
+- [ ] tree_sum.mochi
+- [ ] two-sum.mochi
+- [ ] update_stmt.mochi
+- [ ] user_type_literal.mochi
+- [ ] values_builtin.mochi

--- a/tests/human/scheme/append_builtin.scm
+++ b/tests/human/scheme/append_builtin.scm
@@ -1,0 +1,7 @@
+(define (print-list lst)
+  (display (car lst))
+  (for-each (lambda (x) (display " ") (display x)) (cdr lst))
+  (newline))
+
+(let ((a (list 1 2)))
+  (print-list (append a (list 3))))

--- a/tests/human/scheme/avg_builtin.scm
+++ b/tests/human/scheme/avg_builtin.scm
@@ -1,0 +1,2 @@
+(display (/ (+ 1 2 3) 3))
+(newline)

--- a/tests/human/scheme/basic_compare.scm
+++ b/tests/human/scheme/basic_compare.scm
@@ -1,0 +1,8 @@
+(define (displayln x) (display x) (newline))
+(define (bool->string b) (if b "true" "false"))
+
+(let* ((a (- 10 3))
+       (b (+ 2 2)))
+  (displayln a)
+  (displayln (bool->string (= a 7)))
+  (displayln (bool->string (< b 5))))

--- a/tests/human/scheme/binary_precedence.scm
+++ b/tests/human/scheme/binary_precedence.scm
@@ -1,0 +1,5 @@
+(define (displayln x) (display x) (newline))
+(displayln (+ 1 (* 2 3)))
+(displayln (* (+ 1 2) 3))
+(displayln (+ (* 2 3) 1))
+(displayln (* 2 (+ 3 1)))

--- a/tests/human/scheme/bool_chain.scm
+++ b/tests/human/scheme/bool_chain.scm
@@ -1,0 +1,6 @@
+(define (displayln x) (display x) (newline))
+(define (bool->string b) (if b "true" "false"))
+(define (boom) (display "boom") (newline) #t)
+(displayln (bool->string (and (< 1 2) (< 2 3) (< 3 4))))
+(displayln (bool->string (and (< 1 2) (> 2 3) (boom))))
+(displayln (bool->string (and (< 1 2) (< 2 3) (> 3 4) (boom))))

--- a/tests/human/scheme/cast_string_to_int.scm
+++ b/tests/human/scheme/cast_string_to_int.scm
@@ -1,0 +1,2 @@
+(display (string->number "1995"))
+(newline)

--- a/tests/human/scheme/closure.scm
+++ b/tests/human/scheme/closure.scm
@@ -1,0 +1,6 @@
+(define (make-adder n)
+  (lambda (x) (+ x n)))
+
+(define add10 (make-adder 10))
+(display (add10 7))
+(newline)

--- a/tests/human/scheme/count_builtin.scm
+++ b/tests/human/scheme/count_builtin.scm
@@ -1,0 +1,2 @@
+(display (length '(1 2 3)))
+(newline)

--- a/tests/human/scheme/for_list_collection.scm
+++ b/tests/human/scheme/for_list_collection.scm
@@ -1,0 +1,4 @@
+(for-each (lambda (n)
+            (display n)
+            (newline))
+          '(1 2 3))

--- a/tests/human/scheme/for_loop.scm
+++ b/tests/human/scheme/for_loop.scm
@@ -1,0 +1,4 @@
+(do ((i 1 (+ i 1)))
+    ((>= i 4))
+  (display i)
+  (newline))

--- a/tests/human/scheme/fun_call.scm
+++ b/tests/human/scheme/fun_call.scm
@@ -1,0 +1,4 @@
+(define (add a b)
+  (+ a b))
+(display (add 2 3))
+(newline)

--- a/tests/human/scheme/print_hello.scm
+++ b/tests/human/scheme/print_hello.scm
@@ -1,0 +1,2 @@
+(display "hello")
+(newline)

--- a/tests/human/scheme/str_builtin.scm
+++ b/tests/human/scheme/str_builtin.scm
@@ -1,0 +1,2 @@
+(display (number->string 123))
+(newline)

--- a/tests/human/scheme/string_concat.scm
+++ b/tests/human/scheme/string_concat.scm
@@ -1,0 +1,2 @@
+(display (string-append "hello " "world"))
+(newline)

--- a/tests/human/scheme/string_contains.scm
+++ b/tests/human/scheme/string_contains.scm
@@ -1,0 +1,13 @@
+(define (string-contains? s sub)
+  (let* ((n (string-length s))
+         (m (string-length sub)))
+    (let loop ((i 0))
+      (cond ((> i (- n m)) #f)
+            ((string=? sub (substring s i (+ i m))) #t)
+            (else (loop (+ i 1)))))))
+
+(define (display-bool b) (display (if b "true" "false")) (newline))
+
+(define s "catch")
+(display-bool (string-contains? s "cat"))
+(display-bool (string-contains? s "dog"))

--- a/tests/human/scheme/string_index.scm
+++ b/tests/human/scheme/string_index.scm
@@ -1,0 +1,2 @@
+(display (string-ref "mochi" 1))
+(newline)

--- a/tests/human/scheme/substring_builtin.scm
+++ b/tests/human/scheme/substring_builtin.scm
@@ -1,0 +1,2 @@
+(display (substring "mochi" 1 4))
+(newline)

--- a/tests/human/scheme/sum_builtin.scm
+++ b/tests/human/scheme/sum_builtin.scm
@@ -1,0 +1,2 @@
+(display (+ 1 2 3))
+(newline)

--- a/tests/human/scheme/tail_recursion.scm
+++ b/tests/human/scheme/tail_recursion.scm
@@ -1,0 +1,7 @@
+(define (sum-rec n acc)
+  (if (= n 0)
+      acc
+      (sum-rec (- n 1) (+ acc n))))
+
+(display (sum-rec 10 0))
+(newline)

--- a/tests/human/scheme/typed_let.scm
+++ b/tests/human/scheme/typed_let.scm
@@ -1,0 +1,2 @@
+(display "<nil>")
+(newline)

--- a/tests/human/scheme/typed_var.scm
+++ b/tests/human/scheme/typed_var.scm
@@ -1,0 +1,2 @@
+(display "<nil>")
+(newline)

--- a/tests/human/scheme/unary_neg.scm
+++ b/tests/human/scheme/unary_neg.scm
@@ -1,0 +1,3 @@
+(define (displayln x) (display x) (newline))
+(displayln (- 3))
+(displayln (+ 5 -2))

--- a/tests/human/scheme/var_assignment.scm
+++ b/tests/human/scheme/var_assignment.scm
@@ -1,0 +1,4 @@
+(let ((x 1))
+  (set! x 2)
+  (display x)
+  (newline))

--- a/tests/human/scheme/while_loop.scm
+++ b/tests/human/scheme/while_loop.scm
@@ -1,0 +1,6 @@
+(define (loop i)
+  (when (< i 3)
+    (display i)
+    (newline)
+    (loop (+ i 1))))
+(loop 0)


### PR DESCRIPTION
## Summary
- add Scheme implementations for a selection of Mochi examples
- track completed and remaining translations in a checklist

## Testing
- `go test ./tests/vm -run .` *(fails: build constraints exclude all Go files)*

------
https://chatgpt.com/codex/tasks/task_e_686ba51db8a08320ba4f9954519c40fa