### PR TITLE
Enable C# compiler

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -1,5 +1,3 @@
-//go:build slow
-
 package cscode
 
 import (

--- a/compiler/x/cs/compiler_test.go
+++ b/compiler/x/cs/compiler_test.go
@@ -1,5 +1,3 @@
-//go:build slow
-
 package cscode_test
 
 import (

--- a/compiler/x/cs/helpers.go
+++ b/compiler/x/cs/helpers.go
@@ -1,5 +1,3 @@
-//go:build slow
-
 package cscode
 
 import (

--- a/compiler/x/cs/infer.go
+++ b/compiler/x/cs/infer.go
@@ -1,5 +1,3 @@
-//go:build slow
-
 package cscode
 
 import (

--- a/compiler/x/cs/runtime.go
+++ b/compiler/x/cs/runtime.go
@@ -1,5 +1,3 @@
-//go:build slow
-
 package cscode
 
 func (c *Compiler) emitRuntime() {

--- a/compiler/x/cs/tools.go
+++ b/compiler/x/cs/tools.go
@@ -1,5 +1,3 @@
-//go:build slow
-
 package cscode
 
 import (


### PR DESCRIPTION
## Summary
- remove `//go:build slow` from C# compiler sources so it builds with default tests

## Testing
- `go test -run TestCompileValidPrograms ./compiler/x/cs`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ddb2d7d548320aa7791b0cbef3111