### PR TITLE
Add break/continue support to Erlang compiler

### DIFF
--- a/tests/machine/x/erlang/README.md
+++ b/tests/machine/x/erlang/README.md
@@ -2,8 +2,8 @@
 
 This directory contains Erlang source files compiled from Mochi programs in `tests/vm/valid`.
 
-- **42/97 programs compiled and ran successfully** (have `.out` files)
-- **55 programs failed** to compile or run (have `.error` files)
+- **43/97 programs compiled and ran successfully** (have `.out` files)
+- **54 programs failed** to compile or run (have `.error` files)
 
 ## Successful programs
 append_builtin
@@ -50,9 +50,9 @@ map_in_operator
 map_membership
 membership
 string_in_operator
+break_continue
 
 ## Failed programs
-break_continue
 cross_join
 cross_join_filter
 cross_join_triple

--- a/tests/machine/x/erlang/break_continue.erl
+++ b/tests/machine/x/erlang/break_continue.erl
@@ -1,0 +1,6 @@
+#!/usr/bin/env escript
+% break_continue.erl - generated from break_continue.mochi
+
+main(_) ->
+    Numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    try lists:foreach(fun(N) -> try (if ((N rem 2) == 0) -> throw(continue); true -> ok end), (if (N > 7) -> throw(break); true -> ok end), io:format("~p ~p~n", ["odd number:", N]) catch throw:continue -> ok end end, Numbers) catch throw:break -> ok end.

--- a/tests/machine/x/erlang/break_continue.error
+++ b/tests/machine/x/erlang/break_continue.error
@@ -1,6 +1,0 @@
-line 5: unsupported statement at line 5
-   3: for n in numbers {
-   4:   if n % 2 == 0 {
-   5:     continue
-   6:   }
-   7:   if n > 7 {

--- a/tests/machine/x/erlang/break_continue.out
+++ b/tests/machine/x/erlang/break_continue.out
@@ -1,0 +1,4 @@
+"odd number:" 1
+"odd number:" 3
+"odd number:" 5
+"odd number:" 7


### PR DESCRIPTION
## Summary
- update Erlang compiler to handle `break` and `continue`
- regenerate Erlang output for `break_continue.mochi`
- update success/failure counts in Erlang machine README

## Testing
- `go test ./compiler/x/erlang -tags slow -run TestCompilePrograms/break_continue -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_686ddb34fdc4832089b72525448e9b99