### PR TITLE
Enhance PHP compiler

### DIFF
--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -29,6 +29,21 @@ func sanitizeName(name string) string {
 	return s
 }
 
+func isSimpleIdentExpr(e *parser.Expr) (string, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.Selector == nil || len(p.Target.Selector.Tail) != 0 {
+		return "", false
+	}
+	return p.Target.Selector.Root, true
+}
+
 func (c *Compiler) isMapExpr(e *parser.Expr) bool {
 	if e == nil {
 		return false


### PR DESCRIPTION
## Summary
- ignore Mochi `test` blocks and `expect` statements when generating PHP
- support map literals with identifier keys by quoting them

## Testing
- `go test ./compiler/x/php -tags slow -run TestPHPCompiler_ValidPrograms -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_686e238b44548320aa109221adace28e