### PR TITLE
Add slow build tags to compiler

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c
 
 import (

--- a/compiler/x/c/compiler_test.go
+++ b/compiler/x/c/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c_test
 
 import (

--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cljcode
 
 import (

--- a/compiler/x/clj/helpers.go
+++ b/compiler/x/clj/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cljcode
 
 import (

--- a/compiler/x/clj/infer.go
+++ b/compiler/x/clj/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cljcode
 
 import (

--- a/compiler/x/clj/runtime.go
+++ b/compiler/x/clj/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cljcode
 
 import (

--- a/compiler/x/clj/tools.go
+++ b/compiler/x/clj/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cljcode
 
 import (

--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp
 
 import (

--- a/compiler/x/cpp/compiler_test.go
+++ b/compiler/x/cpp/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp_test
 
 import (

--- a/compiler/x/dart/compiler.go
+++ b/compiler/x/dart/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart
 
 import (

--- a/compiler/x/dart/compiler_test.go
+++ b/compiler/x/dart/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart_test
 
 import (

--- a/compiler/x/erlang/compiler.go
+++ b/compiler/x/erlang/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erlang
 
 import (

--- a/compiler/x/erlang/compiler_test.go
+++ b/compiler/x/erlang/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erlang_test
 
 import (

--- a/compiler/x/ex/compiler.go
+++ b/compiler/x/ex/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 // Package excode translates Mochi ASTs into Elixir source code.
 package excode
 

--- a/compiler/x/ex/compiler_test.go
+++ b/compiler/x/ex/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package excode_test
 
 import (

--- a/compiler/x/ex/expr.go
+++ b/compiler/x/ex/expr.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package excode
 
 import (

--- a/compiler/x/ex/helpers.go
+++ b/compiler/x/ex/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package excode
 
 import (

--- a/compiler/x/ex/infer.go
+++ b/compiler/x/ex/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package excode
 
 import (

--- a/compiler/x/ex/runtime.go
+++ b/compiler/x/ex/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package excode
 
 const (

--- a/compiler/x/ex/tools.go
+++ b/compiler/x/ex/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package excode
 
 import (

--- a/compiler/x/fortran/compiler.go
+++ b/compiler/x/fortran/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ftncode
 
 import (

--- a/compiler/x/fortran/compiler_test.go
+++ b/compiler/x/fortran/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ftncode_test
 
 import (

--- a/compiler/x/fs/compiler.go
+++ b/compiler/x/fs/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fscode
 
 import (

--- a/compiler/x/fs/compiler_test.go
+++ b/compiler/x/fs/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fscode_test
 
 import (

--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hscode
 
 import (

--- a/compiler/x/hs/compiler_test.go
+++ b/compiler/x/hs/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hscode_test
 
 import (

--- a/compiler/x/hs/helpers.go
+++ b/compiler/x/hs/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hscode
 
 import (

--- a/compiler/x/hs/infer.go
+++ b/compiler/x/hs/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hscode
 
 import (

--- a/compiler/x/hs/runtime.go
+++ b/compiler/x/hs/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hscode
 
 const runtime = `

--- a/compiler/x/hs/tools.go
+++ b/compiler/x/hs/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hscode
 
 import (

--- a/compiler/x/java/compiler.go
+++ b/compiler/x/java/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package javacode
 
 import (

--- a/compiler/x/java/compiler_test.go
+++ b/compiler/x/java/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package javacode_test
 
 import (

--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package kotlin
 
 import (

--- a/compiler/x/kotlin/compiler_test.go
+++ b/compiler/x/kotlin/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package kotlin_test
 
 import (

--- a/compiler/x/lua/compiler.go
+++ b/compiler/x/lua/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode
 
 import (

--- a/compiler/x/lua/compiler_test.go
+++ b/compiler/x/lua/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode_test
 
 import (

--- a/compiler/x/lua/expressions.go
+++ b/compiler/x/lua/expressions.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode
 
 import (

--- a/compiler/x/lua/helpers.go
+++ b/compiler/x/lua/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode
 
 import (

--- a/compiler/x/lua/infer.go
+++ b/compiler/x/lua/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode
 
 import (

--- a/compiler/x/lua/runtime.go
+++ b/compiler/x/lua/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode
 
 import "sort"

--- a/compiler/x/lua/statements.go
+++ b/compiler/x/lua/statements.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode
 
 import (

--- a/compiler/x/lua/tools.go
+++ b/compiler/x/lua/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package luacode
 
 import (

--- a/compiler/x/ocaml/compiler.go
+++ b/compiler/x/ocaml/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ocaml
 
 import (

--- a/compiler/x/ocaml/compiler_test.go
+++ b/compiler/x/ocaml/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ocaml_test
 
 import (

--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pascode
 
 import (

--- a/compiler/x/pascal/compiler_test.go
+++ b/compiler/x/pascal/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pascode_test
 
 import (

--- a/compiler/x/pascal/helpers.go
+++ b/compiler/x/pascal/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pascode
 
 import (

--- a/compiler/x/pascal/tools.go
+++ b/compiler/x/pascal/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pascode
 
 import (

--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode
 
 import (

--- a/compiler/x/php/compiler_test.go
+++ b/compiler/x/php/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode_test
 
 import (

--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode
 
 import (

--- a/compiler/x/php/infer.go
+++ b/compiler/x/php/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode
 
 import (

--- a/compiler/x/php/runtime.go
+++ b/compiler/x/php/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode
 
 // Runtime helpers emitted by the PHP compiler.

--- a/compiler/x/php/tools.go
+++ b/compiler/x/php/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package phpcode
 
 import (

--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pl
 
 import (

--- a/compiler/x/pl/compiler_test.go
+++ b/compiler/x/pl/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pl_test
 
 import (

--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package racket
 
 import (

--- a/compiler/x/racket/compiler_test.go
+++ b/compiler/x/racket/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package racket_test
 
 import (

--- a/compiler/x/racket/tools.go
+++ b/compiler/x/racket/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package racket
 
 import (

--- a/compiler/x/rb/compiler.go
+++ b/compiler/x/rb/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rbcode
 
 import (

--- a/compiler/x/rb/compiler_test.go
+++ b/compiler/x/rb/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rbcode_test
 
 import (

--- a/compiler/x/rb/helpers.go
+++ b/compiler/x/rb/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rbcode
 
 import (

--- a/compiler/x/rb/infer.go
+++ b/compiler/x/rb/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rbcode
 
 import (

--- a/compiler/x/rb/runtime.go
+++ b/compiler/x/rb/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rbcode
 
 import "sort"

--- a/compiler/x/rb/tools.go
+++ b/compiler/x/rb/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rbcode
 
 import (

--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scalacode
 
 import (

--- a/compiler/x/scala/compiler_test.go
+++ b/compiler/x/scala/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scalacode_test
 
 import (

--- a/compiler/x/scheme/compiler.go
+++ b/compiler/x/scheme/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode
 
 import (

--- a/compiler/x/scheme/compiler_test.go
+++ b/compiler/x/scheme/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode_test
 
 import (

--- a/compiler/x/scheme/control.go
+++ b/compiler/x/scheme/control.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode
 
 import (

--- a/compiler/x/scheme/infer.go
+++ b/compiler/x/scheme/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode
 
 import (

--- a/compiler/x/scheme/loops.go
+++ b/compiler/x/scheme/loops.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode
 
 import (

--- a/compiler/x/scheme/tools.go
+++ b/compiler/x/scheme/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode
 
 import (

--- a/compiler/x/scheme/update.go
+++ b/compiler/x/scheme/update.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode
 
 import (

--- a/compiler/x/scheme/util.go
+++ b/compiler/x/scheme/util.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package schemecode
 
 import "mochi/parser"

--- a/compiler/x/smalltalk/compiler.go
+++ b/compiler/x/smalltalk/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package smalltalk
 
 import (

--- a/compiler/x/smalltalk/compiler_test.go
+++ b/compiler/x/smalltalk/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package smalltalk_test
 
 import (

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/compiler/x/swift/compiler_test.go
+++ b/compiler/x/swift/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift_test
 
 import (

--- a/compiler/x/testutil/testutil.go
+++ b/compiler/x/testutil/testutil.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package testutil
 
 import (

--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode
 
 import (

--- a/compiler/x/ts/compiler_test.go
+++ b/compiler/x/ts/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode_test
 
 import (

--- a/compiler/x/ts/helpers.go
+++ b/compiler/x/ts/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode
 
 import (

--- a/compiler/x/ts/infer.go
+++ b/compiler/x/ts/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode
 
 import (

--- a/compiler/x/ts/machine_test.go
+++ b/compiler/x/ts/machine_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode_test
 
 import (

--- a/compiler/x/ts/roundtrip_vm_test.go
+++ b/compiler/x/ts/roundtrip_vm_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode_test
 
 import (

--- a/compiler/x/ts/runtime.go
+++ b/compiler/x/ts/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode
 
 import "sort"

--- a/compiler/x/ts/tools.go
+++ b/compiler/x/ts/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package tscode
 
 import (

--- a/compiler/x/zig/builtins.go
+++ b/compiler/x/zig/builtins.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zigcode
 
 func (c *Compiler) writeBuiltins() {

--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zigcode
 
 import (

--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zigcode
 
 import (

--- a/compiler/x/zig/infer.go
+++ b/compiler/x/zig/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zigcode
 
 import (

--- a/compiler/x/zig/tools.go
+++ b/compiler/x/zig/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zigcode
 
 import (


### PR DESCRIPTION
## Summary
- mark every Go file in `compiler` directory with `//go:build slow`

## Testing
- `go test ./compiler/x/c -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686bf91d056483209cb561d0f45dc3db