### PR TITLE
Fix Clojure compiler let bindings

### DIFF
--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -2108,6 +2108,7 @@ func (c *Compiler) compileQueryHelper(q *parser.QueryExpr) (string, error) {
 		}
 		b.WriteString(" })\n")
 		b.WriteString("      _groups (_group_by _rows (fn [" + allParams + "] " + groupKey + "))\n")
+		b.WriteString("      ]\n")
 		genv := types.NewEnv(child)
 		var gElem types.Type
 		gElem, _ = child.GetVar(q.Var)


### PR DESCRIPTION
## Summary
- ensure query helper closes let bindings when emitting group-by logic for clj compiler

## Testing
- `go test -tags slow ./compiler/x/clj -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c826806608320969dc90439042d53