### PR TITLE
Fix Elixir group_by_left_join test

### DIFF
--- a/tests/machine/x/ex/README.md
+++ b/tests/machine/x/ex/README.md
@@ -4,8 +4,8 @@ This directory contains Elixir source code generated from Mochi programs and the
 
 ## Summary
 
-- 79/97 programs compiled and executed successfully.
-- 18 programs failed to compile or run.
+- 80/97 programs compiled and executed successfully.
+- 17 programs failed to compile or run.
 
 ### Successful
 - append_builtin
@@ -32,6 +32,7 @@ This directory contains Elixir source code generated from Mochi programs and the
 - fun_three_args
 - group_by_multi_join
 - group_by_join
+- group_by_left_join
 - if_else
 - if_then_else
 - if_then_else_nested
@@ -92,7 +93,6 @@ This directory contains Elixir source code generated from Mochi programs and the
 - group_by
 - group_by_conditional_sum
 - group_by_having
-- group_by_left_join
 - group_by_multi_join_sort
 - group_by_sort
 - group_items_iteration

--- a/tests/machine/x/ex/group_by_left_join.mochi.exs
+++ b/tests/machine/x/ex/group_by_left_join.mochi.exs
@@ -19,7 +19,7 @@ defmodule Main do
              %{select: fn c, o -> [c, o] end}
            )
 
-         groups = _group_by(rows, fn c, o -> c.name end)
+         groups = _group_by(rows, fn [c, o] -> c.name end)
 
          groups =
            Enum.map(groups, fn g -> %{g | items: Enum.map(g.items, fn [c, o] -> c end)} end)
@@ -38,7 +38,7 @@ defmodule Main do
   defp _count(v) do
     cond do
       is_list(v) -> length(v)
-      is_map(v) and Map.has_key?(v, :items) -> length(v[:items])
+      is_map(v) and Map.has_key?(v, :items) -> length(Map.get(v, :items))
       true -> raise "count() expects list or group"
     end
   end

--- a/tests/machine/x/ex/group_by_left_join.mochi.out
+++ b/tests/machine/x/ex/group_by_left_join.mochi.out
@@ -1,0 +1,4 @@
+--- Group Left Join ---
+Alice orders: 2
+Bob orders: 1
+Charlie orders: 0


### PR DESCRIPTION
## Summary
- regenerate Elixir output for `group_by_left_join`
- mark program as successful in Elixir machine README

## Testing
- `go test -tags slow ./compiler/x/ex -run TestElixirCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ddc73749c83208a12c6162048ec03