### PR TITLE
Add Erlang membership support

### DIFF
--- a/tests/machine/x/erlang/README.md
+++ b/tests/machine/x/erlang/README.md
@@ -2,8 +2,8 @@
 
 This directory contains Erlang source files compiled from Mochi programs in `tests/vm/valid`.
 
-- **37/97 programs compiled and ran successfully** (have `.out` files)
-- **60 programs failed** to compile or run (have `.error` files)
+- **42/97 programs compiled and ran successfully** (have `.out` files)
+- **55 programs failed** to compile or run (have `.error` files)
 
 ## Successful programs
 append_builtin
@@ -45,6 +45,11 @@ string_concat
 string_index
 substring_builtin
 sum_builtin
+in_operator
+map_in_operator
+map_membership
+membership
+string_in_operator
 
 ## Failed programs
 break_continue
@@ -63,7 +68,6 @@ group_by_multi_join
 group_by_multi_join_sort
 group_by_sort
 group_items_iteration
-in_operator
 in_operator_extended
 inner_join
 join_multi
@@ -73,12 +77,9 @@ left_join_multi
 list_nested_assign
 list_set_ops
 load_yaml
-map_in_operator
-map_membership
 map_nested_assign
 match_expr
 match_full
-membership
 nested_function
 order_by_map
 outer_join
@@ -91,5 +92,4 @@ sort_stable
 str_builtin
 string_compare
 string_contains
-string_in_operator
 string_prefix_slice

--- a/tests/machine/x/erlang/in_operator.erl
+++ b/tests/machine/x/erlang/in_operator.erl
@@ -1,0 +1,7 @@
+#!/usr/bin/env escript
+% in_operator.erl - generated from in_operator.mochi
+
+main(_) ->
+    Xs = [1, 2, 3],
+    io:format("~p~n", [lists:member(2, Xs)]),
+    io:format("~p~n", [not (lists:member(5, Xs))]).

--- a/tests/machine/x/erlang/in_operator.error
+++ b/tests/machine/x/erlang/in_operator.error
@@ -1,1 +1,0 @@
-line 0: unsupported operator in

--- a/tests/machine/x/erlang/in_operator.out
+++ b/tests/machine/x/erlang/in_operator.out
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/machine/x/erlang/map_in_operator.erl
+++ b/tests/machine/x/erlang/map_in_operator.erl
@@ -1,0 +1,7 @@
+#!/usr/bin/env escript
+% map_in_operator.erl - generated from map_in_operator.mochi
+
+main(_) ->
+    M = #{1 => "a", 2 => "b"},
+    io:format("~p~n", [maps:is_key(1, M)]),
+    io:format("~p~n", [maps:is_key(3, M)]).

--- a/tests/machine/x/erlang/map_in_operator.error
+++ b/tests/machine/x/erlang/map_in_operator.error
@@ -1,1 +1,0 @@
-line 0: unsupported operator in

--- a/tests/machine/x/erlang/map_in_operator.out
+++ b/tests/machine/x/erlang/map_in_operator.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/machine/x/erlang/map_membership.erl
+++ b/tests/machine/x/erlang/map_membership.erl
@@ -1,0 +1,7 @@
+#!/usr/bin/env escript
+% map_membership.erl - generated from map_membership.mochi
+
+main(_) ->
+    M = #{"a" => 1, "b" => 2},
+    io:format("~p~n", [maps:is_key("a", M)]),
+    io:format("~p~n", [maps:is_key("c", M)]).

--- a/tests/machine/x/erlang/map_membership.error
+++ b/tests/machine/x/erlang/map_membership.error
@@ -1,1 +1,0 @@
-line 0: unsupported operator in

--- a/tests/machine/x/erlang/map_membership.out
+++ b/tests/machine/x/erlang/map_membership.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/machine/x/erlang/membership.erl
+++ b/tests/machine/x/erlang/membership.erl
@@ -1,0 +1,7 @@
+#!/usr/bin/env escript
+% membership.erl - generated from membership.mochi
+
+main(_) ->
+    Nums = [1, 2, 3],
+    io:format("~p~n", [lists:member(2, Nums)]),
+    io:format("~p~n", [lists:member(4, Nums)]).

--- a/tests/machine/x/erlang/membership.error
+++ b/tests/machine/x/erlang/membership.error
@@ -1,1 +1,0 @@
-line 0: unsupported operator in

--- a/tests/machine/x/erlang/membership.out
+++ b/tests/machine/x/erlang/membership.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/machine/x/erlang/string_in_operator.erl
+++ b/tests/machine/x/erlang/string_in_operator.erl
@@ -1,0 +1,7 @@
+#!/usr/bin/env escript
+% string_in_operator.erl - generated from string_in_operator.mochi
+
+main(_) ->
+    S = "catch",
+    io:format("~p~n", [string:str(S, "cat") > 0]),
+    io:format("~p~n", [string:str(S, "dog") > 0]).

--- a/tests/machine/x/erlang/string_in_operator.error
+++ b/tests/machine/x/erlang/string_in_operator.error
@@ -1,1 +1,0 @@
-line 0: unsupported operator in

--- a/tests/machine/x/erlang/string_in_operator.out
+++ b/tests/machine/x/erlang/string_in_operator.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- support `in`, `union`, `except`, `intersect` operators in Erlang compiler
- regenerate Erlang machine code for membership tests
- update README counts

## Testing
- `go test ./compiler/x/erlang -run "TestCompilePrograms/(membership|map_membership|in_operator$|map_in_operator|string_in_operator)" -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_686d2331522c83208c2d35ef1de99c48