### PR TITLE
Fix C++ compiler string quoting

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -3,6 +3,7 @@ package cpp
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"mochi/parser"
@@ -409,7 +410,7 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 		return "false", nil
 	}
 	if l.Str != nil {
-		return *l.Str, nil
+		return strconv.Quote(*l.Str), nil
 	}
 	if l.Null {
 		return "nullptr", nil


### PR DESCRIPTION
## Summary
- update the C++ compiler to properly quote string literals

## Testing
- `go test ./compiler/x/cpp -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686bf5aed84483209b3d1b85718e7dd1