### PR TITLE
Fix COBOL compiler function formatting

### DIFF
--- a/compiler/x/cobol/compiler.go
+++ b/compiler/x/cobol/compiler.go
@@ -142,9 +142,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		using := ""
 		if len(fn.params) > 0 {
 			using = " USING " + strings.Join(fn.params, " ")
+			c.writeln("PROCEDURE DIVISION" + using + ".")
+			c.indent += 4
 		}
-		c.writeln("PROCEDURE DIVISION" + using + ".")
-		c.indent += 4
 		c.curFun = &fn
 		for _, st := range fn.body {
 			if err := c.compileStmt(st); err != nil {

--- a/tests/machine/x/cobol/README.md
+++ b/tests/machine/x/cobol/README.md
@@ -1,10 +1,10 @@
-# Mochi to COBOL Machine Translations (13/97 compiled)
+# Mochi to COBOL Machine Translations (14/97 compiled)
 
 - [ ] append_builtin.mochi
 - [ ] avg_builtin.mochi
 - [x] basic_compare.mochi
 - [x] binary_precedence.mochi
-- [ ] bool_chain.mochi
+- [x] bool_chain.mochi
 - [ ] break_continue.mochi
 - [x] cast_string_to_int.mochi
 - [ ] cast_struct.mochi

--- a/tests/machine/x/cobol/bool_chain.cob
+++ b/tests/machine/x/cobol/bool_chain.cob
@@ -5,18 +5,26 @@
        01 BOOM_RES PIC 9 VALUE 0.
        01 TMP PIC 9 VALUE 0.
        PROCEDURE DIVISION.
-       COMPUTE TMP = (1 < 2) AND (2 < 3) AND (3 < 4)
-       DISPLAY TMP
+       IF (1 < 2) AND (2 < 3) AND (3 < 4)
+           DISPLAY "true"
+       ELSE
+           DISPLAY "false"
+       END-IF
        PERFORM BOOM
-       COMPUTE TMP = (1 < 2) AND (2 > 3) AND BOOM_RES
-       DISPLAY TMP
+       IF (1 < 2) AND (2 > 3) AND BOOM_RES
+           DISPLAY "true"
+       ELSE
+           DISPLAY "false"
+       END-IF
        PERFORM BOOM
-       COMPUTE TMP = (1 < 2) AND (2 < 3) AND (3 > 4) AND BOOM_RES
-       DISPLAY TMP
+       IF (1 < 2) AND (2 < 3) AND (3 > 4) AND BOOM_RES
+           DISPLAY "true"
+       ELSE
+           DISPLAY "false"
+       END-IF
        STOP RUN.
        
        BOOM.
-           PROCEDURE DIVISION.
-               DISPLAY "boom"
-               COMPUTE BOOM_RES = 1
-               EXIT.
+           DISPLAY "boom"
+           COMPUTE BOOM_RES = 1
+           EXIT.

--- a/tests/machine/x/cobol/bool_chain.error
+++ b/tests/machine/x/cobol/bool_chain.error
@@ -1,7 +1,0 @@
-cobc: exit status 1
-/workspace/mochi/tests/machine/x/cobol/bool_chain.cob:8: error: syntax error, unexpected <, expecting ) or - or +
-/workspace/mochi/tests/machine/x/cobol/bool_chain.cob:11: error: syntax error, unexpected <, expecting ) or - or +
-/workspace/mochi/tests/machine/x/cobol/bool_chain.cob:14: error: syntax error, unexpected <, expecting ) or - or +
-/workspace/mochi/tests/machine/x/cobol/bool_chain.cob: in paragraph 'BOOM':
-/workspace/mochi/tests/machine/x/cobol/bool_chain.cob:19: error: syntax error, unexpected PROCEDURE
-

--- a/tests/machine/x/cobol/bool_chain.out
+++ b/tests/machine/x/cobol/bool_chain.out
@@ -1,0 +1,5 @@
+true
+boom
+false
+boom
+false


### PR DESCRIPTION
## Summary
- handle zero-argument functions in the COBOL compiler
- regenerate machine output for `bool_chain` now that it compiles
- update COBOL machine README to reflect the additional passing test

## Testing
- `go test ./compiler/x/cobol -run TestCobolCompiler_Programs/bool_chain -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_686ddb2def74832086427e01f6da3283