### PR TITLE
Add python benchmark tools

### DIFF
--- a/compiler/x/python/tools.go
+++ b/compiler/x/python/tools.go
@@ -1,0 +1,221 @@
+//go:build slow
+
+package pycode
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// EnsurePython installs Python3 if missing. Useful for benchmarks and tests.
+func EnsurePython() error {
+	if _, err := exec.LookPath("python3"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("🐍 Installing Python3 via Homebrew...")
+			cmd := exec.Command("brew", "install", "python")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("🐍 Installing Python3...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "python3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🐍 Installing Python via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "python")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🐍 Installing Python via Scoop...")
+			cmd := exec.Command("scoop", "install", "python")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("python3"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("python3 not found")
+}
+
+// EnsurePyPy installs pypy3 if missing. Useful for benchmarks.
+func EnsurePyPy() error {
+	if _, err := exec.LookPath("pypy3"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("🐍 Installing PyPy via Homebrew...")
+			cmd := exec.Command("brew", "install", "pypy3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("🐍 Installing PyPy3...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "pypy3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🐍 Installing PyPy via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "pypy3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("pypy3"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("pypy3 not found")
+}
+
+// EnsureCython installs cython3 if missing. Useful for benchmarks.
+func EnsureCython() error {
+	if _, err := exec.LookPath("cython3"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("🐍 Installing Cython via Homebrew...")
+			cmd := exec.Command("brew", "install", "cython")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("🐍 Installing Cython...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "cython3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🐍 Installing Cython via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "cython")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("cython3"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("cython3 not found")
+}
+
+// EnsureBlack installs the Black formatter if missing. Useful for codegen tests.
+func EnsureBlack() error {
+	if _, err := exec.LookPath("black"); err == nil {
+		return nil
+	}
+	installers := []string{"pip3", "pip"}
+	for _, bin := range installers {
+		if _, err := exec.LookPath(bin); err == nil {
+			fmt.Println("🐍 Installing Black via", bin, "...")
+			cmd := exec.Command(bin, "install", "--user", "black")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			break
+		}
+	}
+	if _, err := exec.LookPath("black"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("black not found")
+}
+
+// EnsurePyright installs the Pyright language server if needed.
+// It attempts installation using npm or pip.
+func EnsurePyright() error {
+	if _, err := exec.LookPath("pyright-langserver"); err == nil {
+		return nil
+	}
+	installers := []struct {
+		bin  string
+		args []string
+	}{
+		{"npm", []string{"install", "-g", "pyright"}},
+		{"pip3", []string{"install", "--user", "pyright"}},
+		{"pip", []string{"install", "--user", "pyright"}},
+	}
+	for _, inst := range installers {
+		if _, err := exec.LookPath(inst.bin); err == nil {
+			fmt.Println("🐍 Installing Pyright via", inst.bin, "...")
+			cmd := exec.Command(inst.bin, inst.args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			break
+		}
+	}
+	if _, err := exec.LookPath("pyright-langserver"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("pyright-langserver not found")
+}
+
+// FormatPy formats Python source using Black if available.
+// If Black is not installed, the input is returned unchanged.
+func FormatPy(src []byte) []byte {
+	tool, err := exec.LookPath("black")
+	if err == nil {
+		cmd := exec.Command(tool, "-q", "-")
+		cmd.Stdin = bytes.NewReader(src)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err == nil {
+			res := out.Bytes()
+			if len(res) > 0 && res[len(res)-1] != '\n' {
+				res = append(res, '\n')
+			}
+			return res
+		}
+	}
+	if len(src) > 0 && src[len(src)-1] != '\n' {
+		src = append(src, '\n')
+	}
+	return src
+}


### PR DESCRIPTION
## Summary
- add `tools.go` for the Python backend so benchmarks can ensure Python tools are present

## Testing
- `go test ./compiler/x/python -run TestPythonCompiler -tags slow` *(fails: query features not supported)*
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686cf92bb420832090d2d7e2e3e2a583