### PR TITLE
Expand Scala compiler features

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -1,31 +1,34 @@
 # Scala Compiler Machine Tests
 
+Currently 43/97 programs compile successfully.
+
 This directory stores generated Scala source files and their outputs from compiling
 Mochi programs under `tests/vm/valid`.
 
 ## Checklist
-- [ ] append_builtin.mochi
-- [ ] avg_builtin.mochi
+
+- [x] append_builtin.mochi
+- [x] avg_builtin.mochi
 - [x] basic_compare.mochi
 - [x] binary_precedence.mochi
-- [ ] bool_chain.mochi
+- [x] bool_chain.mochi
 - [ ] break_continue.mochi
-- [ ] cast_string_to_int.mochi
+- [x] cast_string_to_int.mochi
 - [ ] cast_struct.mochi
 - [ ] closure.mochi
-- [ ] count_builtin.mochi
+- [x] count_builtin.mochi
 - [ ] cross_join.mochi
 - [ ] cross_join_filter.mochi
 - [ ] cross_join_triple.mochi
 - [ ] dataset_sort_take_limit.mochi
 - [ ] dataset_where_filter.mochi
 - [ ] exists_builtin.mochi
-- [ ] for_list_collection.mochi
-- [ ] for_loop.mochi
-- [ ] for_map_collection.mochi
-- [ ] fun_call.mochi
+- [x] for_list_collection.mochi
+- [x] for_loop.mochi
+- [x] for_map_collection.mochi
+- [x] fun_call.mochi
 - [ ] fun_expr_in_let.mochi
-- [ ] fun_three_args.mochi
+- [x] fun_three_args.mochi
 - [ ] group_by.mochi
 - [ ] group_by_conditional_sum.mochi
 - [ ] group_by_having.mochi
@@ -35,7 +38,7 @@ Mochi programs under `tests/vm/valid`.
 - [ ] group_by_multi_join_sort.mochi
 - [ ] group_by_sort.mochi
 - [ ] group_items_iteration.mochi
-- [ ] if_else.mochi
+- [x] if_else.mochi
 - [ ] if_then_else.mochi
 - [ ] if_then_else_nested.mochi
 - [ ] in_operator.mochi
@@ -45,28 +48,28 @@ Mochi programs under `tests/vm/valid`.
 - [ ] json_builtin.mochi
 - [ ] left_join.mochi
 - [ ] left_join_multi.mochi
-- [ ] len_builtin.mochi
-- [ ] len_map.mochi
-- [ ] len_string.mochi
-- [ ] let_and_print.mochi
+- [x] len_builtin.mochi
+- [x] len_map.mochi
+- [x] len_string.mochi
+- [x] let_and_print.mochi
 - [ ] list_assign.mochi
-- [ ] list_index.mochi
+- [x] list_index.mochi
 - [ ] list_nested_assign.mochi
 - [ ] list_set_ops.mochi
 - [ ] load_yaml.mochi
 - [ ] map_assign.mochi
 - [ ] map_in_operator.mochi
-- [ ] map_index.mochi
-- [ ] map_int_key.mochi
-- [ ] map_literal_dynamic.mochi
+- [x] map_index.mochi
+- [x] map_int_key.mochi
+- [x] map_literal_dynamic.mochi
 - [ ] map_membership.mochi
 - [ ] map_nested_assign.mochi
 - [ ] match_expr.mochi
 - [ ] match_full.mochi
-- [ ] math_ops.mochi
+- [x] math_ops.mochi
 - [ ] membership.mochi
-- [ ] min_max_builtin.mochi
-- [ ] nested_function.mochi
+- [x] min_max_builtin.mochi
+- [x] nested_function.mochi
 - [ ] order_by_map.mochi
 - [ ] outer_join.mochi
 - [ ] partial_application.mochi
@@ -77,27 +80,27 @@ Mochi programs under `tests/vm/valid`.
 - [ ] record_assign.mochi
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
-- [ ] short_circuit.mochi
-- [ ] slice.mochi
+- [x] short_circuit.mochi
+- [x] slice.mochi
 - [ ] sort_stable.mochi
-- [ ] str_builtin.mochi
-- [ ] string_compare.mochi
-- [ ] string_concat.mochi
-- [ ] string_contains.mochi
+- [x] str_builtin.mochi
+- [x] string_compare.mochi
+- [x] string_concat.mochi
+- [x] string_contains.mochi
 - [ ] string_in_operator.mochi
-- [ ] string_index.mochi
-- [ ] string_prefix_slice.mochi
-- [ ] substring_builtin.mochi
-- [ ] sum_builtin.mochi
-- [ ] tail_recursion.mochi
+- [x] string_index.mochi
+- [x] string_prefix_slice.mochi
+- [x] substring_builtin.mochi
+- [x] sum_builtin.mochi
+- [x] tail_recursion.mochi
 - [ ] test_block.mochi
 - [ ] tree_sum.mochi
-- [ ] two-sum.mochi
+- [x] two-sum.mochi
 - [x] typed_let.mochi
 - [x] typed_var.mochi
 - [x] unary_neg.mochi
 - [ ] update_stmt.mochi
 - [ ] user_type_literal.mochi
-- [ ] values_builtin.mochi
+- [x] values_builtin.mochi
 - [x] var_assignment.mochi
-- [ ] while_loop.mochi
+- [x] while_loop.mochi


### PR DESCRIPTION
## Summary
- extend Scala compiler to handle indexing, slicing, casts and map literals
- support several built‑in functions (avg, len, min, max, etc.)
- enhance `for` loops for map iteration
- update Scala machine test checklist

## Testing
- `go test ./compiler/x/scala -run TestScalaCompilerGolden -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_686bfddfaf0c8320b574fac00f09f18f