### PR TITLE
Fix C# cross join tests

### DIFF
--- a/tests/machine/x/cs/cross_join.cs
+++ b/tests/machine/x/cs/cross_join.cs
@@ -11,8 +11,8 @@ public class Program
 {
     public static void Main()
     {
-        var customers = new Dictionary<string, dynamic>[] { new Dictionary<string, dynamic> { { "id", 1L }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2L }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3L }, { "name", "Charlie" } } };
-        Dictionary<string, long>[] orders = new Dictionary<string, long>[] { new Dictionary<string, long> { { "id", 100L }, { "customerId", 1L }, { "total", 250L } }, new Dictionary<string, long> { { "id", 101L }, { "customerId", 2L }, { "total", 125L } }, new Dictionary<string, long> { { "id", 102L }, { "customerId", 1L }, { "total", 300L } } };
+        var customers = new Dictionary<string, dynamic>[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
+        Dictionary<string, long>[] orders = new Dictionary<string, long>[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } } };
         var result = new Func<List<Dictionary<string, dynamic>>>(() =>
         {
             var _res = new List<Dictionary<string, dynamic>>();
@@ -28,7 +28,7 @@ public class Program
         Console.WriteLine("--- Cross Join: All order-customer pairs ---");
         foreach (var entry in result)
         {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString("Order"), Convert.ToString(entry.orderId), Convert.ToString("(customerId:"), Convert.ToString(entry.orderCustomerId), Convert.ToString(", total: $"), Convert.ToString(entry.orderTotal), Convert.ToString(") paired with"), Convert.ToString(entry.pairedCustomerName) }));
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString("Order"), Convert.ToString(entry["orderId"]), Convert.ToString("(customerId:"), Convert.ToString(entry["orderCustomerId"]), Convert.ToString(", total: $"), Convert.ToString(entry["orderTotal"]), Convert.ToString(") paired with"), Convert.ToString(entry["pairedCustomerName"]) }));
         }
     }
 }

--- a/tests/machine/x/cs/cross_join.error
+++ b/tests/machine/x/cs/cross_join.error
@@ -1,1 +1,0 @@
-exit status 1

--- a/tests/machine/x/cs/cross_join.out
+++ b/tests/machine/x/cs/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/tests/machine/x/cs/cross_join_filter.cs
+++ b/tests/machine/x/cs/cross_join_filter.cs
@@ -11,14 +11,14 @@ public class Program
 {
     public static void Main()
     {
-        long[] nums = new long[] { 1L, 2L, 3L };
+        long[] nums = new long[] { 1, 2, 3 };
         string[] letters = new string[] { "A", "B" };
         var pairs = new Func<List<Dictionary<string, dynamic>>>(() =>
         {
             var _res = new List<Dictionary<string, dynamic>>();
             foreach (var n in nums)
             {
-                if (!(((n % 2L) == 0L))) continue;
+                if (!(((n % 2) == 0))) continue;
                 foreach (var l in letters)
                 {
                     _res.Add(new Dictionary<string, dynamic> { { "n", n }, { "l", l } });
@@ -29,7 +29,7 @@ public class Program
         Console.WriteLine("--- Even pairs ---");
         foreach (var p in pairs)
         {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(p.n), Convert.ToString(p.l) }));
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(p["n"]), Convert.ToString(p["l"]) }));
         }
     }
 }

--- a/tests/machine/x/cs/cross_join_filter.error
+++ b/tests/machine/x/cs/cross_join_filter.error
@@ -1,1 +1,0 @@
-exit status 1

--- a/tests/machine/x/cs/cross_join_filter.out
+++ b/tests/machine/x/cs/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B

--- a/tests/machine/x/cs/cross_join_triple.cs
+++ b/tests/machine/x/cs/cross_join_triple.cs
@@ -11,7 +11,7 @@ public class Program
 {
     public static void Main()
     {
-        long[] nums = new long[] { 1L, 2L };
+        long[] nums = new long[] { 1, 2 };
         string[] letters = new string[] { "A", "B" };
         bool[] bools = new bool[] { true, false };
         var combos = new Func<List<Dictionary<string, dynamic>>>(() =>
@@ -32,7 +32,7 @@ public class Program
         Console.WriteLine("--- Cross Join of three lists ---");
         foreach (var c in combos)
         {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(c.n), Convert.ToString(c.l), Convert.ToString(c.b) }));
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(c["n"]), Convert.ToString(c["l"]), Convert.ToString(c["b"]) }));
         }
     }
 }

--- a/tests/machine/x/cs/cross_join_triple.error
+++ b/tests/machine/x/cs/cross_join_triple.error
@@ -1,1 +1,0 @@
-exit status 1

--- a/tests/machine/x/cs/cross_join_triple.out
+++ b/tests/machine/x/cs/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A True
+1 A False
+1 B True
+1 B False
+2 A True
+2 A False
+2 B True
+2 B False


### PR DESCRIPTION
## Summary
- regenerate cross join examples for the C# compiler
- remove stale `.error` files and add `.out` results

## Testing
- `go test ./compiler/x/cs -tags=slow -run TestCompileValidPrograms/cross_join`

------
https://chatgpt.com/codex/tasks/task_e_686c8778770483208d7c6a08879ca0c5