### PR TITLE
Format C++ compiler output

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -125,7 +125,7 @@ func (c *Compiler) Compile(p *parser.Program) ([]byte, error) {
 	var out bytes.Buffer
 	out.Write(c.header.Bytes())
 	out.Write(c.buf.Bytes())
-	return out.Bytes(), nil
+	return FormatCPP(out.Bytes()), nil
 }
 
 func (c *Compiler) compileFun(fn *parser.FunStmt) error {

--- a/compiler/x/cpp/tools.go
+++ b/compiler/x/cpp/tools.go
@@ -1,0 +1,33 @@
+package cpp
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+// FormatCPP runs clang-format on the given source code if available.
+// If clang-format is missing or fails, the input is returned unchanged.
+func FormatCPP(src []byte) []byte {
+	path, err := exec.LookPath("clang-format")
+	if err != nil {
+		if len(src) > 0 && src[len(src)-1] != '\n' {
+			src = append(src, '\n')
+		}
+		return src
+	}
+	cmd := exec.Command(path, "-style=LLVM")
+	cmd.Stdin = bytes.NewReader(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		res := out.Bytes()
+		if len(res) == 0 || res[len(res)-1] != '\n' {
+			res = append(res, '\n')
+		}
+		return res
+	}
+	if len(src) > 0 && src[len(src)-1] != '\n' {
+		src = append(src, '\n')
+	}
+	return src
+}


### PR DESCRIPTION
## Summary
- add `FormatCPP` for formatting generated C++ code
- format code when compiling with the C++ backend

## Testing
- `go test ./compiler/x/cpp -tags slow -run TestCompilePrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686db9e0f1d0832086816be51523cb06