### PR TITLE
Improve Racket compiler loop control

### DIFF
--- a/tests/machine/x/racket/README.md
+++ b/tests/machine/x/racket/README.md
@@ -1,13 +1,13 @@
 # Machine Generated Racket Programs
 
-36/97 programs compiled
+37/97 programs compiled
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
 - [x] binary_precedence.mochi
 - [x] bool_chain.mochi
-- [ ] break_continue.mochi
+- [x] break_continue.mochi
 - [x] cast_string_to_int.mochi
 - [ ] cast_struct.mochi
 - [x] closure.mochi

--- a/tests/machine/x/racket/break_continue.error
+++ b/tests/machine/x/racket/break_continue.error
@@ -1,1 +1,0 @@
-unsupported statement

--- a/tests/machine/x/racket/break_continue.out
+++ b/tests/machine/x/racket/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7

--- a/tests/machine/x/racket/break_continue.rkt
+++ b/tests/machine/x/racket/break_continue.rkt
@@ -1,0 +1,21 @@
+#lang racket
+(define numbers '(1 2 3 4 5 6 7 8 9))
+(let/ec break
+  (for ([n numbers])
+    (let/ec continue
+(if (= (remainder n 2) 0)
+  (begin
+(continue)
+  )
+  (void)
+)
+(if (> n 7)
+  (begin
+(break)
+  )
+  (void)
+)
+(displayln (string-join (map ~a (list "odd number:" n)) " "))
+    )
+  )
+)


### PR DESCRIPTION
## Summary
- support `break` and `continue` inside conditional branches in the Racket compiler
- allow printing multiple arguments
- fix closing parens in generated `for` loops
- regenerate machine output for `break_continue.mochi`
- update Racket machine checklist

## Testing
- `go test ./compiler/x/racket -run TestRacketCompiler/break_continue -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_686c892c42808320b060a73dadb01518