### PR TITLE
Extend Prolog compiler

### DIFF
--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -297,6 +297,54 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, bool, error) {
 		c.writeln(fmt.Sprintf("%s > 0,", n))
 		c.writeln(fmt.Sprintf("%s is %s / %s,", tmp, s, n))
 		return tmp, true, nil
+	case "sum":
+		if len(call.Args) != 1 {
+			return "", false, fmt.Errorf("sum expects 1 arg")
+		}
+		arg, _, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return "", false, err
+		}
+		tmp := c.newTmp()
+		c.writeln(fmt.Sprintf("sum_list(%s, %s),", arg, tmp))
+		return tmp, true, nil
+	case "min":
+		if len(call.Args) != 1 {
+			return "", false, fmt.Errorf("min expects 1 arg")
+		}
+		arg, _, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return "", false, err
+		}
+		tmp := c.newTmp()
+		c.writeln(fmt.Sprintf("min_list(%s, %s),", arg, tmp))
+		return tmp, true, nil
+	case "max":
+		if len(call.Args) != 1 {
+			return "", false, fmt.Errorf("max expects 1 arg")
+		}
+		arg, _, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return "", false, err
+		}
+		tmp := c.newTmp()
+		c.writeln(fmt.Sprintf("max_list(%s, %s),", arg, tmp))
+		return tmp, true, nil
+	case "len":
+		if len(call.Args) != 1 {
+			return "", false, fmt.Errorf("len expects 1 arg")
+		}
+		arg, _, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return "", false, err
+		}
+		tmp := c.newTmp()
+		if strings.HasPrefix(arg, "\"") {
+			c.writeln(fmt.Sprintf("string_length(%s, %s),", arg, tmp))
+		} else {
+			c.writeln(fmt.Sprintf("length(%s, %s),", arg, tmp))
+		}
+		return tmp, true, nil
 	default:
 		return "", false, fmt.Errorf("unsupported call")
 	}

