### PR TITLE
Improve PHP compiler match expr handling

### DIFF
--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -333,6 +333,21 @@ func (c *Compiler) use(name string) {
 	c.helpers[name] = true
 }
 
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	return p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0
+}
+
 func (c *Compiler) emitRuntime() {
 	names := make([]string, 0, len(c.helpers))
 	for n := range c.helpers {


### PR DESCRIPTION
## Summary
- support wildcard cases in PHP match expressions
- add missing machine outputs for match tests
- update PHP machine README

## Testing
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_ValidPrograms/match_full -v`
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_ValidPrograms/match_expr -v`
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_ValidPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686cf8262c048320bbff04ab46cd72ad