### PR TITLE
Handle '-' path in Python runtime

### DIFF
--- a/compiler/x/python/runtime.go
+++ b/compiler/x/python/runtime.go
@@ -147,7 +147,7 @@ var helperLoad = "def _load(path, opts):\n" +
 	"            delim = delim[0]\n" +
 	"    if path is not None and not os.path.isabs(path):\n" +
 	"        path = os.path.join(os.path.dirname(__file__), path)\n" +
-	"    f = sys.stdin if path is None else open(path, 'r')\n" +
+	"    f = sys.stdin if path is None or path == '-' else open(path, 'r')\n" +
 	"    try:\n" +
 	"        if fmt == 'tsv':\n" +
 	"            delim = '\t'; fmt = 'csv'\n" +
@@ -194,7 +194,7 @@ var helperLoad = "def _load(path, opts):\n" +
 	"        else:\n" +
 	"            raise Exception('unknown format: ' + fmt)\n" +
 	"    finally:\n" +
-	"        if path is not None:\n" +
+	"        if path is not None and path != '-':\n" +
 	"            f.close()\n"
 
 var helperSave = "def _save(rows, path, opts):\n" +
@@ -209,7 +209,7 @@ var helperSave = "def _save(rows, path, opts):\n" +
 	"        if isinstance(delim, str) and delim:\n" +
 	"            delim = delim[0]\n" +
 	"    rows = [ dataclasses.asdict(r) if dataclasses.is_dataclass(r) else r for r in rows ]\n" +
-	"    f = sys.stdout if path is None else open(path, 'w')\n" +
+	"    f = sys.stdout if path is None or path == '-' else open(path, 'w')\n" +
 	"    try:\n" +
 	"        if fmt == 'tsv':\n" +
 	"            delim = '\t'; fmt = 'csv'\n" +
@@ -242,7 +242,7 @@ var helperSave = "def _save(rows, path, opts):\n" +
 	"        else:\n" +
 	"            raise Exception('unknown format: ' + fmt)\n" +
 	"    finally:\n" +
-	"        if path is not None:\n" +
+	"        if path is not None and path != '-':\n" +
 	"            f.close()\n"
 
 var helperSlice = "def _slice(obj: list[T] | str, i: int, j: int) -> list[T] | str:\n" +

--- a/tests/machine/x/python/load_yaml.error
+++ b/tests/machine/x/python/load_yaml.error
@@ -6,7 +6,7 @@ Traceback (most recent call last):
     for _it in _load("../interpreter/valid/people.yaml", dict({"format": "yaml"}))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/workspace/mochi/tests/machine/x/python/load_yaml.py", line 27, in _load
-    f = sys.stdin if path is None else open(path, "r")
-                                       ^^^^^^^^^^^^^^^
+    f = sys.stdin if path is None or path == "-" else open(path, "r")
+                                                      ^^^^^^^^^^^^^^^
 FileNotFoundError: [Errno 2] No such file or directory: '/workspace/mochi/tests/machine/x/python/../interpreter/valid/people.yaml'
 

--- a/tests/machine/x/python/load_yaml.py
+++ b/tests/machine/x/python/load_yaml.py
@@ -24,7 +24,7 @@ def _load(path, opts):
             delim = delim[0]
     if path is not None and not os.path.isabs(path):
         path = os.path.join(os.path.dirname(__file__), path)
-    f = sys.stdin if path is None else open(path, "r")
+    f = sys.stdin if path is None or path == "-" else open(path, "r")
     try:
         if fmt == "tsv":
             delim = "	"
@@ -74,7 +74,7 @@ def _load(path, opts):
         else:
             raise Exception("unknown format: " + fmt)
     finally:
-        if path is not None:
+        if path is not None and path != "-":
             f.close()
 
 

--- a/tests/machine/x/python/save_jsonl_stdout.out
+++ b/tests/machine/x/python/save_jsonl_stdout.out
@@ -1,0 +1,2 @@
+{"name": "Alice", "age": 30}
+{"name": "Bob", "age": 25}

--- a/tests/machine/x/python/save_jsonl_stdout.py
+++ b/tests/machine/x/python/save_jsonl_stdout.py
@@ -22,7 +22,7 @@ def _save(rows, path, opts):
         if isinstance(delim, str) and delim:
             delim = delim[0]
     rows = [dataclasses.asdict(r) if dataclasses.is_dataclass(r) else r for r in rows]
-    f = sys.stdout if path is None else open(path, "w")
+    f = sys.stdout if path is None or path == "-" else open(path, "w")
     try:
         if fmt == "tsv":
             delim = "	"
@@ -57,7 +57,7 @@ def _save(rows, path, opts):
         else:
             raise Exception("unknown format: " + fmt)
     finally:
-        if path is not None:
+        if path is not None and path != "-":
             f.close()
 
 


### PR DESCRIPTION
## Summary
- ensure Python runtime treats `-` as stdin/stdout when loading or saving data
- regenerate machine output for affected examples

## Testing
- `go test ./compiler/x/python -run TestCompilePrograms -tags slow -count=1`
- `go test ./...` *(fails: undefined packages)*

------
https://chatgpt.com/codex/tasks/task_e_686d2e72b4ec832097f9afb4e6f680b2