### PR TITLE
Improve Smalltalk compiler

### DIFF
--- a/compiler/x/st/compiler.go
+++ b/compiler/x/st/compiler.go
@@ -200,19 +200,79 @@ func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 }
 
 func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
-	left, err := c.compileUnary(b.Left)
+	if b == nil {
+		return "", fmt.Errorf("nil binary expression")
+	}
+
+	operands := []string{}
+	ops := []string{}
+
+	first, err := c.compileUnary(b.Left)
 	if err != nil {
 		return "", err
 	}
-	res := left
-	for _, op := range b.Right {
-		r, err := c.compilePostfix(op.Right)
+	operands = append(operands, first)
+	for _, p := range b.Right {
+		o, err := c.compilePostfix(p.Right)
 		if err != nil {
 			return "", err
 		}
-		res = fmt.Sprintf("%s %s %s", res, op.Op, r)
+		op := p.Op
+		if p.All {
+			op = op + "_all"
+		}
+		ops = append(ops, op)
+		operands = append(operands, o)
 	}
-	return res, nil
+
+	levels := [][]string{
+		{"*", "/", "%"},
+		{"+", "-"},
+		{"<", "<=", ">", ">="},
+		{"==", "!=", "in"},
+		{"&&"},
+		{"||"},
+		{"union", "union_all", "except", "intersect"},
+	}
+
+	apply := func(left, op, right string) string {
+		switch op {
+		case "&&":
+			return fmt.Sprintf("(%s and: [%s])", left, right)
+		case "||":
+			return fmt.Sprintf("(%s or: [%s])", left, right)
+		case "==":
+			return fmt.Sprintf("(%s = %s)", left, right)
+		case "!=":
+			return fmt.Sprintf("(%s ~= %s)", left, right)
+		default:
+			return fmt.Sprintf("(%s %s %s)", left, op, right)
+		}
+	}
+
+	for _, level := range levels {
+		for i := 0; i < len(ops); {
+			matched := false
+			for _, t := range level {
+				if ops[i] == t {
+					res := apply(operands[i], ops[i], operands[i+1])
+					operands[i] = res
+					operands = append(operands[:i+1], operands[i+2:]...)
+					ops = append(ops[:i], ops[i+1:]...)
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				i++
+			}
+		}
+	}
+
+	if len(operands) != 1 {
+		return "", fmt.Errorf("expression reduction failed")
+	}
+	return operands[0], nil
 }
 
 func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
@@ -221,10 +281,11 @@ func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
 		return "", err
 	}
 	for i := len(u.Ops) - 1; i >= 0; i-- {
-		if u.Ops[i] == "-" {
+		switch u.Ops[i] {
+		case "-":
 			val = "-" + val
-		} else if u.Ops[i] == "!" {
-			val = "not " + val
+		case "!":
+			val = val + " not"
 		}
 	}
 	return val, nil
@@ -235,14 +296,79 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(p.Ops) > 0 {
-		return "", fmt.Errorf("postfix operations not supported")
+	for _, op := range p.Ops {
+		switch {
+		case op.Call != nil:
+			args := make([]string, len(op.Call.Args))
+			for i, a := range op.Call.Args {
+				s, err := c.compileExpr(a)
+				if err != nil {
+					return "", err
+				}
+				args[i] = s
+			}
+			if val == "print" {
+				if len(args) == 0 {
+					return "", fmt.Errorf("print expects at least 1 arg")
+				}
+				stmt := "Transcript show: "
+				if isStringLiteral(op.Call.Args[0]) {
+					stmt += args[0]
+				} else {
+					stmt += fmt.Sprintf("(%s) printString", args[0])
+				}
+				for i, a := range args[1:] {
+					stmt += "; show: ' '; show: "
+					if isStringLiteral(op.Call.Args[i+1]) {
+						stmt += a
+					} else {
+						stmt += fmt.Sprintf("(%s) printString", a)
+					}
+				}
+				val = stmt + "; cr"
+			} else {
+				call := val
+				for _, a := range args {
+					call += " value: " + a
+				}
+				val = call
+			}
+		case op.Index != nil:
+			idx, err := c.compileExpr(op.Index.Start)
+			if err != nil {
+				return "", err
+			}
+			val = fmt.Sprintf("%s at: %s", val, idx)
+		case op.Field != nil:
+			val = fmt.Sprintf("%s at: %q", val, op.Field.Name)
+		case op.Cast != nil:
+			var tname string
+			if op.Cast.Type.Simple != nil {
+				tname = *op.Cast.Type.Simple
+			}
+			switch tname {
+			case "int":
+				val = fmt.Sprintf("%s asInteger", val)
+			case "float":
+				val = fmt.Sprintf("%s asFloat", val)
+			case "string":
+				val = fmt.Sprintf("%s asString", val)
+			}
+		default:
+			return "", fmt.Errorf("unsupported postfix expression")
+		}
 	}
 	return val, nil
 }
 
 func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 	switch {
+	case p.Selector != nil:
+		name := p.Selector.Root
+		for _, s := range p.Selector.Tail {
+			name += "." + s
+		}
+		return name, nil
 	case p.Lit != nil:
 		return c.compileLiteral(p.Lit), nil
 	case p.List != nil:
@@ -255,6 +381,8 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			elems[i] = s
 		}
 		return "{" + strings.Join(elems, ". ") + "}", nil
+	case p.Group != nil:
+		return c.compileExpr(p.Group)
 	case p.Map != nil:
 		pairs := make([]string, len(p.Map.Items))
 		for i, it := range p.Map.Items {
@@ -269,6 +397,46 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			pairs[i] = fmt.Sprintf("%s -> %s", k, v)
 		}
 		return "Dictionary newFrom: {" + strings.Join(pairs, ". ") + "}", nil
+	case p.FunExpr != nil:
+		params := make([]string, len(p.FunExpr.Params))
+		for i, pa := range p.FunExpr.Params {
+			params[i] = ":" + pa.Name
+		}
+		var body string
+		if p.FunExpr.ExprBody != nil {
+			b, err := c.compileExpr(p.FunExpr.ExprBody)
+			if err != nil {
+				return "", err
+			}
+			body = b
+		} else {
+			b, err := c.blockString(p.FunExpr.BlockBody)
+			if err != nil {
+				return "", err
+			}
+			body = b
+		}
+		return "[" + strings.Join(params, " ") + " | " + body + " ]", nil
+	case p.If != nil:
+		cond, err := c.compileExpr(p.If.Cond)
+		if err != nil {
+			return "", err
+		}
+		th, err := c.compileExpr(p.If.Then)
+		if err != nil {
+			return "", err
+		}
+		el := ""
+		if p.If.Else != nil {
+			el, err = c.compileExpr(p.If.Else)
+			if err != nil {
+				return "", err
+			}
+		}
+		if el == "" {
+			return fmt.Sprintf("(%s) ifTrue: [%s]", cond, th), nil
+		}
+		return fmt.Sprintf("(%s) ifTrue: [%s] ifFalse: [%s]", cond, th, el), nil
 	case p.Call != nil:
 		args := make([]string, len(p.Call.Args))
 		for i, a := range p.Call.Args {
@@ -278,28 +446,217 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			}
 			args[i] = s
 		}
