### PR TITLE
Update Kotlin results for closure example

### DIFF
--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -2,7 +2,7 @@
 
 This checklist tracks which Mochi programs from `tests/vm/valid` have been compiled to Kotlin and executed successfully.
 
-## Progress: 59/97
+## Progress: 60/97
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -12,7 +12,7 @@ This checklist tracks which Mochi programs from `tests/vm/valid` have been compi
 - [x] break_continue.mochi
 - [x] cast_string_to_int.mochi
 - [x] cast_struct.mochi
-- [ ] closure.mochi
+- [x] closure.mochi
 - [x] count_builtin.mochi
 - [ ] cross_join.mochi
 - [ ] cross_join_filter.mochi

--- a/tests/machine/x/kotlin/closure.error
+++ b/tests/machine/x/kotlin/closure.error
@@ -1,9 +1,0 @@
-line 67:
-OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/machine/x/kotlin/closure.kt:67:13: error: expression 'add10' of type 'Any' cannot be invoked as a function. The function 'invoke()' is not found
-    println(add10(7))
-            ^
-
- 66:     val add10 = makeAdder(10)
- 67:     println(add10(7))
- 68: }


### PR DESCRIPTION
## Summary
- remove stale error for closure example
- mark closure example as passing in Kotlin README

## Testing
- `go test ./compiler/x/kotlin -tags slow -run TestKotlinPrograms/closure -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686c95c0a06c8320b1c1d60a1f292495