--- a/compiler/x/pl/compiler_test.go
+++ b/compiler/x/pl/compiler_test.go
@@ -24,6 +24,13 @@ var supported = map[string]bool{
 	"append_builtin":      true,
 	"avg_builtin":         true,
 	"basic_compare":       true,
+	"binary_precedence":   true,
+	"math_ops":            true,
+	"unary_neg":           true,
+	"len_builtin":         true,
+	"len_string":          true,
+	"sum_builtin":         true,
+	"min_max_builtin":     true,
 }
 
 func TestPrologCompiler(t *testing.T) {

--- a/tests/machine/x/pl/README.md
+++ b/tests/machine/x/pl/README.md
@@ -3,7 +3,7 @@
 This directory holds Prolog code generated from Mochi programs by the compiler tests.
 Below is a checklist of programs that were compiled and executed successfully.
 
-**8/8 programs compiled**
+**15/15 programs compiled**
 
 - [x] print_hello.mochi
 - [x] let_and_print.mochi
@@ -13,3 +13,10 @@ Below is a checklist of programs that were compiled and executed successfully.
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
+- [x] binary_precedence.mochi
+- [x] len_builtin.mochi
+- [x] len_string.mochi
+- [x] math_ops.mochi
+- [x] min_max_builtin.mochi
+- [x] sum_builtin.mochi
+- [x] unary_neg.mochi

--- a/tests/machine/x/pl/binary_precedence.pl
+++ b/tests/machine/x/pl/binary_precedence.pl
@@ -1,12 +1,11 @@
-:- style_check(-singleton).
-main :-
-    write(((1 + 2) * 3)),
-    nl,
-    write(((1 + 2) * 3)),
-    nl,
-    write(((2 * 3) + 1)),
-    nl,
-    write((2 * (3 + 1))),
-    nl,
-    true.
 :- initialization(main, main).
+main :-
+    _V0 is ((1 + 2) * 3),
+    writeln(_V0),
+    _V1 is ((1 + 2) * 3),
+    writeln(_V1),
+    _V2 is ((2 * 3) + 1),
+    writeln(_V2),
+    _V3 is (2 * (3 + 1)),
+    writeln(_V3),
+    true.

--- a/tests/machine/x/pl/len_builtin.out
+++ b/tests/machine/x/pl/len_builtin.out
@@ -1,0 +1,4 @@
+Warning: /workspace/mochi/tests/machine/x/pl/len_builtin.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+Warning:    Singleton-marked variable appears more than once: _V1
+3

--- a/tests/machine/x/pl/len_builtin.pl
+++ b/tests/machine/x/pl/len_builtin.pl
@@ -1,0 +1,6 @@
+:- initialization(main, main).
+main :-
+    length([1, 2, 3], _V0),
+    _V1 is _V0,
+    writeln(_V1),
+    true.

--- a/tests/machine/x/pl/len_string.out
+++ b/tests/machine/x/pl/len_string.out
@@ -1,0 +1,4 @@
+Warning: /workspace/mochi/tests/machine/x/pl/len_string.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+Warning:    Singleton-marked variable appears more than once: _V1
+5

--- a/tests/machine/x/pl/len_string.pl
+++ b/tests/machine/x/pl/len_string.pl
@@ -1,0 +1,6 @@
+:- initialization(main, main).
+main :-
+    string_length("mochi", _V0),
+    _V1 is _V0,
+    writeln(_V1),
+    true.

--- a/tests/machine/x/pl/math_ops.out
+++ b/tests/machine/x/pl/math_ops.out
@@ -1,9 +1,7 @@
-Warning: /workspace/mochi/tests/machine/x/pl/binary_precedence.pl:2:
+Warning: /workspace/mochi/tests/machine/x/pl/math_ops.pl:2:
 Warning:    Singleton-marked variable appears more than once: _V0
 Warning:    Singleton-marked variable appears more than once: _V1
 Warning:    Singleton-marked variable appears more than once: _V2
-Warning:    Singleton-marked variable appears more than once: _V3
-9
-9
-7
-8
+42
+3.5
+1

--- a/tests/machine/x/pl/math_ops.pl
+++ b/tests/machine/x/pl/math_ops.pl
@@ -1,0 +1,9 @@
+:- initialization(main, main).
+main :-
+    _V0 is (6 * 7),
+    writeln(_V0),
+    _V1 is (7 / 2),
+    writeln(_V1),
+    _V2 is (7 mod 2),
+    writeln(_V2),
+    true.

--- a/tests/machine/x/pl/min_max_builtin.out
+++ b/tests/machine/x/pl/min_max_builtin.out
@@ -1,9 +1,7 @@
-Warning: /workspace/mochi/tests/machine/x/pl/binary_precedence.pl:2:
+Warning: /workspace/mochi/tests/machine/x/pl/min_max_builtin.pl:2:
 Warning:    Singleton-marked variable appears more than once: _V0
 Warning:    Singleton-marked variable appears more than once: _V1
 Warning:    Singleton-marked variable appears more than once: _V2
 Warning:    Singleton-marked variable appears more than once: _V3
-9
-9
-7
-8
+1
+4

--- a/tests/machine/x/pl/min_max_builtin.pl
+++ b/tests/machine/x/pl/min_max_builtin.pl
@@ -1,0 +1,10 @@
+:- initialization(main, main).
+main :-
+    Nums = [3, 1, 4],
+    min_list(Nums, _V0),
+    _V1 is _V0,
+    writeln(_V1),
+    max_list(Nums, _V2),
+    _V3 is _V2,
+    writeln(_V3),
+    true.

--- a/tests/machine/x/pl/sum_builtin.out
+++ b/tests/machine/x/pl/sum_builtin.out
@@ -1,0 +1,4 @@
+Warning: /workspace/mochi/tests/machine/x/pl/sum_builtin.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+Warning:    Singleton-marked variable appears more than once: _V1
+6

--- a/tests/machine/x/pl/sum_builtin.pl
+++ b/tests/machine/x/pl/sum_builtin.pl
@@ -1,0 +1,6 @@
+:- initialization(main, main).
+main :-
+    sum_list([1, 2, 3], _V0),
+    _V1 is _V0,
+    writeln(_V1),
+    true.

--- a/tests/machine/x/pl/unary_neg.out
+++ b/tests/machine/x/pl/unary_neg.out
@@ -1,0 +1,5 @@
+Warning: /workspace/mochi/tests/machine/x/pl/unary_neg.pl:2:
+Warning:    Singleton-marked variable appears more than once: _V0
+Warning:    Singleton-marked variable appears more than once: _V1
+-3
+3

--- a/tests/machine/x/pl/unary_neg.pl
+++ b/tests/machine/x/pl/unary_neg.pl
@@ -1,0 +1,7 @@
+:- initialization(main, main).
+main :-
+    _V0 is (-3),
+    writeln(_V0),
+    _V1 is (5 + (-2)),
+    writeln(_V1),
+    true.


### PR DESCRIPTION
## Summary
- support additional builtins in the Prolog compiler (`sum`, `min`, `max`, `len`)
- regenerate golden files for new sample programs
- update compiler tests with more supported programs
- update machine generated README

## Testing
- `go test ./compiler/x/pl -run TestPrologCompiler -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686c8cf4e7788320807064ec9f8cb71d