### PR TITLE
Fix go tests by ignoring machine examples

### DIFF
--- a/tests/machine/x/go/append_builtin.go
+++ b/tests/machine/x/go/append_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/avg_builtin.go
+++ b/tests/machine/x/go/avg_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/basic_compare.go
+++ b/tests/machine/x/go/basic_compare.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/binary_precedence.go
+++ b/tests/machine/x/go/binary_precedence.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/bool_chain.go
+++ b/tests/machine/x/go/bool_chain.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/break_continue.go
+++ b/tests/machine/x/go/break_continue.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/cast_string_to_int.go
+++ b/tests/machine/x/go/cast_string_to_int.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/cast_struct.go
+++ b/tests/machine/x/go/cast_struct.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/closure.go
+++ b/tests/machine/x/go/closure.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/count_builtin.go
+++ b/tests/machine/x/go/count_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/cross_join.go
+++ b/tests/machine/x/go/cross_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/cross_join_filter.go
+++ b/tests/machine/x/go/cross_join_filter.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/cross_join_triple.go
+++ b/tests/machine/x/go/cross_join_triple.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/dataset_sort_take_limit.go
+++ b/tests/machine/x/go/dataset_sort_take_limit.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/dataset_where_filter.go
+++ b/tests/machine/x/go/dataset_where_filter.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/exists_builtin.go
+++ b/tests/machine/x/go/exists_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/for_list_collection.go
+++ b/tests/machine/x/go/for_list_collection.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/for_loop.go
+++ b/tests/machine/x/go/for_loop.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/for_map_collection.go
+++ b/tests/machine/x/go/for_map_collection.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/fun_call.go
+++ b/tests/machine/x/go/fun_call.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/fun_expr_in_let.go
+++ b/tests/machine/x/go/fun_expr_in_let.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/fun_three_args.go
+++ b/tests/machine/x/go/fun_three_args.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by.go
+++ b/tests/machine/x/go/group_by.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by_conditional_sum.go
+++ b/tests/machine/x/go/group_by_conditional_sum.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by_having.go
+++ b/tests/machine/x/go/group_by_having.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by_join.go
+++ b/tests/machine/x/go/group_by_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by_left_join.go
+++ b/tests/machine/x/go/group_by_left_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by_multi_join.go
+++ b/tests/machine/x/go/group_by_multi_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by_multi_join_sort.go
+++ b/tests/machine/x/go/group_by_multi_join_sort.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/group_by_sort.go
+++ b/tests/machine/x/go/group_by_sort.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/if_else.go
+++ b/tests/machine/x/go/if_else.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/if_then_else.go
+++ b/tests/machine/x/go/if_then_else.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/if_then_else_nested.go
+++ b/tests/machine/x/go/if_then_else_nested.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/in_operator.go
+++ b/tests/machine/x/go/in_operator.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/in_operator_extended.go
+++ b/tests/machine/x/go/in_operator_extended.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/inner_join.go
+++ b/tests/machine/x/go/inner_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/join_multi.go
+++ b/tests/machine/x/go/join_multi.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/json_builtin.go
+++ b/tests/machine/x/go/json_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/left_join.go
+++ b/tests/machine/x/go/left_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/left_join_multi.go
+++ b/tests/machine/x/go/left_join_multi.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/len_builtin.go
+++ b/tests/machine/x/go/len_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/len_map.go
+++ b/tests/machine/x/go/len_map.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/len_string.go
+++ b/tests/machine/x/go/len_string.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/let_and_print.go
+++ b/tests/machine/x/go/let_and_print.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/list_assign.go
+++ b/tests/machine/x/go/list_assign.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/list_index.go
+++ b/tests/machine/x/go/list_index.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/list_nested_assign.go
+++ b/tests/machine/x/go/list_nested_assign.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/list_set_ops.go
+++ b/tests/machine/x/go/list_set_ops.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/load_yaml.go
+++ b/tests/machine/x/go/load_yaml.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/map_assign.go
+++ b/tests/machine/x/go/map_assign.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/map_in_operator.go
+++ b/tests/machine/x/go/map_in_operator.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/map_index.go
+++ b/tests/machine/x/go/map_index.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/map_int_key.go
+++ b/tests/machine/x/go/map_int_key.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/map_literal_dynamic.go
+++ b/tests/machine/x/go/map_literal_dynamic.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/map_membership.go
+++ b/tests/machine/x/go/map_membership.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/map_nested_assign.go
+++ b/tests/machine/x/go/map_nested_assign.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/match_expr.go
+++ b/tests/machine/x/go/match_expr.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/match_full.go
+++ b/tests/machine/x/go/match_full.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/math_ops.go
+++ b/tests/machine/x/go/math_ops.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/membership.go
+++ b/tests/machine/x/go/membership.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/min_max_builtin.go
+++ b/tests/machine/x/go/min_max_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/nested_function.go
+++ b/tests/machine/x/go/nested_function.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/order_by_map.go
+++ b/tests/machine/x/go/order_by_map.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/outer_join.go
+++ b/tests/machine/x/go/outer_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/partial_application.go
+++ b/tests/machine/x/go/partial_application.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/print_hello.go
+++ b/tests/machine/x/go/print_hello.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/pure_fold.go
+++ b/tests/machine/x/go/pure_fold.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/pure_global_fold.go
+++ b/tests/machine/x/go/pure_global_fold.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/query_sum_select.go
+++ b/tests/machine/x/go/query_sum_select.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/record_assign.go
+++ b/tests/machine/x/go/record_assign.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/right_join.go
+++ b/tests/machine/x/go/right_join.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/save_jsonl_stdout.go
+++ b/tests/machine/x/go/save_jsonl_stdout.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/short_circuit.go
+++ b/tests/machine/x/go/short_circuit.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/slice.go
+++ b/tests/machine/x/go/slice.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/sort_stable.go
+++ b/tests/machine/x/go/sort_stable.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/str_builtin.go
+++ b/tests/machine/x/go/str_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/string_compare.go
+++ b/tests/machine/x/go/string_compare.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/string_concat.go
+++ b/tests/machine/x/go/string_concat.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/string_contains.go
+++ b/tests/machine/x/go/string_contains.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/string_in_operator.go
+++ b/tests/machine/x/go/string_in_operator.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/string_index.go
+++ b/tests/machine/x/go/string_index.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/string_prefix_slice.go
+++ b/tests/machine/x/go/string_prefix_slice.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/substring_builtin.go
+++ b/tests/machine/x/go/substring_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/sum_builtin.go
+++ b/tests/machine/x/go/sum_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/tail_recursion.go
+++ b/tests/machine/x/go/tail_recursion.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/test_block.go
+++ b/tests/machine/x/go/test_block.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/tree_sum.go
+++ b/tests/machine/x/go/tree_sum.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/two-sum.go
+++ b/tests/machine/x/go/two-sum.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/typed_let.go
+++ b/tests/machine/x/go/typed_let.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/typed_var.go
+++ b/tests/machine/x/go/typed_var.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/unary_neg.go
+++ b/tests/machine/x/go/unary_neg.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/update_stmt.go
+++ b/tests/machine/x/go/update_stmt.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/user_type_literal.go
+++ b/tests/machine/x/go/user_type_literal.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/values_builtin.go
+++ b/tests/machine/x/go/values_builtin.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/var_assignment.go
+++ b/tests/machine/x/go/var_assignment.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/machine/x/go/while_loop.go
+++ b/tests/machine/x/go/while_loop.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- add `//go:build ignore` tags to Go example programs in `tests/machine/x/go`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d1a7a5168832095ada33a68e20d15