-		if len(args) == 0 {
-			return p.Call.Func, nil
+		switch p.Call.Func {
+		case "print":
+			if len(args) == 0 {
+				return "", fmt.Errorf("print expects at least 1 arg")
+			}
+			stmt := "Transcript show: "
+			if isStringLiteral(p.Call.Args[0]) {
+				stmt += args[0]
+			} else {
+				stmt += fmt.Sprintf("(%s) printString", args[0])
+			}
+			for i, a := range args[1:] {
+				stmt += "; show: ' '; show: "
+				if isStringLiteral(p.Call.Args[i+1]) {
+					stmt += a
+				} else {
+					stmt += fmt.Sprintf("(%s) printString", a)
+				}
+			}
+			return stmt + "; cr", nil
+		case "append":
+			if len(args) != 2 {
+				return "", fmt.Errorf("append expects 2 args")
+			}
+			return fmt.Sprintf("%s copyWith: %s", args[0], args[1]), nil
+		case "count", "len":
+			if len(args) != 1 {
+				return "", fmt.Errorf("%s expects 1 arg", p.Call.Func)
+			}
+			return fmt.Sprintf("(%s size)", args[0]), nil
+		case "values":
+			if len(args) != 1 {
+				return "", fmt.Errorf("values expects 1 arg")
+			}
+			return fmt.Sprintf("(%s values)", args[0]), nil
+		case "sum":
+			if len(args) != 1 {
+				return "", fmt.Errorf("sum expects 1 arg")
+			}
+			return fmt.Sprintf("(%s inject: 0 into: [:s :x | s + x])", args[0]), nil
+		case "min":
+			if len(args) != 1 {
+				return "", fmt.Errorf("min expects 1 arg")
+			}
+			return fmt.Sprintf("(%s min)", args[0]), nil
+		case "max":
+			if len(args) != 1 {
+				return "", fmt.Errorf("max expects 1 arg")
+			}
+			return fmt.Sprintf("(%s max)", args[0]), nil
+		case "str":
+			if len(args) != 1 {
+				return "", fmt.Errorf("str expects 1 arg")
+			}
+			return fmt.Sprintf("(%s asString)", args[0]), nil
+		case "substring", "substr":
+			if len(args) != 3 {
+				return "", fmt.Errorf("substring expects 3 args")
+			}
+			return fmt.Sprintf("(%s copyFrom: %s to: %s)", args[0], args[1], args[2]), nil
+		default:
+			call := p.Call.Func
+			for _, a := range args {
+				call += " value: " + a
+			}
+			return call, nil
 		}
-		return fmt.Sprintf("%s(%s)", p.Call.Func, strings.Join(args, ", ")), nil
-	case p.Selector != nil:
-		parts := append([]string{p.Selector.Root}, p.Selector.Tail...)
-		return strings.Join(parts, "."), nil
-	case p.Group != nil:
-		s, err := c.compileExpr(p.Group)
-		if err != nil {
-			return "", err
-		}
-		return "(" + s + ")", nil
+	case p.Match != nil:
+		return c.compileMatchExpr(p.Match)
+	case p.Query != nil:
+		return c.compileQueryExpr(p.Query)
 	default:
 		return "", fmt.Errorf("unsupported expression at line %d", p.Pos.Line)
 	}
