### PR TITLE
Remove _print from php tests

### DIFF
--- a/tests/human/x/php/append_builtin.php
+++ b/tests/human/x/php/append_builtin.php
@@ -1,16 +1,4 @@
 <?php
 $a = [1, 2];
-_print(array_merge($a, [3]));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(array_merge($a, [3]));
 ?>

--- a/tests/human/x/php/avg_builtin.php
+++ b/tests/human/x/php/avg_builtin.php
@@ -1,17 +1,5 @@
 <?php
 $nums = [1, 2, 3];
 $avg = count($nums) ? array_sum($nums) / count($nums) : 0;
-_print($avg);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($avg);
 ?>

--- a/tests/human/x/php/basic_compare.php
+++ b/tests/human/x/php/basic_compare.php
@@ -1,19 +1,7 @@
 <?php
 $a = 10 - 3;
 $b = 2 + 2;
-_print($a);
-_print($a == 7);
-_print($b < 5);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($a);
+var_dump($a == 7);
+var_dump($b < 5);
 ?>

--- a/tests/human/x/php/binary_precedence.php
+++ b/tests/human/x/php/binary_precedence.php
@@ -1,18 +1,6 @@
 <?php
-_print(1 + 2 * 3);
-_print((1 + 2) * 3);
-_print(2 * 3 + 1);
-_print(2 * (3 + 1));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(1 + 2 * 3);
+var_dump((1 + 2) * 3);
+var_dump(2 * 3 + 1);
+var_dump(2 * (3 + 1));
 ?>

--- a/tests/human/x/php/bool_chain.php
+++ b/tests/human/x/php/bool_chain.php
@@ -1,22 +1,10 @@
 <?php
 function boom() {
-    _print("boom");
+    var_dump("boom");
     return true;
 }
 
-_print((1 < 2) && (2 < 3) && (3 < 4));
-_print((1 < 2) && (2 > 3) && boom());
-_print((1 < 2) && (2 < 3) && (3 > 4) && boom());
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump((1 < 2) && (2 < 3) && (3 < 4));
+var_dump((1 < 2) && (2 > 3) && boom());
+var_dump((1 < 2) && (2 < 3) && (3 > 4) && boom());
 ?>

--- a/tests/human/x/php/break_continue.php
+++ b/tests/human/x/php/break_continue.php
@@ -7,18 +7,6 @@ foreach ($numbers as $n) {
     if ($n > 7) {
         break;
     }
-    _print("odd number:", $n);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump("odd number:", $n);
 }
 ?>

--- a/tests/human/x/php/cast_string_to_int.php
+++ b/tests/human/x/php/cast_string_to_int.php
@@ -1,15 +1,3 @@
 <?php
-_print((int)"1995");
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump((int)"1995");
 ?>

--- a/tests/human/x/php/cast_struct.php
+++ b/tests/human/x/php/cast_struct.php
@@ -7,17 +7,5 @@ class Todo {
 }
 
 $todo = new Todo(['title' => 'hi']);
-_print($todo->title);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($todo->title);
 ?>

--- a/tests/human/x/php/closure.php
+++ b/tests/human/x/php/closure.php
@@ -6,17 +6,5 @@ function makeAdder($n) {
 }
 
 $add10 = makeAdder(10);
-_print($add10(7));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($add10(7));
 ?>

--- a/tests/human/x/php/count_builtin.php
+++ b/tests/human/x/php/count_builtin.php
@@ -1,15 +1,3 @@
 <?php
-_print(count([1, 2, 3]));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(count([1, 2, 3]));
 ?>

--- a/tests/human/x/php/cross_join.php
+++ b/tests/human/x/php/cross_join.php
@@ -20,20 +20,8 @@ foreach ($orders as $o) {
         ];
     }
 }
-_print("--- Cross Join: All order-customer pairs ---");
+var_dump("--- Cross Join: All order-customer pairs ---");
 foreach ($result as $entry) {
-    _print("Order", $entry['orderId'], "(customerId:", $entry['orderCustomerId'], ", total: $", $entry['orderTotal'], ") paired with", $entry['pairedCustomerName']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump("Order", $entry['orderId'], "(customerId:", $entry['orderCustomerId'], ", total: $", $entry['orderTotal'], ") paired with", $entry['pairedCustomerName']);
 }
 ?>

--- a/tests/human/x/php/cross_join_filter.php
+++ b/tests/human/x/php/cross_join_filter.php
@@ -9,20 +9,8 @@ foreach ($nums as $n) {
         }
     }
 }
