### PR TITLE
Fix query sort compilation

### DIFF
--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -4,8 +4,8 @@ This directory contains C++ source code generated from Mochi programs and the co
 
 ## Summary
 
-- 59/97 programs compiled and executed successfully.
-- 38 programs failed to compile or run.
+- 60/97 programs compiled and executed successfully.
+- 37 programs failed to compile or run.
 
 ### Successful
 - append_builtin
@@ -67,9 +67,9 @@ This directory contains C++ source code generated from Mochi programs and the co
 - values_builtin
 - var_assignment
 - while_loop
+- dataset_sort_take_limit
 
 ### Failed
-- dataset_sort_take_limit
 - dataset_where_filter
 - exists_builtin
 - for_map_collection

--- a/tests/machine/x/cpp/dataset_sort_take_limit.cpp
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.cpp
@@ -1,33 +1,65 @@
-#include <iostream>
-#include <vector>
-#include <unordered_map>
-#include <map>
 #include <algorithm>
+#include <iostream>
+#include <map>
 #include <numeric>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-template<typename T> void print_val(const T& v){ std::cout << v; }
-void print_val(const std::vector<int>& v){ for(size_t i=0;i<v.size();++i){ if(i) std::cout<<' '; std::cout<<v[i]; }}
-void print_val(bool b){ std::cout<<(b?"true":"false"); }
-void print(){ std::cout<<std::endl; }
-template<typename First, typename... Rest> void print(const First& first, const Rest&... rest){ print_val(first); if constexpr(sizeof...(rest)>0){ std::cout<<' '; print(rest...); } else { std::cout<<std::endl; }}
+template <typename T> void print_val(const T &v) { std::cout << v; }
+void print_val(const std::vector<int> &v) {
+  for (size_t i = 0; i < v.size(); ++i) {
+    if (i)
+      std::cout << ' ';
+    std::cout << v[i];
+  }
+}
+void print_val(bool b) { std::cout << (b ? "true" : "false"); }
+void print() { std::cout << std::endl; }
+template <typename First, typename... Rest>
+void print(const First &first, const Rest &...rest) {
+  print_val(first);
+  if constexpr (sizeof...(rest) > 0) {
+    std::cout << ' ';
+    print(rest...);
+  } else {
+    std::cout << std::endl;
+  }
+}
 
+struct __struct1 {
+  decltype(std::string("Laptop")) name;
+  decltype(1500) price;
+};
 int main() {
-    auto products = std::vector<int>{std::unordered_map<int,std::string>{{name, std::string("Laptop")}, {price, 1500}}, std::unordered_map<int,std::string>{{name, std::string("Smartphone")}, {price, 900}}, std::unordered_map<int,std::string>{{name, std::string("Tablet")}, {price, 600}}, std::unordered_map<int,std::string>{{name, std::string("Monitor")}, {price, 300}}, std::unordered_map<int,std::string>{{name, std::string("Keyboard")}, {price, 100}}, std::unordered_map<int,std::string>{{name, std::string("Mouse")}, {price, 50}}, std::unordered_map<int,std::string>{{name, std::string("Headphones")}, {price, 200}}};
-    auto expensive = ([&]() {
-    std::vector<std::pair<decltype((-p.price)), decltype(p)>>> __items;
+  auto products = std::vector<decltype(__struct1{std::string("Laptop"), 1500})>{
+      __struct1{std::string("Laptop"), 1500},
+      __struct1{std::string("Smartphone"), 900},
+      __struct1{std::string("Tablet"), 600},
+      __struct1{std::string("Monitor"), 300},
+      __struct1{std::string("Keyboard"), 100},
+      __struct1{std::string("Mouse"), 50},
+      __struct1{std::string("Headphones"), 200}};
+  auto expensive = ([&]() {
+    std::vector<std::pair<decltype(std::declval<__struct1>().price), __struct1>>
+        __items;
     for (auto p : products) {
-        __items.push_back({(-p.price), p});
+      __items.push_back({(-p.price), p});
     }
-    std::sort(__items.begin(), __items.end(), [](auto &a, auto &b){ return a.first < b.first; });
-    if ((size_t)1 < __items.size()) __items.erase(__items.begin(), __items.begin()+1);
-    if ((size_t)3 < __items.size()) __items.resize(3);
-    std::vector<decltype(p)> __res;
-    for (auto &p : __items) __res.push_back(p.second);
+    std::sort(__items.begin(), __items.end(),
+              [](auto &a, auto &b) { return a.first < b.first; });
+    if ((size_t)1 < __items.size())
+      __items.erase(__items.begin(), __items.begin() + 1);
+    if ((size_t)3 < __items.size())
+      __items.resize(3);
+    std::vector<__struct1> __res;
+    for (auto &p : __items)
+      __res.push_back(p.second);
     return __res;
-})();
-    print(std::string("--- Top products (excluding most expensive) ---"));
-    for (auto item : expensive) {
-        print(item.name, std::string("costs $"), item.price);
-    }
-    return 0;
+  })();
+  print(std::string("--- Top products (excluding most expensive) ---"));
+  for (auto item : expensive) {
+    print(item.name, std::string("costs $"), item.price);
+  }
+  return 0;
 }

--- a/tests/machine/x/cpp/dataset_sort_take_limit.error
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.error
@@ -1,1 +1,0 @@
-line 0: compile error: unsupported primary at 11:17

--- a/tests/machine/x/cpp/dataset_sort_take_limit.out
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- improve C++ compiler query handling
- update generated dataset_sort_take_limit output
- update C++ machine README

## Testing
- `go test -tags slow -run TestCompilePrograms/dataset_sort_take_limit -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686df4a714848320bbd51aeac9752493