### PR TITLE
Fix load_yaml test for TS compiler

### DIFF
--- a/compiler/x/ts/machine_test.go
+++ b/compiler/x/ts/machine_test.go
@@ -54,7 +54,7 @@ func TestGenerateMachineOutput(t *testing.T) {
 			}
 			cmd := exec.Command("deno", "run", "--quiet", "--allow-net", "--allow-read", codePath)
 			cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system")
-			cmd.Dir = filepath.Dir(src)
+			cmd.Dir = filepath.Join(filepath.Dir(src), "..")
 			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 				cmd.Stdin = bytes.NewReader(data)
 			}

--- a/tests/machine/x/ts/README.md
+++ b/tests/machine/x/ts/README.md
@@ -4,7 +4,7 @@ This directory contains TypeScript source files compiled from Mochi programs.
 
 ## Summary
 
-96/97 files compiled successfully
+97/97 files compiled successfully
 
 ## Checklist
 - [x] append_builtin.mochi
@@ -56,7 +56,7 @@ This directory contains TypeScript source files compiled from Mochi programs.
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
 - [x] list_set_ops.mochi
- - [ ] load_yaml.mochi
+- [x] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi


### PR DESCRIPTION
## Summary
- adjust working directory for TS machine output generation to match VM
- mark `load_yaml.mochi` as compiled

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686c7ca9675c832085e9d0513d76287c