### PR TITLE
Fix C# int literals

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -2349,7 +2349,7 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 	switch {
 	case l.Int != nil:
-		return fmt.Sprintf("%dL", *l.Int), nil
+		return fmt.Sprintf("%d", *l.Int), nil
 	case l.Float != nil:
 		return fmt.Sprintf("%f", *l.Float), nil
 	case l.Bool != nil:

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -2,7 +2,7 @@
 
 This checklist tracks which Mochi programs from `tests/vm/valid` have been compiled to C# and executed successfully.
 
-**28/97 files compiled**
+**29/97 files compiled**
 
 - [ ] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -17,7 +17,7 @@ This checklist tracks which Mochi programs from `tests/vm/valid` have been compi
 - [x] cross_join.mochi
 - [x] cross_join_filter.mochi
 - [x] cross_join_triple.mochi
-- [ ] dataset_sort_take_limit.mochi
+- [x] dataset_sort_take_limit.mochi
 - [x] dataset_where_filter.mochi
 - [ ] exists_builtin.mochi
 - [x] for_list_collection.mochi

--- a/tests/machine/x/cs/dataset_sort_take_limit.cs
+++ b/tests/machine/x/cs/dataset_sort_take_limit.cs
@@ -11,12 +11,12 @@ public class Program
 {
     public static void Main()
     {
-        var products = new Dictionary<string, dynamic>[] { new Dictionary<string, dynamic> { { "name", "Laptop" }, { "price", 1500L } }, new Dictionary<string, dynamic> { { "name", "Smartphone" }, { "price", 900L } }, new Dictionary<string, dynamic> { { "name", "Tablet" }, { "price", 600L } }, new Dictionary<string, dynamic> { { "name", "Monitor" }, { "price", 300L } }, new Dictionary<string, dynamic> { { "name", "Keyboard" }, { "price", 100L } }, new Dictionary<string, dynamic> { { "name", "Mouse" }, { "price", 50L } }, new Dictionary<string, dynamic> { { "name", "Headphones" }, { "price", 200L } } };
-        var expensive = new List<dynamic>(products.OrderBy(p => (-p["price"])).Skip(1L).Take(3L).Select(p => p));
+        var products = new Dictionary<string, dynamic>[] { new Dictionary<string, dynamic> { { "name", "Laptop" }, { "price", 1500 } }, new Dictionary<string, dynamic> { { "name", "Smartphone" }, { "price", 900 } }, new Dictionary<string, dynamic> { { "name", "Tablet" }, { "price", 600 } }, new Dictionary<string, dynamic> { { "name", "Monitor" }, { "price", 300 } }, new Dictionary<string, dynamic> { { "name", "Keyboard" }, { "price", 100 } }, new Dictionary<string, dynamic> { { "name", "Mouse" }, { "price", 50 } }, new Dictionary<string, dynamic> { { "name", "Headphones" }, { "price", 200 } } };
+        var expensive = new List<dynamic>(products.OrderBy(p => (-p["price"])).Skip(1).Take(3).Select(p => p));
         Console.WriteLine("--- Top products (excluding most expensive) ---");
         foreach (var item in expensive)
         {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(item.name), Convert.ToString("costs $"), Convert.ToString(item.price) }));
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(item["name"]), Convert.ToString("costs $"), Convert.ToString(item["price"]) }));
         }
     }
 }

--- a/tests/machine/x/cs/dataset_sort_take_limit.error
+++ b/tests/machine/x/cs/dataset_sort_take_limit.error
@@ -1,1 +1,0 @@
-exit status 1

--- a/tests/machine/x/cs/dataset_sort_take_limit.out
+++ b/tests/machine/x/cs/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- generate plain integer literals in the C# compiler
- compile `dataset_sort_take_limit.mochi`
- update checklist

## Testing
- `go test ./compiler/x/cs -tags slow -run TestCompileValidPrograms/dataset_sort_take_limit -v`

------
https://chatgpt.com/codex/tasks/task_e_686c0da2cd588320a99c25953341313b