### PR TITLE
Fix Scheme slice helper and regenerate test

### DIFF
--- a/compiler/x/scheme/compiler.go
+++ b/compiler/x/scheme/compiler.go
@@ -126,7 +126,7 @@ const sliceHelper = `(define (_slice obj i j)
               (loop (+ idx 1) (cdr xs)
                     (if (>= idx start)
                         (cons (car xs) out)
-                        out))))))`
+                        out)))))))`
 
 const groupHelpers = `(define (_count v)
   (cond

--- a/tests/machine/x/scheme/README.md
+++ b/tests/machine/x/scheme/README.md
@@ -1,4 +1,4 @@
-# Scheme Machine Results (72/97 compiled and ran)
+# Scheme Machine Results (73/97 compiled and ran)
 
 ## Success
 - [x] append_builtin.mochi
@@ -15,6 +15,7 @@
 - [x] cross_join_filter.mochi
 - [x] cross_join_triple.mochi
 - [x] dataset_where_filter.mochi
+- [x] dataset_sort_take_limit.mochi
 - [x] for_list_collection.mochi
 - [x] for_loop.mochi
 - [x] for_map_collection.mochi
@@ -75,7 +76,6 @@
 - [x] var_assignment.mochi
 
 ## Failed
-- [ ] dataset_sort_take_limit.mochi
 - [ ] exists_builtin.mochi
 - [ ] group_by_left_join.mochi
 - [ ] group_by_multi_join_sort.mochi

--- a/tests/machine/x/scheme/dataset_sort_take_limit.error
+++ b/tests/machine/x/scheme/dataset_sort_take_limit.error
@@ -1,7 +1,0 @@
-error running dataset_sort_take_limit:
-ERROR on line 120 of file /workspace/mochi/tests/machine/x/scheme/dataset_sort_take_limit.scm: missing trailing ')' started on line: 79
-  called from <anonymous> on line 821 of file /usr/share/chibi/init-7.scm
-
-context (line 120):
-)
-

--- a/tests/machine/x/scheme/dataset_sort_take_limit.out
+++ b/tests/machine/x/scheme/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/machine/x/scheme/dataset_sort_take_limit.scm
+++ b/tests/machine/x/scheme/dataset_sort_take_limit.scm
@@ -93,7 +93,7 @@
               (loop (+ idx 1) (cdr xs)
                     (if (>= idx start)
                         (cons (car xs) out)
-                        out))))))
+                        out)))))))
 
 (define products (list (list (cons "name" "Laptop") (cons "price" 1500)) (list (cons "name" "Smartphone") (cons "price" 900)) (list (cons "name" "Tablet") (cons "price" 600)) (list (cons "name" "Monitor") (cons "price" 300)) (list (cons "name" "Keyboard") (cons "price" 100)) (list (cons "name" "Mouse") (cons "price" 50)) (list (cons "name" "Headphones") (cons "price" 200))))
 (define expensive (let ((_res '()) (_tmp '()))

--- a/tests/machine/x/scheme/slice.scm
+++ b/tests/machine/x/scheme/slice.scm
@@ -15,7 +15,7 @@
               (loop (+ idx 1) (cdr xs)
                     (if (>= idx start)
                         (cons (car xs) out)
-                        out))))))
+                        out)))))))
 
 (begin (display (_slice (list 1 2 3) 1 3)) (newline))
 (begin (display (_slice (list 1 2 3) 0 2)) (newline))

--- a/tests/machine/x/scheme/string_prefix_slice.scm
+++ b/tests/machine/x/scheme/string_prefix_slice.scm
@@ -15,7 +15,7 @@
               (loop (+ idx 1) (cdr xs)
                     (if (>= idx start)
                         (cons (car xs) out)
-                        out))))))
+                        out)))))))
 
 (define prefix "fore")
 (define s1 "forest")


### PR DESCRIPTION
## Summary
- add missing parenthesis in Scheme slice helper
- regenerate Scheme machine result for dataset_sort_take_limit
- fix slice helper in generated Scheme tests
- update Scheme machine README

## Testing
- `chibi-scheme -m chibi tests/machine/x/scheme/dataset_sort_take_limit.scm > tests/machine/x/scheme/dataset_sort_take_limit.out`

------
https://chatgpt.com/codex/tasks/task_e_686cf5fd70908320aaea13b186880757