### PR TITLE
Improve Erlang compiler

### DIFF
--- a/tests/machine/x/erlang/README.md
+++ b/tests/machine/x/erlang/README.md
@@ -2,8 +2,8 @@
 
 This directory contains Erlang source files compiled from Mochi programs in `tests/vm/valid`.
 
-- **30/97 programs compiled and ran successfully** (have `.out` files)
-- **67 programs failed** to compile or run (have `.error` files)
+- **37/97 programs compiled and ran successfully** (have `.out` files)
+- **60 programs failed** to compile or run (have `.error` files)
 
 ## Successful programs
 append_builtin
@@ -11,12 +11,16 @@ avg_builtin
 basic_compare
 binary_precedence
 bool_chain
+cast_string_to_int
+cast_struct
+closure
 count_builtin
 for_list_collection
 for_loop
 for_map_collection
 fun_call
 fun_three_args
+fun_expr_in_let
 if_else
 if_then_else
 if_then_else_nested
@@ -29,11 +33,14 @@ list_index
 map_assign
 map_index
 map_int_key
+map_literal_dynamic
 math_ops
 min_max_builtin
+partial_application
 print_hello
 pure_fold
 short_circuit
+slice
 string_concat
 string_index
 substring_builtin
@@ -41,16 +48,12 @@ sum_builtin
 
 ## Failed programs
 break_continue
-cast_string_to_int
-cast_struct
-closure
 cross_join
 cross_join_filter
 cross_join_triple
 dataset_sort_take_limit
 dataset_where_filter
 exists_builtin
-fun_expr_in_let
 group_by
 group_by_conditional_sum
 group_by_having
@@ -71,7 +74,6 @@ list_nested_assign
 list_set_ops
 load_yaml
 map_in_operator
-map_literal_dynamic
 map_membership
 map_nested_assign
 match_expr
@@ -80,13 +82,11 @@ membership
 nested_function
 order_by_map
 outer_join
-partial_application
 pure_global_fold
 query_sum_select
 record_assign
 right_join
 save_jsonl_stdout
-slice
 sort_stable
 str_builtin
 string_compare


### PR DESCRIPTION
## Summary
- enhance Erlang compiler with function map and partial application
- support slicing and casting operations
- allow `print` with multiple arguments
- ignore type declarations so struct casts work
- update Erlang compiler README

## Testing
- `go test -v ./compiler/x/erlang -run TestCompilePrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ceaefa0a88320a8188df8a18e8b5f