### PR TITLE
Refine PHP compiler print output

### DIFF
--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -393,8 +393,7 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 	}
 	switch call.Func {
 	case "print":
-		c.use("_print")
-		return fmt.Sprintf("_print(%s)", strings.Join(args, ", ")), nil
+		return fmt.Sprintf("var_dump(%s)", strings.Join(args, ", ")), nil
 	case "append":
 		if len(args) != 2 {
 			return "", fmt.Errorf("append expects 2 args")

--- a/compiler/x/php/runtime.go
+++ b/compiler/x/php/runtime.go
@@ -2,18 +2,6 @@
 
 package phpcode
 
-const helperPrint = "function _print(...$args) {\n" +
-	"    $parts = [];\n" +
-	"    foreach ($args as $a) {\n" +
-	"        if (is_array($a) || is_object($a)) {\n" +
-	"            $parts[] = json_encode($a);\n" +
-	"        } else {\n" +
-	"            $parts[] = strval($a);\n" +
-	"        }\n" +
-	"    }\n" +
-	"    echo implode(' ', $parts), PHP_EOL;\n" +
-	"}\n"
-
-var helperMap = map[string]string{
-	"_print": helperPrint,
-}
+// helperMap stores snippets of runtime helper functions that the compiler
+// can emit if needed. The PHP backend currently has no helpers.
+var helperMap = map[string]string{}


### PR DESCRIPTION
## Summary
- improve PHP backend to use `var_dump` directly
- remove unused runtime helper

## Testing
- `go test -run TestPHPCompiler_ValidPrograms -tags=slow ./compiler/x/php -v` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c8500c56083208ce5accf7519baf5