### PR TITLE
Add else-if support to Smalltalk compiler

### DIFF
--- a/compiler/x/smalltalk/compiler.go
+++ b/compiler/x/smalltalk/compiler.go
@@ -174,6 +174,16 @@ func (c *Compiler) compileIf(i *parser.IfStmt) error {
 		}
 	}
 	c.indent--
+	if i.ElseIf != nil {
+		c.writeln("] ifFalse: [")
+		c.indent++
+		if err := c.compileIf(i.ElseIf); err != nil {
+			return err
+		}
+		c.indent--
+		c.writeln("].")
+		return nil
+	}
 	if i.Else == nil {
 		c.writeln("] .")
 		return nil


### PR DESCRIPTION
## Summary
- enhance smalltalk compiler `compileIf` to emit nested else-if blocks

## Testing
- `go test ./compiler/x/smalltalk -tags=slow -run TestCompilePrograms -v`

------
https://chatgpt.com/codex/tasks/task_e_686c8297b8c083209c10de1b7c4af9ba