### PR TITLE
Expand Prolog compiler coverage

### DIFF
--- a/compiler/x/pl/compiler_test.go
+++ b/compiler/x/pl/compiler_test.go
@@ -21,6 +21,9 @@ var supported = map[string]bool{
 	"var_assignment":      true,
 	"for_loop":            true,
 	"for_list_collection": true,
+	"append_builtin":      true,
+	"avg_builtin":         true,
+	"basic_compare":       true,
 }
 
 func TestPrologCompiler(t *testing.T) {

--- a/tests/machine/x/pl/README.md
+++ b/tests/machine/x/pl/README.md
@@ -3,10 +3,13 @@
 This directory holds Prolog code generated from Mochi programs by the compiler tests.
 Below is a checklist of programs that were compiled and executed successfully.
 
-**5/5 programs compiled**
+**8/8 programs compiled**
 
 - [x] print_hello.mochi
 - [x] let_and_print.mochi
 - [x] var_assignment.mochi
 - [x] for_loop.mochi
 - [x] for_list_collection.mochi
+- [x] append_builtin.mochi
+- [x] avg_builtin.mochi
+- [x] basic_compare.mochi

--- a/tests/machine/x/pl/append_builtin.error
+++ b/tests/machine/x/pl/append_builtin.error
@@ -1,3 +1,0 @@
-run: exit status 2
-ERROR: /workspace/mochi/tests/machine/x/pl/append_builtin.pl:6: user:main is/2: Type error: `[]' expected, found `[1,2]' (a list) ("x" must hold one character)
-

--- a/tests/machine/x/pl/append_builtin.out
+++ b/tests/machine/x/pl/append_builtin.out
@@ -1,0 +1,3 @@
+Warning: /workspace/mochi/tests/machine/x/pl/append_builtin.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+[1,2,3]

--- a/tests/machine/x/pl/append_builtin.pl
+++ b/tests/machine/x/pl/append_builtin.pl
@@ -1,6 +1,6 @@
-:- style_check(-singleton).
-main :-
-    A is [1, 2],
-    % unsupported: unsupported primary
-    true.
 :- initialization(main, main).
+main :-
+    A = [1, 2],
+    append(A, [3], _V0),
+    writeln(_V0),
+    true.

--- a/tests/machine/x/pl/avg_builtin.out
+++ b/tests/machine/x/pl/avg_builtin.out
@@ -1,0 +1,6 @@
+Warning: /workspace/mochi/tests/machine/x/pl/avg_builtin.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+Warning:    Singleton-marked variable appears more than once: _V1
+Warning:    Singleton-marked variable appears more than once: _V2
+Warning:    Singleton-marked variable appears more than once: _V3
+2

--- a/tests/machine/x/pl/avg_builtin.pl
+++ b/tests/machine/x/pl/avg_builtin.pl
@@ -1,5 +1,9 @@
-:- style_check(-singleton).
-main :-
-    % unsupported: unsupported primary
-    true.
 :- initialization(main, main).
+main :-
+    sum_list([1, 2, 3], _V0),
+    length([1, 2, 3], _V1),
+    _V1 > 0,
+    _V2 is _V0 / _V1,
+    _V3 is _V2,
+    writeln(_V3),
+    true.

--- a/tests/machine/x/pl/basic_compare.out
+++ b/tests/machine/x/pl/basic_compare.out
@@ -1,3 +1,6 @@
+Warning: /workspace/mochi/tests/machine/x/pl/basic_compare.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+Warning:    Singleton-marked variable appears more than once: _V1
 7
-7=:=7
-4<5
+true
+true

--- a/tests/machine/x/pl/basic_compare.pl
+++ b/tests/machine/x/pl/basic_compare.pl
@@ -1,12 +1,10 @@
-:- style_check(-singleton).
+:- initialization(main, main).
 main :-
     A is (10 - 3),
     B is (2 + 2),
-    write(A),
-    nl,
-    write((A =:= 7)),
-    nl,
-    write((B < 5)),
-    nl,
+    writeln(A),
+    ((A =:= 7) -> _V0 = true ; _V0 = false),
+    writeln(_V0),
+    ((B < 5) -> _V1 = true ; _V1 = false),
+    writeln(_V1),
     true.
-:- initialization(main, main).

--- a/tests/machine/x/pl/for_list_collection.pl
+++ b/tests/machine/x/pl/for_list_collection.pl
@@ -1,9 +1,7 @@
-:- style_check(-singleton).
+:- initialization(main, main).
 main :-
     (member(N, [1, 2, 3]),
-        write(N),
-        nl,
+        writeln(N),
         fail
     ; true),
     true.
-:- initialization(main, main).

--- a/tests/machine/x/pl/for_loop.out
+++ b/tests/machine/x/pl/for_loop.out
@@ -1,3 +1,5 @@
+Warning: /workspace/mochi/tests/machine/x/pl/for_loop.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
 1
 2
 3

--- a/tests/machine/x/pl/for_loop.pl
+++ b/tests/machine/x/pl/for_loop.pl
@@ -1,10 +1,8 @@
-:- style_check(-singleton).
+:- initialization(main, main).
 main :-
     _V0 is 4 - 1,
     (between(1, _V0, I),
-        write(I),
-        nl,
+        writeln(I),
         fail
     ; true),
     true.
-:- initialization(main, main).

--- a/tests/machine/x/pl/let_and_print.out
+++ b/tests/machine/x/pl/let_and_print.out
@@ -1,1 +1,3 @@
-10+20
+Warning: /workspace/mochi/tests/machine/x/pl/let_and_print.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+30

--- a/tests/machine/x/pl/let_and_print.pl
+++ b/tests/machine/x/pl/let_and_print.pl
@@ -1,8 +1,7 @@
-:- style_check(-singleton).
-main :-
-    A = 10,
-    B = 20,
-    write((A + B)),
-    nl,
-    true.
 :- initialization(main, main).
+main :-
+    A is 10,
+    B is 20,
+    _V0 is (A + B),
+    writeln(_V0),
+    true.

--- a/tests/machine/x/pl/print_hello.pl
+++ b/tests/machine/x/pl/print_hello.pl
@@ -1,6 +1,4 @@
-:- style_check(-singleton).
-main :-
-    write("hello"),
-    nl,
-    true.
 :- initialization(main, main).
+main :-
+    writeln("hello"),
+    true.

--- a/tests/machine/x/pl/var_assignment.out
+++ b/tests/machine/x/pl/var_assignment.out
@@ -1,1 +1,3 @@
-_321
+Warning: /workspace/mochi/tests/machine/x/pl/var_assignment.pl:2:
+Warning:    Singleton variables: [X]
+2

--- a/tests/machine/x/pl/var_assignment.pl
+++ b/tests/machine/x/pl/var_assignment.pl
@@ -1,8 +1,6 @@
-:- style_check(-singleton).
-main :-
-    nb_setval(x, 1),
-    nb_setval(x, 2),
-    write(X),
-    nl,
-    true.
 :- initialization(main, main).
+main :-
+    X is 1,
+    X_0 is 2,
+    writeln(X_0),
+    true.


### PR DESCRIPTION
## Summary
- enhance Prolog compiler with mutable variable handling and simple builtin calls
- update Prolog compiler tests and expand supported programs
- regenerate machine generated Prolog code and outputs
- keep checklist of compiled programs up to date

## Testing
- `go test ./compiler/x/pl -run TestPrologCompiler -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_686c8a9aed048320a5d4a1662a2c5f35