### PR TITLE
Fix dart formatter

### DIFF
--- a/compiler/x/dart/tools.go
+++ b/compiler/x/dart/tools.go
@@ -2,6 +2,7 @@ package dart
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 )
 
@@ -9,16 +10,29 @@ import (
 func formatDart(src []byte) []byte {
 	path, err := exec.LookPath("dart")
 	if err == nil {
-		cmd := exec.Command(path, "format", "--output", "show", "-")
-		cmd.Stdin = bytes.NewReader(src)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		if cmd.Run() == nil {
-			res := out.Bytes()
-			if len(res) == 0 || res[len(res)-1] != '\n' {
-				res = append(res, '\n')
+		tmp, err := os.CreateTemp("", "mochi_*.dart")
+		if err == nil {
+			tmp.Write(src)
+			tmp.Close()
+			defer os.Remove(tmp.Name())
+			cmd := exec.Command(path, "format", "--output", "show", tmp.Name())
+			var out bytes.Buffer
+			cmd.Stdout = &out
+			if cmd.Run() == nil {
+				res := out.Bytes()
+				lines := bytes.Split(res, []byte("\n"))
+				if len(lines) > 0 && len(lines[len(lines)-1]) == 0 {
+					lines = lines[:len(lines)-1]
+				}
+				if n := len(lines); n > 0 && bytes.HasPrefix(lines[n-1], []byte("Formatted")) {
+					lines = lines[:n-1]
+				}
+				res = bytes.Join(lines, []byte("\n"))
+				if len(res) == 0 || res[len(res)-1] != '\n' {
+					res = append(res, '\n')
+				}
+				return res
 			}
-			return res
 		}
 	}
 	src = bytes.ReplaceAll(src, []byte("\t"), []byte("  "))


### PR DESCRIPTION
## Summary
- update Dart compiler formatting helper to work with recent Dart SDK

## Testing
- `go test ./compiler/x/dart -run ValidPrograms -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686de65105c08320ac123115d83521d1