### PR TITLE
Add slow tag for archived packages

### DIFF
--- a/archived/tools/any2mochi/cmd/any2mochi/main.go
+++ b/archived/tools/any2mochi/cmd/any2mochi/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/archived/tools/any2mochi/convert_lua.go
+++ b/archived/tools/any2mochi/convert_lua.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/archived/tools/any2mochi/detect.go
+++ b/archived/tools/any2mochi/detect.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/archived/tools/any2mochi/go/ast.go
+++ b/archived/tools/any2mochi/go/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package golang
 
 import (

--- a/archived/tools/any2mochi/go/ast_test.go
+++ b/archived/tools/any2mochi/go/ast_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package golang
 
 import "testing"

--- a/archived/tools/any2mochi/go/convert.go
+++ b/archived/tools/any2mochi/go/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package golang
 
 import (

--- a/archived/tools/any2mochi/helpers.go
+++ b/archived/tools/any2mochi/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/archived/tools/any2mochi/jvm/convert.go
+++ b/archived/tools/any2mochi/jvm/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package jvm
 
 import (

--- a/archived/tools/any2mochi/lsp.go
+++ b/archived/tools/any2mochi/lsp.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 // Basic types mirroring the subset of LSP structures used by converters.

--- a/archived/tools/any2mochi/lsp_stub.go
+++ b/archived/tools/any2mochi/lsp_stub.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import ()

--- a/archived/tools/any2mochi/parse.go
+++ b/archived/tools/any2mochi/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/archived/tools/any2mochi/phpast/main.go
+++ b/archived/tools/any2mochi/phpast/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/archived/tools/any2mochi/server_stub.go
+++ b/archived/tools/any2mochi/server_stub.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 // LanguageServer represents an external parser command.

--- a/archived/tools/any2mochi/ts/parse_simple.go
+++ b/archived/tools/any2mochi/ts/parse_simple.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ts
 
 import (

--- a/archived/tools/any2mochi/util.go
+++ b/archived/tools/any2mochi/util.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package any2mochi
 
 import (

--- a/archived/tools/any2mochi/x/asm/convert.go
+++ b/archived/tools/any2mochi/x/asm/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package asm
 
 import (

--- a/archived/tools/any2mochi/x/c/convert.go
+++ b/archived/tools/any2mochi/x/c/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c
 
 import (

--- a/archived/tools/any2mochi/x/c/parse_clang.go
+++ b/archived/tools/any2mochi/x/c/parse_clang.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c
 
 import (

--- a/archived/tools/any2mochi/x/c/types.go
+++ b/archived/tools/any2mochi/x/c/types.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c
 
 // function describes a parsed C function.

--- a/archived/tools/any2mochi/x/clj/convert.go
+++ b/archived/tools/any2mochi/x/clj/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package clj
 
 import (

--- a/archived/tools/any2mochi/x/cobol/convert.go
+++ b/archived/tools/any2mochi/x/cobol/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cobol
 
 import (

--- a/archived/tools/any2mochi/x/cobol/parse.go
+++ b/archived/tools/any2mochi/x/cobol/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cobol
 
 import (

--- a/archived/tools/any2mochi/x/cpp/convert.go
+++ b/archived/tools/any2mochi/x/cpp/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp
 
 import (

--- a/archived/tools/any2mochi/x/cpp/parse.go
+++ b/archived/tools/any2mochi/x/cpp/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp
 
 import (

--- a/archived/tools/any2mochi/x/dart/convert.go
+++ b/archived/tools/any2mochi/x/dart/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart
 
 import (

--- a/archived/tools/any2mochi/x/dart/parse.go
+++ b/archived/tools/any2mochi/x/dart/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart
 
 import (

--- a/archived/tools/any2mochi/x/erlang/convert.go
+++ b/archived/tools/any2mochi/x/erlang/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erlang
 
 import (

--- a/archived/tools/any2mochi/x/erlang/parse.go
+++ b/archived/tools/any2mochi/x/erlang/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erlang
 
 import (

--- a/archived/tools/any2mochi/x/fortran/convert.go
+++ b/archived/tools/any2mochi/x/fortran/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fortran
 
 import (

--- a/archived/tools/any2mochi/x/fs/convert.go
+++ b/archived/tools/any2mochi/x/fs/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fs
 
 import (

--- a/archived/tools/any2mochi/x/fs/parse.go
+++ b/archived/tools/any2mochi/x/fs/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fs
 
 // Package fs provides a tiny F# parser used by the any2mochi tool. It mirrors

--- a/archived/tools/any2mochi/x/hs/ast.go
+++ b/archived/tools/any2mochi/x/hs/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hs
 
 import (

--- a/archived/tools/any2mochi/x/hs/convert.go
+++ b/archived/tools/any2mochi/x/hs/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hs
 
 import (

--- a/archived/tools/any2mochi/x/java/convert.go
+++ b/archived/tools/any2mochi/x/java/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package java
 
 import (

--- a/archived/tools/any2mochi/x/java/parse.go
+++ b/archived/tools/any2mochi/x/java/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package java
 
 import (

--- a/archived/tools/any2mochi/x/kt/convert.go
+++ b/archived/tools/any2mochi/x/kt/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package kt
 
 import (

--- a/archived/tools/any2mochi/x/mlir/convert.go
+++ b/archived/tools/any2mochi/x/mlir/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package mlir
 
 import (

--- a/archived/tools/any2mochi/x/ocaml/convert.go
+++ b/archived/tools/any2mochi/x/ocaml/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ocaml
 
 import (

--- a/archived/tools/any2mochi/x/ocaml/parse.go
+++ b/archived/tools/any2mochi/x/ocaml/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ocaml
 
 import (

--- a/archived/tools/any2mochi/x/pas/convert.go
+++ b/archived/tools/any2mochi/x/pas/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pas
 
 import (

--- a/archived/tools/any2mochi/x/php/convert.go
+++ b/archived/tools/any2mochi/x/php/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package php
 
 import (

--- a/archived/tools/any2mochi/x/php/parse.go
+++ b/archived/tools/any2mochi/x/php/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package php
 
 import (

--- a/archived/tools/any2mochi/x/prolog/convert.go
+++ b/archived/tools/any2mochi/x/prolog/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package prolog
 
 import (

--- a/archived/tools/any2mochi/x/prolog/parse_ast.go
+++ b/archived/tools/any2mochi/x/prolog/parse_ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package prolog
 
 import (

--- a/archived/tools/any2mochi/x/racket/convert.go
+++ b/archived/tools/any2mochi/x/racket/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package racket
 
 import (

--- a/archived/tools/any2mochi/x/racket/parser.go
+++ b/archived/tools/any2mochi/x/racket/parser.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package racket
 
 import (

--- a/archived/tools/any2mochi/x/ruby/convert.go
+++ b/archived/tools/any2mochi/x/ruby/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ruby
 
 import (

--- a/archived/tools/any2mochi/x/rust/ast.go
+++ b/archived/tools/any2mochi/x/rust/ast.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rust
 
 import (

--- a/archived/tools/any2mochi/x/rust/convert.go
+++ b/archived/tools/any2mochi/x/rust/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rust
 
 import (

--- a/archived/tools/any2mochi/x/scala/convert.go
+++ b/archived/tools/any2mochi/x/scala/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scala
 
 import (

--- a/archived/tools/any2mochi/x/scala/parse.go
+++ b/archived/tools/any2mochi/x/scala/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scala
 
 import (

--- a/archived/tools/any2mochi/x/scheme/cmd/generate/main.go
+++ b/archived/tools/any2mochi/x/scheme/cmd/generate/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (
@@ -7,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	scheme "mochi/archived/tools/any2mochi/x/scheme"
 	"mochi/parser"
 	vm "mochi/runtime/vm"
-	scheme "mochi/archived/tools/any2mochi/x/scheme"
 	"mochi/types"
 )
 

--- a/archived/tools/any2mochi/x/scheme/cmd/schemeast/main.go
+++ b/archived/tools/any2mochi/x/scheme/cmd/schemeast/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/archived/tools/any2mochi/x/scheme/convert.go
+++ b/archived/tools/any2mochi/x/scheme/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (

--- a/archived/tools/any2mochi/x/scheme/parser.go
+++ b/archived/tools/any2mochi/x/scheme/parser.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (

--- a/archived/tools/any2mochi/x/scheme/simple.go
+++ b/archived/tools/any2mochi/x/scheme/simple.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (

--- a/archived/tools/any2mochi/x/st/convert.go
+++ b/archived/tools/any2mochi/x/st/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package st
 
 import (

--- a/archived/tools/any2mochi/x/st/parse_cli.go
+++ b/archived/tools/any2mochi/x/st/parse_cli.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package st
 
 import (

--- a/archived/tools/any2mochi/x/swift/convert.go
+++ b/archived/tools/any2mochi/x/swift/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/archived/tools/any2mochi/x/wasm/convert.go
+++ b/archived/tools/any2mochi/x/wasm/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package wasm
 
 import (

--- a/archived/tools/any2mochi/x/zig/convert.go
+++ b/archived/tools/any2mochi/x/zig/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zig
 
 import (

--- a/archived/update_job/main.go
+++ b/archived/update_job/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/archived/update_tpcds/main.go
+++ b/archived/update_tpcds/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/archived/update_tpcds_ir/main.go
+++ b/archived/update_tpcds_ir/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/archived/update_tpch/main.go
+++ b/archived/update_tpch/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/cmd/ft2mochi/main.go
+++ b/cmd/ft2mochi/main.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- mark archived packages with `//go:build slow` so they are skipped on normal test runs
- mark `cmd/ft2mochi` as slow because it imports archived code

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e17683f98832093e194c877fe0d39