### PR TITLE
Mark compiler packages as slow

### DIFF
--- a/compiler/x/cobol/compiler.go
+++ b/compiler/x/cobol/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cobol
 
 import (

--- a/compiler/x/cobol/compiler_test.go
+++ b/compiler/x/cobol/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cobol_test
 
 import (

--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rustcode
 
 import (

--- a/compiler/x/rust/compiler_test.go
+++ b/compiler/x/rust/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rustcode_test
 
 import (


### PR DESCRIPTION
## Summary
- label Cobol and Rust compiler packages with `//go:build slow`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bff36d0b883209e0d13642ea34c0d