### PR TITLE
Update Pascal golden outputs

### DIFF
--- a/tests/machine/x/pascal/append_builtin.pas
+++ b/tests/machine/x/pascal/append_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/avg_builtin.pas
+++ b/tests/machine/x/pascal/avg_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/basic_compare.pas
+++ b/tests/machine/x/pascal/basic_compare.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/binary_precedence.pas
+++ b/tests/machine/x/pascal/binary_precedence.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/bool_chain.pas
+++ b/tests/machine/x/pascal/bool_chain.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/break_continue.pas
+++ b/tests/machine/x/pascal/break_continue.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/cast_string_to_int.pas
+++ b/tests/machine/x/pascal/cast_string_to_int.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/cast_struct.pas
+++ b/tests/machine/x/pascal/cast_struct.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/count_builtin.pas
+++ b/tests/machine/x/pascal/count_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/cross_join.error
+++ b/tests/machine/x/pascal/cross_join.error
@@ -1,23 +1,23 @@
-line: 71
+line: 72
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/cross_join.pas
-cross_join.pas(35,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-cross_join.pas(48,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-cross_join.pas(50,35) Error: identifier idents no member "id"
-cross_join.pas(51,43) Error: identifier idents no member "customerId"
-cross_join.pas(52,46) Error: identifier idents no member "name"
-cross_join.pas(53,38) Error: identifier idents no member "total"
-cross_join.pas(59,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-cross_join.pas(59,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-cross_join.pas(62,14) Error: Incompatible types: got "TArray$1$crcE0B4E8C7" expected "TArray$1$crc7ED07D64"
-cross_join.pas(66,35) Error: identifier idents no member "orderId"
-cross_join.pas(66,76) Error: identifier idents no member "orderCustomerId"
-cross_join.pas(67,40) Error: identifier idents no member "orderTotal"
-cross_join.pas(68,15) Error: identifier idents no member "pairedCustomerName"
-cross_join.pas(71) Fatal: There were 13 errors compiling module, stopping
+cross_join.pas(36,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+cross_join.pas(49,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+cross_join.pas(51,35) Error: identifier idents no member "id"
+cross_join.pas(52,43) Error: identifier idents no member "customerId"
+cross_join.pas(53,46) Error: identifier idents no member "name"
+cross_join.pas(54,38) Error: identifier idents no member "total"
+cross_join.pas(60,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+cross_join.pas(60,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+cross_join.pas(63,14) Error: Incompatible types: got "TArray$1$crcE0B4E8C7" expected "TArray$1$crc7ED07D64"
+cross_join.pas(67,35) Error: identifier idents no member "orderId"
+cross_join.pas(67,76) Error: identifier idents no member "orderCustomerId"
+cross_join.pas(68,40) Error: identifier idents no member "orderTotal"
+cross_join.pas(69,15) Error: identifier idents no member "pairedCustomerName"
+cross_join.pas(72) Fatal: There were 13 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/cross_join.pas
+++ b/tests/machine/x/pascal/cross_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/cross_join_filter.error
+++ b/tests/machine/x/pascal/cross_join_filter.error
@@ -1,16 +1,16 @@
-line: 41
+line: 42
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/cross_join_filter.pas
-cross_join_filter.pas(23,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
 cross_join_filter.pas(24,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
-cross_join_filter.pas(31,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcB529B9ED" expected "TArray$1$crcE0B4E8C7"
-cross_join_filter.pas(31,35) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-cross_join_filter.pas(38,17) Error: identifier idents no member "n"
-cross_join_filter.pas(38,27) Error: identifier idents no member "l"
-cross_join_filter.pas(41) Fatal: There were 6 errors compiling module, stopping
+cross_join_filter.pas(25,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
+cross_join_filter.pas(32,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcB529B9ED" expected "TArray$1$crcE0B4E8C7"
+cross_join_filter.pas(32,35) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+cross_join_filter.pas(39,17) Error: identifier idents no member "n"
+cross_join_filter.pas(39,27) Error: identifier idents no member "l"
+cross_join_filter.pas(42) Fatal: There were 6 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/cross_join_filter.pas
+++ b/tests/machine/x/pascal/cross_join_filter.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/cross_join_triple.error
+++ b/tests/machine/x/pascal/cross_join_triple.error
@@ -1,18 +1,18 @@
-line: 47
+line: 48
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/cross_join_triple.pas
-cross_join_triple.pas(26,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
 cross_join_triple.pas(27,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
 cross_join_triple.pas(28,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
-cross_join_triple.pas(36,45) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcB529B9ED" expected "TArray$1$crcE0B4E8C7"
-cross_join_triple.pas(36,39) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-cross_join_triple.pas(44,17) Error: identifier idents no member "n"
-cross_join_triple.pas(44,27) Error: identifier idents no member "l"
-cross_join_triple.pas(44,37) Error: identifier idents no member "b"
-cross_join_triple.pas(47) Fatal: There were 8 errors compiling module, stopping
+cross_join_triple.pas(29,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
+cross_join_triple.pas(37,45) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcB529B9ED" expected "TArray$1$crcE0B4E8C7"
+cross_join_triple.pas(37,39) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+cross_join_triple.pas(45,17) Error: identifier idents no member "n"
+cross_join_triple.pas(45,27) Error: identifier idents no member "l"
+cross_join_triple.pas(45,37) Error: identifier idents no member "b"
+cross_join_triple.pas(48) Fatal: There were 8 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/cross_join_triple.pas
+++ b/tests/machine/x/pascal/cross_join_triple.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/dataset_sort_take_limit.error
+++ b/tests/machine/x/pascal/dataset_sort_take_limit.error
@@ -1,15 +1,15 @@
-line: 101
+line: 102
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/dataset_sort_take_limit.pas
-dataset_sort_take_limit.pas(82,15) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc09D74DF2"
-dataset_sort_take_limit.pas(89,34) Error: identifier idents no member "price"
-dataset_sort_take_limit.pas(89,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-dataset_sort_take_limit.pas(98,20) Error: identifier idents no member "name"
-dataset_sort_take_limit.pas(98,52) Error: identifier idents no member "price"
-dataset_sort_take_limit.pas(101) Fatal: There were 5 errors compiling module, stopping
+dataset_sort_take_limit.pas(83,15) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc09D74DF2"
+dataset_sort_take_limit.pas(90,34) Error: identifier idents no member "price"
+dataset_sort_take_limit.pas(90,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+dataset_sort_take_limit.pas(99,20) Error: identifier idents no member "name"
+dataset_sort_take_limit.pas(99,52) Error: identifier idents no member "price"
+dataset_sort_take_limit.pas(102) Fatal: There were 5 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/dataset_sort_take_limit.pas
+++ b/tests/machine/x/pascal/dataset_sort_take_limit.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/dataset_where_filter.error
+++ b/tests/machine/x/pascal/dataset_where_filter.error
@@ -1,22 +1,22 @@
-line: 60
+line: 61
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/dataset_where_filter.pas
-dataset_where_filter.pas(34,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-dataset_where_filter.pas(36,37) Error: identifier idents no member "name"
-dataset_where_filter.pas(37,36) Error: identifier idents no member "age"
-dataset_where_filter.pas(38,43) Error: identifier idents no member "age"
-dataset_where_filter.pas(42,23) Error: identifier idents no member "age"
-dataset_where_filter.pas(43,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-dataset_where_filter.pas(43,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-dataset_where_filter.pas(49,17) Error: identifier idents no member "is_senior"
-dataset_where_filter.pas(51,20) Error: Incompatible types: got "Constant String" expected "LongInt"
-dataset_where_filter.pas(55,20) Error: Incompatible types: got "Constant String" expected "LongInt"
-dataset_where_filter.pas(57,22) Error: identifier idents no member "name"
-dataset_where_filter.pas(57,51) Error: identifier idents no member "age"
-dataset_where_filter.pas(60) Fatal: There were 12 errors compiling module, stopping
+dataset_where_filter.pas(35,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+dataset_where_filter.pas(37,37) Error: identifier idents no member "name"
+dataset_where_filter.pas(38,36) Error: identifier idents no member "age"
+dataset_where_filter.pas(39,43) Error: identifier idents no member "age"
+dataset_where_filter.pas(43,23) Error: identifier idents no member "age"
+dataset_where_filter.pas(44,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+dataset_where_filter.pas(44,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+dataset_where_filter.pas(50,17) Error: identifier idents no member "is_senior"
+dataset_where_filter.pas(52,20) Error: Incompatible types: got "Constant String" expected "LongInt"
+dataset_where_filter.pas(56,20) Error: Incompatible types: got "Constant String" expected "LongInt"
+dataset_where_filter.pas(58,22) Error: identifier idents no member "name"
+dataset_where_filter.pas(58,51) Error: identifier idents no member "age"
+dataset_where_filter.pas(61) Fatal: There were 12 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/dataset_where_filter.pas
+++ b/tests/machine/x/pascal/dataset_where_filter.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/exists_builtin.error
+++ b/tests/machine/x/pascal/exists_builtin.error
@@ -1,11 +1,11 @@
-line: 26
+line: 27
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/exists_builtin.pas
-exists_builtin.pas(23,11) Error: Identifier not found "exists"
-exists_builtin.pas(26) Fatal: There were 1 errors compiling module, stopping
+exists_builtin.pas(24,11) Error: Identifier not found "exists"
+exists_builtin.pas(27) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/exists_builtin.pas
+++ b/tests/machine/x/pascal/exists_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/for_list_collection.pas
+++ b/tests/machine/x/pascal/for_list_collection.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/for_loop.pas
+++ b/tests/machine/x/pascal/for_loop.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/for_map_collection.error
+++ b/tests/machine/x/pascal/for_map_collection.error
@@ -1,12 +1,12 @@
-line: 24
+line: 25
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/for_map_collection.pas
-for_map_collection.pas(21,16) Error: Can't read or write variables of this type
-for_map_collection.pas(19,12) Error: Cannot find an enumerator for the type "TFPGMap$2$crcD929FFD2"
-for_map_collection.pas(24) Fatal: There were 2 errors compiling module, stopping
+for_map_collection.pas(22,16) Error: Can't read or write variables of this type
+for_map_collection.pas(20,12) Error: Cannot find an enumerator for the type "TFPGMap$2$crcD929FFD2"
+for_map_collection.pas(25) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/for_map_collection.pas
+++ b/tests/machine/x/pascal/for_map_collection.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/fun_call.pas
+++ b/tests/machine/x/pascal/fun_call.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/fun_expr_in_let.pas
+++ b/tests/machine/x/pascal/fun_expr_in_let.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 
@@ -13,7 +14,7 @@ begin
 end;
 
 var
-  square: function (p0: integer): integer;
+  square: function (p0: integer): integer is nested;
 
 begin
   square := @_lambda0;

--- a/tests/machine/x/pascal/fun_three_args.pas
+++ b/tests/machine/x/pascal/fun_three_args.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by.error
+++ b/tests/machine/x/pascal/group_by.error
@@ -4,8 +4,8 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by.pas
-group_by.pas(25,65) Error: Type identifier expected
-group_by.pas(25,65) Fatal: Syntax error, ")" expected but "FUNCTION" found
+group_by.pas(26,65) Error: Type identifier expected
+group_by.pas(26,65) Fatal: Syntax error, ")" expected but "FUNCTION" found
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by.pas
+++ b/tests/machine/x/pascal/group_by.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by_conditional_sum.error
+++ b/tests/machine/x/pascal/group_by_conditional_sum.error
@@ -1,27 +1,27 @@
-line: 114
+line: 115
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by_conditional_sum.pas
-group_by_conditional_sum.pas(79,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
-group_by_conditional_sum.pas(81,29) Error: Identifier not found "g"
-group_by_conditional_sum.pas(82,8) Error: Illegal qualifier
-group_by_conditional_sum.pas(84,18) Error: Illegal qualifier
-group_by_conditional_sum.pas(88,16) Error: Incompatible types: got "ShortInt" expected "TArray$1$crc90DE1C48"
-group_by_conditional_sum.pas(91,12) Error: Identifier not found "g"
-group_by_conditional_sum.pas(91,12) Error: Cannot find an enumerator for the type "<erroneous type>"
-group_by_conditional_sum.pas(96,12) Error: Identifier not found "g"
-group_by_conditional_sum.pas(98,33) Error: Illegal qualifier
-group_by_conditional_sum.pas(98,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-group_by_conditional_sum.pas(96,12) Error: Cannot find an enumerator for the type "<erroneous type>"
-group_by_conditional_sum.pas(40,64) Error: Operator is not overloaded: "Double" div "Double"
-group_by_conditional_sum.pas(107,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc90DE1C48"
-group_by_conditional_sum.pas(107,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-group_by_conditional_sum.pas(108,31) Error: Identifier not found "g"
-group_by_conditional_sum.pas(108,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-group_by_conditional_sum.pas(16,19) Error: Can't read or write variables of this type
-group_by_conditional_sum.pas(114) Fatal: There were 17 errors compiling module, stopping
+group_by_conditional_sum.pas(80,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
+group_by_conditional_sum.pas(82,29) Error: Identifier not found "g"
+group_by_conditional_sum.pas(83,8) Error: Illegal qualifier
+group_by_conditional_sum.pas(85,18) Error: Illegal qualifier
+group_by_conditional_sum.pas(89,16) Error: Incompatible types: got "ShortInt" expected "TArray$1$crc90DE1C48"
+group_by_conditional_sum.pas(92,12) Error: Identifier not found "g"
+group_by_conditional_sum.pas(92,12) Error: Cannot find an enumerator for the type "<erroneous type>"
+group_by_conditional_sum.pas(97,12) Error: Identifier not found "g"
+group_by_conditional_sum.pas(99,33) Error: Illegal qualifier
+group_by_conditional_sum.pas(99,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+group_by_conditional_sum.pas(97,12) Error: Cannot find an enumerator for the type "<erroneous type>"
+group_by_conditional_sum.pas(41,64) Error: Operator is not overloaded: "Double" div "Double"
+group_by_conditional_sum.pas(108,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc90DE1C48"
+group_by_conditional_sum.pas(108,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+group_by_conditional_sum.pas(109,31) Error: Identifier not found "g"
+group_by_conditional_sum.pas(109,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+group_by_conditional_sum.pas(17,19) Error: Can't read or write variables of this type
+group_by_conditional_sum.pas(115) Fatal: There were 17 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by_conditional_sum.pas
+++ b/tests/machine/x/pascal/group_by_conditional_sum.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by_having.error
+++ b/tests/machine/x/pascal/group_by_having.error
@@ -4,8 +4,8 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by_having.pas
-group_by_having.pas(14,67) Error: Type identifier expected
-group_by_having.pas(14,67) Fatal: Syntax error, ")" expected but "FUNCTION" found
+group_by_having.pas(15,67) Error: Type identifier expected
+group_by_having.pas(15,67) Fatal: Syntax error, ")" expected but "FUNCTION" found
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by_having.pas
+++ b/tests/machine/x/pascal/group_by_having.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by_join.error
+++ b/tests/machine/x/pascal/group_by_join.error
@@ -1,20 +1,20 @@
-line: 60
+line: 61
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by_join.pas
-group_by_join.pas(30,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-group_by_join.pas(40,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-group_by_join.pas(42,30) Error: Identifier not found "g"
-group_by_join.pas(43,38) Error: Identifier not found "g"
-group_by_join.pas(47,11) Error: Identifier not found "c"
-group_by_join.pas(49,22) Error: identifier idents no member "customerId"
-group_by_join.pas(49,35) Error: Identifier not found "c"
-group_by_join.pas(50,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-group_by_join.pas(50,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-group_by_join.pas(57,17) Error: identifier idents no member "name"
-group_by_join.pas(60) Fatal: There were 10 errors compiling module, stopping
+group_by_join.pas(31,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+group_by_join.pas(41,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+group_by_join.pas(43,30) Error: Identifier not found "g"
+group_by_join.pas(44,38) Error: Identifier not found "g"
+group_by_join.pas(48,11) Error: Identifier not found "c"
+group_by_join.pas(50,22) Error: identifier idents no member "customerId"
+group_by_join.pas(50,35) Error: Identifier not found "c"
+group_by_join.pas(51,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+group_by_join.pas(51,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+group_by_join.pas(58,17) Error: identifier idents no member "name"
+group_by_join.pas(61) Fatal: There were 10 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by_join.pas
+++ b/tests/machine/x/pascal/group_by_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by_left_join.error
+++ b/tests/machine/x/pascal/group_by_left_join.error
@@ -1,22 +1,22 @@
-line: 77
+line: 78
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by_left_join.pas
-group_by_left_join.pas(41,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc7ED07D64"
-group_by_left_join.pas(51,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc09D74DF2"
-group_by_left_join.pas(53,30) Error: Identifier not found "g"
-group_by_left_join.pas(55,12) Error: Identifier not found "g"
-group_by_left_join.pas(57,17) Error: Illegal qualifier
-group_by_left_join.pas(55,12) Error: Cannot find an enumerator for the type "<erroneous type>"
-group_by_left_join.pas(64,11) Error: Identifier not found "o"
-group_by_left_join.pas(66,20) Error: Identifier not found "o"
-group_by_left_join.pas(66,37) Error: identifier idents no member "id"
-group_by_left_join.pas(67,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc7ED07D64"
-group_by_left_join.pas(67,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-group_by_left_join.pas(74,17) Error: identifier idents no member "name"
-group_by_left_join.pas(77) Fatal: There were 12 errors compiling module, stopping
+group_by_left_join.pas(42,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc7ED07D64"
+group_by_left_join.pas(52,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc09D74DF2"
+group_by_left_join.pas(54,30) Error: Identifier not found "g"
+group_by_left_join.pas(56,12) Error: Identifier not found "g"
+group_by_left_join.pas(58,17) Error: Illegal qualifier
+group_by_left_join.pas(56,12) Error: Cannot find an enumerator for the type "<erroneous type>"
+group_by_left_join.pas(65,11) Error: Identifier not found "o"
+group_by_left_join.pas(67,20) Error: Identifier not found "o"
+group_by_left_join.pas(67,37) Error: identifier idents no member "id"
+group_by_left_join.pas(68,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc7ED07D64"
+group_by_left_join.pas(68,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+group_by_left_join.pas(75,17) Error: identifier idents no member "name"
+group_by_left_join.pas(78) Fatal: There were 12 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by_left_join.pas
+++ b/tests/machine/x/pascal/group_by_left_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by_multi_join.error
+++ b/tests/machine/x/pascal/group_by_multi_join.error
@@ -4,8 +4,8 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by_multi_join.pas
-group_by_multi_join.pas(14,67) Error: Type identifier expected
-group_by_multi_join.pas(14,67) Fatal: Syntax error, ")" expected but "FUNCTION" found
+group_by_multi_join.pas(15,67) Error: Type identifier expected
+group_by_multi_join.pas(15,67) Fatal: Syntax error, ")" expected but "FUNCTION" found
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by_multi_join.pas
+++ b/tests/machine/x/pascal/group_by_multi_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by_multi_join_sort.error
+++ b/tests/machine/x/pascal/group_by_multi_join_sort.error
@@ -1,46 +1,46 @@
-line: 153
+line: 154
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by_multi_join_sort.pas
-group_by_multi_join_sort.pas(77,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
-group_by_multi_join_sort.pas(86,15) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
-group_by_multi_join_sort.pas(95,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
-group_by_multi_join_sort.pas(106,15) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
-group_by_multi_join_sort.pas(110,35) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(111,32) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(113,12) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(115,33) Error: Illegal qualifier
-group_by_multi_join_sort.pas(115,59) Error: Illegal qualifier
-group_by_multi_join_sort.pas(115,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-group_by_multi_join_sort.pas(113,12) Error: Cannot find an enumerator for the type "<erroneous type>"
-group_by_multi_join_sort.pas(118,35) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(119,32) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(120,35) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(121,33) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(122,35) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(124,12) Error: Identifier not found "g"
-group_by_multi_join_sort.pas(126,33) Error: Illegal qualifier
-group_by_multi_join_sort.pas(126,59) Error: Illegal qualifier
-group_by_multi_join_sort.pas(126,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-group_by_multi_join_sort.pas(124,12) Error: Cannot find an enumerator for the type "<erroneous type>"
-group_by_multi_join_sort.pas(132,11) Error: Identifier not found "o"
-group_by_multi_join_sort.pas(134,20) Error: Identifier not found "o"
-group_by_multi_join_sort.pas(134,36) Error: identifier idents no member "c_custkey"
-group_by_multi_join_sort.pas(135,15) Error: Identifier not found "l"
-group_by_multi_join_sort.pas(137,24) Error: Identifier not found "l"
-group_by_multi_join_sort.pas(137,39) Error: Identifier not found "o"
-group_by_multi_join_sort.pas(138,19) Error: Identifier not found "n"
-group_by_multi_join_sort.pas(140,28) Error: Identifier not found "n"
-group_by_multi_join_sort.pas(140,46) Error: identifier idents no member "c_nationkey"
-group_by_multi_join_sort.pas(141,30) Error: Identifier not found "o"
-group_by_multi_join_sort.pas(141,64) Error: Identifier not found "o"
-group_by_multi_join_sort.pas(141,96) Error: Identifier not found "l"
-group_by_multi_join_sort.pas(143,49) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc90DE1C48"
-group_by_multi_join_sort.pas(143,43) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-group_by_multi_join_sort.pas(16,19) Error: Can't read or write variables of this type
-group_by_multi_join_sort.pas(153) Fatal: There were 36 errors compiling module, stopping
+group_by_multi_join_sort.pas(78,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
+group_by_multi_join_sort.pas(87,15) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
+group_by_multi_join_sort.pas(96,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
+group_by_multi_join_sort.pas(107,15) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
+group_by_multi_join_sort.pas(111,35) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(112,32) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(114,12) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(116,33) Error: Illegal qualifier
+group_by_multi_join_sort.pas(116,59) Error: Illegal qualifier
+group_by_multi_join_sort.pas(116,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+group_by_multi_join_sort.pas(114,12) Error: Cannot find an enumerator for the type "<erroneous type>"
+group_by_multi_join_sort.pas(119,35) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(120,32) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(121,35) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(122,33) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(123,35) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(125,12) Error: Identifier not found "g"
+group_by_multi_join_sort.pas(127,33) Error: Illegal qualifier
+group_by_multi_join_sort.pas(127,59) Error: Illegal qualifier
+group_by_multi_join_sort.pas(127,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+group_by_multi_join_sort.pas(125,12) Error: Cannot find an enumerator for the type "<erroneous type>"
+group_by_multi_join_sort.pas(133,11) Error: Identifier not found "o"
+group_by_multi_join_sort.pas(135,20) Error: Identifier not found "o"
+group_by_multi_join_sort.pas(135,36) Error: identifier idents no member "c_custkey"
+group_by_multi_join_sort.pas(136,15) Error: Identifier not found "l"
+group_by_multi_join_sort.pas(138,24) Error: Identifier not found "l"
+group_by_multi_join_sort.pas(138,39) Error: Identifier not found "o"
+group_by_multi_join_sort.pas(139,19) Error: Identifier not found "n"
+group_by_multi_join_sort.pas(141,28) Error: Identifier not found "n"
+group_by_multi_join_sort.pas(141,46) Error: identifier idents no member "c_nationkey"
+group_by_multi_join_sort.pas(142,30) Error: Identifier not found "o"
+group_by_multi_join_sort.pas(142,64) Error: Identifier not found "o"
+group_by_multi_join_sort.pas(142,96) Error: Identifier not found "l"
+group_by_multi_join_sort.pas(144,49) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc90DE1C48"
+group_by_multi_join_sort.pas(144,43) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+group_by_multi_join_sort.pas(17,19) Error: Can't read or write variables of this type
+group_by_multi_join_sort.pas(154) Fatal: There were 36 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by_multi_join_sort.pas
+++ b/tests/machine/x/pascal/group_by_multi_join_sort.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_by_sort.error
+++ b/tests/machine/x/pascal/group_by_sort.error
@@ -1,23 +1,23 @@
-line: 104
+line: 105
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_by_sort.pas
-group_by_sort.pas(79,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
-group_by_sort.pas(81,29) Error: Identifier not found "g"
-group_by_sort.pas(83,12) Error: Identifier not found "g"
-group_by_sort.pas(85,33) Error: Illegal qualifier
-group_by_sort.pas(85,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-group_by_sort.pas(83,12) Error: Cannot find an enumerator for the type "<erroneous type>"
-group_by_sort.pas(89,12) Error: Identifier not found "g"
-group_by_sort.pas(91,33) Error: Illegal qualifier
-group_by_sort.pas(91,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-group_by_sort.pas(89,12) Error: Cannot find an enumerator for the type "<erroneous type>"
-group_by_sort.pas(97,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc90DE1C48"
-group_by_sort.pas(97,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-group_by_sort.pas(16,19) Error: Can't read or write variables of this type
-group_by_sort.pas(104) Fatal: There were 13 errors compiling module, stopping
+group_by_sort.pas(80,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc90DE1C48"
+group_by_sort.pas(82,29) Error: Identifier not found "g"
+group_by_sort.pas(84,12) Error: Identifier not found "g"
+group_by_sort.pas(86,33) Error: Illegal qualifier
+group_by_sort.pas(86,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+group_by_sort.pas(84,12) Error: Cannot find an enumerator for the type "<erroneous type>"
+group_by_sort.pas(90,12) Error: Identifier not found "g"
+group_by_sort.pas(92,33) Error: Illegal qualifier
+group_by_sort.pas(92,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+group_by_sort.pas(90,12) Error: Cannot find an enumerator for the type "<erroneous type>"
+group_by_sort.pas(98,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crc90DE1C48"
+group_by_sort.pas(98,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+group_by_sort.pas(17,19) Error: Can't read or write variables of this type
+group_by_sort.pas(105) Fatal: There were 13 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_by_sort.pas
+++ b/tests/machine/x/pascal/group_by_sort.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/group_items_iteration.error
+++ b/tests/machine/x/pascal/group_items_iteration.error
@@ -4,9 +4,9 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/group_items_iteration.pas
-group_items_iteration.pas(19,19) Warning: function result variable of a managed type does not seem to be initialized
-group_items_iteration.pas(25,65) Error: Type identifier expected
-group_items_iteration.pas(25,65) Fatal: Syntax error, ")" expected but "FUNCTION" found
+group_items_iteration.pas(20,19) Warning: function result variable of a managed type does not seem to be initialized
+group_items_iteration.pas(26,65) Error: Type identifier expected
+group_items_iteration.pas(26,65) Fatal: Syntax error, ")" expected but "FUNCTION" found
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/group_items_iteration.pas
+++ b/tests/machine/x/pascal/group_items_iteration.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/if_else.pas
+++ b/tests/machine/x/pascal/if_else.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/if_then_else.pas
+++ b/tests/machine/x/pascal/if_then_else.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/if_then_else_nested.pas
+++ b/tests/machine/x/pascal/if_then_else_nested.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/in_operator.error
+++ b/tests/machine/x/pascal/in_operator.error
@@ -1,12 +1,12 @@
-line: 17
+line: 18
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/in_operator.pas
-in_operator.pas(14,14) Error: Operator is not overloaded
-in_operator.pas(15,18) Error: Operator is not overloaded
-in_operator.pas(17) Fatal: There were 2 errors compiling module, stopping
+in_operator.pas(15,14) Error: Operator is not overloaded
+in_operator.pas(16,18) Error: Operator is not overloaded
+in_operator.pas(18) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/in_operator.pas
+++ b/tests/machine/x/pascal/in_operator.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/in_operator_extended.error
+++ b/tests/machine/x/pascal/in_operator_extended.error
@@ -1,15 +1,15 @@
-line: 38
+line: 39
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/in_operator_extended.pas
-in_operator_extended.pas(27,14) Error: Operator is not overloaded
 in_operator_extended.pas(28,14) Error: Operator is not overloaded
-in_operator_extended.pas(31,8) Error: Incompatible types: got "TFPGMap<System.Variant,System.LongInt>" expected "TFPGMap<System.ShortString,System.LongInt>"
-in_operator_extended.pas(35,18) Error: Operator is not overloaded
+in_operator_extended.pas(29,14) Error: Operator is not overloaded
+in_operator_extended.pas(32,8) Error: Incompatible types: got "TFPGMap<System.Variant,System.LongInt>" expected "TFPGMap<System.ShortString,System.LongInt>"
 in_operator_extended.pas(36,18) Error: Operator is not overloaded
-in_operator_extended.pas(38) Fatal: There were 5 errors compiling module, stopping
+in_operator_extended.pas(37,18) Error: Operator is not overloaded
+in_operator_extended.pas(39) Fatal: There were 5 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/in_operator_extended.pas
+++ b/tests/machine/x/pascal/in_operator_extended.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/inner_join.error
+++ b/tests/machine/x/pascal/inner_join.error
@@ -1,24 +1,24 @@
-line: 74
+line: 75
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/inner_join.pas
-inner_join.pas(35,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-inner_join.pas(52,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-inner_join.pas(54,35) Error: identifier idents no member "id"
-inner_join.pas(55,38) Error: Identifier not found "c"
-inner_join.pas(56,33) Error: identifier idents no member "total"
-inner_join.pas(60,11) Error: Identifier not found "c"
-inner_join.pas(62,22) Error: identifier idents no member "customerId"
-inner_join.pas(62,35) Error: Identifier not found "c"
-inner_join.pas(63,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-inner_join.pas(63,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-inner_join.pas(66,14) Error: Incompatible types: got "TArray$1$crcE0B4E8C7" expected "TArray$1$crc7ED07D64"
-inner_join.pas(70,35) Error: identifier idents no member "orderId"
-inner_join.pas(70,66) Error: identifier idents no member "customerName"
-inner_join.pas(71,21) Error: identifier idents no member "total"
-inner_join.pas(74) Fatal: There were 14 errors compiling module, stopping
+inner_join.pas(36,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+inner_join.pas(53,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+inner_join.pas(55,35) Error: identifier idents no member "id"
+inner_join.pas(56,38) Error: Identifier not found "c"
+inner_join.pas(57,33) Error: identifier idents no member "total"
+inner_join.pas(61,11) Error: Identifier not found "c"
+inner_join.pas(63,22) Error: identifier idents no member "customerId"
+inner_join.pas(63,35) Error: Identifier not found "c"
+inner_join.pas(64,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+inner_join.pas(64,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+inner_join.pas(67,14) Error: Incompatible types: got "TArray$1$crcE0B4E8C7" expected "TArray$1$crc7ED07D64"
+inner_join.pas(71,35) Error: identifier idents no member "orderId"
+inner_join.pas(71,66) Error: identifier idents no member "customerName"
+inner_join.pas(72,21) Error: identifier idents no member "total"
+inner_join.pas(75) Fatal: There were 14 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/inner_join.pas
+++ b/tests/machine/x/pascal/inner_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/join_multi.error
+++ b/tests/machine/x/pascal/join_multi.error
@@ -1,25 +1,25 @@
-line: 70
+line: 71
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/join_multi.pas
-join_multi.pas(32,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-join_multi.pas(39,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-join_multi.pas(46,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-join_multi.pas(48,30) Error: Identifier not found "c"
-join_multi.pas(49,29) Error: Identifier not found "i"
-join_multi.pas(53,11) Error: Identifier not found "c"
-join_multi.pas(55,22) Error: identifier idents no member "customerId"
-join_multi.pas(55,35) Error: Identifier not found "c"
-join_multi.pas(56,15) Error: Identifier not found "i"
-join_multi.pas(58,26) Error: identifier idents no member "id"
-join_multi.pas(58,31) Error: Identifier not found "i"
-join_multi.pas(59,45) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-join_multi.pas(59,39) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-join_multi.pas(67,17) Error: identifier idents no member "name"
-join_multi.pas(67,50) Error: identifier idents no member "sku"
-join_multi.pas(70) Fatal: There were 15 errors compiling module, stopping
+join_multi.pas(33,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+join_multi.pas(40,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+join_multi.pas(47,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+join_multi.pas(49,30) Error: Identifier not found "c"
+join_multi.pas(50,29) Error: Identifier not found "i"
+join_multi.pas(54,11) Error: Identifier not found "c"
+join_multi.pas(56,22) Error: identifier idents no member "customerId"
+join_multi.pas(56,35) Error: Identifier not found "c"
+join_multi.pas(57,15) Error: Identifier not found "i"
+join_multi.pas(59,26) Error: identifier idents no member "id"
+join_multi.pas(59,31) Error: Identifier not found "i"
+join_multi.pas(60,45) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+join_multi.pas(60,39) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+join_multi.pas(68,17) Error: identifier idents no member "name"
+join_multi.pas(68,50) Error: identifier idents no member "sku"
+join_multi.pas(71) Fatal: There were 15 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/join_multi.pas
+++ b/tests/machine/x/pascal/join_multi.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/json_builtin.error
+++ b/tests/machine/x/pascal/json_builtin.error
@@ -1,11 +1,11 @@
-line: 25
+line: 26
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/json_builtin.pas
-json_builtin.pas(22,8) Error: Incompatible types: got "TFPGMap<System.Variant,System.LongInt>" expected "TFPGMap<System.ShortString,System.LongInt>"
-json_builtin.pas(25) Fatal: There were 1 errors compiling module, stopping
+json_builtin.pas(23,8) Error: Incompatible types: got "TFPGMap<System.Variant,System.LongInt>" expected "TFPGMap<System.ShortString,System.LongInt>"
+json_builtin.pas(26) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/json_builtin.pas
+++ b/tests/machine/x/pascal/json_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/left_join.error
+++ b/tests/machine/x/pascal/left_join.error
@@ -1,23 +1,23 @@
-line: 60
+line: 61
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/left_join.pas
-left_join.pas(29,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-left_join.pas(38,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-left_join.pas(40,35) Error: identifier idents no member "id"
-left_join.pas(41,34) Error: Identifier not found "c"
-left_join.pas(42,33) Error: identifier idents no member "total"
-left_join.pas(46,11) Error: Identifier not found "c"
-left_join.pas(48,22) Error: identifier idents no member "customerId"
-left_join.pas(48,35) Error: Identifier not found "c"
-left_join.pas(49,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-left_join.pas(49,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-left_join.pas(56,35) Error: identifier idents no member "orderId"
-left_join.pas(56,72) Error: identifier idents no member "customer"
-left_join.pas(57,21) Error: identifier idents no member "total"
-left_join.pas(60) Fatal: There were 13 errors compiling module, stopping
+left_join.pas(30,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+left_join.pas(39,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+left_join.pas(41,35) Error: identifier idents no member "id"
+left_join.pas(42,34) Error: Identifier not found "c"
+left_join.pas(43,33) Error: identifier idents no member "total"
+left_join.pas(47,11) Error: Identifier not found "c"
+left_join.pas(49,22) Error: identifier idents no member "customerId"
+left_join.pas(49,35) Error: Identifier not found "c"
+left_join.pas(50,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+left_join.pas(50,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+left_join.pas(57,35) Error: identifier idents no member "orderId"
+left_join.pas(57,72) Error: identifier idents no member "customer"
+left_join.pas(58,21) Error: identifier idents no member "total"
+left_join.pas(61) Fatal: There were 13 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/left_join.pas
+++ b/tests/machine/x/pascal/left_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/left_join_multi.error
+++ b/tests/machine/x/pascal/left_join_multi.error
@@ -1,27 +1,27 @@
-line: 67
+line: 68
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/left_join_multi.pas
-left_join_multi.pas(31,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-left_join_multi.pas(38,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-left_join_multi.pas(42,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-left_join_multi.pas(44,35) Error: identifier idents no member "id"
-left_join_multi.pas(45,30) Error: Identifier not found "c"
-left_join_multi.pas(46,30) Error: Identifier not found "i"
-left_join_multi.pas(50,11) Error: Identifier not found "c"
-left_join_multi.pas(52,22) Error: identifier idents no member "customerId"
-left_join_multi.pas(52,35) Error: Identifier not found "c"
-left_join_multi.pas(53,15) Error: Identifier not found "i"
-left_join_multi.pas(55,26) Error: identifier idents no member "id"
-left_join_multi.pas(55,31) Error: Identifier not found "i"
-left_join_multi.pas(56,45) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-left_join_multi.pas(56,39) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-left_join_multi.pas(64,17) Error: identifier idents no member "orderId"
-left_join_multi.pas(64,33) Error: identifier idents no member "name"
-left_join_multi.pas(64,46) Error: identifier idents no member "item"
-left_join_multi.pas(67) Fatal: There were 17 errors compiling module, stopping
+left_join_multi.pas(32,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+left_join_multi.pas(39,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+left_join_multi.pas(43,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+left_join_multi.pas(45,35) Error: identifier idents no member "id"
+left_join_multi.pas(46,30) Error: Identifier not found "c"
+left_join_multi.pas(47,30) Error: Identifier not found "i"
+left_join_multi.pas(51,11) Error: Identifier not found "c"
+left_join_multi.pas(53,22) Error: identifier idents no member "customerId"
+left_join_multi.pas(53,35) Error: Identifier not found "c"
+left_join_multi.pas(54,15) Error: Identifier not found "i"
+left_join_multi.pas(56,26) Error: identifier idents no member "id"
+left_join_multi.pas(56,31) Error: Identifier not found "i"
+left_join_multi.pas(57,45) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+left_join_multi.pas(57,39) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+left_join_multi.pas(65,17) Error: identifier idents no member "orderId"
+left_join_multi.pas(65,33) Error: identifier idents no member "name"
+left_join_multi.pas(65,46) Error: identifier idents no member "item"
+left_join_multi.pas(68) Fatal: There were 17 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/left_join_multi.pas
+++ b/tests/machine/x/pascal/left_join_multi.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/len_builtin.pas
+++ b/tests/machine/x/pascal/len_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/len_map.error
+++ b/tests/machine/x/pascal/len_map.error
@@ -1,11 +1,11 @@
-line: 18
+line: 19
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/len_map.pas
-len_map.pas(16,11) Error: Type mismatch
-len_map.pas(18) Fatal: There were 1 errors compiling module, stopping
+len_map.pas(17,11) Error: Type mismatch
+len_map.pas(19) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/len_map.pas
+++ b/tests/machine/x/pascal/len_map.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/len_string.pas
+++ b/tests/machine/x/pascal/len_string.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/let_and_print.pas
+++ b/tests/machine/x/pascal/let_and_print.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/list_assign.pas
+++ b/tests/machine/x/pascal/list_assign.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/list_index.pas
+++ b/tests/machine/x/pascal/list_index.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/list_nested_assign.error
+++ b/tests/machine/x/pascal/list_nested_assign.error
@@ -1,11 +1,11 @@
-line: 27
+line: 28
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/list_nested_assign.pas
-list_nested_assign.pas(25,31) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc7ED07D64"
-list_nested_assign.pas(27) Fatal: There were 1 errors compiling module, stopping
+list_nested_assign.pas(26,31) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc7ED07D64"
+list_nested_assign.pas(28) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/list_nested_assign.pas
+++ b/tests/machine/x/pascal/list_nested_assign.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/list_set_ops.pas
+++ b/tests/machine/x/pascal/list_set_ops.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/load_yaml.error
+++ b/tests/machine/x/pascal/load_yaml.error
@@ -4,8 +4,8 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/load_yaml.pas
-load_yaml.pas(23,21) Warning: function result variable of a managed type does not seem to be initialized
-load_yaml.pas(40,19) Fatal: illegal character "'"'" ($22)
+load_yaml.pas(24,21) Warning: function result variable of a managed type does not seem to be initialized
+load_yaml.pas(41,19) Fatal: illegal character "'"'" ($22)
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/load_yaml.pas
+++ b/tests/machine/x/pascal/load_yaml.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/map_assign.pas
+++ b/tests/machine/x/pascal/map_assign.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/map_in_operator.error
+++ b/tests/machine/x/pascal/map_in_operator.error
@@ -1,11 +1,11 @@
-line: 21
+line: 22
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/map_in_operator.pas
-map_in_operator.pas(17,8) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.LongInt,System.ShortString>"
-map_in_operator.pas(21) Fatal: There were 1 errors compiling module, stopping
+map_in_operator.pas(18,8) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.LongInt,System.ShortString>"
+map_in_operator.pas(22) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/map_in_operator.pas
+++ b/tests/machine/x/pascal/map_in_operator.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/map_index.pas
+++ b/tests/machine/x/pascal/map_index.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/map_int_key.error
+++ b/tests/machine/x/pascal/map_int_key.error
@@ -1,11 +1,11 @@
-line: 20
+line: 21
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/map_int_key.pas
-map_int_key.pas(17,8) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.LongInt,System.ShortString>"
-map_int_key.pas(20) Fatal: There were 1 errors compiling module, stopping
+map_int_key.pas(18,8) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.LongInt,System.ShortString>"
+map_int_key.pas(21) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/map_int_key.pas
+++ b/tests/machine/x/pascal/map_int_key.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/map_literal_dynamic.pas
+++ b/tests/machine/x/pascal/map_literal_dynamic.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/map_membership.pas
+++ b/tests/machine/x/pascal/map_membership.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/map_nested_assign.error
+++ b/tests/machine/x/pascal/map_nested_assign.error
@@ -1,12 +1,12 @@
-line: 23
+line: 24
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/map_nested_assign.pas
-map_nested_assign.pas(18,36) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.LongInt>", expected "Variant"
-map_nested_assign.pas(19,11) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,main.TFPGMap<System.ShortString,System.LongInt>>"
-map_nested_assign.pas(23) Fatal: There were 2 errors compiling module, stopping
+map_nested_assign.pas(19,36) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.LongInt>", expected "Variant"
+map_nested_assign.pas(20,11) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,main.TFPGMap<System.ShortString,System.LongInt>>"
+map_nested_assign.pas(24) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/map_nested_assign.pas
+++ b/tests/machine/x/pascal/map_nested_assign.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/match_expr.error
+++ b/tests/machine/x/pascal/match_expr.error
@@ -4,7 +4,7 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/match_expr.pas
-match_expr.pas(21,7) Fatal: Syntax error, ";" expected but "ELSE" found
+match_expr.pas(22,7) Fatal: Syntax error, ";" expected but "ELSE" found
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/match_expr.pas
+++ b/tests/machine/x/pascal/match_expr.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/match_full.error
+++ b/tests/machine/x/pascal/match_full.error
@@ -4,8 +4,7 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/match_full.pas
-match_full.pas(18,16) Error: Incompatible types: got "Constant String" expected "LongInt"
-match_full.pas(19,7) Fatal: Syntax error, ";" expected but "ELSE" found
+match_full.pas(20,7) Fatal: Syntax error, ";" expected but "ELSE" found
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/match_full.pas
+++ b/tests/machine/x/pascal/match_full.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 
@@ -9,7 +10,7 @@ type
 function classify(n: integer): string;
 
 var
-  _tmp0: integer;
+  _tmp0: string;
   _tmp1: integer;
 begin
   _tmp1 := n;

--- a/tests/machine/x/pascal/math_ops.pas
+++ b/tests/machine/x/pascal/math_ops.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/membership.error
+++ b/tests/machine/x/pascal/membership.error
@@ -1,12 +1,12 @@
-line: 17
+line: 18
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/membership.pas
-membership.pas(14,14) Error: Operator is not overloaded
 membership.pas(15,14) Error: Operator is not overloaded
-membership.pas(17) Fatal: There were 2 errors compiling module, stopping
+membership.pas(16,14) Error: Operator is not overloaded
+membership.pas(18) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/membership.pas
+++ b/tests/machine/x/pascal/membership.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/min_max_builtin.error
+++ b/tests/machine/x/pascal/min_max_builtin.error
@@ -1,12 +1,12 @@
-line: 17
+line: 18
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/min_max_builtin.pas
-min_max_builtin.pas(14,11) Error: Identifier not found "min"
-min_max_builtin.pas(15,11) Error: Identifier not found "max"
-min_max_builtin.pas(17) Fatal: There were 2 errors compiling module, stopping
+min_max_builtin.pas(15,11) Error: Identifier not found "min"
+min_max_builtin.pas(16,11) Error: Identifier not found "max"
+min_max_builtin.pas(18) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/min_max_builtin.pas
+++ b/tests/machine/x/pascal/min_max_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/nested_function.error
+++ b/tests/machine/x/pascal/nested_function.error
@@ -1,11 +1,11 @@
-line: 18
+line: 19
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/nested_function.pas
-nested_function.pas(11,13) Error: Identifier not found "inner"
-nested_function.pas(18) Fatal: There were 1 errors compiling module, stopping
+nested_function.pas(12,13) Error: Identifier not found "inner"
+nested_function.pas(19) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/nested_function.pas
+++ b/tests/machine/x/pascal/nested_function.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/order_by_map.error
+++ b/tests/machine/x/pascal/order_by_map.error
@@ -1,16 +1,16 @@
-line: 76
+line: 77
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/order_by_map.pas
-order_by_map.pas(61,11) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc09D74DF2"
-order_by_map.pas(63,29) Error: identifier idents no member "a"
-order_by_map.pas(64,29) Error: identifier idents no member "b"
-order_by_map.pas(70,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" expected "TArray$1$crcE41905E8"
-order_by_map.pas(70,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.LongInt>" expected "Variant"
-order_by_map.pas(16,19) Error: Can't read or write variables of this type
-order_by_map.pas(76) Fatal: There were 6 errors compiling module, stopping
+order_by_map.pas(62,11) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc09D74DF2"
+order_by_map.pas(64,29) Error: identifier idents no member "a"
+order_by_map.pas(65,29) Error: identifier idents no member "b"
+order_by_map.pas(71,37) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" expected "TArray$1$crcE41905E8"
+order_by_map.pas(71,31) Error: Incompatible types: got "TFPGMap<System.Variant,System.LongInt>" expected "Variant"
+order_by_map.pas(17,19) Error: Can't read or write variables of this type
+order_by_map.pas(77) Fatal: There were 6 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/order_by_map.pas
+++ b/tests/machine/x/pascal/order_by_map.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/outer_join.error
+++ b/tests/machine/x/pascal/outer_join.error
@@ -1,28 +1,28 @@
-line: 92
+line: 93
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/outer_join.pas
-outer_join.pas(39,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-outer_join.pas(56,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-outer_join.pas(58,32) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.LongInt>", expected "Variant"
-outer_join.pas(59,34) Error: Identifier not found "c"
-outer_join.pas(63,11) Error: Identifier not found "c"
-outer_join.pas(65,22) Error: identifier idents no member "customerId"
-outer_join.pas(65,35) Error: Identifier not found "c"
-outer_join.pas(66,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-outer_join.pas(66,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-outer_join.pas(69,14) Error: Incompatible types: got "TArray$1$crcE0B4E8C7" expected "TArray$1$crc09D74DF2"
-outer_join.pas(73,14) Error: identifier idents no member "order"
-outer_join.pas(75,18) Error: identifier idents no member "customer"
-outer_join.pas(77,41) Error: identifier idents no member "order"
-outer_join.pas(77,71) Error: identifier idents no member "customer"
-outer_join.pas(78,29) Error: identifier idents no member "order"
-outer_join.pas(82,41) Error: identifier idents no member "order"
-outer_join.pas(83,23) Error: identifier idents no member "order"
-outer_join.pas(88,40) Error: identifier idents no member "customer"
-outer_join.pas(92) Fatal: There were 18 errors compiling module, stopping
+outer_join.pas(40,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+outer_join.pas(57,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+outer_join.pas(59,32) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.LongInt>", expected "Variant"
+outer_join.pas(60,34) Error: Identifier not found "c"
+outer_join.pas(64,11) Error: Identifier not found "c"
+outer_join.pas(66,22) Error: identifier idents no member "customerId"
+outer_join.pas(66,35) Error: Identifier not found "c"
+outer_join.pas(67,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+outer_join.pas(67,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+outer_join.pas(70,14) Error: Incompatible types: got "TArray$1$crcE0B4E8C7" expected "TArray$1$crc09D74DF2"
+outer_join.pas(74,14) Error: identifier idents no member "order"
+outer_join.pas(76,18) Error: identifier idents no member "customer"
+outer_join.pas(78,41) Error: identifier idents no member "order"
+outer_join.pas(78,71) Error: identifier idents no member "customer"
+outer_join.pas(79,29) Error: identifier idents no member "order"
+outer_join.pas(83,41) Error: identifier idents no member "order"
+outer_join.pas(84,23) Error: identifier idents no member "order"
+outer_join.pas(89,40) Error: identifier idents no member "customer"
+outer_join.pas(93) Fatal: There were 18 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/outer_join.pas
+++ b/tests/machine/x/pascal/outer_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/partial_application.error
+++ b/tests/machine/x/pascal/partial_application.error
@@ -1,10 +1,12 @@
-line: 0
+line: 23
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/partial_application.pas
-partial_application.pas(16,26) Fatal: Syntax error, ":" expected but ")" found
+partial_application.pas(20,11) Error: Wrong number of parameters specified for call to "add"
+partial_application.pas(10,10) Error: Found declaration: add(LongInt;LongInt):LongInt;
+partial_application.pas(23) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/partial_application.pas
+++ b/tests/machine/x/pascal/partial_application.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 
@@ -13,7 +14,7 @@ begin
 end;
 
 var
-  add5: function (integer): integer;
+  add5: function (p0: integer): integer is nested;
 
 begin
   add5 := add(5);

--- a/tests/machine/x/pascal/print_hello.pas
+++ b/tests/machine/x/pascal/print_hello.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/pure_fold.pas
+++ b/tests/machine/x/pascal/pure_fold.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/pure_global_fold.error
+++ b/tests/machine/x/pascal/pure_global_fold.error
@@ -1,11 +1,11 @@
-line: 22
+line: 23
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/pure_global_fold.pas
-pure_global_fold.pas(11,17) Error: Identifier not found "k"
-pure_global_fold.pas(22) Fatal: There were 1 errors compiling module, stopping
+pure_global_fold.pas(12,17) Error: Identifier not found "k"
+pure_global_fold.pas(23) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/pure_global_fold.pas
+++ b/tests/machine/x/pascal/pure_global_fold.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/query_sum_select.error
+++ b/tests/machine/x/pascal/query_sum_select.error
@@ -1,11 +1,11 @@
-line: 26
+line: 27
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/query_sum_select.pas
-query_sum_select.pas(23,14) Error: Incompatible types: got "TArray$1$crcFD0234A9" expected "Double"
-query_sum_select.pas(26) Fatal: There were 1 errors compiling module, stopping
+query_sum_select.pas(24,14) Error: Incompatible types: got "TArray$1$crcFD0234A9" expected "Double"
+query_sum_select.pas(27) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/query_sum_select.pas
+++ b/tests/machine/x/pascal/query_sum_select.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/record_assign.error
+++ b/tests/machine/x/pascal/record_assign.error
@@ -1,11 +1,11 @@
-line: 28
+line: 29
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/record_assign.pas
-record_assign.pas(15,12) Error: Incompatible types: got "Int64" expected "Counter"
-record_assign.pas(28) Fatal: There were 1 errors compiling module, stopping
+record_assign.pas(16,12) Error: Incompatible types: got "Int64" expected "Counter"
+record_assign.pas(29) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/record_assign.pas
+++ b/tests/machine/x/pascal/record_assign.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/right_join.error
+++ b/tests/machine/x/pascal/right_join.error
@@ -1,24 +1,24 @@
-line: 79
+line: 80
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/right_join.pas
-right_join.pas(38,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-right_join.pas(51,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-right_join.pas(53,40) Error: identifier idents no member "name"
-right_join.pas(54,31) Error: Identifier not found "o"
-right_join.pas(58,11) Error: Identifier not found "o"
-right_join.pas(60,20) Error: Identifier not found "o"
-right_join.pas(60,37) Error: identifier idents no member "id"
-right_join.pas(61,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-right_join.pas(61,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
-right_join.pas(68,16) Error: identifier idents no member "order"
-right_join.pas(70,42) Error: identifier idents no member "customerName"
-right_join.pas(70,85) Error: identifier idents no member "order"
-right_join.pas(71,37) Error: identifier idents no member "order"
-right_join.pas(75,42) Error: identifier idents no member "customerName"
-right_join.pas(79) Fatal: There were 14 errors compiling module, stopping
+right_join.pas(39,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
+right_join.pas(52,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
+right_join.pas(54,40) Error: identifier idents no member "name"
+right_join.pas(55,31) Error: Identifier not found "o"
+right_join.pas(59,11) Error: Identifier not found "o"
+right_join.pas(61,20) Error: Identifier not found "o"
+right_join.pas(61,37) Error: identifier idents no member "id"
+right_join.pas(62,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
+right_join.pas(62,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
+right_join.pas(69,16) Error: identifier idents no member "order"
+right_join.pas(71,42) Error: identifier idents no member "customerName"
+right_join.pas(71,85) Error: identifier idents no member "order"
+right_join.pas(72,37) Error: identifier idents no member "order"
+right_join.pas(76,42) Error: identifier idents no member "customerName"
+right_join.pas(80) Fatal: There were 14 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/right_join.pas
+++ b/tests/machine/x/pascal/right_join.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/save_jsonl_stdout.error
+++ b/tests/machine/x/pascal/save_jsonl_stdout.error
@@ -4,14 +4,14 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/save_jsonl_stdout.pas
-save_jsonl_stdout.pas(13,7) Error: Identifier not found "TJSONStreamer"
-save_jsonl_stdout.pas(13,20) Error: Error in type definition
-save_jsonl_stdout.pas(16,9) Error: Identifier not found "TJSONStreamer"
-save_jsonl_stdout.pas(20,19) Error: Illegal qualifier
-save_jsonl_stdout.pas(24,8) Error: Illegal qualifier
-save_jsonl_stdout.pas(41,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc7ED07D64"
-save_jsonl_stdout.pas(42,3) Error: Generics without specialization cannot be used as a type for a variable
-save_jsonl_stdout.pas(42,22) Fatal: illegal character "'"'" ($22)
+save_jsonl_stdout.pas(14,7) Error: Identifier not found "TJSONStreamer"
+save_jsonl_stdout.pas(14,20) Error: Error in type definition
+save_jsonl_stdout.pas(17,9) Error: Identifier not found "TJSONStreamer"
+save_jsonl_stdout.pas(21,19) Error: Illegal qualifier
+save_jsonl_stdout.pas(25,8) Error: Illegal qualifier
+save_jsonl_stdout.pas(42,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc7ED07D64"
+save_jsonl_stdout.pas(43,3) Error: Generics without specialization cannot be used as a type for a variable
+save_jsonl_stdout.pas(43,22) Fatal: illegal character "'"'" ($22)
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/save_jsonl_stdout.pas
+++ b/tests/machine/x/pascal/save_jsonl_stdout.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/short_circuit.pas
+++ b/tests/machine/x/pascal/short_circuit.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/slice.pas
+++ b/tests/machine/x/pascal/slice.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/sort_stable.error
+++ b/tests/machine/x/pascal/sort_stable.error
@@ -1,15 +1,15 @@
-line: 72
+line: 73
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/sort_stable.pas
-sort_stable.pas(60,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc09D74DF2"
-sort_stable.pas(65,33) Error: identifier idents no member "v"
-sort_stable.pas(65,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-sort_stable.pas(66,33) Error: identifier idents no member "n"
+sort_stable.pas(61,12) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crc09D74DF2"
+sort_stable.pas(66,33) Error: identifier idents no member "v"
 sort_stable.pas(66,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
-sort_stable.pas(72) Fatal: There were 5 errors compiling module, stopping
+sort_stable.pas(67,33) Error: identifier idents no member "n"
+sort_stable.pas(67,16) Error: Incompatible type for arg no. 3: Got "{Array Of Const/Constant Open} Array of TArray$1$crcE41905E8", expected "{Open} Array Of Pointer"
+sort_stable.pas(73) Fatal: There were 5 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/sort_stable.pas
+++ b/tests/machine/x/pascal/sort_stable.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/str_builtin.pas
+++ b/tests/machine/x/pascal/str_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/string_compare.pas
+++ b/tests/machine/x/pascal/string_compare.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/string_concat.pas
+++ b/tests/machine/x/pascal/string_concat.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/string_contains.error
+++ b/tests/machine/x/pascal/string_contains.error
@@ -1,12 +1,12 @@
-line: 17
+line: 18
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/string_contains.pas
-string_contains.pas(14,13) Error: Illegal qualifier
 string_contains.pas(15,13) Error: Illegal qualifier
-string_contains.pas(17) Fatal: There were 2 errors compiling module, stopping
+string_contains.pas(16,13) Error: Illegal qualifier
+string_contains.pas(18) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/string_contains.pas
+++ b/tests/machine/x/pascal/string_contains.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/string_in_operator.error
+++ b/tests/machine/x/pascal/string_in_operator.error
@@ -1,12 +1,12 @@
-line: 17
+line: 18
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/string_in_operator.pas
-string_in_operator.pas(14,18) Error: Operator is not overloaded
 string_in_operator.pas(15,18) Error: Operator is not overloaded
-string_in_operator.pas(17) Fatal: There were 2 errors compiling module, stopping
+string_in_operator.pas(16,18) Error: Operator is not overloaded
+string_in_operator.pas(18) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/string_in_operator.pas
+++ b/tests/machine/x/pascal/string_in_operator.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/string_index.pas
+++ b/tests/machine/x/pascal/string_index.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/string_prefix_slice.pas
+++ b/tests/machine/x/pascal/string_prefix_slice.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/substring_builtin.pas
+++ b/tests/machine/x/pascal/substring_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/sum_builtin.pas
+++ b/tests/machine/x/pascal/sum_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/tail_recursion.pas
+++ b/tests/machine/x/pascal/tail_recursion.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/test_block.pas
+++ b/tests/machine/x/pascal/test_block.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/two-sum.error
+++ b/tests/machine/x/pascal/two-sum.error
@@ -4,9 +4,9 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/two-sum.pas
-two-sum.pas(19,11) Error: Ordinal expression expected
-two-sum.pas(21,26) Error: Identifier not found "_indexList"
-two-sum.pas(21,50) Fatal: Syntax error, ")" expected but "," found
+two-sum.pas(20,11) Error: Ordinal expression expected
+two-sum.pas(22,26) Error: Identifier not found "_indexList"
+two-sum.pas(22,50) Fatal: Syntax error, ")" expected but "," found
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/two-sum.pas
+++ b/tests/machine/x/pascal/two-sum.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/typed_let.pas
+++ b/tests/machine/x/pascal/typed_let.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/typed_var.pas
+++ b/tests/machine/x/pascal/typed_var.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/unary_neg.pas
+++ b/tests/machine/x/pascal/unary_neg.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/update_stmt.pas
+++ b/tests/machine/x/pascal/update_stmt.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/user_type_literal.pas
+++ b/tests/machine/x/pascal/user_type_literal.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/values_builtin.error
+++ b/tests/machine/x/pascal/values_builtin.error
@@ -1,11 +1,11 @@
-line: 33
+line: 34
 error: fpc error: exit status 1
 Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/values_builtin.pas
-values_builtin.pas(31,34) Error: Identifier not found "values"
-values_builtin.pas(33) Fatal: There were 1 errors compiling module, stopping
+values_builtin.pas(32,34) Error: Identifier not found "values"
+values_builtin.pas(34) Fatal: There were 1 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/values_builtin.pas
+++ b/tests/machine/x/pascal/values_builtin.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/var_assignment.pas
+++ b/tests/machine/x/pascal/var_assignment.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 

--- a/tests/machine/x/pascal/while_loop.pas
+++ b/tests/machine/x/pascal/while_loop.pas
@@ -1,5 +1,6 @@
 program main;
 {$mode objfpc}
+{$modeswitch nestedprocvars}
 
 uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
 


### PR DESCRIPTION
## Summary
- regenerate Pascal test outputs
- include `$modeswitch nestedprocvars` directive in generated programs

## Testing
- `go test ./compiler/x/pascal -run TestCompileValidPrograms -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e238e2e7c83208e59f04b43630995