### PR TITLE
Improve Elixir compiler runtime

### DIFF
--- a/compiler/x/ex/runtime.go
+++ b/compiler/x/ex/runtime.go
@@ -5,13 +5,13 @@ package excode
 const (
 	helperInput = "defp _input() do\n  String.trim(IO.gets(\"\"))\nend\n"
 
-	helperCount = "defp _count(v) do\n  cond do\n    is_list(v) -> length(v)\n    is_map(v) and Map.has_key?(v, :items) -> length(v[:items])\n    true -> raise \"count() expects list or group\"\n  end\nend\n"
+	helperCount = "defp _count(v) do\n  cond do\n    is_list(v) -> length(v)\n    is_map(v) and Map.has_key?(v, :items) -> length(v.items)\n    true -> raise \"count() expects list or group\"\n  end\nend\n"
 
-	helperSum = "defp _sum(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v[:items]\n    is_list(v) -> v\n    true -> raise \"sum() expects list or group\"\n  end\n  Enum.sum(list)\nend\n"
+	helperSum = "defp _sum(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v.items\n    is_list(v) -> v\n    true -> raise \"sum() expects list or group\"\n  end\n  Enum.sum(list)\nend\n"
 
-	helperAvg = "defp _avg(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v[:items]\n    is_list(v) -> v\n    true -> raise \"avg() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    Enum.sum(list) / Enum.count(list)\n  end\nend\n"
+	helperAvg = "defp _avg(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v.items\n    is_list(v) -> v\n    true -> raise \"avg() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    Enum.sum(list) / Enum.count(list)\n  end\nend\n"
 
-	helperExists = "defp _exists(v) do\n  cond do\n    is_list(v) -> length(v) > 0\n    is_map(v) and Map.has_key?(v, :items) -> length(v[:items]) > 0\n    is_map(v) -> map_size(v) > 0\n    is_binary(v) -> String.length(v) > 0\n    true -> raise \"exists expects list, map or string\"\n  end\nend\n"
+	helperExists = "defp _exists(v) do\n  cond do\n    is_list(v) -> length(v) > 0\n    is_map(v) and Map.has_key?(v, :items) -> length(v.items) > 0\n    is_map(v) -> map_size(v) > 0\n    is_binary(v) -> String.length(v) > 0\n    true -> raise \"exists expects list, map or string\"\n  end\nend\n"
 
 	helperJson = `defp _escape_json(<<>>), do: ""
 defp _escape_json(<<"\\", rest::binary>>), do: "\\\\" <> _escape_json(rest)
@@ -30,11 +30,11 @@ defp _to_json(_), do: "null"
 defp _json(v), do: IO.puts(_to_json(v))
 `
 
-	helperMin = "defp _min(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v[:items]\n    is_list(v) -> v\n    true -> raise \"min() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    hd = hd(list)\n    Enum.reduce(tl(list), hd, fn it, acc ->\n      cond do\n        is_binary(acc) and is_binary(it) -> if it < acc, do: it, else: acc\n        true -> if Kernel.<(it, acc), do: it, else: acc\n      end\n    end)\n  end\nend\n"
+	helperMin = "defp _min(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v.items\n    is_list(v) -> v\n    true -> raise \"min() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    hd = hd(list)\n    Enum.reduce(tl(list), hd, fn it, acc ->\n      cond do\n        is_binary(acc) and is_binary(it) -> if it < acc, do: it, else: acc\n        true -> if Kernel.<(it, acc), do: it, else: acc\n      end\n    end)\n  end\nend\n"
 
-	helperMax = "defp _max(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v[:items]\n    is_list(v) -> v\n    true -> raise \"max() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    hd = hd(list)\n    Enum.reduce(tl(list), hd, fn it, acc ->\n      cond do\n        is_binary(acc) and is_binary(it) -> if it > acc, do: it, else: acc\n        true -> if Kernel.>(it, acc), do: it, else: acc\n      end\n    end)\n  end\nend\n"
+	helperMax = "defp _max(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :items) -> v.items\n    is_list(v) -> v\n    true -> raise \"max() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    hd = hd(list)\n    Enum.reduce(tl(list), hd, fn it, acc ->\n      cond do\n        is_binary(acc) and is_binary(it) -> if it > acc, do: it, else: acc\n        true -> if Kernel.>(it, acc), do: it, else: acc\n      end\n    end)\n  end\nend\n"
 
-	helperFirst = "defp _first(v) do\n  cond do\n    is_map(v) and Map.has_key?(v, :items) ->\n      if length(v[:items]) == 0, do: nil, else: hd(v[:items])\n    is_list(v) ->\n      if v == [], do: nil, else: hd(v)\n    true -> nil\n  end\nend\n"
+	helperFirst = "defp _first(v) do\n  cond do\n    is_map(v) and Map.has_key?(v, :items) ->\n      if length(v.items) == 0, do: nil, else: hd(v.items)\n    is_list(v) ->\n      if v == [], do: nil, else: hd(v)\n    true -> nil\n  end\nend\n"
 
 	helperReverse = "defp _reverse(v) do\n  cond do\n    is_list(v) -> Enum.reverse(v)\n    is_binary(v) -> String.graphemes(v) |> Enum.reverse() |> Enum.join()\n    true -> raise \"reverse expects list or string\"\n  end\nend\n"
 

--- a/tests/machine/x/ex/README.md
+++ b/tests/machine/x/ex/README.md
@@ -4,8 +4,8 @@ This directory contains Elixir source code generated from Mochi programs and the
 
 ## Summary
 
-- 76/97 programs compiled and executed successfully.
-- 21 programs failed to compile or run.
+- 78/97 programs compiled and executed successfully.
+- 19 programs failed to compile or run.
 
 ### Successful
 - append_builtin
@@ -31,6 +31,8 @@ This directory contains Elixir source code generated from Mochi programs and the
 - fun_expr_in_let
 - fun_three_args
 - group_by_multi_join
+- group_by
+- group_by_having
 - if_else
 - if_then_else
 - if_then_else_nested
@@ -86,9 +88,7 @@ This directory contains Elixir source code generated from Mochi programs and the
 - while_loop
 
 ### Failed
-- group_by
-- group_by_conditional_sum
-- group_by_having
+ - group_by_conditional_sum
 - group_by_join
 - group_by_left_join
 - group_by_multi_join_sort

--- a/tests/machine/x/ex/group_by.mochi.error
+++ b/tests/machine/x/ex/group_by.mochi.error
@@ -1,9 +1,0 @@
-line 288
-** (UndefinedFunctionError) function Main.Group.fetch/2 is undefined (Main.Group does not implement the Access behaviour. If you are using get_in/put_in/update_in, you can specify the field to be accessed using Access.key!/1)
-    Main.Group.fetch(%Main.Group{key: "Paris", items: [%{age: 30, city: "Paris", name: "Alice"}, %{age: 65, city: "Paris", name: "Charlie"}, %{age: 70, city: "Paris", name: "Eve"}]}, :items)
-    (elixir 1.14.0) lib/access.ex:288: Access.get/3
-    /workspace/mochi/tests/machine/x/ex/group_by.mochi.exs:50: Main._count/1
-    /workspace/mochi/tests/machine/x/ex/group_by.mochi.exs:17: anonymous fn/1 in Main.main/0
-    (elixir 1.14.0) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
-    /workspace/mochi/tests/machine/x/ex/group_by.mochi.exs:16: Main.main/0
-

--- a/tests/machine/x/ex/group_by.mochi.out
+++ b/tests/machine/x/ex/group_by.mochi.out
@@ -1,0 +1,3 @@
+"--- People grouped by city ---"
+Paris : count = 3 , avg_age = 55.0
+Hanoi : count = 3 , avg_age = 27.333333333333332

--- a/tests/machine/x/ex/group_by_having.mochi.error
+++ b/tests/machine/x/ex/group_by_having.mochi.error
@@ -1,9 +1,0 @@
-line 288
-** (UndefinedFunctionError) function Main.Group.fetch/2 is undefined (Main.Group does not implement the Access behaviour. If you are using get_in/put_in/update_in, you can specify the field to be accessed using Access.key!/1)
-    Main.Group.fetch(%Main.Group{key: "Paris", items: [%{city: "Paris", name: "Alice"}, %{city: "Paris", name: "Charlie"}, %{city: "Paris", name: "Eve"}, %{city: "Paris", name: "George"}]}, :items)
-    (elixir 1.14.0) lib/access.ex:288: Access.get/3
-    /workspace/mochi/tests/machine/x/ex/group_by_having.mochi.exs:25: Main._count/1
-    /workspace/mochi/tests/machine/x/ex/group_by_having.mochi.exs:17: anonymous fn/1 in Main.main/0
-    (elixir 1.14.0) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
-    /workspace/mochi/tests/machine/x/ex/group_by_having.mochi.exs:17: Main.main/0
-

--- a/tests/machine/x/ex/group_by_having.mochi.out
+++ b/tests/machine/x/ex/group_by_having.mochi.out
@@ -1,0 +1,1 @@
+[{"city":"Paris","num":4},{"city":"Hanoi","num":3}]


### PR DESCRIPTION
## Summary
- fix Elixir runtime helpers to access group structs without Access behaviour
- regenerate machine outputs for newly working examples
- mark additional programs as successful in machine README

## Testing
- `go test -tags slow ./compiler/x/ex -run TestElixirCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686dbb6e3ae08320bde8ad22d738d53f