### PR TITLE
Add PHP syntax validation

### DIFF
--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -112,8 +112,11 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		c.writeln("")
 		c.emitRuntime()
 	}
-	code := c.buf.Bytes()
-	return FormatPHP(code), nil
+	code := FormatPHP(c.buf.Bytes())
+	if err := ValidatePHP(code); err != nil {
+		return code, err
+	}
+	return code, nil
 }
 
 // --- Statements ---

--- a/tests/machine/x/php/load_yaml.error
+++ b/tests/machine/x/php/load_yaml.error
@@ -1,0 +1,8 @@
+line: 33
+error: run error: exit status 255
+PHP Fatal error:  Uncaught Error: Call to undefined function yaml_parse() in /workspace/mochi/tests/machine/x/php/load_yaml.php:33
+Stack trace:
+#0 /workspace/mochi/tests/machine/x/php/load_yaml.php(14): _load_yaml()
+#1 {main}
+  thrown in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 33
+


### PR DESCRIPTION
## Summary
- validate generated PHP code with `php -l`
- capture YAML runtime failure in machine output

## Testing
- `go test ./compiler/x/php -tags=slow -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c731f2b2483208619d68839f10943