### PR TITLE
Improve COBOL print logic

### DIFF
--- a/compiler/x/cobol/compiler.go
+++ b/compiler/x/cobol/compiler.go
@@ -308,7 +308,7 @@ func (c *Compiler) compilePrint(call *parser.CallExpr) error {
 		c.writeln(fmt.Sprintf("DISPLAY %s", val))
 		return nil
 	}
-	if isComparisonExpr(arg) {
+	if isComparisonExpr(arg) || isBoolExpr(arg) {
 		cond, err := c.compileExpr(arg)
 		if err != nil {
 			return err
@@ -635,6 +635,19 @@ func isSimpleExpr(e *parser.Expr) bool {
 	}
 	p := u.Value
 	return len(p.Ops) == 0 && p.Target != nil && (p.Target.Lit != nil || p.Target.Selector != nil)
+}
+
+func isBoolExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil {
+		return false
+	}
+	for _, op := range e.Binary.Right {
+		switch op.Op {
+		case "&&", "||", "==", "!=", "<", "<=", ">", ">=":
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Compiler) ensureTmpVar() string {


### PR DESCRIPTION
## Summary
- handle boolean expressions in `print` for COBOL compiler
- detect boolean operators via new `isBoolExpr`

## Testing
- `go test ./...`
- `go test -tags slow ./compiler/x/cobol -run TestCobolCompiler_Programs -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c8bc5dbb48320a663b089252caf92