### PR TITLE
Improve join code generation in Go backend

### DIFF
--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -6,7 +6,7 @@ This directory contains Go source code generated from Mochi programs and the cor
 
 - 97/97 programs compiled and executed successfully.
 
-Left joins are now generated using explicit loops instead of the generic `_query` helper for clearer output.
+Left and right joins are now generated using explicit loops instead of the generic `_query` helper for clearer output.
 
 
 ### Successful


### PR DESCRIPTION
## Summary
- enhance Go compiler to emit direct loops for right joins rather than using `_query`
- document new join handling in the Go machine README

## Testing
- `go test ./compiler/x/go -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686ddc3cebf48320bbe446520a17ceb7