### PR TITLE
Update benchmarks using latest compilers

### DIFF
--- a/bench/out/math_matrix_mul_10.py.out
+++ b/bench/out/math_matrix_mul_10.py.out
@@ -35,11 +35,11 @@ def matmul(a, b):
     n = len(a)
     m = len(b[0])
     p = len(b)
-    result = []
+    result: list[list[int]] = []
     for i in range(0, n):
-        row = []
+        row: list[int] = []
         for j in range(0, m):
-            sum = 0
+            sum: typing.Callable[[typing.Any], float] = 0
             for k in range(0, p):
                 sum = sum + a[i][k] * b[k][j]
             row = row + [sum]

--- a/bench/out/math_matrix_mul_20.py.out
+++ b/bench/out/math_matrix_mul_20.py.out
@@ -35,11 +35,11 @@ def matmul(a, b):
     n = len(a)
     m = len(b[0])
     p = len(b)
-    result = []
+    result: list[list[int]] = []
     for i in range(0, n):
-        row = []
+        row: list[int] = []
         for j in range(0, m):
-            sum = 0
+            sum: typing.Callable[[typing.Any], float] = 0
             for k in range(0, p):
                 sum = sum + a[i][k] * b[k][j]
             row = row + [sum]

--- a/bench/out/math_matrix_mul_30.py.out
+++ b/bench/out/math_matrix_mul_30.py.out
@@ -35,11 +35,11 @@ def matmul(a, b):
     n = len(a)
     m = len(b[0])
     p = len(b)
-    result = []
+    result: list[list[int]] = []
     for i in range(0, n):
-        row = []
+        row: list[int] = []
         for j in range(0, m):
-            sum = 0
+            sum: typing.Callable[[typing.Any], float] = 0
             for k in range(0, p):
                 sum = sum + a[i][k] * b[k][j]
             row = row + [sum]

--- a/tools/install/main.go
+++ b/tools/install/main.go
@@ -5,9 +5,9 @@ package main
 import (
 	"fmt"
 
-	"mochi/archived/go"
-	"mochi/archived/py"
-	"mochi/archived/ts"
+	"mochi/compiler/x/go"
+	"mochi/compiler/x/python"
+	"mochi/compiler/x/ts"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- refresh benchmark outputs using latest compilers
- regenerate BENCHMARK.md
- switch benchmark runner to new compiler/x packages
- update installer to reference new compilers

## Testing
- `go run -tags="archived slow" ./cmd/mochi-bench`
- `go test -tags="archived slow" ./...` *(fails: package mochi/archived/go is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_686d101ea7a8832084e9f85d357a1b52