-_print("--- Even pairs ---");
+var_dump("--- Even pairs ---");
 foreach ($pairs as $p) {
-    _print($p['n'], $p['l']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($p['n'], $p['l']);
 }
 ?>

--- a/tests/human/x/php/cross_join_triple.php
+++ b/tests/human/x/php/cross_join_triple.php
@@ -10,20 +10,8 @@ foreach ($nums as $n) {
         }
     }
 }
-_print("--- Cross Join of three lists ---");
+var_dump("--- Cross Join of three lists ---");
 foreach ($combos as $c) {
-    _print($c['n'], $c['l'], $c['b'] ? 'true' : 'false');
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($c['n'], $c['l'], $c['b'] ? 'true' : 'false');
 }
 ?>

--- a/tests/human/x/php/dataset_sort_take_limit.php
+++ b/tests/human/x/php/dataset_sort_take_limit.php
@@ -10,20 +10,8 @@ $products = [
 ];
 usort($products,function($a,$b){return $b['price'] <=> $a['price'];});
 $expensive = array_slice($products,1,3);
-_print("--- Top products (excluding most expensive) ---");
+var_dump("--- Top products (excluding most expensive) ---");
 foreach ($expensive as $item) {
-    _print($item['name'], "costs $", $item['price']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($item['name'], "costs $", $item['price']);
 }
 ?>

--- a/tests/human/x/php/dataset_where_filter.php
+++ b/tests/human/x/php/dataset_where_filter.php
@@ -15,21 +15,9 @@ foreach ($people as $person) {
         ];
     }
 }
-_print("--- Adults ---");
+var_dump("--- Adults ---");
 foreach ($adults as $person) {
     $extra = $person['is_senior'] ? " (senior)" : "";
-    _print($person['name'], "is", $person['age'] . $extra);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($person['name'], "is", $person['age'] . $extra);
 }
 ?>

--- a/tests/human/x/php/exists_builtin.php
+++ b/tests/human/x/php/exists_builtin.php
@@ -4,17 +4,5 @@ $flag = false;
 foreach ($data as $x) {
     if ($x == 1) { $flag = true; break; }
 }
-_print($flag ? 'true' : 'false');
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($flag ? 'true' : 'false');
 ?>

--- a/tests/human/x/php/for_list_collection.php
+++ b/tests/human/x/php/for_list_collection.php
@@ -1,17 +1,5 @@
 <?php
 foreach ([1,2,3] as $n) {
-    _print($n);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($n);
 }
 ?>

--- a/tests/human/x/php/for_loop.php
+++ b/tests/human/x/php/for_loop.php
@@ -1,17 +1,5 @@
 <?php
 for ($i = 1; $i <= 4; $i++) {
-    _print($i);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($i);
 }
 ?>

--- a/tests/human/x/php/for_map_collection.php
+++ b/tests/human/x/php/for_map_collection.php
@@ -1,18 +1,6 @@
 <?php
 $m = ["a"=>1, "b"=>2];
 foreach ($m as $k => $_) {
-    _print($k);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($k);
 }
 ?>

--- a/tests/human/x/php/fun_call.php
+++ b/tests/human/x/php/fun_call.php
@@ -2,17 +2,5 @@
 function add($a, $b) {
     return $a + $b;
 }
-_print(add(2,3));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(add(2,3));
 ?>

--- a/tests/human/x/php/fun_expr_in_let.php
+++ b/tests/human/x/php/fun_expr_in_let.php
@@ -1,16 +1,4 @@
 <?php
 $square = function($x) { return $x * $x; };
-_print($square(6));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($square(6));
 ?>

--- a/tests/human/x/php/fun_three_args.php
+++ b/tests/human/x/php/fun_three_args.php
@@ -1,16 +1,4 @@
 <?php
 function sum3($a,$b,$c) { return $a+$b+$c; }
-_print(sum3(1,2,3));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(sum3(1,2,3));
 ?>

--- a/tests/human/x/php/group_by.php
+++ b/tests/human/x/php/group_by.php
@@ -20,20 +20,8 @@ foreach ($groups as $city => $persons) {
     $avg = $total / count($persons);
     $stats[] = ["city" => $city, "count" => count($persons), "avg_age" => $avg];
 }
-_print("--- People grouped by city ---");
+var_dump("--- People grouped by city ---");
 foreach ($stats as $s) {
-    _print($s['city'], ": count =", $s['count'], ", avg_age =", $s['avg_age']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($s['city'], ": count =", $s['count'], ", avg_age =", $s['avg_age']);
 }
 ?>

--- a/tests/human/x/php/group_by_conditional_sum.php
+++ b/tests/human/x/php/group_by_conditional_sum.php
@@ -21,17 +21,5 @@ foreach ($groups as $cat => $group) {
     }
     $result[] = ["cat" => $cat, "share" => $flagged / $total];
 }
-_print($result);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($result);
 ?>

