### PR TITLE
Add more Scheme examples

### DIFF
--- a/tests/human/x/scheme/README.md
+++ b/tests/human/x/scheme/README.md
@@ -3,7 +3,7 @@
 This directory contains manual Scheme implementations of the programs found in
 `tests/vm/valid`.
 
-## Checklist (65/97 translated)
+## Checklist (70/97 translated)
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -30,7 +30,7 @@ This directory contains manual Scheme implementations of the programs found in
 - [x] group_by.mochi
 - [ ] group_by_conditional_sum.mochi
 - [x] group_by_having.mochi
-- [ ] group_by_join.mochi
+- [x] group_by_join.mochi
 - [ ] group_by_left_join.mochi
 - [ ] group_by_multi_join.mochi
 - [ ] group_by_multi_join_sort.mochi
@@ -62,12 +62,12 @@ This directory contains manual Scheme implementations of the programs found in
 - [x] map_literal_dynamic.mochi
 - [x] map_membership.mochi
 - [x] map_nested_assign.mochi
-- [ ] match_expr.mochi
+- [x] match_expr.mochi
 - [ ] match_full.mochi
 - [ ] math_ops.mochi
 - [x] membership.mochi
-- [ ] min_max_builtin.mochi
-- [ ] nested_function.mochi
+- [x] min_max_builtin.mochi
+- [x] nested_function.mochi
 - [ ] order_by_map.mochi
 - [ ] outer_join.mochi
 - [ ] partial_application.mochi
@@ -79,7 +79,7 @@ This directory contains manual Scheme implementations of the programs found in
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
-- [ ] slice.mochi
+- [x] slice.mochi
 - [ ] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi

--- a/tests/human/x/scheme/group_by_join.scm
+++ b/tests/human/x/scheme/group_by_join.scm
@@ -1,0 +1,25 @@
+(define customers '((1 . "Alice") (2 . "Bob")))
+(define orders '((100 . 1) (101 . 1) (102 . 2)))
+
+(define counts '())
+
+(for-each (lambda (o)
+            (let* ((cid (cdr o))
+                   (name (cdr (assoc cid customers)))
+                   (entry (assoc name counts)))
+              (if entry
+                  (set-cdr! entry (+ 1 (cdr entry)))
+                  (set! counts (append counts (list (cons name 1)))))))
+          orders)
+
+(display "--- Orders per customer ---")
+(newline)
+(for-each (lambda (c)
+            (let* ((name (cdr c))
+                   (count (let ((e (assoc name counts)))
+                            (if e (cdr e) 0))))
+              (display name)
+              (display " orders: ")
+              (display count)
+              (newline)))
+          customers)

--- a/tests/human/x/scheme/match_expr.scm
+++ b/tests/human/x/scheme/match_expr.scm
@@ -1,0 +1,8 @@
+(define x 2)
+(define label
+  (cond ((= x 1) "one")
+        ((= x 2) "two")
+        ((= x 3) "three")
+        (else "unknown")))
+(display label)
+(newline)

--- a/tests/human/x/scheme/min_max_builtin.scm
+++ b/tests/human/x/scheme/min_max_builtin.scm
@@ -1,0 +1,5 @@
+(define nums '(3 1 4))
+(display (apply min nums))
+(newline)
+(display (apply max nums))
+(newline)

--- a/tests/human/x/scheme/nested_function.scm
+++ b/tests/human/x/scheme/nested_function.scm
@@ -1,0 +1,7 @@
+(define (outer x)
+  (define (inner y)
+    (+ x y))
+  (inner 5))
+
+(display (outer 3))
+(newline)

--- a/tests/human/x/scheme/slice.scm
+++ b/tests/human/x/scheme/slice.scm
@@ -1,0 +1,13 @@
+(define (list-slice lst start end)
+  (let loop ((i 0) (xs lst) (acc '()))
+    (cond ((or (null? xs) (>= i end)) (reverse acc))
+          ((>= i start) (loop (+ i 1) (cdr xs) (cons (car xs) acc)))
+          (else (loop (+ i 1) (cdr xs) acc)))))
+
+(define lst '(1 2 3))
+(display (list-slice lst 1 3))
+(newline)
+(display (list-slice lst 0 2))
+(newline)
+(display (substring "hello" 1 4))
+(newline)


### PR DESCRIPTION
## Summary
- translate five more Mochi programs into Scheme:
  - `group_by_join`
  - `match_expr`
  - `min_max_builtin`
  - `nested_function`
  - `slice`
- update checklist in `tests/human/x/scheme/README.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686bab459a188320992fe2f552fde70f