### PR TITLE
Enhance OCaml compiler

### DIFF
--- a/compiler/x/ocaml/compiler.go
+++ b/compiler/x/ocaml/compiler.go
@@ -129,6 +129,17 @@ func (c *Compiler) compileGlobalLet(l *parser.LetStmt) error {
 		if err != nil {
 			return err
 		}
+	} else if l.Type != nil && l.Type.Simple != nil {
+		switch *l.Type.Simple {
+		case "int":
+			val = "0"
+		case "float":
+			val = "0.0"
+		case "bool":
+			val = "false"
+		case "string":
+			val = "\"\""
+		}
 	}
 	c.writeln(fmt.Sprintf("let %s = %s", l.Name, val))
 	return nil
@@ -406,6 +417,11 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("avg expects 1 arg")
 		}
 		return fmt.Sprintf("(List.fold_left (+) 0 %s / List.length %s)", args[0], args[0]), nil
+	case "str":
+		if len(args) != 1 {
+			return "", fmt.Errorf("str expects 1 arg")
+		}
+		return fmt.Sprintf("__show (%s)", args[0]), nil
 	default:
 		return fmt.Sprintf("%s %s", call.Func, strings.Join(args, " ")), nil
 	}

--- a/tests/machine/x/ocaml/README.md
+++ b/tests/machine/x/ocaml/README.md
@@ -1,7 +1,7 @@
 # Generated OCaml Programs
 
 This directory stores OCaml source files produced by the experimental Mochi to OCaml compiler under `compiler/x/ocaml`. Each entry corresponds to a program in `tests/vm/valid`.
-Compiled programs: 7/97
+Compiled programs: 13/97
 
 The checklist below indicates which programs compiled and ran successfully (`[x]`).
 
@@ -22,7 +22,7 @@ The checklist below indicates which programs compiled and ran successfully (`[x]
 - [ ] dataset_where_filter.mochi
 - [ ] exists_builtin.mochi
 - [ ] for_list_collection.mochi
-- [ ] for_loop.mochi
+ - [x] for_loop.mochi
 - [ ] for_map_collection.mochi
 - [ ] fun_call.mochi
 - [ ] fun_expr_in_let.mochi
@@ -81,7 +81,7 @@ The checklist below indicates which programs compiled and ran successfully (`[x]
 - [ ] short_circuit.mochi
 - [ ] slice.mochi
 - [ ] sort_stable.mochi
-- [ ] str_builtin.mochi
+ - [x] str_builtin.mochi
 - [ ] string_compare.mochi
 - [ ] string_concat.mochi
 - [ ] string_contains.mochi
@@ -94,11 +94,11 @@ The checklist below indicates which programs compiled and ran successfully (`[x]
 - [ ] test_block.mochi
 - [ ] tree_sum.mochi
 - [ ] two-sum.mochi
-- [ ] typed_let.mochi
-- [ ] typed_var.mochi
+ - [x] typed_let.mochi
+ - [x] typed_var.mochi
 - [ ] unary_neg.mochi
 - [ ] update_stmt.mochi
 - [ ] user_type_literal.mochi
 - [ ] values_builtin.mochi
-- [ ] var_assignment.mochi
-- [ ] while_loop.mochi
+ - [x] var_assignment.mochi
+ - [x] while_loop.mochi


### PR DESCRIPTION
## Summary
- add default initialization for typed `let` statements
- implement `str()` builtin
- update generated README checklist

## Testing
- `go test -tags slow ./compiler/x/ocaml -run TestPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c82828b148320aa94e8dd71bae794