### PR TITLE
Add basic query support to Go compiler

### DIFF
--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -4,8 +4,8 @@ This directory contains Go source code generated from Mochi programs and the cor
 
 ## Summary
 
-- 60/97 programs compiled and executed successfully.
-- 37 programs failed to compile or run.
+- 63/97 programs compiled and executed successfully.
+- 34 programs failed to compile or run.
 
 ### Successful
 - append_builtin
@@ -18,6 +18,9 @@ This directory contains Go source code generated from Mochi programs and the cor
 - cast_struct
 - closure
 - count_builtin
+- cross_join
+- cross_join_filter
+- cross_join_triple
 - exists_builtin
 - for_list_collection
 - for_loop
@@ -70,9 +73,6 @@ This directory contains Go source code generated from Mochi programs and the cor
 - while_loop
 
 ### Failed
-- cross_join
-- cross_join_filter
-- cross_join_triple
 - dataset_sort_take_limit
 - dataset_where_filter
 - group_by

--- a/tests/machine/x/go/cross_join.error
+++ b/tests/machine/x/go/cross_join.error
@@ -1,4 +1,0 @@
-unsupported expression at line 12
-]
-let result = from o in orders
-             from c in customers

--- a/tests/machine/x/go/cross_join.go
+++ b/tests/machine/x/go/cross_join.go
@@ -1,0 +1,43 @@
+//go:build ignore
+
+package main
+
+import (
+    "fmt"
+    "strings"
+    "reflect"
+)
+
+func getField(v interface{}, name string) interface{} {
+    if m, ok := v.(map[interface{}]interface{}); ok {
+        return m[name]
+    }
+    val := reflect.ValueOf(v)
+    name = strings.Title(name)
+    if val.Kind() == reflect.Pointer {
+        val = val.Elem()
+    }
+    f := val.FieldByName(name)
+    if f.IsValid() {
+        return f.Interface()
+    }
+    return nil
+}
+
+func main() {
+    customers := []interface{}{map[interface{}]interface{}{"id": 1, "name": "Alice"}, map[interface{}]interface{}{"id": 2, "name": "Bob"}, map[interface{}]interface{}{"id": 3, "name": "Charlie"}}
+    orders := []interface{}{map[interface{}]interface{}{"id": 100, "customerId": 1, "total": 250}, map[interface{}]interface{}{"id": 101, "customerId": 2, "total": 125}, map[interface{}]interface{}{"id": 102, "customerId": 1, "total": 300}}
+    result := func() []struct{ OrderId interface{}; OrderCustomerId interface{}; PairedCustomerName interface{}; OrderTotal interface{} } {
+        var _res []struct{ OrderId interface{}; OrderCustomerId interface{}; PairedCustomerName interface{}; OrderTotal interface{} }
+        for _, o := range orders {
+            for _, c := range customers {
+                _res = append(_res, struct{ OrderId interface{}; OrderCustomerId interface{}; PairedCustomerName interface{}; OrderTotal interface{} }{OrderId: getField(o, "id"), OrderCustomerId: getField(o, "customerId"), PairedCustomerName: getField(c, "name"), OrderTotal: getField(o, "total")})
+            }
+        }
+        return _res
+    }()
+    fmt.Println("--- Cross Join: All order-customer pairs ---")
+    for _, entry := range result {
+        fmt.Println("Order", getField(entry, "orderId"), "(customerId:", getField(entry, "orderCustomerId"), ", total: $", getField(entry, "orderTotal"), ") paired with", getField(entry, "pairedCustomerName"))
+    }
+}

--- a/tests/machine/x/go/cross_join.out
+++ b/tests/machine/x/go/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/tests/machine/x/go/cross_join_filter.error
+++ b/tests/machine/x/go/cross_join_filter.error
@@ -1,4 +1,0 @@
-unsupported expression at line 3
-let letters = ["A", "B"]
-let pairs = from n in nums
-            from l in letters

--- a/tests/machine/x/go/cross_join_filter.go
+++ b/tests/machine/x/go/cross_join_filter.go
@@ -1,0 +1,45 @@
+//go:build ignore
+
+package main
+
+import (
+    "fmt"
+    "strings"
+    "reflect"
+)
+
+func getField(v interface{}, name string) interface{} {
+    if m, ok := v.(map[interface{}]interface{}); ok {
+        return m[name]
+    }
+    val := reflect.ValueOf(v)
+    name = strings.Title(name)
+    if val.Kind() == reflect.Pointer {
+        val = val.Elem()
+    }
+    f := val.FieldByName(name)
+    if f.IsValid() {
+        return f.Interface()
+    }
+    return nil
+}
+
+func main() {
+    nums := []int{1, 2, 3}
+    letters := []interface{}{"A", "B"}
+    pairs := func() []struct{ N interface{}; L interface{} } {
+        var _res []struct{ N interface{}; L interface{} }
+        for _, n := range nums {
+            for _, l := range letters {
+                if n % 2 == 0 {
+                    _res = append(_res, struct{ N interface{}; L interface{} }{N: n, L: l})
+                }
+            }
+        }
+        return _res
+    }()
+    fmt.Println("--- Even pairs ---")
+    for _, p := range pairs {
+        fmt.Println(getField(p, "n"), getField(p, "l"))
+    }
+}

--- a/tests/machine/x/go/cross_join_filter.out
+++ b/tests/machine/x/go/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B

--- a/tests/machine/x/go/cross_join_triple.error
+++ b/tests/machine/x/go/cross_join_triple.error
@@ -1,4 +1,0 @@
-unsupported expression at line 4
-let bools = [true, false]
-let combos = from n in nums
-             from l in letters

--- a/tests/machine/x/go/cross_join_triple.go
+++ b/tests/machine/x/go/cross_join_triple.go
@@ -1,0 +1,46 @@
+//go:build ignore
+
+package main
+
+import (
+    "fmt"
+    "strings"
+    "reflect"
+)
+
+func getField(v interface{}, name string) interface{} {
+    if m, ok := v.(map[interface{}]interface{}); ok {
+        return m[name]
+    }
+    val := reflect.ValueOf(v)
+    name = strings.Title(name)
+    if val.Kind() == reflect.Pointer {
+        val = val.Elem()
+    }
+    f := val.FieldByName(name)
+    if f.IsValid() {
+        return f.Interface()
+    }
+    return nil
+}
+
+func main() {
+    nums := []int{1, 2}
+    letters := []interface{}{"A", "B"}
+    bools := []interface{}{true, false}
+    combos := func() []struct{ N interface{}; L interface{}; B interface{} } {
+        var _res []struct{ N interface{}; L interface{}; B interface{} }
+        for _, n := range nums {
+            for _, l := range letters {
+                for _, b := range bools {
+                    _res = append(_res, struct{ N interface{}; L interface{}; B interface{} }{N: n, L: l, B: b})
+                }
+            }
+        }
+        return _res
+    }()
+    fmt.Println("--- Cross Join of three lists ---")
+    for _, c := range combos {
+        fmt.Println(getField(c, "n"), getField(c, "l"), getField(c, "b"))
+    }
+}

--- a/tests/machine/x/go/cross_join_triple.out
+++ b/tests/machine/x/go/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false


### PR DESCRIPTION
## Summary
- extend Go compiler with query expression handling
- support anonymous struct generation from map literals
- add dynamic field access helper
- update generated machine outputs for Go

## Testing
- `go test ./compiler/x/go -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_686cf081fdf883208519ef0fa4bf5139