### PR TITLE
Improve Go backend iteration over any

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -1145,6 +1145,17 @@ func (c *Compiler) compileFor(stmt *parser.ForStmt) error {
 		} else {
 			c.buf.WriteString(fmt.Sprintf("for range %s {\n", src))
 		}
+	case types.AnyType:
+		c.writeIndent()
+		c.use("_toAnySlice")
+		if useVar {
+			c.buf.WriteString(fmt.Sprintf("for _, %s := range _toAnySlice(%s) {\n", name, src))
+			if c.env != nil {
+				c.env.SetVar(stmt.Name, types.AnyType{}, true)
+			}
+		} else {
+			c.buf.WriteString(fmt.Sprintf("for range _toAnySlice(%s) {\n", src))
+		}
 	default:
 		return fmt.Errorf("cannot iterate over type %s", t)
 	}

--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -4,8 +4,8 @@ This directory contains Go source code generated from Mochi programs and the cor
 
 ## Summary
 
-- 96/97 programs compiled and executed successfully.
-- 1 program failed to compile or run.
+- 97/97 programs compiled and executed successfully.
+
 
 ### Successful
 - append_builtin
@@ -105,6 +105,3 @@ This directory contains Go source code generated from Mochi programs and the cor
 - update_stmt
 - values_builtin
 
-### Failed
-
-- group_items_iteration


### PR DESCRIPTION
## Summary
- handle `any` type in Go backend's for-loops
- update machine README to reflect all programs compiling

## Testing
- `go test ./compiler/x/go -tags slow -run TestGoCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686d374ee5088320a6b34cbdb6476aa7