### PR TITLE
Improve Haskell join generation

### DIFF
--- a/tests/machine/x/hs/README.md
+++ b/tests/machine/x/hs/README.md
@@ -2,6 +2,8 @@
 
 96/97 programs compiled
 
+The compiler now handles basic `left join` queries.
+
 ## Compiled
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi

--- a/tests/machine/x/hs/left_join.hs
+++ b/tests/machine/x/hs/left_join.hs
@@ -174,7 +174,10 @@ customers = [Map.fromList [("id", VInt (1)), ("name", VString ("Alice"))], Map.f
 
 orders = [Map.fromList [("id", 100), ("customerId", 1), ("total", 250)], Map.fromList [("id", 101), ("customerId", 3), ("total", 80)]]
 
-result = [Map.fromList [("orderId", VInt (fromMaybe (error "missing") (Map.lookup "id" o))), ("customer", VString (c)), ("total", VInt (fromMaybe (error "missing") (Map.lookup "total" o)))] | o <- orders, c <- customers, (fromMaybe (error "missing") (Map.lookup "customerId" (o)) == fromMaybe (error "missing") (Map.lookup "id" (c)))]
+result = [Map.fromList [("orderId", VInt (fromMaybe (error "missing") (Map.lookup "id" o))), ("customer", VString (c)), ("total", VInt (fromMaybe (error "missing") (Map.lookup "total" o)))] |
+  o <- orders,
+  c <- let _ms0 = [c | c <- customers, (fromMaybe (error "missing") (Map.lookup "customerId" o) == fromMaybe (error "missing") (Map.lookup "id" c))]
+       in if null _ms0 then [Map.empty] else _ms0]
 
 main :: IO ()
 main = do


### PR DESCRIPTION
## Summary
- support `left join` in the Haskell compiler
- regenerate machine sample for `left_join` program
- document new join ability in the Haskell machine README

## Testing
- `go test -tags slow ./compiler/x/hs -run TestHSCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ddc77f7688320803e2a906da339d6