### PR TITLE
Fix build tag in tests

### DIFF
--- a/tests/machine/x/go/nested_function.go
+++ b/tests/machine/x/go/nested_function.go
@@ -1,7 +1,8 @@
+//go:build ignore
+
     func inner(y int) int {
         return x + y
     }
-//go:build ignore
 
 package main
 


### PR DESCRIPTION
## Summary
- fix `nested_function.go` build tag so it won't be parsed

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686c0d2d6b8c83209afa6015fc9e7779