### PR TITLE
Improve Scala compiler print handling

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -369,12 +369,20 @@ func (c *Compiler) compileAssign(s *parser.AssignStmt) error {
 
 func (c *Compiler) compileExprStmt(s *parser.ExprStmt) error {
 	call, ok := callPattern(s.Expr)
-	if ok && call.Func == "print" && len(call.Args) == 1 {
-		arg, err := c.compileExpr(call.Args[0])
-		if err != nil {
-			return err
+	if ok && call.Func == "print" {
+		args := make([]string, len(call.Args))
+		for i, a := range call.Args {
+			v, err := c.compileExpr(a)
+			if err != nil {
+				return err
+			}
+			args[i] = v
 		}
-		c.writeln(fmt.Sprintf("println(%s)", arg))
+		if len(args) == 1 {
+			c.writeln(fmt.Sprintf("println(%s)", args[0]))
+		} else {
+			c.writeln(fmt.Sprintf("println(%s)", strings.Join(args, " + \" \" + ")))
+		}
 		return nil
 	}
 	expr, err := c.compileExpr(s.Expr)


### PR DESCRIPTION
## Summary
- add support for `print` with multiple arguments in the Scala compiler
- update tests

## Testing
- `go test -tags slow -run TestScalaCompilerGolden -v`

------
https://chatgpt.com/codex/tasks/task_e_686c87bc9628832096b8e1c0dc0bd692