### PR TITLE
Update clj compiler to support simple group-by

### DIFF
--- a/tests/machine/x/clj/README.md
+++ b/tests/machine/x/clj/README.md
@@ -1,6 +1,6 @@
 - # Clojure Compiler Results
 
-78/97 files compiled
+79/97 files compiled
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -24,7 +24,7 @@
 - [x] fun_call.mochi
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
-- [ ] group_by.mochi
+- [x] group_by.mochi
 - [ ] group_by_conditional_sum.mochi
 - [ ] group_by_having.mochi
 - [ ] group_by_join.mochi

--- a/tests/machine/x/clj/group_by.clj
+++ b/tests/machine/x/clj/group_by.clj
@@ -1,11 +1,5 @@
 (ns main)
 
-(defn _count [v]
-  (cond
-    (sequential? v) (count v)
-    (and (map? v) (contains? v :Items)) (count (:Items v))
-    :else (throw (ex-info "count() expects list or group" {}))))
-
 (defn _avg [v]
   (let [lst (cond
               (and (map? v) (contains? v :Items)) (:Items v)
@@ -31,73 +25,11 @@
     )
     (map (fn [k] (@groups k)) @order)))
 
-(defn _query [src joins opts]
-  (let [items (atom (mapv vector src))]
-    (doseq [j joins]
-      (let [joined (atom [])]
-        (cond
-          (and (:right j) (:left j))
-            (let [matched (boolean-array (count (:items j)))]
-              (doseq [left @items]
-                (let [m (atom false)]
-                  (doseq [[ri right] (map-indexed vector (:items j))]
-                    (let [keep (if-let [f (:on j)]
-                                 (apply f (conj left right))
-                                 true)]
-                      (when keep
-                        (reset! m true)
-                        (aset matched ri true)
-                        (swap! joined conj (conj left right))))
-                  (when-not @m
-                    (swap! joined conj (conj left nil))))
-              (doseq [[ri right] (map-indexed vector (:items j))]
-                (when-not (aget matched ri)
-                  (swap! joined conj (vec (concat (repeat (count (first (or @items []))) nil) [right])))))
-            (reset! items @joined)
-          (:right j)
-            (do
-              (doseq [right (:items j)]
-                (let [m (atom false)]
-                  (doseq [left @items]
-                    (let [keep (if-let [f (:on j)]
-                                 (apply f (conj left right))
-                                 true)]
-                      (when keep
-                        (reset! m true)
-                        (swap! joined conj (conj left right))))
-                  (when-not @m
-                    (swap! joined conj (vec (concat (repeat (count (first (or @items []))) nil) [right])))))
-              (reset! items @joined))
-          :else
-            (do
-              (doseq [left @items]
-                (let [m (atom false)]
-                  (doseq [right (:items j)]
-                    (let [keep (if-let [f (:on j)]
-                                 (apply f (conj left right))
-                                 true)]
-                      (when keep
-                        (reset! m true)
-                        (swap! joined conj (conj left right))))
-                  (when (and (:left j) (not @m))
-                    (swap! joined conj (conj left nil))))
-              (reset! items @joined))))
-    (let [it @items
-          it (if-let [w (:where opts)] (vec (filter #(apply w %) it)) it)
-          it (if-let [sk (:sortKey opts)] (vec (sort-by #(apply sk %) it)) it)
-          it (if (contains? opts :skip) (vec (drop (:skip opts) it)) it)
-          it (if (contains? opts :take) (vec (take (:take opts) it)) it)]
-      (mapv #(apply (:select opts) %) it)))
 (declare people stats)
 
 (defn -main []
   (def people [{:name "Alice" :age 30 :city "Paris"} {:name "Bob" :age 15 :city "Hanoi"} {:name "Charlie" :age 65 :city "Paris"} {:name "Diana" :age 45 :city "Hanoi"} {:name "Eve" :age 70 :city "Paris"} {:name "Frank" :age 22 :city "Hanoi"}]) ;; list of map of string to any
-  (def stats (let [_src people
-      _rows (_query _src [
-
-      ] { :select (fn [person] [person]) })
-      _groups (_group_by _rows (fn [person] (:city person)))
-  (vec (map (fn [g] {:city (:key g) :count (count (:Items g)) :avg_age (_avg (vec (->> (for [p g] (:age p)))))}) _groups)))) ;; list of map of string to any
+  (def stats (map (fn [g] {:city (:key g) :count (count (:Items g)) :avg_age (_avg (vec (->> (for [p (:Items g)] (:age p)))))}) (_group_by people (fn [person] (:city person))))) ;; list of map of string to any
   (println "--- People grouped by city ---")
   (loop [_tmp0 (seq stats)]
     (when _tmp0

--- a/tests/machine/x/clj/group_by.error
+++ b/tests/machine/x/clj/group_by.error
@@ -1,6 +1,0 @@
-exit status 1
-Syntax error reading source at (/workspace/mochi/tests/machine/x/clj/group_by.clj:100:124).
-Unmatched delimiter: )
-
-Full report at:
-/tmp/clojure-12442329948278323987.edn

--- a/tests/machine/x/clj/group_by.out
+++ b/tests/machine/x/clj/group_by.out
@@ -1,0 +1,3 @@
+--- People grouped by city ---
+Paris : count = 3 , avg_age = 55.0
+Hanoi : count = 3 , avg_age = 27.333333333333332


### PR DESCRIPTION
## Summary
- support simple `group_by` queries in the Clojure backend
- regenerate Clojure machine code for `group_by.mochi`
- track successful compilation in the checklist

## Testing
- `go test -tags slow ./compiler/x/clj -run 'TestCompileValidPrograms/group_by\.mochi' -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686c8be49db88320a95371ef859b77fd