### PR TITLE
Improve C# compiler tests

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -2273,20 +2273,20 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			elem = csTypeOf(lt.Elem)
 		}
 		expr := fmt.Sprintf("new List<%s>(%s)", elem, args[0])
-		return fmt.Sprintf("(()=>{var %s=%s;%s.Add(%s);return %s;})()", tmp, expr, tmp, args[1], tmp), nil
+		return fmt.Sprintf("(new Func<List<%s>>(() => {var %s=%s;%s.Add(%s);return %s;}))()", elem, tmp, expr, tmp, args[1], tmp), nil
 	case "values":
 		if len(args) != 1 {
 			return "", fmt.Errorf("values expects 1 arg")
 		}
 		tmp := c.newVar()
 		c.useLinq = true
-		return fmt.Sprintf("(()=>{var %s=new List<dynamic>();foreach(System.Collections.DictionaryEntry kv in %s){%s.Add(kv.Value);}return %s;})()", tmp, args[0], tmp, tmp), nil
+		return fmt.Sprintf("(new Func<List<dynamic>>(() => {var %s=new List<dynamic>();foreach(System.Collections.DictionaryEntry kv in %s){%s.Add(kv.Value);}return %s;}))()", tmp, args[0], tmp, tmp), nil
 	case "exists":
 		if len(args) != 1 {
 			return "", fmt.Errorf("exists() expects 1 arg")
 		}
 		tmp := c.newVar()
-		return fmt.Sprintf("(()=>{var %s=%s;if(%s is string s) return s.Length>0;if(%s is System.Collections.IEnumerable e) return e.GetEnumerator().MoveNext();return %s!=null;})()", tmp, args[0], tmp, tmp, tmp), nil
+		return fmt.Sprintf("(new Func<bool>(() => {var %s=%s;if(%s is string s) return s.Length>0;if(%s is System.Collections.IEnumerable e) return e.GetEnumerator().MoveNext();return %s!=null;}))()", tmp, args[0], tmp, tmp, tmp), nil
 	case "avg":
 		if len(args) != 1 {
 			return "", fmt.Errorf("avg() expects 1 arg")

--- a/compiler/x/cs/compiler_test.go
+++ b/compiler/x/cs/compiler_test.go
@@ -4,9 +4,12 @@ package cscode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -33,21 +36,25 @@ func TestCompileValidPrograms(t *testing.T) {
 	for _, file := range files {
 		name := strings.TrimSuffix(filepath.Base(file), ".mochi")
 		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
 			prog, err := parser.Parse(file)
 			if err != nil {
-				writeError(outDir, name, err)
+				writeError(outDir, name, data, err)
 				t.Skip("parse error")
 				return
 			}
 			env := types.NewEnv(nil)
 			if errs := types.Check(prog, env); len(errs) > 0 {
-				writeError(outDir, name, errs[0])
+				writeError(outDir, name, data, errs[0])
 				t.Skip("type error")
 				return
 			}
 			code, err := cscode.New(env).Compile(prog)
 			if err != nil {
-				writeError(outDir, name, err)
+				writeError(outDir, name, data, err)
 				t.Skip("compile error")
 				return
 			}
@@ -74,18 +81,56 @@ func TestCompileValidPrograms(t *testing.T) {
 			cmd.Stdout = &out
 			cmd.Stderr = &out
 			if err := cmd.Run(); err != nil {
-				writeError(outDir, name, err)
+				writeError(outDir, name, data, err)
 				return
 			}
 			if err := os.WriteFile(filepath.Join(outDir, name+".out"), bytes.TrimSpace(out.Bytes()), 0644); err != nil {
 				t.Fatal(err)
 			}
+			_ = os.Remove(filepath.Join(outDir, name+".error"))
 		})
 	}
 }
 
-func writeError(dir, name string, err error) {
-	_ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(err.Error()), 0644)
+func writeError(dir, name string, src []byte, err error) {
+	line := extractLine(err.Error())
+	var context string
+	if line > 0 {
+		lines := bytes.Split(src, []byte("\n"))
+		start := line - 2
+		if start < 1 {
+			start = 1
+		}
+		end := line + 2
+		if end > len(lines) {
+			end = len(lines)
+		}
+		var b strings.Builder
+		for i := start; i <= end; i++ {
+			if i-1 < len(lines) {
+				fmt.Fprintf(&b, "%4d: %s\n", i, lines[i-1])
+			}
+		}
+		context = b.String()
+	}
+	msg := fmt.Sprintf("line: %d\nerror: %v\n%s", line, err, context)
+	_ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(msg), 0644)
+}
+
+func extractLine(msg string) int {
+	re := regexp.MustCompile(`:(\d+):`)
+	if m := re.FindStringSubmatch(msg); m != nil {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	re = regexp.MustCompile(`line (\d+)`)
+	if m := re.FindStringSubmatch(msg); m != nil {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
 }
 
 func findRepoRoot(t *testing.T) string {

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -2,7 +2,7 @@
 
 This checklist tracks which Mochi programs from `tests/vm/valid` have been compiled to C# and executed successfully.
 
-**32/97 files compiled**
+**33/97 files compiled**
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi

--- a/tests/machine/x/cs/append_builtin.error
+++ b/tests/machine/x/cs/append_builtin.error
@@ -1,1 +1,0 @@
-exit status 1

--- a/tests/machine/x/cs/append_builtin.out
+++ b/tests/machine/x/cs/append_builtin.out
@@ -1,0 +1,1 @@
+System.Collections.Generic.List`1[System.Int64]


### PR DESCRIPTION
## Summary
- fix C# compiler lambda IIFEs using `new Func<>()`
- enhance C# compiler tests with context-rich error reporting
- remove obsolete error output and record successful run
- update compilation checklist for C# programs

## Testing
- `go test ./compiler/x/cs -tags slow -run TestCompileValidPrograms/append_builtin -v`

------
https://chatgpt.com/codex/tasks/task_e_686c8acdbd5083208db2c81d3cecdecb