### PR TITLE
Add basic query support to TypeScript compiler

### DIFF
--- a/tests/machine/x/ts/README.md
+++ b/tests/machine/x/ts/README.md
@@ -4,7 +4,7 @@ This directory stores the generated TypeScript code and execution results for Mo
 
 ## Summary
 
-32/97 files compiled
+37/97 files compiled
 
 ## Checklist
 
@@ -18,11 +18,11 @@ This directory stores the generated TypeScript code and execution results for Mo
 - [ ] cast_struct.mochi
 - [ ] closure.mochi
 - [ ] count_builtin.mochi
-- [ ] cross_join.mochi
-- [ ] cross_join_filter.mochi
-- [ ] cross_join_triple.mochi
-- [ ] dataset_sort_take_limit.mochi
-- [ ] dataset_where_filter.mochi
+- [x] cross_join.mochi
+- [x] cross_join_filter.mochi
+- [x] cross_join_triple.mochi
+- [x] dataset_sort_take_limit.mochi
+- [x] dataset_where_filter.mochi
 - [ ] exists_builtin.mochi
 - [x] for_list_collection.mochi
 - [x] for_loop.mochi

--- a/tests/machine/x/ts/cross_join.error
+++ b/tests/machine/x/ts/cross_join.error
@@ -1,2 +1,0 @@
-line 0: unsupported expression at line 12
-// cross_join.mochi

--- a/tests/machine/x/ts/cross_join.out
+++ b/tests/machine/x/ts/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/tests/machine/x/ts/cross_join.ts
+++ b/tests/machine/x/ts/cross_join.ts
@@ -1,0 +1,17 @@
+let customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}];
+let orders = [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}];
+let result = (() => {
+  const _tmp1 = [];
+  for (const o of orders) {
+    for (const c of customers) {
+      _tmp1.push({orderId: o.id, orderCustomerId: o.customerId, pairedCustomerName: c.name, orderTotal: o.total});
+    }
+  }
+  let res = _tmp1;
+  return res;
+})()
+;
+console.log("--- Cross Join: All order-customer pairs ---");
+for (const entry of result) {
+  console.log("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName);
+}

--- a/tests/machine/x/ts/cross_join_filter.error
+++ b/tests/machine/x/ts/cross_join_filter.error
@@ -1,2 +1,0 @@
-line 0: unsupported expression at line 3
-let nums = [1, 2, 3]

--- a/tests/machine/x/ts/cross_join_filter.out
+++ b/tests/machine/x/ts/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B

--- a/tests/machine/x/ts/cross_join_filter.ts
+++ b/tests/machine/x/ts/cross_join_filter.ts
@@ -1,0 +1,18 @@
+let nums = [1, 2, 3];
+let letters = ["A", "B"];
+let pairs = (() => {
+  const _tmp1 = [];
+  for (const n of nums) {
+    for (const l of letters) {
+      if (!(((n % 2) == 0))) continue;
+      _tmp1.push({n: n, l: l});
+    }
+  }
+  let res = _tmp1;
+  return res;
+})()
+;
+console.log("--- Even pairs ---");
+for (const p of pairs) {
+  console.log(p.n, p.l);
+}

--- a/tests/machine/x/ts/cross_join_triple.error
+++ b/tests/machine/x/ts/cross_join_triple.error
@@ -1,2 +1,0 @@
-line 0: unsupported expression at line 4
-let nums = [1, 2]

--- a/tests/machine/x/ts/cross_join_triple.out
+++ b/tests/machine/x/ts/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false

--- a/tests/machine/x/ts/cross_join_triple.ts
+++ b/tests/machine/x/ts/cross_join_triple.ts
@@ -1,0 +1,20 @@
+let nums = [1, 2];
+let letters = ["A", "B"];
+let bools = [true, false];
+let combos = (() => {
+  const _tmp1 = [];
+  for (const n of nums) {
+    for (const l of letters) {
+      for (const b of bools) {
+        _tmp1.push({n: n, l: l, b: b});
+      }
+    }
+  }
+  let res = _tmp1;
+  return res;
+})()
+;
+console.log("--- Cross Join of three lists ---");
+for (const c of combos) {
+  console.log(c.n, c.l, c.b);
+}

--- a/tests/machine/x/ts/dataset_sort_take_limit.error
+++ b/tests/machine/x/ts/dataset_sort_take_limit.error
@@ -1,2 +1,0 @@
-line 0: unsupported expression at line 11
-// dataset-sort-take-limit.mochi

--- a/tests/machine/x/ts/dataset_sort_take_limit.out
+++ b/tests/machine/x/ts/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/machine/x/ts/dataset_sort_take_limit.ts
+++ b/tests/machine/x/ts/dataset_sort_take_limit.ts
@@ -1,0 +1,16 @@
+let products = [{name: "Laptop", price: 1500}, {name: "Smartphone", price: 900}, {name: "Tablet", price: 600}, {name: "Monitor", price: 300}, {name: "Keyboard", price: 100}, {name: "Mouse", price: 50}, {name: "Headphones", price: 200}];
+let expensive = (() => {
+  const _tmp1 = [];
+  for (const p of products) {
+    _tmp1.push({item: p, key: (-p.price)});
+  }
+  let res = _tmp1;
+  res = res.sort((a,b)=> a.key < b.key ? -1 : a.key > b.key ? 1 : 0).map(x=>x.item);
+  res = res.slice(1, (1 + 3));
+  return res;
+})()
+;
+console.log("--- Top products (excluding most expensive) ---");
+for (const item of expensive) {
+  console.log(item.name, "costs $", item.price);
+}

--- a/tests/machine/x/ts/dataset_where_filter.error
+++ b/tests/machine/x/ts/dataset_where_filter.error
@@ -1,2 +1,0 @@
-line 0: unsupported expression at line 7
-let people = [

--- a/tests/machine/x/ts/dataset_where_filter.out
+++ b/tests/machine/x/ts/dataset_where_filter.out
@@ -1,0 +1,4 @@
+--- Adults ---
+Alice is 30 
+Charlie is 65  (senior)
+Diana is 45

--- a/tests/machine/x/ts/dataset_where_filter.ts
+++ b/tests/machine/x/ts/dataset_where_filter.ts
@@ -1,0 +1,15 @@
+let people = [{name: "Alice", age: 30}, {name: "Bob", age: 15}, {name: "Charlie", age: 65}, {name: "Diana", age: 45}];
+let adults = (() => {
+  const _tmp1 = [];
+  for (const person of people) {
+    if (!((person.age >= 18))) continue;
+    _tmp1.push({name: person.name, age: person.age, is_senior: (person.age >= 60)});
+  }
+  let res = _tmp1;
+  return res;
+})()
+;
+console.log("--- Adults ---");
+for (const person of adults) {
+  console.log(person.name, "is", person.age, (person.is_senior ? " (senior)" : ""));
+}


### PR DESCRIPTION
## Summary
- implement simple query expression compilation in the TypeScript compiler
- support `break`, `continue`, type declarations, function literals and `if` expressions
- add generated TypeScript outputs for several query-based programs
- update the TS machine README

## Testing
- `go test ./compiler/x/ts -tags=slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c85e5ef688320b2b4f244ee6193bf