### PR TITLE
Add COBOL compiler improvements

### DIFF
--- a/tests/machine/x/cobol/README.md
+++ b/tests/machine/x/cobol/README.md
@@ -7,3 +7,11 @@ Each program is compiled and executed if a COBOL compiler is available.
 
 - [ ] print_hello.mochi
 - [ ] while_loop.mochi
+- [ ] var_assignment.mochi
+- [ ] typed_var.mochi
+- [ ] typed_let.mochi
+- [ ] let_and_print.mochi
+- [ ] basic_compare.mochi
+- [ ] binary_precedence.mochi
+- [ ] unary_neg.mochi
+- [ ] if_else.mochi


### PR DESCRIPTION
## Summary
- enhance COBOL compiler with support for `let` declarations and `if` statements
- record initialization statements and allow typed variables
- update COBOL compiler tests to process all VM samples
- expand COBOL machine README checklist

## Testing
- `go test ./...` *(fails: fsharpc/swipl not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfa5234248320aefea92e49c00830