### PR TITLE
Improve Scala compiler type check

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -402,7 +402,7 @@ func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 		case "+", "-", "*", "/", "%", "==", "!=", "<", "<=", ">", ">=", "&&", "||":
 			s = fmt.Sprintf("%s %s %s", s, op.Op, r)
 		case "in":
-			ct := types.ExprType(op.Right, c.env)
+			ct := types.TypeOfPostfix(op.Right, c.env)
 			switch ct.(type) {
 			case types.MapType, types.ListType, types.StringType:
 				s = fmt.Sprintf("%s.contains(%s)", r, s)


### PR DESCRIPTION
## Summary
- fix compile error in Scala compiler due to wrong type inference call

## Testing
- `go test ./compiler/x/scala -tags slow -run TestScalaCompilerMachine -count=1` *(fails: scalac not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c852241ac8320b7e1633f9398a340