### PR TITLE
Enhance C# compiler with append/values

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -2259,6 +2259,18 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		c.use("_count")
 		return fmt.Sprintf("_count(%s)", argStr), nil
+	case "append":
+		if len(args) != 2 {
+			return "", fmt.Errorf("append expects 2 args")
+		}
+		c.use("_append")
+		return fmt.Sprintf("_append(%s, %s)", args[0], args[1]), nil
+	case "values":
+		if len(args) != 1 {
+			return "", fmt.Errorf("values expects 1 arg")
+		}
+		c.use("_values")
+		return fmt.Sprintf("_values(%s)", args[0]), nil
 	case "exists":
 		if len(args) != 1 {
 			return "", fmt.Errorf("exists() expects 1 arg")

--- a/compiler/x/cs/runtime.go
+++ b/compiler/x/cs/runtime.go
@@ -22,6 +22,23 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("throw new Exception(\"count() expects list or string\");")
 				c.indent--
 				c.writeln("}")
+			case "_append":
+				c.writeln("static List<dynamic> _append(IEnumerable<dynamic> a, dynamic b) {")
+				c.indent++
+				c.writeln("var res = new List<dynamic>();")
+				c.writeln("if (a != null) foreach (var it in a) res.Add(it);")
+				c.writeln("res.Add(b);")
+				c.writeln("return res;")
+				c.indent--
+				c.writeln("}")
+			case "_values":
+				c.writeln("static List<dynamic> _values(IDictionary<dynamic, dynamic> m) {")
+				c.indent++
+				c.writeln("var res = new List<dynamic>();")
+				c.writeln("foreach (System.Collections.DictionaryEntry kv in m) res.Add(kv.Value);")
+				c.writeln("return res;")
+				c.indent--
+				c.writeln("}")
 			case "_avg":
 				c.writeln("static double _avg(dynamic v) {")
 				c.indent++

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -2,9 +2,9 @@
 
 This checklist tracks which Mochi programs from `tests/vm/valid` have been compiled to C# and executed successfully.
 
-**29/97 files compiled**
+**31/97 files compiled**
 
-- [ ] append_builtin.mochi
+- [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
 - [x] binary_precedence.mochi
@@ -98,6 +98,6 @@ This checklist tracks which Mochi programs from `tests/vm/valid` have been compi
 - [ ] unary_neg.mochi
 - [ ] update_stmt.mochi
 - [ ] user_type_literal.mochi
-- [ ] values_builtin.mochi
+- [x] values_builtin.mochi
 - [ ] var_assignment.mochi
 - [ ] while_loop.mochi


### PR DESCRIPTION
## Summary
- implement `append` and `values` built-ins in the C# compiler
- emit runtime helpers for these built-ins
- update C# machine test checklist

## Testing
- `go test -tags slow ./compiler/x/cs -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c6a31722c8320a7ee885e6920c001