### PR TITLE
Enhance Python compiler with struct and indexing support

### DIFF
--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -1,6 +1,6 @@
 # Python Compiler Results
 
-Compiled programs: 53/97
+Compiled programs: 63/97
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -9,7 +9,7 @@ Compiled programs: 53/97
 - [x] bool_chain.mochi
 - [x] break_continue.mochi
 - [x] cast_string_to_int.mochi
-- [ ] cast_struct.mochi
+- [x] cast_struct.mochi
 - [x] closure.mochi
 - [x] count_builtin.mochi
 - [ ] cross_join.mochi
@@ -40,25 +40,25 @@ Compiled programs: 53/97
 - [ ] in_operator_extended.mochi
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi
-- [ ] json_builtin.mochi
+- [x] json_builtin.mochi
 - [ ] left_join.mochi
 - [ ] left_join_multi.mochi
 - [x] len_builtin.mochi
 - [x] len_map.mochi
 - [x] len_string.mochi
 - [x] let_and_print.mochi
-- [ ] list_assign.mochi
+- [x] list_assign.mochi
 - [x] list_index.mochi
-- [ ] list_nested_assign.mochi
+- [x] list_nested_assign.mochi
 - [ ] list_set_ops.mochi
 - [x] load_yaml.mochi
-- [ ] map_assign.mochi
+- [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi
 - [x] map_int_key.mochi
 - [x] map_literal_dynamic.mochi
 - [x] map_membership.mochi
-- [ ] map_nested_assign.mochi
+- [x] map_nested_assign.mochi
 - [ ] match_expr.mochi
 - [ ] match_full.mochi
 - [x] math_ops.mochi
@@ -76,15 +76,15 @@ Compiled programs: 53/97
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
-- [ ] slice.mochi
+- [x] slice.mochi
 - [ ] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi
-- [ ] string_contains.mochi
+- [x] string_contains.mochi
 - [x] string_in_operator.mochi
 - [x] string_index.mochi
-- [ ] string_prefix_slice.mochi
+- [x] string_prefix_slice.mochi
 - [x] substring_builtin.mochi
 - [x] sum_builtin.mochi
 - [x] tail_recursion.mochi
@@ -95,7 +95,7 @@ Compiled programs: 53/97
 - [x] typed_var.mochi
 - [x] unary_neg.mochi
 - [ ] update_stmt.mochi
-- [ ] user_type_literal.mochi
+- [x] user_type_literal.mochi
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi


### PR DESCRIPTION
## Summary
- support defining struct types and struct literals in the Python backend
- handle indexing and field assignments
- implement method calls, slices, and quoting of map keys
- add type mapping for basic Mochi types
- update Python compiler progress checklist

## Testing
- `go test -tags slow ./compiler/x/python -run TestPythonCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c82552af48320813861da18c1da26