+}
+
+func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) (string, error) {
+	target, err := c.compileExpr(m.Target)
+	if err != nil {
+		return "", err
+	}
+	expr := "nil"
+	for i := len(m.Cases) - 1; i >= 0; i-- {
+		cs := m.Cases[i]
+		res, err := c.compileExpr(cs.Result)
+		if err != nil {
+			return "", err
+		}
+		if isUnderscoreExpr(cs.Pattern) {
+			expr = res
+			continue
+		}
+		pat, err := c.compileExpr(cs.Pattern)
+		if err != nil {
+			return "", err
+		}
+		expr = fmt.Sprintf("(%s = %s) ifTrue: [%s] ifFalse: [%s]", target, pat, res, expr)
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
+	if q.Group != nil || len(q.Joins) > 0 {
+		return "", fmt.Errorf("query features not supported")
+	}
+
+	srcs := make([]string, 1+len(q.Froms))
+	vars := make([]string, 1+len(q.Froms))
+
+	s, err := c.compileExpr(q.Source)
+	if err != nil {
+		return "", err
+	}
+	srcs[0] = s
+	vars[0] = q.Var
+
+	for i, f := range q.Froms {
+		fs, err := c.compileExpr(f.Src)
+		if err != nil {
+			return "", err
+		}
+		srcs[i+1] = fs
+		vars[i+1] = f.Var
+	}
+
+	cond := ""
+	if q.Where != nil {
+		cond, err = c.compileExpr(q.Where)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	sel, err := c.compileExpr(q.Select)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	b.WriteString("[ | tmp |\n")
+	b.WriteString("  tmp := OrderedCollection new.\n")
+
+	var loop func(int, string)
+	loop = func(i int, indent string) {
+		b.WriteString(indent + srcs[i] + " do: [:" + vars[i] + " |\n")
+		next := indent + "  "
+		if i+1 < len(srcs) {
+			loop(i+1, next)
+		} else {
+			if cond != "" {
+				b.WriteString(next + "(" + cond + ") ifTrue: [\n")
+				b.WriteString(next + "  tmp add: " + sel + ".\n")
+				b.WriteString(next + "].\n")
+			} else {
+				b.WriteString(next + "tmp add: " + sel + ".\n")
+			}
+		}
+		b.WriteString(indent + "].\n")
+	}
+	loop(0, "  ")
+
+	if q.Sort != nil {
+		key, err := c.compileExpr(q.Sort)
+		if err != nil {
+			return "", err
+		}
+		keyA := strings.ReplaceAll(key, vars[0], "a")
+		keyB := strings.ReplaceAll(key, vars[0], "b")
+		b.WriteString("  tmp := tmp asSortedCollection: [:a :b | " + keyA + " < " + keyB + "].\n")
+	}
+
+	if q.Skip != nil || q.Take != nil {
+		start := "1"
+		if q.Skip != nil {
+			st, err := c.compileExpr(q.Skip)
+			if err != nil {
+				return "", err
+			}
+			start = "(" + st + ") + 1"
+		}
+		end := "tmp size"
+		if q.Take != nil {
+			tk, err := c.compileExpr(q.Take)
+			if err != nil {
+				return "", err
+			}
+			if q.Skip != nil {
+				end = "(" + start + " - 1 + " + tk + ")"
+			} else {
+				end = tk
+			}
+		}
+		b.WriteString("  tmp := tmp copyFrom: " + start + " to: " + end + ".\n")
+	}
+
+	if q.Distinct {
+		b.WriteString("  tmp := tmp asSet asOrderedCollection.\n")
+	}
+
+	b.WriteString("  tmp\n")
+	b.WriteString("] value")
+	return b.String(), nil
 }
 
 func (c *Compiler) compileLiteral(l *parser.Literal) string {
 	switch {
 	case l.Int != nil:
 		return fmt.Sprintf("%d", *l.Int)
+	case l.Str != nil:
+		s := strings.ReplaceAll(*l.Str, "'", "''")
+		return fmt.Sprintf("'%s'", s)
 	case l.Float != nil:
 		return fmt.Sprintf("%g", *l.Float)
 	case l.Bool != nil:
@@ -307,13 +664,42 @@ func (c *Compiler) compileLiteral(l *parser.Literal) string {
 			return "true"
 		}
 		return "false"
-	case l.Str != nil:
-		return fmt.Sprintf("'%s'", strings.Trim(*l.Str, "\""))
-	case l.Null:
-		return "nil"
 	default:
-		return ""
+		return "nil"
 	}
+}
+
+func isStringLiteral(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) > 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) > 0 || u.Value == nil || len(u.Value.Ops) > 0 {
+		return false
+	}
+	return u.Value.Target != nil && u.Value.Target.Lit != nil && u.Value.Target.Lit.Str != nil
+}
+
+func (c *Compiler) blockString(stmts []*parser.Statement) (string, error) {
+	sub := &Compiler{}
+	for _, st := range stmts {
+		if err := sub.compileStmt(st); err != nil {
+			return "", err
+		}
+	}
+	return strings.TrimSpace(sub.buf.String()), nil
+}
+
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 || u.Value == nil || len(u.Value.Ops) != 0 {
+		return false
+	}
+	return u.Value.Target != nil && u.Value.Target.Selector != nil &&
+		u.Value.Target.Selector.Root == "_" && len(u.Value.Target.Selector.Tail) == 0
 }
 
 func getCall(e *parser.Expr) *parser.CallExpr {


### PR DESCRIPTION
## Summary
- expand the Smalltalk `st` compiler to handle built‑ins and more expression forms

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686cf9b44b1083208acdc993b9c70e77