### PR TITLE
Improve Dart compiler output

### DIFF
--- a/tests/machine/x/dart/README.md
+++ b/tests/machine/x/dart/README.md
@@ -7,8 +7,8 @@ output resembles hand written Dart code.
 ## Summary
 
 - Total Mochi programs: 97
-- Successful compilations: 66
-- Failed compilations or runtime errors: 31
+- Successful compilations: 67
+- Failed compilations or runtime errors: 30
 
 ## Successful programs
 - append_builtin
@@ -77,9 +77,9 @@ output resembles hand written Dart code.
 - values_builtin
 - var_assignment
 - while_loop
+- dataset_sort_take_limit
 
 ## Failed programs
-- dataset_sort_take_limit
 - dataset_where_filter
 - exists_builtin
 - group_by

--- a/tests/machine/x/dart/dataset_sort_take_limit.dart
+++ b/tests/machine/x/dart/dataset_sort_take_limit.dart
@@ -1,17 +1,27 @@
 void main() {
-  var products = [{'name': 'Laptop', 'price': 1500}, {'name': 'Smartphone', 'price': 900}, {'name': 'Tablet', 'price': 600}, {'name': 'Monitor', 'price': 300}, {'name': 'Keyboard', 'price': 100}, {'name': 'Mouse', 'price': 50}, {'name': 'Headphones', 'price': 200}];
+  var products = [
+    {'name': 'Laptop', 'price': 1500},
+    {'name': 'Smartphone', 'price': 900},
+    {'name': 'Tablet', 'price': 600},
+    {'name': 'Monitor', 'price': 300},
+    {'name': 'Keyboard', 'price': 100},
+    {'name': 'Mouse', 'price': 50},
+    {'name': 'Headphones', 'price': 200},
+  ];
   var expensive = (() {
-  var _q0 = <dynamic>[];
-  for (var p in products) {
-    _q0.add([-p.price, p]);
-  }
-  _q0.sort((a,b) => (a[0] as Comparable).compareTo(b[0]));
-  _q0 = [for (var x in _q0) x[1]];
-  _q0 = _q0.sublist(1, (1)+(3));
-  return _q0;
-})();
+    var _q0 = <dynamic>[];
+    for (var p in products) {
+      _q0.add([-(p['price'] as num), p]);
+    }
+    _q0.sort((a, b) => (a[0] as Comparable).compareTo(b[0]));
+    _q0 = [for (var x in _q0) x[1]];
+    _q0 = _q0.sublist(1, (1) + (3));
+    return _q0;
+  })();
   print('--- Top products (excluding most expensive) ---');
-  for (var item in expensive) {
-    print([item.name, 'costs $', item.price].join(' '));
+  var _iter1 = expensive;
+  for (var item
+      in (_iter1 is Map ? (_iter1 as Map).keys : _iter1) as Iterable) {
+    print([item['name'], 'costs \$', item['price']].join(' '));
   }
 }

--- a/tests/machine/x/dart/dataset_sort_take_limit.out
+++ b/tests/machine/x/dart/dataset_sort_take_limit.out
@@ -1,0 +1,5 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300
+


### PR DESCRIPTION
## Summary
- fix `dart format` usage to properly format generated files
- regenerate `dataset_sort_take_limit` example
- document new success in Dart machine README

## Testing
- `go test -tags slow ./compiler/x/dart -run TestDartCompiler_ValidPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686de2c4c3048320947b6772d5a0e5cc