--- a/tests/human/x/php/group_by_having.php
+++ b/tests/human/x/php/group_by_having.php
@@ -18,17 +18,5 @@ foreach ($groups as $city => $persons) {
         $big[] = ["city" => $city, "num" => count($persons)];
     }
 }
-_print($big);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($big);
 ?>

--- a/tests/human/x/php/group_by_join.php
+++ b/tests/human/x/php/group_by_join.php
@@ -21,20 +21,8 @@ $stats = [];
 foreach ($groups as $name => $ordersFor) {
     $stats[] = ['name'=>$name, 'count'=>count($ordersFor)];
 }
-_print("--- Orders per customer ---");
+var_dump("--- Orders per customer ---");
 foreach ($stats as $s) {
-    _print($s['name'], "orders:", $s['count']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($s['name'], "orders:", $s['count']);
 }
 ?>

--- a/tests/human/x/php/group_by_left_join.php
+++ b/tests/human/x/php/group_by_left_join.php
@@ -19,20 +19,8 @@ foreach ($customers as $c) {
     }
     $stats[] = ['name'=>$c['name'], 'count'=>$count];
 }
-_print("--- Group Left Join ---");
+var_dump("--- Group Left Join ---");
 foreach ($stats as $s) {
-    _print($s['name'], "orders:", $s['count']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($s['name'], "orders:", $s['count']);
 }
 ?>

--- a/tests/human/x/php/group_by_multi_join.php
+++ b/tests/human/x/php/group_by_multi_join.php
@@ -21,7 +21,7 @@ foreach($filtered as $x){
 }
 $grouped=[];
 foreach($groups as $p=>$tot){$grouped[]=['part'=>$p,'total'=>$tot];}
-_print($grouped);
+var_dump($grouped);
 
-function _print(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
+function var_dump(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
 ?>

--- a/tests/human/x/php/group_by_multi_join_sort.php
+++ b/tests/human/x/php/group_by_multi_join_sort.php
@@ -34,7 +34,7 @@ foreach($map as $k=>$rev){$key=json_decode($k,true);$result[]=[
   'c_phone'=>$key['c_phone'],
   'c_comment'=>$key['c_comment']];}
 usort($result,function($a,$b){return $b['revenue']<=>$a['revenue'];});
-_print($result);
+var_dump($result);
 
-function _print(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
+function var_dump(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
 ?>

--- a/tests/human/x/php/group_by_sort.php
+++ b/tests/human/x/php/group_by_sort.php
@@ -8,7 +8,7 @@ foreach($items as $i){
 $grouped=[];
 foreach($groups as $cat=>$total){$grouped[]=['cat'=>$cat,'total'=>$total];}
 usort($grouped,function($a,$b){return $b['total']<=>$a['total'];});
-_print($grouped);
+var_dump($grouped);
 
-function _print(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
+function var_dump(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
 ?>

--- a/tests/human/x/php/group_items_iteration.php
+++ b/tests/human/x/php/group_items_iteration.php
@@ -6,7 +6,7 @@ $tmp=[];
 foreach($groups as $tag=>$items){$total=0;foreach($items as $x){$total+=$x['val'];}$tmp[]=['tag'=>$tag,'total'=>$total];}
 usort($tmp,function($a,$b){return $a['tag']<=>$b['tag'];});
 $result=$tmp;
-_print($result);
+var_dump($result);
 
-function _print(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
+function var_dump(...$args){$parts=[];foreach($args as $a){if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);}}echo implode(' ',$parts),PHP_EOL;}
 ?>

--- a/tests/human/x/php/if_else.php
+++ b/tests/human/x/php/if_else.php
@@ -1,20 +1,8 @@
 <?php
 $x = 5;
 if ($x > 3) {
-    _print("big");
+    var_dump("big");
 } else {
-    _print("small");
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump("small");
 }
 ?>

--- a/tests/human/x/php/if_then_else.php
+++ b/tests/human/x/php/if_then_else.php
@@ -1,17 +1,5 @@
 <?php
 $x = 12;
 $msg = $x > 10 ? "yes" : "no";
-_print($msg);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($msg);
 ?>

--- a/tests/human/x/php/if_then_else_nested.php
+++ b/tests/human/x/php/if_then_else_nested.php
@@ -1,17 +1,5 @@
 <?php
 $x = 8;
 $msg = $x > 10 ? "big" : ($x > 5 ? "medium" : "small");
-_print($msg);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($msg);
 ?>

--- a/tests/human/x/php/in_operator.php
+++ b/tests/human/x/php/in_operator.php
@@ -1,17 +1,5 @@
 <?php
 $xs = [1, 2, 3];
-_print(in_array(2, $xs));
-_print(!in_array(5, $xs));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(in_array(2, $xs));
+var_dump(!in_array(5, $xs));
 ?>

--- a/tests/human/x/php/in_operator_extended.php
+++ b/tests/human/x/php/in_operator_extended.php
@@ -1,26 +1,14 @@
 <?php
 $xs = [1, 2, 3];
 $ys = array_values(array_filter($xs, fn($x) => $x % 2 == 1));
-_print(in_array(1, $ys));
-_print(in_array(2, $ys));
+var_dump(in_array(1, $ys));
+var_dump(in_array(2, $ys));
 
 $m = ["a" => 1];
-_print(array_key_exists("a", $m));
-_print(array_key_exists("b", $m));
+var_dump(array_key_exists("a", $m));
+var_dump(array_key_exists("b", $m));
 
 $s = "hello";
-_print(strpos($s, "ell") !== false);
-_print(strpos($s, "foo") !== false);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(strpos($s, "ell") !== false);
+var_dump(strpos($s, "foo") !== false);
 ?>

--- a/tests/human/x/php/inner_join.php
+++ b/tests/human/x/php/inner_join.php
@@ -22,20 +22,8 @@ foreach ($orders as $o) {
         }
     }
 }
-_print("--- Orders with customer info ---");
+var_dump("--- Orders with customer info ---");
 foreach ($result as $entry) {
-    _print("Order", $entry['orderId'], "by", $entry['customerName'], "- $", $entry['total']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump("Order", $entry['orderId'], "by", $entry['customerName'], "- $", $entry['total']);
 }
 ?>

--- a/tests/human/x/php/join_multi.php
+++ b/tests/human/x/php/join_multi.php
@@ -23,20 +23,8 @@ foreach ($orders as $o) {
         }
     }
 }
-_print("--- Multi Join ---");
+var_dump("--- Multi Join ---");
 foreach ($result as $r) {
-    _print($r['name'], "bought item", $r['sku']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($r['name'], "bought item", $r['sku']);
 }
 ?>

--- a/tests/human/x/php/json_builtin.php
+++ b/tests/human/x/php/json_builtin.php
@@ -1,16 +1,4 @@
 <?php
 $m = ['a' => 1, 'b' => 2];
-_print(json_encode($m));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(json_encode($m));
 ?>

--- a/tests/human/x/php/left_join.php
+++ b/tests/human/x/php/left_join.php
@@ -22,20 +22,8 @@ foreach ($orders as $o) {
         'total' => $o['total']
     ];
 }
-_print("--- Left Join ---");
+var_dump("--- Left Join ---");
 foreach ($result as $entry) {
-    _print("Order", $entry['orderId'], "customer", $entry['customer'], "total", $entry['total']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump("Order", $entry['orderId'], "customer", $entry['customer'], "total", $entry['total']);
 }
 ?>

--- a/tests/human/x/php/left_join_multi.php
+++ b/tests/human/x/php/left_join_multi.php
@@ -27,20 +27,8 @@ foreach ($orders as $o) {
         }
     }
 }
-_print("--- Left Join Multi ---");
+var_dump("--- Left Join Multi ---");
 foreach ($result as $r) {
-    _print($r['orderId'], $r['name'], $r['item']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($r['orderId'], $r['name'], $r['item']);
 }
 ?>

--- a/tests/human/x/php/len_builtin.php
+++ b/tests/human/x/php/len_builtin.php
@@ -1,15 +1,3 @@
 <?php
-_print(count([1, 2, 3]));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(count([1, 2, 3]));
 ?>

--- a/tests/human/x/php/len_map.php
+++ b/tests/human/x/php/len_map.php
@@ -1,15 +1,3 @@
 <?php
-_print(count(["a" => 1, "b" => 2]));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(count(["a" => 1, "b" => 2]));
 ?>

--- a/tests/human/x/php/len_string.php
+++ b/tests/human/x/php/len_string.php
@@ -1,15 +1,3 @@
 <?php
-_print(strlen("mochi"));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(strlen("mochi"));
 ?>

--- a/tests/human/x/php/let_and_print.php
+++ b/tests/human/x/php/let_and_print.php
@@ -1,17 +1,5 @@
 <?php
 $a = 10;
 $b = 20;
-_print($a + $b);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($a + $b);
 ?>

--- a/tests/human/x/php/list_assign.php
+++ b/tests/human/x/php/list_assign.php
@@ -1,17 +1,5 @@
 <?php
 $nums = [1, 2];
 $nums[1] = 3;
-_print($nums[1]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($nums[1]);
 ?>

--- a/tests/human/x/php/list_index.php
+++ b/tests/human/x/php/list_index.php
@@ -1,16 +1,4 @@
 <?php
 $xs = [10, 20, 30];
-_print($xs[1]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($xs[1]);
 ?>

--- a/tests/human/x/php/list_nested_assign.php
+++ b/tests/human/x/php/list_nested_assign.php
@@ -1,17 +1,5 @@
 <?php
 $matrix = [[1,2],[3,4]];
 $matrix[1][0] = 5;
-_print($matrix[1][0]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($matrix[1][0]);
 ?>

--- a/tests/human/x/php/list_set_ops.php
+++ b/tests/human/x/php/list_set_ops.php
@@ -1,20 +1,8 @@
 <?php
 $a = [1,2];
 $b = [2,3];
-_print(array_values(array_unique(array_merge($a, $b))));
-_print(array_values(array_diff([1,2,3], [2])));
-_print(array_values(array_intersect([1,2,3], [2,4])));
-_print(count(array_merge([1,2],[2,3])));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(array_values(array_unique(array_merge($a, $b))));
+var_dump(array_values(array_diff([1,2,3], [2])));
+var_dump(array_values(array_intersect([1,2,3], [2,4])));
+var_dump(count(array_merge([1,2],[2,3])));
 ?>

--- a/tests/human/x/php/load_yaml.php
+++ b/tests/human/x/php/load_yaml.php
@@ -21,18 +21,6 @@ foreach ($lines as $line) {
 if ($current) $people[] = $current;
 $adults = array_filter($people, fn($p) => $p['age'] >= 18);
 foreach ($adults as $a) {
-    _print($a['name'], $a['email']);
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
+    var_dump($a['name'], $a['email']);
 }
 ?>

--- a/tests/human/x/php/map_assign.php
+++ b/tests/human/x/php/map_assign.php
@@ -1,17 +1,5 @@
 <?php
 $scores = ["alice" => 1];
 $scores["bob"] = 2;
-_print($scores["bob"]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($scores["bob"]);
 ?>

--- a/tests/human/x/php/map_in_operator.php
+++ b/tests/human/x/php/map_in_operator.php
@@ -1,17 +1,5 @@
 <?php
 $m = [1 => 'a', 2 => 'b'];
-_print(array_key_exists(1, $m));
-_print(array_key_exists(3, $m));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(array_key_exists(1, $m));
+var_dump(array_key_exists(3, $m));
 ?>

--- a/tests/human/x/php/map_index.php
+++ b/tests/human/x/php/map_index.php
@@ -1,16 +1,4 @@
 <?php
 $m = ["a" => 1, "b" => 2];
-_print($m["b"]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($m["b"]);
 ?>

--- a/tests/human/x/php/map_int_key.php
+++ b/tests/human/x/php/map_int_key.php
@@ -1,16 +1,4 @@
 <?php
 $m = [1 => 'a', 2 => 'b'];
-_print($m[1]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($m[1]);
 ?>

--- a/tests/human/x/php/map_literal_dynamic.php
+++ b/tests/human/x/php/map_literal_dynamic.php
@@ -2,17 +2,5 @@
 $x = 3;
 $y = 4;
 $m = ["a" => $x, "b" => $y];
-_print($m["a"], $m["b"]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($m["a"], $m["b"]);
 ?>

--- a/tests/human/x/php/map_membership.php
+++ b/tests/human/x/php/map_membership.php
@@ -1,17 +1,5 @@
 <?php
 $m = ["a" => 1, "b" => 2];
-_print(array_key_exists("a", $m));
-_print(array_key_exists("c", $m));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(array_key_exists("a", $m));
+var_dump(array_key_exists("c", $m));
 ?>

--- a/tests/human/x/php/map_nested_assign.php
+++ b/tests/human/x/php/map_nested_assign.php
@@ -1,17 +1,5 @@
 <?php
 $data = ["outer" => ["inner" => 1]];
 $data["outer"]["inner"] = 2;
-_print($data["outer"]["inner"]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($data["outer"]["inner"]);
 ?>

--- a/tests/human/x/php/match_expr.php
+++ b/tests/human/x/php/match_expr.php
@@ -6,17 +6,5 @@ $label = match($x) {
     3 => "three",
     default => "unknown",
 };
-_print($label);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($label);
 ?>

--- a/tests/human/x/php/match_full.php
+++ b/tests/human/x/php/match_full.php
@@ -6,7 +6,7 @@ $label = match($x) {
     3 => "three",
     default => "unknown",
 };
-_print($label);
+var_dump($label);
 
 $day = "sun";
 $mood = match($day) {
@@ -15,11 +15,11 @@ $mood = match($day) {
     "sun" => "relaxed",
     default => "normal",
 };
-_print($mood);
+var_dump($mood);
 
 $ok = true;
 $status = $ok ? "confirmed" : "denied";
-_print($status);
+var_dump($status);
 
 function classify($n) {
     return match($n) {
@@ -28,18 +28,6 @@ function classify($n) {
         default => "many",
     };
 }
-_print(classify(0));
-_print(classify(5));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(classify(0));
+var_dump(classify(5));
 ?>

--- a/tests/human/x/php/math_ops.php
+++ b/tests/human/x/php/math_ops.php
@@ -1,17 +1,5 @@
 <?php
-_print(6 * 7);
-_print(7 / 2);
-_print(7 % 2);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(6 * 7);
+var_dump(7 / 2);
+var_dump(7 % 2);
 ?>

--- a/tests/human/x/php/membership.php
+++ b/tests/human/x/php/membership.php
@@ -1,17 +1,5 @@
 <?php
 $nums = [1,2,3];
-_print(in_array(2, $nums));
-_print(in_array(4, $nums));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(in_array(2, $nums));
+var_dump(in_array(4, $nums));
 ?>

--- a/tests/human/x/php/min_max_builtin.php
+++ b/tests/human/x/php/min_max_builtin.php
@@ -1,17 +1,5 @@
 <?php
 $nums = [3,1,4];
-_print(min($nums));
-_print(max($nums));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(min($nums));
+var_dump(max($nums));
 ?>

--- a/tests/human/x/php/nested_function.php
+++ b/tests/human/x/php/nested_function.php
@@ -5,17 +5,5 @@ function outer($x) {
     };
     return $inner(5);
 }
-_print(outer(3));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(outer(3));
 ?>

--- a/tests/human/x/php/order_by_map.php
+++ b/tests/human/x/php/order_by_map.php
@@ -11,17 +11,5 @@ usort($data, function($x,$y){
 });
 foreach ($data as &$d) { unset($d['_i']); }
 $sorted = $data;
-_print($sorted);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($sorted);
 ?>

--- a/tests/human/x/php/outer_join.php
+++ b/tests/human/x/php/outer_join.php
@@ -28,28 +28,16 @@ foreach ($customers as $c) {
         $result[] = ['order'=>null, 'customer'=>$c];
     }
 }
-_print("--- Outer Join using syntax ---");
+var_dump("--- Outer Join using syntax ---");
 foreach ($result as $row) {
     if ($row['order']) {
         if ($row['customer']) {
-            _print("Order", $row['order']['id'], "by", $row['customer']['name'], "- $", $row['order']['total']);
+            var_dump("Order", $row['order']['id'], "by", $row['customer']['name'], "- $", $row['order']['total']);
         } else {
-            _print("Order", $row['order']['id'], "by", "Unknown", "- $", $row['order']['total']);
+            var_dump("Order", $row['order']['id'], "by", "Unknown", "- $", $row['order']['total']);
         }
     } else {
-        _print("Customer", $row['customer']['name'], "has no orders");
+        var_dump("Customer", $row['customer']['name'], "has no orders");
     }
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
 }
 ?>

--- a/tests/human/x/php/partial_application.php
+++ b/tests/human/x/php/partial_application.php
@@ -3,17 +3,5 @@ function add($a, $b) {
     return $a + $b;
 }
 $add5 = function($b) { return add(5, $b); };
-_print($add5(3));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($add5(3));
 ?>

--- a/tests/human/x/php/print_hello.php
+++ b/tests/human/x/php/print_hello.php
@@ -1,15 +1,3 @@
 <?php
-_print("hello");
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump("hello");
 ?>

--- a/tests/human/x/php/pure_fold.php
+++ b/tests/human/x/php/pure_fold.php
@@ -1,16 +1,4 @@
 <?php
 function triple($x) { return $x * 3; }
-_print(triple(1 + 2));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(triple(1 + 2));
 ?>

--- a/tests/human/x/php/pure_global_fold.php
+++ b/tests/human/x/php/pure_global_fold.php
@@ -4,17 +4,5 @@ function inc($x) {
     global $k;
     return $x + $k;
 }
-_print(inc(3));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(inc(3));
 ?>

--- a/tests/human/x/php/query_sum_select.php
+++ b/tests/human/x/php/query_sum_select.php
@@ -4,17 +4,5 @@ $result = 0;
 foreach ($nums as $n) {
     if ($n > 1) $result += $n;
 }
-_print($result);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($result);
 ?>

--- a/tests/human/x/php/record_assign.php
+++ b/tests/human/x/php/record_assign.php
@@ -2,17 +2,5 @@
 $c = ["n" => 0];
 function inc(&$c) { $c['n'] = $c['n'] + 1; }
 inc($c);
-_print($c['n']);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($c['n']);
 ?>

--- a/tests/human/x/php/right_join.php
+++ b/tests/human/x/php/right_join.php
@@ -23,24 +23,12 @@ foreach ($customers as $c) {
         $result[] = ['customerName'=>$c['name'], 'order'=>null];
     }
 }
-_print("--- Right Join using syntax ---");
+var_dump("--- Right Join using syntax ---");
 foreach ($result as $e) {
     if ($e['order']) {
-        _print("Customer", $e['customerName'], "has order", $e['order']['id'], "- $", $e['order']['total']);
+        var_dump("Customer", $e['customerName'], "has order", $e['order']['id'], "- $", $e['order']['total']);
     } else {
-        _print("Customer", $e['customerName'], "has no orders");
+        var_dump("Customer", $e['customerName'], "has no orders");
     }
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
 }
 ?>

--- a/tests/human/x/php/short_circuit.php
+++ b/tests/human/x/php/short_circuit.php
@@ -1,20 +1,8 @@
 <?php
 function boom($a,$b){
-    _print("boom");
+    var_dump("boom");
     return true;
 }
-_print(false && boom(1,2));
-_print(true || boom(1,2));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(false && boom(1,2));
+var_dump(true || boom(1,2));
 ?>

--- a/tests/human/x/php/slice.php
+++ b/tests/human/x/php/slice.php
@@ -1,17 +1,5 @@
 <?php
-_print(array_slice([1,2,3],1,2));
-_print(array_slice([1,2,3],0,2));
-_print(substr("hello",1,3));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(array_slice([1,2,3],1,2));
+var_dump(array_slice([1,2,3],0,2));
+var_dump(substr("hello",1,3));
 ?>

--- a/tests/human/x/php/sort_stable.php
+++ b/tests/human/x/php/sort_stable.php
@@ -10,12 +10,5 @@ usort($items,function($x,$y){
     return $x['n'] <=> $y['n'];
 });
 $result = array_map(fn($x)=>$x['v'],$items);
-_print($result);
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
-}
+var_dump($result);
 ?>

--- a/tests/human/x/php/str_builtin.php
+++ b/tests/human/x/php/str_builtin.php
@@ -1,10 +1,3 @@
 <?php
-_print(strval(123));
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
-}
+var_dump(strval(123));
 ?>

--- a/tests/human/x/php/string_compare.php
+++ b/tests/human/x/php/string_compare.php
@@ -1,18 +1,6 @@
 <?php
-_print("a" < "b");
-_print("a" <= "a");
-_print("b" > "a");
-_print("b" >= "b");
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump("a" < "b");
+var_dump("a" <= "a");
+var_dump("b" > "a");
+var_dump("b" >= "b");
 ?>

--- a/tests/human/x/php/string_concat.php
+++ b/tests/human/x/php/string_concat.php
@@ -1,15 +1,3 @@
 <?php
-_print("hello " . "world");
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump("hello " . "world");
 ?>

--- a/tests/human/x/php/string_contains.php
+++ b/tests/human/x/php/string_contains.php
@@ -1,17 +1,5 @@
 <?php
 $s = "catch";
-_print(strpos($s, "cat") !== false);
-_print(strpos($s, "dog") !== false);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(strpos($s, "cat") !== false);
+var_dump(strpos($s, "dog") !== false);
 ?>

--- a/tests/human/x/php/string_in_operator.php
+++ b/tests/human/x/php/string_in_operator.php
@@ -1,17 +1,5 @@
 <?php
 $s = "catch";
-_print(strpos($s, "cat") !== false);
-_print(strpos($s, "dog") !== false);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(strpos($s, "cat") !== false);
+var_dump(strpos($s, "dog") !== false);
 ?>

--- a/tests/human/x/php/string_index.php
+++ b/tests/human/x/php/string_index.php
@@ -1,16 +1,4 @@
 <?php
 $s = "mochi";
-_print($s[1]);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($s[1]);
 ?>

--- a/tests/human/x/php/string_prefix_slice.php
+++ b/tests/human/x/php/string_prefix_slice.php
@@ -1,19 +1,7 @@
 <?php
 $prefix = "fore";
 $s1 = "forest";
-_print(substr($s1, 0, strlen($prefix)) == $prefix);
+var_dump(substr($s1, 0, strlen($prefix)) == $prefix);
 $s2 = "desert";
-_print(substr($s2, 0, strlen($prefix)) == $prefix);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(substr($s2, 0, strlen($prefix)) == $prefix);
 ?>

--- a/tests/human/x/php/substring_builtin.php
+++ b/tests/human/x/php/substring_builtin.php
@@ -1,15 +1,3 @@
 <?php
-_print(substr("mochi", 1, 3));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(substr("mochi", 1, 3));
 ?>

--- a/tests/human/x/php/sum_builtin.php
+++ b/tests/human/x/php/sum_builtin.php
@@ -1,15 +1,3 @@
 <?php
-_print(array_sum([1, 2, 3]));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(array_sum([1, 2, 3]));
 ?>

--- a/tests/human/x/php/tail_recursion.php
+++ b/tests/human/x/php/tail_recursion.php
@@ -3,12 +3,5 @@ function sum_rec($n,$acc){
     if($n==0) return $acc;
     return sum_rec($n-1,$acc+$n);
 }
-_print(sum_rec(10,0));
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
-}
+var_dump(sum_rec(10,0));
 ?>

--- a/tests/human/x/php/test_block.php
+++ b/tests/human/x/php/test_block.php
@@ -6,12 +6,5 @@ function expect($cond){
 }
 $x = 1 + 2;
 expect($x == 3);
-_print("ok");
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
-}
+var_dump("ok");
 ?>

--- a/tests/human/x/php/tree_sum.php
+++ b/tests/human/x/php/tree_sum.php
@@ -6,12 +6,5 @@ function sum_tree($t){
     return sum_tree($t->left)+$t->value+sum_tree($t->right);
 }
 $t = new Node(new Leaf(),1,new Node(new Leaf(),2,new Leaf()));
-_print(sum_tree($t));
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
-}
+var_dump(sum_tree($t));
 ?>

--- a/tests/human/x/php/two_sum.php
+++ b/tests/human/x/php/two_sum.php
@@ -11,13 +11,6 @@ function twoSum($nums,$target){
     return [-1,-1];
 }
 $result=twoSum([2,7,11,15],9);
-_print($result[0]);
-_print($result[1]);
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
-}
+var_dump($result[0]);
+var_dump($result[1]);
 ?>

--- a/tests/human/x/php/typed_let.php
+++ b/tests/human/x/php/typed_let.php
@@ -1,16 +1,4 @@
 <?php
 $y = null;
-_print($y);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($y);
 ?>

--- a/tests/human/x/php/typed_var.php
+++ b/tests/human/x/php/typed_var.php
@@ -1,16 +1,4 @@
 <?php
 $x = null;
-_print($x);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($x);
 ?>

--- a/tests/human/x/php/unary_neg.php
+++ b/tests/human/x/php/unary_neg.php
@@ -1,16 +1,4 @@
 <?php
-_print(-3);
-_print(5 + (-2));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(-3);
+var_dump(5 + (-2));
 ?>

--- a/tests/human/x/php/update_stmt.php
+++ b/tests/human/x/php/update_stmt.php
@@ -18,15 +18,8 @@ $expected=[
     ["name"=>"Diana","age"=>16,"status"=>"minor"],
 ];
 if($people==$expected){
-    _print("ok");
+    var_dump("ok");
 }else{
-    _print("mismatch");
-}
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
+    var_dump("mismatch");
 }
 ?>

--- a/tests/human/x/php/user_type_literal.php
+++ b/tests/human/x/php/user_type_literal.php
@@ -3,12 +3,5 @@ $book = [
     'title' => 'Go',
     'author' => ['name'=>'Bob','age'=>42],
 ];
-_print($book['author']['name']);
-
-function _print(...$args){
-    $parts=[];
-    foreach($args as $a){
-        if(is_array($a)||is_object($a)){$parts[]=json_encode($a);}else{$parts[]=strval($a);} }
-    echo implode(' ',$parts),PHP_EOL;
-}
+var_dump($book['author']['name']);
 ?>

--- a/tests/human/x/php/values_builtin.php
+++ b/tests/human/x/php/values_builtin.php
@@ -1,16 +1,4 @@
 <?php
 $m = ["a" => 1, "b" => 2, "c" => 3];
-_print(array_values($m));
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump(array_values($m));
 ?>

--- a/tests/human/x/php/var_assignment.php
+++ b/tests/human/x/php/var_assignment.php
@@ -1,17 +1,5 @@
 <?php
 $x = 1;
 $x = 2;
-_print($x);
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
+var_dump($x);
 ?>

--- a/tests/human/x/php/while_loop.php
+++ b/tests/human/x/php/while_loop.php
@@ -1,19 +1,7 @@
 <?php
 $i = 0;
 while ($i < 3) {
-    _print($i);
+    var_dump($i);
     $i = $i + 1;
-}
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) {
-            $parts[] = json_encode($a);
-        } else {
-            $parts[] = strval($a);
-        }
-    }
-    echo implode(' ', $parts), PHP_EOL;
 }
 ?>


### PR DESCRIPTION
## Summary
- delete custom `_print` helper from PHP fixtures
- replace `_print()` calls with `var_dump()`

## Testing
- `make fmt`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686c81679dec8320a2b378baac7ee3dd