### PR TITLE
Improve Dart compiler

### DIFF
--- a/tests/machine/x/dart/cross_join.error
+++ b/tests/machine/x/dart/cross_join.error
@@ -1,4 +1,0 @@
-line 15: exit status 254
-  for (var entry in result) {
-    print(['Order', entry.orderId, '(customerId:', entry.orderCustomerId, ', total: $', entry.orderTotal, ') paired with', entry.pairedCustomerName].join(' '));
-  }

--- a/tests/machine/x/dart/cross_join.out
+++ b/tests/machine/x/dart/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie


### PR DESCRIPTION
## Summary
- refine Dart compiler to better handle selector access for map variables
- track variables that come from map lists and iterate safely in for loops
- escape `$` in string literals for Dart
- output compiled result for `cross_join.mochi`

## Testing
- `go test -tags slow ./compiler/x/dart -run TestDartCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ceadd30c48320aad98cfe0866ca3d