### PR TITLE
Improve Erlang compiler with query support

### DIFF
--- a/tests/machine/x/erlang/README.md
+++ b/tests/machine/x/erlang/README.md
@@ -2,8 +2,8 @@
 
 This directory contains Erlang source files compiled from Mochi programs in `tests/vm/valid`.
 
-- **43/97 programs compiled and ran successfully** (have `.out` files)
-- **54 programs failed** to compile or run (have `.error` files)
+- **48/97 programs compiled and ran successfully** (have `.out` files)
+- **49 programs failed** to compile or run (have `.error` files)
 
 ## Successful programs
 append_builtin
@@ -51,13 +51,13 @@ map_membership
 membership
 string_in_operator
 break_continue
-
-## Failed programs
 cross_join
 cross_join_filter
 cross_join_triple
 dataset_sort_take_limit
 dataset_where_filter
+
+## Failed programs
 exists_builtin
 group_by
 group_by_conditional_sum


### PR DESCRIPTION
## Summary
- enhance Erlang compiler with selector field access and query comprehension
- compile `if` expressions using `case` to avoid guard restrictions
- support literal map keys from identifiers
- update Erlang machine README counts

## Testing
- `go test ./compiler/x/erlang -tags slow -run TestCompilePrograms/cross_join -v`
- `go test ./compiler/x/erlang -tags slow -run TestCompilePrograms/dataset_where_filter -v`
- `go test ./compiler/x/erlang -tags slow -run TestCompilePrograms/dataset_sort_take_limit -v`


------
https://chatgpt.com/codex/tasks/task_e_686de5f829888320aa5ad3f14129b45c