### PR TITLE
Enable Python compiler with VM test harness

### DIFF
--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -1,5 +1,3 @@
-//go:build archived
-
 package pycode
 
 import (

--- a/compiler/x/python/helpers.go
+++ b/compiler/x/python/helpers.go
@@ -1,5 +1,3 @@
-//go:build archived
-
 package pycode
 
 // Helper functions used by the Python compiler. Splitting them into this file

--- a/compiler/x/python/infer.go
+++ b/compiler/x/python/infer.go
@@ -1,5 +1,3 @@
-//go:build archived
-
 package pycode
 
 import (

--- a/compiler/x/python/runtime.go
+++ b/compiler/x/python/runtime.go
@@ -1,5 +1,3 @@
-//go:build archived
-
 package pycode
 
 import "sort"

--- a/compiler/x/python/statements.go
+++ b/compiler/x/python/statements.go
@@ -1,5 +1,3 @@
-//go:build archived
-
 package pycode
 
 import (

--- a/compiler/x/python/tools.go
+++ b/compiler/x/python/tools.go
@@ -1,5 +1,3 @@
-//go:build archived
-
 package pycode
 
 import (


### PR DESCRIPTION
## Summary
- remove `archived` build tags from Python backend sources
- update Python compiler tests to use active package
- add `TestCompilePrograms` to compile programs from `tests/vm/valid`

## Testing
- `go test ./compiler/x/python -run TestCompilePrograms -tags slow -count=1`
- `go vet ./compiler/x/python`

------
https://chatgpt.com/codex/tasks/task_e_686d15416ac483208e8c57c19ab2d952