### PR TITLE
Fix Go compiler build by removing build tag

### DIFF
--- a/compiler/x/go/tools.go
+++ b/compiler/x/go/tools.go
@@ -1,5 +1,3 @@
-//go:build slow
-
 package gocode
 
 import (


### PR DESCRIPTION
## Summary
- remove `slow` build tag from Go compiler tools
- allow the `FormatGo` helper to compile normally

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d3bec45a08320af3bc28cae1f8c5a