### PR TITLE
Add group-by support to smalltalk compiler

### DIFF
--- a/tests/machine/x/st/README.md
+++ b/tests/machine/x/st/README.md
@@ -1,4 +1,4 @@
-# Mochi to Smalltalk Machine Outputs (77/97 compiled)
+# Mochi to Smalltalk Machine Outputs (82/97 compiled)
 
 This directory contains Smalltalk source code generated from the Mochi programs in `tests/vm/valid`. A checkbox indicates the program compiled and executed successfully during tests. Because the `gst` interpreter is not available, all programs currently fail at runtime.
 
@@ -77,15 +77,15 @@ This directory contains Smalltalk source code generated from the Mochi programs 
 - [x] user_type_literal.mochi
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
-- [ ] group_by.mochi
-- [ ] group_by_conditional_sum.mochi
-- [ ] group_by_having.mochi
+- [x] group_by.mochi
+- [x] group_by_conditional_sum.mochi
+- [x] group_by_having.mochi
 - [ ] group_by_join.mochi
 - [ ] group_by_left_join.mochi
 - [ ] group_by_multi_join.mochi
 - [ ] group_by_multi_join_sort.mochi
-- [ ] group_by_sort.mochi
-- [ ] group_items_iteration.mochi
+- [x] group_by_sort.mochi
+- [x] group_items_iteration.mochi
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi
 - [x] json_builtin.mochi


### PR DESCRIPTION
## Summary
- support basic `group by` queries in the Smalltalk compiler
- update machine checklist for Smalltalk outputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e273fbbcc8320b2730f44c4210843