### PR TITLE
Fix Scala compiler sort query

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -3,7 +3,7 @@
 This directory contains Scala source files generated from Mochi programs using the compiler in `compiler/x/scala`. Each file was compiled and executed using `scalac` and `scala`. The checklist below shows which programs have successfully compiled and run.
 
 
-## Progress: 15/97 files compiled
+## Progress: 16/97 files compiled
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/tests/machine/x/scala/dataset_sort_take_limit.scala
+++ b/tests/machine/x/scala/dataset_sort_take_limit.scala
@@ -1,10 +1,10 @@
 object dataset_sort_take_limit {
   def main(args: Array[String]): Unit = {
     val products = List(Map("name" -> "Laptop", "price" -> 1500), Map("name" -> "Smartphone", "price" -> 900), Map("name" -> "Tablet", "price" -> 600), Map("name" -> "Monitor", "price" -> 300), Map("name" -> "Keyboard", "price" -> 100), Map("name" -> "Mouse", "price" -> 50), Map("name" -> "Headphones", "price" -> 200))
-    val expensive = (for { p <- products } yield p).sortBy(p => -p.price).drop(1).take(3)
-    println("--- Top products (excluding most expensive) ---")
+    val expensive = (for { p <- products } yield p).sortBy(p => -(p("price")).asInstanceOf[Int]).drop(1).take(3)
+    println(("--- Top products (excluding most expensive) ---"))
     for(item <- expensive) {
-      println(item("name") + " " + "costs $" + " " + item("price"))
+      println((item("name")) + " " + ("costs $") + " " + (item("price")))
     }
   }
 }


### PR DESCRIPTION
## Summary
- support sorting queries in Scala compiler with proper environment
- cast Any typed values to Int for unary minus
- adjust print arg handling
- update Scala machine README progress
- regenerate dataset_sort_take_limit Scala output

## Testing
- `go test ./compiler/x/scala -run TestScalaCompilerMachine/dataset_sort_take_limit -tags slow`
- `go test -v ./compiler/x/scala -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686de63b7d8c8320bec50222f42f3126