### PR TITLE
Add machine output summary for F#

### DIFF
--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -1,0 +1,49 @@
+# F# Machine Output
+
+This directory contains F# source code generated from Mochi programs and the corresponding outputs or error logs.
+
+## Summary
+
+- 21/37 programs compiled and executed successfully.
+- 16 programs failed to compile or run.
+
+### Successful
+- append_builtin
+- avg_builtin
+- basic_compare
+- binary_precedence
+- bool_chain
+- break_continue
+- cast_string_to_int
+- cast_struct
+- closure
+- count_builtin
+- exists_builtin
+- for_list_collection
+- for_loop
+- for_map_collection
+- fun_call
+- fun_expr_in_let
+- fun_three_args
+- if_else
+- if_then_else
+- if_then_else_nested
+- in_operator
+
+### Failed
+- cross_join
+- cross_join_filter
+- cross_join_triple
+- dataset_sort_take_limit
+- dataset_where_filter
+- group_by
+- group_by_conditional_sum
+- group_by_having
+- group_by_join
+- group_by_left_join
+- group_by_multi_join
+- group_by_multi_join_sort
+- group_by_sort
+- group_items_iteration
+- in_operator_extended
+- inner_join


### PR DESCRIPTION
## Summary
- add `tests/machine/x/fs/README.md` summarizing compiled Mochi programs for the F# backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ceacb7868832090f2cea276c33dd9