### PR TITLE
Improve Go compiler append handling

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -3582,10 +3582,26 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "str":
 		c.imports["fmt"] = true
 		return fmt.Sprintf("fmt.Sprint(%s)", argStr), nil
-	case "input":
-		c.imports["fmt"] = true
-		c.use("_input")
-		return "_input()", nil
+        case "input":
+                c.imports["fmt"] = true
+                c.use("_input")
+                return "_input()", nil
+        case "append":
+                if len(call.Args) != 2 {
+                        return "", fmt.Errorf("append expects 2 args")
+                }
+                if lt, ok := c.inferExprType(call.Args[0]).(types.ListType); ok {
+                        a0, err := c.compileExprHint(call.Args[0], lt)
+                        if err != nil {
+                                return "", err
+                        }
+                        a1, err := c.compileExprHint(call.Args[1], lt.Elem)
+                        if err != nil {
+                                return "", err
+                        }
+                        return fmt.Sprintf("append(%s, %s)", a0, a1), nil
+                }
+                return fmt.Sprintf("append(%s)", argStr), nil
 	case "contains":
 		if len(args) != 2 {
 			return "", fmt.Errorf("contains expects 2 args")


### PR DESCRIPTION
## Summary
- enhance Go compiler so append() preserves element types

## Testing
- `go test ./compiler/x/go -run TestGoCompiler_ValidPrograms/append_builtin -tags slow`
- `go test ./compiler/x/go -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686dbc6173208320b9f6c5d987f25a73