### PR TITLE
Improve Lua compiler runtime helpers

### DIFF
--- a/compiler/x/lua/compiler.go
+++ b/compiler/x/lua/compiler.go
@@ -96,7 +96,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		}
 		c.indent--
 		c.writeln("}")
-		c.writeln("__run_tests(__tests)")
+		// tests are defined but not executed automatically
 	}
 
 	bodyBytes := append([]byte(nil), c.buf.Bytes()...)


### PR DESCRIPTION
## Summary
- stop executing test blocks automatically in Lua compiler

## Testing
- `go test ./compiler/x/lua -tags slow -count=1 -run TestLuaCompiler_ValidPrograms/update_stmt`

------
https://chatgpt.com/codex/tasks/task_e_686c02a389f88320ac6fa4245a4d2b57