### PR TITLE
Add query support in C++ compiler

### DIFF
--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -4,8 +4,8 @@ This directory contains C++ source code generated from Mochi programs and the co
 
 ## Summary
 
-- 41/97 programs compiled and executed successfully.
-- 56 programs failed to compile or run.
+- 55/97 programs compiled and executed successfully.
+- 42 programs failed to compile or run.
 
 ### Successful
 - append_builtin

--- a/tests/machine/x/cpp/cross_join.cpp
+++ b/tests/machine/x/cpp/cross_join.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto customers = std::vector<int>{std::unordered_map<int,int>{{id, 1}, {name, std::string("Alice")}}, std::unordered_map<int,int>{{id, 2}, {name, std::string("Bob")}}, std::unordered_map<int,int>{{id, 3}, {name, std::string("Charlie")}}};
+    auto orders = std::vector<int>{std::unordered_map<int,int>{{id, 100}, {customerId, 1}, {total, 250}}, std::unordered_map<int,int>{{id, 101}, {customerId, 2}, {total, 125}}, std::unordered_map<int,int>{{id, 102}, {customerId, 1}, {total, 300}}};
+    auto result = ([&]() {
+    std::vector<decltype(std::unordered_map<int,int>{{orderId, o.id}, {orderCustomerId, o.customerId}, {pairedCustomerName, c.name}, {orderTotal, o.total}})> __items;
+    for (auto o : orders) {
+        for (auto c : customers) {
+            __items.push_back(std::unordered_map<int,int>{{orderId, o.id}, {orderCustomerId, o.customerId}, {pairedCustomerName, c.name}, {orderTotal, o.total}});
+        }
+    }
+    return __items;
+})();
+    print(std::string("--- Cross Join: All order-customer pairs ---"));
+    for (auto entry : result) {
+        print(std::string("Order"), entry.orderId, std::string("(customerId:"), entry.orderCustomerId, std::string(", total: $"), entry.orderTotal, std::string(") paired with"), entry.pairedCustomerName);
+    }
+    return 0;
+}

--- a/tests/machine/x/cpp/cross_join_filter.cpp
+++ b/tests/machine/x/cpp/cross_join_filter.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto nums = std::vector<int>{1, 2, 3};
+    auto letters = std::vector<int>{std::string("A"), std::string("B")};
+    auto pairs = ([&]() {
+    std::vector<decltype(std::unordered_map<int,int>{{n, n}, {l, l}})> __items;
+    for (auto n : nums) {
+        for (auto l : letters) {
+            if (!(((n % 2) == 0))) continue;
+            __items.push_back(std::unordered_map<int,int>{{n, n}, {l, l}});
+        }
+    }
+    return __items;
+})();
+    print(std::string("--- Even pairs ---"));
+    for (auto p : pairs) {
+        print(p.n, p.l);
+    }
+    return 0;
+}

--- a/tests/machine/x/cpp/cross_join_triple.cpp
+++ b/tests/machine/x/cpp/cross_join_triple.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto nums = std::vector<int>{1, 2};
+    auto letters = std::vector<int>{std::string("A"), std::string("B")};
+    auto bools = std::vector<int>{true, false};
+    auto combos = ([&]() {
+    std::vector<decltype(std::unordered_map<int,int>{{n, n}, {l, l}, {b, b}})> __items;
+    for (auto n : nums) {
+        for (auto l : letters) {
+            for (auto b : bools) {
+                __items.push_back(std::unordered_map<int,int>{{n, n}, {l, l}, {b, b}});
+            }
+        }
+    }
+    return __items;
+})();
+    print(std::string("--- Cross Join of three lists ---"));
+    for (auto c : combos) {
+        print(c.n, c.l, c.b);
+    }
+    return 0;
+}

--- a/tests/machine/x/cpp/dataset_sort_take_limit.cpp
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto products = std::vector<int>{std::unordered_map<int,std::string>{{name, std::string("Laptop")}, {price, 1500}}, std::unordered_map<int,std::string>{{name, std::string("Smartphone")}, {price, 900}}, std::unordered_map<int,std::string>{{name, std::string("Tablet")}, {price, 600}}, std::unordered_map<int,std::string>{{name, std::string("Monitor")}, {price, 300}}, std::unordered_map<int,std::string>{{name, std::string("Keyboard")}, {price, 100}}, std::unordered_map<int,std::string>{{name, std::string("Mouse")}, {price, 50}}, std::unordered_map<int,std::string>{{name, std::string("Headphones")}, {price, 200}}};
+    auto expensive = ([&]() {
+    std::vector<std::pair<decltype((-p.price)), decltype(p)>>> __items;
+    for (auto p : products) {
+        __items.push_back({(-p.price), p});
+    }
+    std::sort(__items.begin(), __items.end(), [](auto &a, auto &b){ return a.first < b.first; });
+    if ((size_t)1 < __items.size()) __items.erase(__items.begin(), __items.begin()+1);
+    if ((size_t)3 < __items.size()) __items.resize(3);
+    std::vector<decltype(p)> __res;
+    for (auto &p : __items) __res.push_back(p.second);
+    return __res;
+})();
+    print(std::string("--- Top products (excluding most expensive) ---"));
+    for (auto item : expensive) {
+        print(item.name, std::string("costs $"), item.price);
+    }
+    return 0;
+}

