### PR TITLE
Add Prolog string concatenation support

### DIFF
--- a/compiler/x/pl/compiler_test.go
+++ b/compiler/x/pl/compiler_test.go
@@ -35,6 +35,7 @@ var supported = map[string]bool{
 	"bool_chain":          true,
 	"fun_call":            true,
 	"fun_three_args":      true,
+	"string_concat":       true,
 	"typed_var":           true,
 	"typed_let":           true,
 	"if_then_else":        true,

--- a/tests/machine/x/pl/README.md
+++ b/tests/machine/x/pl/README.md
@@ -2,7 +2,7 @@
 
 This directory stores machine generated Prolog translations of programs from `tests/vm/valid`. Each entry is compiled and executed during tests. If a program fails to compile or run, a `.error` file will contain the diagnostic details.
 
-Checklist of programs that currently compile and run (24/97):
+Checklist of programs that currently compile and run (25/97):
 
 - print_hello
 - let_and_print
@@ -23,6 +23,7 @@ Checklist of programs that currently compile and run (24/97):
 - bool_chain
 - fun_call
 - fun_three_args
+- string_concat
 - typed_var
 - typed_let
 - if_then_else


### PR DESCRIPTION
## Summary
- support string concatenation in the Prolog backend
- update compiler test cases for Prolog
- document new program support in `tests/machine/x/pl/README.md`

## Testing
- `go test ./compiler/x/pl -run TestPrologCompiler -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686ddcb4d268832088680701f998f0cc