### PR TITLE
Improve Python join code generation

### DIFF
--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -7,6 +7,10 @@ This directory contains Python source code generated from Mochi programs and the
 - 93/97 programs compiled and executed successfully.
 - 4 programs failed to compile or run.
 
+Generated join queries such as `inner_join` and `join_multi` now use
+native Python loops instead of the generic `_query` helper for more
+readable output.
+
 ### Successful
 - append_builtin
 - avg_builtin

--- a/tests/machine/x/python/group_by_multi_join.py
+++ b/tests/machine/x/python/group_by_multi_join.py
@@ -170,20 +170,15 @@ def main():
         {"part": 200, "supplier": 1, "cost": 5, "qty": 3},
     ]
     global filtered
-    filtered = _query(
-        partsupp,
-        [
-            {"items": suppliers, "on": lambda ps, s: ((s["id"] == ps["supplier"]))},
-            {"items": nations, "on": lambda ps, s, n: ((n["id"] == s["nation"]))},
-        ],
-        {
-            "select": lambda ps, s, n: {
-                "part": ps["part"],
-                "value": (ps["cost"] * ps["qty"]),
-            },
-            "where": lambda ps, s, n: ((n["name"] == "A")),
-        },
-    )
+    filtered = [
+        {"part": ps["part"], "value": (ps["cost"] * ps["qty"])}
+        for ps in partsupp
+        for s in suppliers
+        for n in nations
+        if (s["id"] == ps["supplier"])
+        and (n["id"] == s["nation"])
+        and (n["name"] == "A")
+    ]
 
     def _q0():
         _src = filtered

--- a/tests/machine/x/python/join_multi.py
+++ b/tests/machine/x/python/join_multi.py
@@ -3,90 +3,6 @@ from __future__ import annotations
 
 import typing
 
-from typing import Any, TypeVar, Generic, Callable
-
-T = TypeVar("T")
-K = TypeVar("K")
-
-
-def _query(src, joins, opts):
-    items = [[v] for v in src]
-    for j in joins:
-        joined = []
-        if j.get("right") and j.get("left"):
-            matched = [False] * len(j["items"])
-            for left in items:
-                m = False
-                for ri, right in enumerate(j["items"]):
-                    keep = True
-                    if j.get("on"):
-                        keep = j["on"](*left, right)
-                    if not keep:
-                        continue
-                    m = True
-                    matched[ri] = True
-                    joined.append(left + [right])
-                if not m:
-                    joined.append(left + [None])
-            for ri, right in enumerate(j["items"]):
-                if not matched[ri]:
-                    undef = [None] * (len(items[0]) if items else 0)
-                    joined.append(undef + [right])
-        elif j.get("right"):
-            for right in j["items"]:
-                m = False
-                for left in items:
-                    keep = True
-                    if j.get("on"):
-                        keep = j["on"](*left, right)
-                    if not keep:
-                        continue
-                    m = True
-                    joined.append(left + [right])
-                if not m:
-                    undef = [None] * (len(items[0]) if items else 0)
-                    joined.append(undef + [right])
-        else:
-            for left in items:
-                m = False
-                for right in j["items"]:
-                    keep = True
-                    if j.get("on"):
-                        keep = j["on"](*left, right)
-                    if not keep:
-                        continue
-                    m = True
-                    joined.append(left + [right])
-                if j.get("left") and not m:
-                    joined.append(left + [None])
-        items = joined
-    if opts.get("where"):
-        items = [r for r in items if opts["where"](*r)]
-    if opts.get("sortKey"):
-
-        def _key(it):
-            k = opts["sortKey"](*it)
-            if isinstance(k, (list, tuple, dict)):
-                return str(k)
-            return k
-
-        items.sort(key=_key)
-    if "skip" in opts:
-        n = opts["skip"]
-        if n < 0:
-            n = 0
-        items = items[n:] if n < len(items) else []
-    if "take" in opts:
-        n = opts["take"]
-        if n < 0:
-            n = 0
-        items = items[:n] if n < len(items) else items
-    res = []
-    for r in items:
-        res.append(opts["select"](*r))
-    return res
-
-
 customers: list[dict[str, typing.Any]] = None
 orders: list[dict[str, int]] = None
 items: list[dict[str, typing.Any]] = None
@@ -101,14 +17,13 @@ def main():
     global items
     items = [{"orderId": 100, "sku": "a"}, {"orderId": 101, "sku": "b"}]
     global result
-    result = _query(
-        orders,
-        [
-            {"items": customers, "on": lambda o, c: ((o["customerId"] == c["id"]))},
-            {"items": items, "on": lambda o, c, i: ((o["id"] == i["orderId"]))},
-        ],
-        {"select": lambda o, c, i: {"name": c["name"], "sku": i["sku"]}},
-    )
+    result = [
+        {"name": c["name"], "sku": i["sku"]}
+        for o in orders
+        for c in customers
+        for i in items
+        if (o["customerId"] == c["id"]) and (o["id"] == i["orderId"])
+    ]
     print("--- Multi Join ---")
     for r in result:
         print(r["name"], "bought item", r["sku"])


### PR DESCRIPTION
## Summary
- improve the Python backend to emit list comprehensions for inner joins
- regenerate golden machine outputs for inner join programs
- document new join handling in the Python machine README

## Testing
- `go test -tags slow ./compiler/x/python -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686dc30703a883208c194f20cb79ae02