### PR TITLE
Improve C# compiler query handling

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -1894,6 +1894,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		child.SetVar(j.Var, jt, true)
 	}
 	c.env = child
+	resultType := csTypeOf(c.inferExprType(q.Select))
 	sel, err := c.compileExpr(q.Select)
 	if err != nil {
 		c.env = orig
@@ -2493,8 +2494,15 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	c.env = orig
 
 	parts := []string{src}
+	whereParts := []string{}
+	if flt, ok := aliasFilters[v]; ok {
+		whereParts = append(whereParts, strings.Join(flt, " && "))
+	}
 	if cond != "" {
-		parts = append(parts, fmt.Sprintf("Where(%s => %s)", v, cond))
+		whereParts = append(whereParts, cond)
+	}
+	if len(whereParts) > 0 {
+		parts = append(parts, fmt.Sprintf("Where(%s => %s)", v, strings.Join(whereParts, " && ")))
 	}
 	if sortExpr != "" {
 		parts = append(parts, fmt.Sprintf("OrderBy(%s => %s)", v, sortExpr))


### PR DESCRIPTION
## Summary
- handle query filters where the condition only references the loop variable
- compute query result type after binding the loop variable
- avoid invalid type checks in `exists` builtin
- regenerate C# output for `exists_builtin.mochi`
- update compiled checklist

## Testing
- `go test ./compiler/x/cs -run TestCompileValidPrograms/exists_builtin -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_686c9593e31083209c90905811b58758