### PR TITLE
Add right join support to Haskell compiler

### DIFF
--- a/tests/machine/x/hs/README.md
+++ b/tests/machine/x/hs/README.md
@@ -2,7 +2,7 @@
 
 96/97 programs compiled
 
-The compiler now handles basic `left join` queries.
+The compiler now handles basic `left` and `right` join queries.
 
 ## Compiled
 - [x] append_builtin.mochi


### PR DESCRIPTION
## Summary
- extend Haskell compiler with basic right join handling
- document right join support in machine README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686de1f65d9c8320af964d84c56c8e64