### PR TITLE
Add basic Python compiler

### DIFF
--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -3,6 +3,7 @@
 package pycode
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,23 +13,235 @@ import (
 	"mochi/types"
 )
 
-// Compiler translates Mochi programs to Python code by
-// returning the hand-written translation from tests/human/x/python.
-type Compiler struct{}
+// Compiler translates a subset of Mochi to Python source code.
+type Compiler struct {
+	buf    bytes.Buffer
+	indent int
+}
 
 // New creates a new Python compiler.
 func New(env *types.Env) *Compiler { return &Compiler{} }
 
+// Compile converts the parsed Mochi program into Python code.
 func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
-	// Determine the name of the source file without extension.
-	name := strings.TrimSuffix(filepath.Base(prog.Pos.Filename), filepath.Ext(prog.Pos.Filename))
-	root := findRepoRoot()
-	pyPath := filepath.Join(root, "tests", "human", "x", "python", name+".py")
-	data, err := os.ReadFile(pyPath)
-	if err != nil {
-		return nil, fmt.Errorf("missing Python translation for %s: %w", name, err)
+	c.buf.Reset()
+	c.indent = 0
+	for _, s := range prog.Statements {
+		if err := c.compileStmt(s); err != nil {
+			return nil, err
+		}
 	}
-	return data, nil
+	return c.buf.Bytes(), nil
+}
+
+func (c *Compiler) compileStmt(s *parser.Statement) error {
+	switch {
+	case s.Let != nil:
+		return c.compileLet(s.Let)
+	case s.Var != nil:
+		return c.compileVar(s.Var)
+	case s.Assign != nil:
+		return c.compileAssign(s.Assign)
+	case s.Expr != nil:
+		expr, err := c.compileExpr(s.Expr.Expr)
+		if err != nil {
+			return err
+		}
+		c.writeln(expr)
+		return nil
+	default:
+		return fmt.Errorf("unsupported statement at line %d", s.Pos.Line)
+	}
+}
+
+func (c *Compiler) compileLet(l *parser.LetStmt) error {
+	return c.compileVarStmt(l.Name, l.Type, l.Value)
+}
+
+func (c *Compiler) compileVar(v *parser.VarStmt) error {
+	return c.compileVarStmt(v.Name, v.Type, v.Value)
+}
+
+func (c *Compiler) compileVarStmt(name string, t *parser.TypeRef, val *parser.Expr) error {
+	var value string
+	var err error
+	if val != nil {
+		value, err = c.compileExpr(val)
+		if err != nil {
+			return err
+		}
+	} else {
+		value = "None"
+	}
+	typ := ""
+	if t != nil && t.Simple != nil {
+		typ = *t.Simple
+	}
+	if typ != "" {
+		c.writeln(fmt.Sprintf("%s: %s = %s", name, typ, value))
+	} else {
+		c.writeln(fmt.Sprintf("%s = %s", name, value))
+	}
+	return nil
+}
+
+func (c *Compiler) compileAssign(a *parser.AssignStmt) error {
+	if len(a.Index) > 0 || len(a.Field) > 0 {
+		return fmt.Errorf("assignment with index or field not supported")
+	}
+	val, err := c.compileExpr(a.Value)
+	if err != nil {
+		return err
+	}
+	c.writeln(fmt.Sprintf("%s = %s", a.Name, val))
+	return nil
+}
+
+func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
+	if e == nil || e.Binary == nil {
+		return "", fmt.Errorf("empty expression")
+	}
+	return c.compileBinary(e.Binary)
+}
+
+func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
+	left, err := c.compileUnary(b.Left)
+	if err != nil {
+		return "", err
+	}
+	res := left
+	for _, op := range b.Right {
+		r, err := c.compilePostfix(op.Right)
+		if err != nil {
+			return "", err
+		}
+		opStr := op.Op
+		switch opStr {
+		case "&&":
+			opStr = "and"
+		case "||":
+			opStr = "or"
+		}
+		res = fmt.Sprintf("%s %s %s", res, opStr, r)
+	}
+	return res, nil
+}
+
+func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
+	val, err := c.compilePostfix(u.Value)
+	if err != nil {
+		return "", err
+	}
+	for i := len(u.Ops) - 1; i >= 0; i-- {
+		switch u.Ops[i] {
+		case "-":
+			val = "-" + val
+		case "!":
+			val = "not " + val
+		default:
+			return "", fmt.Errorf("unsupported unary op %s", u.Ops[i])
+		}
+	}
+	return val, nil
+}
+
+func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
+	val, err := c.compilePrimary(p.Target)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range p.Ops {
+		switch {
+		case op.Cast != nil:
+			typ, err := c.compileType(op.Cast.Type)
+			if err != nil {
+				return "", err
+			}
+			val = fmt.Sprintf("%s(%s)", typ, val)
+		case op.Index != nil:
+			if op.Index.Start == nil || op.Index.Colon != nil {
+				return "", fmt.Errorf("complex indexing not supported")
+			}
+			idx, err := c.compileExpr(op.Index.Start)
+			if err != nil {
+				return "", err
+			}
+			val = fmt.Sprintf("%s[%s]", val, idx)
+		default:
+			return "", fmt.Errorf("unsupported postfix at line %d", p.Target.Pos.Line)
+		}
+	}
+	return val, nil
+}
+
+func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
+	switch {
+	case p.Lit != nil:
+		return c.compileLiteral(p.Lit), nil
+	case p.Call != nil:
+		return c.compileCall(p.Call)
+	case p.Group != nil:
+		expr, err := c.compileExpr(p.Group)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("(%s)", expr), nil
+	case p.Selector != nil:
+		name := p.Selector.Root
+		for _, t := range p.Selector.Tail {
+			name += "." + t
+		}
+		return name, nil
+	default:
+		return "", fmt.Errorf("unsupported expression at line %d", p.Pos.Line)
+	}
+}
+
+func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
+	args := make([]string, len(call.Args))
+	for i, a := range call.Args {
+		s, err := c.compileExpr(a)
+		if err != nil {
+			return "", err
+		}
+		args[i] = s
+	}
+	return fmt.Sprintf("%s(%s)", call.Func, strings.Join(args, ", ")), nil
+}
+
+func (c *Compiler) compileLiteral(l *parser.Literal) string {
+	switch {
+	case l.Int != nil:
+		return fmt.Sprintf("%d", *l.Int)
+	case l.Str != nil:
+		return fmt.Sprintf("%q", *l.Str)
+	case l.Float != nil:
+		return fmt.Sprintf("%g", *l.Float)
+	case l.Bool != nil:
+		if bool(*l.Bool) {
+			return "True"
+		}
+		return "False"
+	case l.Null:
+		return "None"
+	default:
+		return "None"
+	}
+}
+
+func (c *Compiler) compileType(t *parser.TypeRef) (string, error) {
+	if t == nil || t.Simple == nil {
+		return "", fmt.Errorf("unsupported type")
+	}
+	return *t.Simple, nil
+}
+
+func (c *Compiler) writeln(s string) {
+	for i := 0; i < c.indent; i++ {
+		c.buf.WriteString("    ")
+	}
+	c.buf.WriteString(s)
+	c.buf.WriteByte('\n')
 }
 
 func findRepoRoot() string {

--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -1,101 +1,101 @@
 # Python Compiler Results
 
-This checklist tracks which Mochi programs from `tests/vm/valid` have been compiled to Python and executed successfully.
+Compiled programs: 16/97
 
-- [x] append_builtin.mochi
-- [x] avg_builtin.mochi
+- [ ] append_builtin.mochi
+- [ ] avg_builtin.mochi
 - [x] basic_compare.mochi
 - [x] binary_precedence.mochi
-- [x] bool_chain.mochi
-- [x] break_continue.mochi
+- [ ] bool_chain.mochi
+- [ ] break_continue.mochi
 - [x] cast_string_to_int.mochi
-- [x] cast_struct.mochi
-- [x] closure.mochi
-- [x] count_builtin.mochi
-- [x] cross_join.mochi
-- [x] cross_join_filter.mochi
-- [x] cross_join_triple.mochi
-- [x] dataset_sort_take_limit.mochi
-- [x] dataset_where_filter.mochi
-- [x] exists_builtin.mochi
-- [x] for_list_collection.mochi
-- [x] for_loop.mochi
-- [x] for_map_collection.mochi
-- [x] fun_call.mochi
-- [x] fun_expr_in_let.mochi
-- [x] fun_three_args.mochi
-- [x] group_by.mochi
-- [x] group_by_conditional_sum.mochi
-- [x] group_by_having.mochi
-- [x] group_by_join.mochi
-- [x] group_by_left_join.mochi
-- [x] group_by_multi_join.mochi
-- [x] group_by_multi_join_sort.mochi
-- [x] group_by_sort.mochi
-- [x] group_items_iteration.mochi
-- [x] if_else.mochi
-- [x] if_then_else.mochi
-- [x] if_then_else_nested.mochi
-- [x] in_operator.mochi
-- [x] in_operator_extended.mochi
-- [x] inner_join.mochi
-- [x] join_multi.mochi
-- [x] json_builtin.mochi
-- [x] left_join.mochi
-- [x] left_join_multi.mochi
-- [x] len_builtin.mochi
-- [x] len_map.mochi
+- [ ] cast_struct.mochi
+- [ ] closure.mochi
+- [ ] count_builtin.mochi
+- [ ] cross_join.mochi
+- [ ] cross_join_filter.mochi
+- [ ] cross_join_triple.mochi
+- [ ] dataset_sort_take_limit.mochi
+- [ ] dataset_where_filter.mochi
+- [ ] exists_builtin.mochi
+- [ ] for_list_collection.mochi
+- [ ] for_loop.mochi
+- [ ] for_map_collection.mochi
+- [ ] fun_call.mochi
+- [ ] fun_expr_in_let.mochi
+- [ ] fun_three_args.mochi
+- [ ] group_by.mochi
+- [ ] group_by_conditional_sum.mochi
+- [ ] group_by_having.mochi
+- [ ] group_by_join.mochi
+- [ ] group_by_left_join.mochi
+- [ ] group_by_multi_join.mochi
+- [ ] group_by_multi_join_sort.mochi
+- [ ] group_by_sort.mochi
+- [ ] group_items_iteration.mochi
+- [ ] if_else.mochi
+- [ ] if_then_else.mochi
+- [ ] if_then_else_nested.mochi
+- [ ] in_operator.mochi
+- [ ] in_operator_extended.mochi
+- [ ] inner_join.mochi
+- [ ] join_multi.mochi
+- [ ] json_builtin.mochi
+- [ ] left_join.mochi
+- [ ] left_join_multi.mochi
+- [ ] len_builtin.mochi
+- [ ] len_map.mochi
 - [x] len_string.mochi
 - [x] let_and_print.mochi
-- [x] list_assign.mochi
-- [x] list_index.mochi
-- [x] list_nested_assign.mochi
-- [x] list_set_ops.mochi
-- [x] load_yaml.mochi
-- [x] map_assign.mochi
-- [x] map_in_operator.mochi
-- [x] map_index.mochi
-- [x] map_int_key.mochi
-- [x] map_literal_dynamic.mochi
-- [x] map_membership.mochi
-- [x] map_nested_assign.mochi
-- [x] match_expr.mochi
-- [x] match_full.mochi
+- [ ] list_assign.mochi
+- [ ] list_index.mochi
+- [ ] list_nested_assign.mochi
+- [ ] list_set_ops.mochi
+- [ ] load_yaml.mochi
+- [ ] map_assign.mochi
+- [ ] map_in_operator.mochi
+- [ ] map_index.mochi
+- [ ] map_int_key.mochi
+- [ ] map_literal_dynamic.mochi
+- [ ] map_membership.mochi
+- [ ] map_nested_assign.mochi
+- [ ] match_expr.mochi
+- [ ] match_full.mochi
 - [x] math_ops.mochi
-- [x] membership.mochi
-- [x] min_max_builtin.mochi
-- [x] nested_function.mochi
-- [x] order_by_map.mochi
-- [x] outer_join.mochi
-- [x] partial_application.mochi
+- [ ] membership.mochi
+- [ ] min_max_builtin.mochi
+- [ ] nested_function.mochi
+- [ ] order_by_map.mochi
+- [ ] outer_join.mochi
+- [ ] partial_application.mochi
 - [x] print_hello.mochi
-- [x] pure_fold.mochi
-- [x] pure_global_fold.mochi
-- [x] query_sum_select.mochi
-- [x] record_assign.mochi
-- [x] right_join.mochi
-- [x] save_jsonl_stdout.mochi
-- [x] short_circuit.mochi
-- [x] slice.mochi
-- [x] sort_stable.mochi
+- [ ] pure_fold.mochi
+- [ ] pure_global_fold.mochi
+- [ ] query_sum_select.mochi
+- [ ] record_assign.mochi
+- [ ] right_join.mochi
+- [ ] save_jsonl_stdout.mochi
+- [ ] short_circuit.mochi
+- [ ] slice.mochi
+- [ ] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi
-- [x] string_contains.mochi
+- [ ] string_contains.mochi
 - [x] string_in_operator.mochi
 - [x] string_index.mochi
-- [x] string_prefix_slice.mochi
-- [x] substring_builtin.mochi
-- [x] sum_builtin.mochi
-- [x] tail_recursion.mochi
-- [x] test_block.mochi
-- [x] tree_sum.mochi
-- [x] two-sum.mochi
+- [ ] string_prefix_slice.mochi
+- [ ] substring_builtin.mochi
+- [ ] sum_builtin.mochi
+- [ ] tail_recursion.mochi
+- [ ] test_block.mochi
+- [ ] tree_sum.mochi
+- [ ] two-sum.mochi
 - [x] typed_let.mochi
 - [x] typed_var.mochi
 - [x] unary_neg.mochi
-- [x] update_stmt.mochi
-- [x] user_type_literal.mochi
-- [x] values_builtin.mochi
+- [ ] update_stmt.mochi
+- [ ] user_type_literal.mochi
+- [ ] values_builtin.mochi
 - [x] var_assignment.mochi
-- [x] while_loop.mochi
+- [ ] while_loop.mochi

--- a/tests/machine/x/python/substring_builtin.error
+++ b/tests/machine/x/python/substring_builtin.error
@@ -1,0 +1,8 @@
+line 1: exit status 1
+Traceback (most recent call last):
+  File "/workspace/mochi/tests/machine/x/python/substring_builtin.py", line 1, in <module>
+    print(substring("mochi", 1, 4))
+          ^^^^^^^^^
+NameError: name 'substring' is not defined
+
+print(substring("mochi", 1, 4))

--- a/tests/machine/x/python/substring_builtin.py
+++ b/tests/machine/x/python/substring_builtin.py
@@ -1,1 +1,1 @@
-print("mochi"[1:4])
+print(substring("mochi", 1, 4))


### PR DESCRIPTION
## Summary
- implement a simple Python compiler translating a subset of Mochi
- generate Python code for each sample program via compiler tests
- record which programs compile in `tests/machine/x/python/README.md`

## Testing
- `go test ./compiler/x/python -tags slow -run TestPythonCompiler_ValidPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686bffc04cb8832096a818722d7939f1