### PR TITLE
Add slow build tags to compiler

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode
 
 import (

--- a/compiler/x/c/compiler_new_test.go
+++ b/compiler/x/c/compiler_new_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode_test
 
 import (

--- a/compiler/x/c/helpers.go
+++ b/compiler/x/c/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode
 
 import (

--- a/compiler/x/c/infer.go
+++ b/compiler/x/c/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode
 
 import (

--- a/compiler/x/c/needs.go
+++ b/compiler/x/c/needs.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode
 
 // Helper requirement keys used by the compiler.

--- a/compiler/x/c/runtime.go
+++ b/compiler/x/c/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode
 
 // Runtime helper functions injected into generated C programs.

--- a/compiler/x/c/tools.go
+++ b/compiler/x/c/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode
 
 import (

--- a/compiler/x/cpp/tools.go
+++ b/compiler/x/cpp/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp
 
 import (

--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cscode
 
 import (

--- a/compiler/x/cs/compiler_test.go
+++ b/compiler/x/cs/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cscode_test
 
 import (

--- a/compiler/x/cs/helpers.go
+++ b/compiler/x/cs/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cscode
 
 import (

--- a/compiler/x/cs/infer.go
+++ b/compiler/x/cs/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cscode
 
 import (

--- a/compiler/x/cs/runtime.go
+++ b/compiler/x/cs/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cscode
 
 func (c *Compiler) emitRuntime() {

--- a/compiler/x/cs/tools.go
+++ b/compiler/x/cs/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cscode
 
 import (

--- a/compiler/x/dart/tools.go
+++ b/compiler/x/dart/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart
 
 import (

--- a/compiler/x/go/cmd/compile_all/main.go
+++ b/compiler/x/go/cmd/compile_all/main.go
@@ -1,4 +1,4 @@
-//go:build archived
+//go:build archived && slow
 
 package main
 

--- a/compiler/x/go/cmd/vm_roundtrip/main.go
+++ b/compiler/x/go/cmd/vm_roundtrip/main.go
@@ -1,4 +1,4 @@
-//go:build archived
+//go:build archived && slow
 
 package main
 

--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gocode
 
 import (

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gocode
 
 import (

--- a/compiler/x/go/infer.go
+++ b/compiler/x/go/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gocode
 
 import (

--- a/compiler/x/go/runtime.go
+++ b/compiler/x/go/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gocode
 
 import "sort"

--- a/compiler/x/go/tools.go
+++ b/compiler/x/go/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gocode
 
 import (

--- a/compiler/x/go/usage.go
+++ b/compiler/x/go/usage.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gocode
 
 import (

--- a/compiler/x/lua/simple_compiler.go
+++ b/compiler/x/lua/simple_compiler.go
@@ -1,4 +1,4 @@
-//go:build ignore
+//go:build ignore && slow
 
 package luacode
 

--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pl
 
 import (

--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pycode
 
 import (

--- a/compiler/x/python/helpers.go
+++ b/compiler/x/python/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pycode
 
 // Helper functions used by the Python compiler. Splitting them into this file

--- a/compiler/x/python/infer.go
+++ b/compiler/x/python/infer.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pycode
 
 import (

--- a/compiler/x/python/runtime.go
+++ b/compiler/x/python/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pycode
 
 import "sort"

--- a/compiler/x/python/statements.go
+++ b/compiler/x/python/statements.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pycode
 
 import (

--- a/compiler/x/python/tools.go
+++ b/compiler/x/python/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pycode
 
 import (

--- a/compiler/x/st/compiler.go
+++ b/compiler/x/st/compiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package st
 
 import (

--- a/tools/compilecs.go
+++ b/tools/compilecs.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- add `slow` build tags to all compiler files
- mark tools/compilecs as slow

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e14b10be48320a674acebbe4eb182