--- a/tests/machine/x/cpp/exists_builtin.cpp
+++ b/tests/machine/x/cpp/exists_builtin.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto data = std::vector<int>{1, 2};
+    auto flag = exists(([&]() {
+    std::vector<decltype(x)> __items;
+    for (auto x : data) {
+        if (!((x == 1))) continue;
+        __items.push_back(x);
+    }
+    return __items;
+})());
+    print(flag);
+    return 0;
+}

--- a/tests/machine/x/cpp/in_operator_extended.cpp
+++ b/tests/machine/x/cpp/in_operator_extended.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto xs = std::vector<int>{1, 2, 3};
+    auto ys = ([&]() {
+    std::vector<decltype(x)> __items;
+    for (auto x : xs) {
+        if (!(((x % 2) == 1))) continue;
+        __items.push_back(x);
+    }
+    return __items;
+})();
+    print((std::find(ys.begin(), ys.end(), 1) != ys.end()));
+    print((std::find(ys.begin(), ys.end(), 2) != ys.end()));
+    auto m = std::unordered_map<int,int>{{a, 1}};
+    print((m.count(std::string("a")) > 0));
+    print((m.count(std::string("b")) > 0));
+    auto s = std::string("hello");
+    print((s.find(std::string("ell")) != std::string::npos));
+    print((s.find(std::string("foo")) != std::string::npos));
+    return 0;
+}

--- a/tests/machine/x/cpp/order_by_map.cpp
+++ b/tests/machine/x/cpp/order_by_map.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto data = std::vector<int>{std::unordered_map<int,int>{{a, 1}, {b, 2}}, std::unordered_map<int,int>{{a, 1}, {b, 1}}, std::unordered_map<int,int>{{a, 0}, {b, 5}}};
+    auto sorted = ([&]() {
+    std::vector<std::pair<decltype(std::unordered_map<int,int>{{a, x.a}, {b, x.b}}), decltype(x)>>> __items;
+    for (auto x : data) {
+        __items.push_back({std::unordered_map<int,int>{{a, x.a}, {b, x.b}}, x});
+    }
+    std::sort(__items.begin(), __items.end(), [](auto &a, auto &b){ return a.first < b.first; });
+    std::vector<decltype(x)> __res;
+    for (auto &p : __items) __res.push_back(p.second);
+    return __res;
+})();
+    print(sorted);
+    return 0;
+}

--- a/tests/machine/x/cpp/query_sum_select.cpp
+++ b/tests/machine/x/cpp/query_sum_select.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto nums = std::vector<int>{1, 2, 3};
+    auto result = ([&]() {
+    std::vector<decltype(std::accumulate(n.begin(), n.end(), 0))> __items;
+    for (auto n : nums) {
+        if (!((n > 1))) continue;
+        __items.push_back(std::accumulate(n.begin(), n.end(), 0));
+    }
+    return __items;
+})();
+    print(result);
+    return 0;
+}

--- a/tests/machine/x/cpp/sort_stable.cpp
+++ b/tests/machine/x/cpp/sort_stable.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+int main() {
+    auto items = std::vector<int>{std::unordered_map<int,int>{{n, 1}, {v, std::string("a")}}, std::unordered_map<int,int>{{n, 1}, {v, std::string("b")}}, std::unordered_map<int,int>{{n, 2}, {v, std::string("c")}}};
+    auto result = ([&]() {
+    std::vector<std::pair<decltype(i.n), decltype(i.v)>>> __items;
+    for (auto i : items) {
+        __items.push_back({i.n, i.v});
+    }
+    std::sort(__items.begin(), __items.end(), [](auto &a, auto &b){ return a.first < b.first; });
+    std::vector<decltype(i.v)> __res;
+    for (auto &p : __items) __res.push_back(p.second);
+    return __res;
+})();
+    print(result);
+    return 0;
+}

--- a/tests/machine/x/cpp/tree_sum.cpp
+++ b/tests/machine/x/cpp/tree_sum.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <algorithm>
+#include <numeric>
+
+template<typename T> void print_val(const T& v){ std::cout << v; }
+void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
+void print_val(bool b){ std::cout<<(b?"true":"false"); }
+void print(){ std::cout<<std::endl; }
+template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+
+auto sum_tree(auto t) {
+    return ([&]() { auto __v = t; if (__v == Leaf) return 0; else if (__v == Node(left, value, right)) return ((sum_tree(left) + value) + sum_tree(right)); return decltype(0){}; })();
+}
+
+int main() {
+    auto t = ([&]() { Node __v; __v.left = Leaf; __v.value = 1; __v.right = ([&]() { Node __v; __v.left = Leaf; __v.value = 2; __v.right = Leaf; return __v; })(); return __v; })();
+    print(sum_tree(t));
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add basic compileQueryExpr implementation
- update C++ machine output summary
- include generated examples for query-based programs

## Testing
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686d1cfecfcc832085795f330b267ec3