### PR TITLE
Improve Go join compilation

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -2450,13 +2450,15 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		return "", err
 	}
 
-	needsHelper := q.Sort != nil
-	for _, j := range q.Joins {
-		if j.Side != nil {
-			needsHelper = true
-			break
-		}
-	}
+       needsHelper := q.Sort != nil
+       for _, j := range q.Joins {
+               if j.Side != nil {
+                       if !(len(q.Joins) == 1 && *j.Side == "left") {
+                               needsHelper = true
+                               break
+                       }
+               }
+       }
 
 	// Prepare environment for the query variable
 	srcType := c.inferExprType(q.Source)

--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -6,6 +6,8 @@ This directory contains Go source code generated from Mochi programs and the cor
 
 - 97/97 programs compiled and executed successfully.
 
+Left joins are now generated using explicit loops instead of the generic `_query` helper for clearer output.
+
 
 ### Successful
 - append_builtin

--- a/tests/machine/x/go/left_join.go
+++ b/tests/machine/x/go/left_join.go
@@ -3,9 +3,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"sort"
 )
 
 func main() {
@@ -38,256 +36,33 @@ func main() {
 		Total:      80,
 	}}
 	var result []map[string]any = func() []map[string]any {
-		src := _toAnySlice(orders)
-		resAny := _query(src, []_joinSpec{
-			{items: _toAnySlice(customers), on: func(_a ...any) bool {
-				o := _cast[OrdersItem](_a[0])
-				_ = o
-				c := _cast[CustomersItem](_a[1])
-				_ = c
-				return (o.CustomerId == c.Id)
-			}, left: true},
-		}, _queryOpts{selectFn: func(_a ...any) any {
-			o := _cast[OrdersItem](_a[0])
-			_ = o
-			c := _cast[CustomersItem](_a[1])
-			_ = c
-			return map[string]any{
-				"orderId":  o.Id,
-				"customer": c,
-				"total":    o.Total,
+		_res := []map[string]any{}
+		for _, o := range orders {
+			matched := false
+			for _, c := range customers {
+				if !(o.CustomerId == c.Id) {
+					continue
+				}
+				matched = true
+				_res = append(_res, map[string]any{
+					"orderId":  o.Id,
+					"customer": c,
+					"total":    o.Total,
+				})
 			}
-		}, skip: -1, take: -1})
-		out := make([]map[string]any, len(resAny))
-		for i, v := range resAny {
-			out[i] = _cast[map[string]any](v)
+			if !matched {
+				var c CustomersItem
+				_res = append(_res, map[string]any{
+					"orderId":  o.Id,
+					"customer": c,
+					"total":    o.Total,
+				})
+			}
 		}
-		return out
+		return _res
 	}()
 	fmt.Println("--- Left Join ---")
 	for _, entry := range result {
 		fmt.Println("Order", entry["orderId"], "customer", entry["customer"], "total", entry["total"])
 	}
-}
-
-func _cast[T any](v any) T {
-	if tv, ok := v.(T); ok {
-		return tv
-	}
-	var out T
-	switch any(out).(type) {
-	case int:
-		switch vv := v.(type) {
-		case int:
-			return any(vv).(T)
-		case float64:
-			return any(int(vv)).(T)
-		case float32:
-			return any(int(vv)).(T)
-		}
-	case float64:
-		switch vv := v.(type) {
-		case int:
-			return any(float64(vv)).(T)
-		case float64:
-			return any(vv).(T)
-		case float32:
-			return any(float64(vv)).(T)
-		}
-	case float32:
-		switch vv := v.(type) {
-		case int:
-			return any(float32(vv)).(T)
-		case float64:
-			return any(float32(vv)).(T)
-		case float32:
-			return any(vv).(T)
-		}
-	}
-	if m, ok := v.(map[any]any); ok {
-		v = _convertMapAny(m)
-	}
-	data, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	if err := json.Unmarshal(data, &out); err != nil {
-		panic(err)
-	}
-	return out
-}
-
-func _convertMapAny(m map[any]any) map[string]any {
-	out := make(map[string]any, len(m))
-	for k, v := range m {
-		key := fmt.Sprint(k)
-		if sub, ok := v.(map[any]any); ok {
-			out[key] = _convertMapAny(sub)
-		} else {
-			out[key] = v
-		}
-	}
-	return out
-}
-
-type _joinSpec struct {
-	items []any
-	on    func(...any) bool
-	left  bool
-	right bool
-}
-type _queryOpts struct {
-	selectFn func(...any) any
-	where    func(...any) bool
-	sortKey  func(...any) any
-	skip     int
-	take     int
-}
-
-func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
-	items := make([][]any, len(src))
-	for i, v := range src {
-		items[i] = []any{v}
-	}
-	for _, j := range joins {
-		joined := [][]any{}
-		if j.right && j.left {
-			matched := make([]bool, len(j.items))
-			for _, left := range items {
-				m := false
-				for ri, right := range j.items {
-					keep := true
-					if j.on != nil {
-						args := append(append([]any(nil), left...), right)
-						keep = j.on(args...)
-					}
-					if !keep {
-						continue
-					}
-					m = true
-					matched[ri] = true
-					joined = append(joined, append(append([]any(nil), left...), right))
-				}
-				if !m {
-					joined = append(joined, append(append([]any(nil), left...), nil))
-				}
-			}
-			for ri, right := range j.items {
-				if !matched[ri] {
-					undef := make([]any, len(items[0]))
-					joined = append(joined, append(undef, right))
-				}
-			}
-		} else if j.right {
-			for _, right := range j.items {
-				m := false
-				for _, left := range items {
-					keep := true
-					if j.on != nil {
-						args := append(append([]any(nil), left...), right)
-						keep = j.on(args...)
-					}
-					if !keep {
-						continue
-					}
-					m = true
-					joined = append(joined, append(append([]any(nil), left...), right))
-				}
-				if !m {
-					undef := make([]any, len(items[0]))
-					joined = append(joined, append(undef, right))
-				}
-			}
-		} else {
-			for _, left := range items {
-				m := false
-				for _, right := range j.items {
-					keep := true
-					if j.on != nil {
-						args := append(append([]any(nil), left...), right)
-						keep = j.on(args...)
-					}
-					if !keep {
-						continue
-					}
-					m = true
-					joined = append(joined, append(append([]any(nil), left...), right))
-				}
-				if j.left && !m {
-					joined = append(joined, append(append([]any(nil), left...), nil))
-				}
-			}
-		}
-		items = joined
-	}
-	if opts.where != nil {
-		filtered := [][]any{}
-		for _, r := range items {
-			if opts.where(r...) {
-				filtered = append(filtered, r)
-			}
-		}
-		items = filtered
-	}
-	if opts.sortKey != nil {
-		type pair struct {
-			item []any
-			key  any
-		}
-		pairs := make([]pair, len(items))
-		for i, it := range items {
-			pairs[i] = pair{it, opts.sortKey(it...)}
-		}
-		sort.Slice(pairs, func(i, j int) bool {
-			a, b := pairs[i].key, pairs[j].key
-			switch av := a.(type) {
-			case int:
-				switch bv := b.(type) {
-				case int:
-					return av < bv
-				case float64:
-					return float64(av) < bv
-				}
-			case float64:
-				switch bv := b.(type) {
-				case int:
-					return av < float64(bv)
-				case float64:
-					return av < bv
-				}
-			case string:
-				bs, _ := b.(string)
-				return av < bs
-			}
-			return fmt.Sprint(a) < fmt.Sprint(b)
-		})
-		for i, p := range pairs {
-			items[i] = p.item
-		}
-	}
-	if opts.skip >= 0 {
-		if opts.skip < len(items) {
-			items = items[opts.skip:]
-		} else {
-			items = [][]any{}
-		}
-	}
-	if opts.take >= 0 {
-		if opts.take < len(items) {
-			items = items[:opts.take]
-		}
-	}
-	res := make([]any, len(items))
-	for i, r := range items {
-		res[i] = opts.selectFn(r...)
-	}
-	return res
-}
-
-func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
-	}
-	return out
 }


### PR DESCRIPTION
## Summary
- improve go query compiler: detect simple left joins so helper is skipped
- regenerate `left_join.go`
- note new join behaviour in Go machine README

## Testing
- `go test ./compiler/x/go -tags slow`
- `go test ./compiler/x/go -tags slow -run TestGoCompiler_ValidPrograms/left_join`


------
https://chatgpt.com/codex/tasks/task_e_686dc2fa08ac8320bece11662d1b2a58