### PR TITLE
Generate TypeScript machine outputs

### DIFF
--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -4,7 +4,7 @@ This directory contains TypeScript code compiled from Mochi programs in `tests/v
 
 ## Progress
 
-Compiled: 97/97 programs
+Compiled: 93/97 programs
 
 ## Checklist
 - [x] append_builtin.mochi
@@ -35,7 +35,7 @@ Compiled: 97/97 programs
 - [x] group_by_join.mochi
 - [x] group_by_left_join.mochi
 - [x] group_by_multi_join.mochi
-- [x] group_by_multi_join_sort.mochi
+- [ ] group_by_multi_join_sort.mochi
 - [x] group_by_sort.mochi
 - [x] group_items_iteration.mochi
 - [x] if_else.mochi
@@ -56,7 +56,7 @@ Compiled: 97/97 programs
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
 - [x] list_set_ops.mochi
-- [x] load_yaml.mochi
+- [ ] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi
@@ -94,12 +94,12 @@ Compiled: 97/97 programs
 - [x] sum_builtin.mochi
 - [x] tail_recursion.mochi
 - [x] test_block.mochi
-- [x] tree_sum.mochi
+- [ ] tree_sum.mochi
 - [x] two-sum.mochi
 - [x] typed_let.mochi
 - [x] typed_var.mochi
 - [x] unary_neg.mochi
-- [x] update_stmt.mochi
+- [ ] update_stmt.mochi
 - [x] user_type_literal.mochi
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi

--- a/tests/machine/x/typescript/group_by_join.out
+++ b/tests/machine/x/typescript/group_by_join.out
@@ -1,3 +1,2 @@
 --- Orders per customer ---
-Alice orders: 2
-Bob orders: 1
+Alice orders: 2Bob orders: 1

--- a/tests/machine/x/typescript/group_by_left_join.out
+++ b/tests/machine/x/typescript/group_by_left_join.out
@@ -1,3 +1,2 @@
 --- Group Left Join ---
-Alice orders: 0
-Bob orders: 0
+Alice orders: 0Bob orders: 0

--- a/tests/machine/x/typescript/group_by_multi_join.error
+++ b/tests/machine/x/typescript/group_by_multi_join.error
@@ -1,2 +1,0 @@
-line 0: unsupported expression at line 10
-let nations = [

--- a/tests/machine/x/typescript/group_by_multi_join.out
+++ b/tests/machine/x/typescript/group_by_multi_join.out
@@ -1,0 +1,1 @@
+[ { part: 100, total: 20 }, { part: 200, total: 15 } ]

--- a/tests/machine/x/typescript/group_by_multi_join.ts
+++ b/tests/machine/x/typescript/group_by_multi_join.ts
@@ -1,0 +1,44 @@
+let nations = [{id: 1, name: "A"}, {id: 2, name: "B"}];
+let suppliers = [{id: 1, nation: 1}, {id: 2, nation: 2}];
+let partsupp = [{part: 100, supplier: 1, cost: 10, qty: 2}, {part: 100, supplier: 2, cost: 20, qty: 1}, {part: 200, supplier: 1, cost: 5, qty: 3}];
+let filtered = (() => {
+  const _tmp1 = [];
+  for (const ps of partsupp) {
+    for (const s of suppliers) {
+      if (!((s.id == ps.supplier))) continue;
+      for (const n of nations) {
+        if (!((n.id == s.nation))) continue;
+        if (!((n.name == "A"))) continue;
+        _tmp1.push({part: ps.part, value: (ps.cost * ps.qty)});
+      }
+    }
+  }
+  let res = _tmp1;
+  return res;
+})()
+;
+let grouped = (() => {
+  const groups = {};
+  for (const x of filtered) {
+    const _k = JSON.stringify(x.part);
+    let g = groups[_k];
+    if (!g) { g = []; g.key = x.part; g.items = g; groups[_k] = g; }
+    g.push(x);
+  }
+  let res = [];
+  for (const _k in groups) {
+    const g = groups[_k];
+    res.push({part: g.key, total: ((() => {
+  const _tmp2 = [];
+  for (const r of g) {
+    _tmp2.push(r.value);
+  }
+  let res = _tmp2;
+  return res;
+})()
+.reduce((a,b)=>a+b,0))});
+  }
+  return res;
+})()
+;
+console.log(grouped);

--- a/tests/machine/x/typescript/group_by_multi_join_sort.error
+++ b/tests/machine/x/typescript/group_by_multi_join_sort.error
@@ -1,2 +1,9 @@
-line 0: unsupported expression at line 9
-let nation = [
+line 0: run: exit status 1
+[0m[1m[31merror[0m: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'l_extendedprice')
+    _tmp1.push((x.l.l_extendedprice * ((1 - x.l.l_discount))));
+[0m[31m                    ^[0m
+    at [0m[36mfile:///workspace/mochi/tests/machine/x/typescript/group_by_multi_join_sort.ts[0m:[0m[33m31[0m:[0m[33m21[0m
+    at [0m[36mfile:///workspace/mochi/tests/machine/x/typescript/group_by_multi_join_sort.ts[0m:[0m[33m35[0m:[0m[33m2[0m
+    at [0m[36mfile:///workspace/mochi/tests/machine/x/typescript/group_by_multi_join_sort.ts[0m:[0m[33m48[0m:[0m[33m2[0m
+
+let nation = [{n_nationkey: 1, n_name: "BRAZIL"}];

--- a/tests/machine/x/typescript/group_by_multi_join_sort.ts
+++ b/tests/machine/x/typescript/group_by_multi_join_sort.ts
@@ -1,0 +1,50 @@
+let nation = [{n_nationkey: 1, n_name: "BRAZIL"}];
+let customer = [{c_custkey: 1, c_name: "Alice", c_acctbal: 100, c_nationkey: 1, c_address: "123 St", c_phone: "123-456", c_comment: "Loyal"}];
+let orders = [{o_orderkey: 1000, o_custkey: 1, o_orderdate: "1993-10-15"}, {o_orderkey: 2000, o_custkey: 1, o_orderdate: "1994-01-02"}];
+let lineitem = [{l_orderkey: 1000, l_returnflag: "R", l_extendedprice: 1000, l_discount: 0.1}, {l_orderkey: 2000, l_returnflag: "N", l_extendedprice: 500, l_discount: 0}];
+let start_date = "1993-10-01";
+let end_date = "1994-01-01";
+let result = (() => {
+  const groups = {};
+  for (const c of customer) {
+    for (const o of orders) {
+      if (!((o.o_custkey == c.c_custkey))) continue;
+      for (const l of lineitem) {
+        if (!((l.l_orderkey == o.o_orderkey))) continue;
+        for (const n of nation) {
+          if (!((n.n_nationkey == c.c_nationkey))) continue;
+          if (!((((((o.o_orderdate >= start_date) && o.o_orderdate) < end_date) && l.l_returnflag) == "R"))) continue;
+          const _k = JSON.stringify({c_custkey: c.c_custkey, c_name: c.c_name, c_acctbal: c.c_acctbal, c_address: c.c_address, c_phone: c.c_phone, c_comment: c.c_comment, n_name: n.n_name});
+          let g = groups[_k];
+          if (!g) { g = []; g.key = {c_custkey: c.c_custkey, c_name: c.c_name, c_acctbal: c.c_acctbal, c_address: c.c_address, c_phone: c.c_phone, c_comment: c.c_comment, n_name: n.n_name}; g.items = g; groups[_k] = g; }
+          g.push(c);
+        }
+      }
+    }
+  }
+  let res = [];
+  for (const _k in groups) {
+    const g = groups[_k];
+    res.push({item: {c_custkey: g.key.c_custkey, c_name: g.key.c_name, revenue: ((() => {
+  const _tmp1 = [];
+  for (const x of g) {
+    _tmp1.push((x.l.l_extendedprice * ((1 - x.l.l_discount))));
+  }
+  let res = _tmp1;
+  return res;
+})()
+.reduce((a,b)=>a+b,0)), c_acctbal: g.key.c_acctbal, n_name: g.key.n_name, c_address: g.key.c_address, c_phone: g.key.c_phone, c_comment: g.key.c_comment}, key: (-((() => {
+  const _tmp2 = [];
+  for (const x of g) {
+    _tmp2.push((x.l.l_extendedprice * ((1 - x.l.l_discount))));
+  }
+  let res = _tmp2;
+  return res;
+})()
+.reduce((a,b)=>a+b,0)))});
+  }
+  res = res.sort((a,b)=> a.key < b.key ? -1 : a.key > b.key ? 1 : 0).map(x=>x.item);
+  return res;
+})()
+;
+console.log(result);

--- a/tests/machine/x/typescript/inner_join.out
+++ b/tests/machine/x/typescript/inner_join.out
@@ -1,4 +1,3 @@
 --- Orders with customer info ---
 Order 100 by Alice - $ 250
-Order 101 by Bob - $ 125
-Order 102 by Alice - $ 300
+Order 101 by Bob - $ 125Order 102 by Alice - $ 300

--- a/tests/machine/x/typescript/join_multi.out
+++ b/tests/machine/x/typescript/join_multi.out
@@ -1,3 +1,2 @@
 --- Multi Join ---
-Alice bought item a
-Bob bought item b
+Alice bought item aBob bought item b

--- a/tests/machine/x/typescript/left_join.out
+++ b/tests/machine/x/typescript/left_join.out
@@ -1,2 +1,1 @@
---- Left Join ---
-Order 100 customer { id: 1, name: "Alice" } total 250
+--- Left Join ---Order 100 customer { id: 1, name: "Alice" } total 250

--- a/tests/machine/x/typescript/left_join_multi.out
+++ b/tests/machine/x/typescript/left_join_multi.out
@@ -1,2 +1,1 @@
---- Left Join Multi ---
-100 Alice { orderId: 100, sku: "a" }
+--- Left Join Multi ---100 Alice { orderId: 100, sku: "a" }

--- a/tests/machine/x/typescript/load_yaml.error
+++ b/tests/machine/x/typescript/load_yaml.error
@@ -1,2 +1,2 @@
-line 0: unsupported expression at line 7
+line 0: open /workspace/mochi/tests/vm/interpreter/valid/people.yaml: no such file or directory
 type Person {

--- a/tests/machine/x/typescript/outer_join.out
+++ b/tests/machine/x/typescript/outer_join.out
@@ -1,4 +1,3 @@
 --- Outer Join using syntax ---
 Order 100 by Alice - $ 250
-Order 101 by Bob - $ 125
-Order 102 by Alice - $ 300
+Order 101 by Bob - $ 125Order 102 by Alice - $ 300

--- a/tests/machine/x/typescript/right_join.out
+++ b/tests/machine/x/typescript/right_join.out
@@ -1,4 +1,3 @@
 --- Right Join using syntax ---
 Customer Alice has order 100 - $ 250
-Customer Alice has order 102 - $ 300
-Customer Bob has order 101 - $ 125
+Customer Alice has order 102 - $ 300Customer Bob has order 101 - $ 125

--- a/tests/machine/x/typescript/save_jsonl_stdout.error
+++ b/tests/machine/x/typescript/save_jsonl_stdout.error
@@ -1,2 +1,0 @@
-line 0: unsupported expression at line 6
-let people = [

--- a/tests/machine/x/typescript/save_jsonl_stdout.out
+++ b/tests/machine/x/typescript/save_jsonl_stdout.out
@@ -1,0 +1,2 @@
+{"name":"Alice","age":30}
+{"name":"Bob","age":25}

--- a/tests/machine/x/typescript/save_jsonl_stdout.ts
+++ b/tests/machine/x/typescript/save_jsonl_stdout.ts
@@ -1,0 +1,6 @@
+let people = [{name: "Alice", age: 30}, {name: "Bob", age: 25}];
+(() => {
+  for (const _tmp1 of people) {
+    console.log(JSON.stringify(_tmp1));
+  }
+})();

--- a/tests/machine/x/typescript/tree_sum.error
+++ b/tests/machine/x/typescript/tree_sum.error
@@ -1,2 +1,7 @@
-line 0: unsupported type declaration
-// tree.mochi
+line 0: run: exit status 1
+[0m[1m[31merror[0m: Uncaught (in promise) ReferenceError: Leaf is not defined
+let t = {left: Leaf, value: 1, right: {left: Leaf, value: 2, right: Leaf}};
+[0m[31m               ^[0m
+    at [0m[36mfile:///workspace/mochi/tests/machine/x/typescript/tree_sum.ts[0m:[0m[33m21[0m:[0m[33m16[0m
+
+type Tree = { kind: "leaf" } | { kind: "node"; left: any; value: any; right: any };

--- a/tests/machine/x/typescript/tree_sum.ts
+++ b/tests/machine/x/typescript/tree_sum.ts
@@ -1,0 +1,22 @@
+type Tree = { kind: "leaf" } | { kind: "node"; left: any; value: any; right: any };
+function sum_tree(t) {
+  return (() => {
+  const _tmp1 = t;
+  let _res;
+  switch (_tmp1) {
+    case Leaf:
+      _res = 0;
+      break;
+    case Node(left, value, right):
+      _res = ((sum_tree(left) + value) + sum_tree(right));
+      break;
+    default:
+      _res = undefined;
+      break;
+  }
+  return _res;
+})()
+;
+}
+let t = {left: Leaf, value: 1, right: {left: Leaf, value: 2, right: Leaf}};
+console.log(sum_tree(t));

--- a/tests/machine/x/typescript/update_stmt.error
+++ b/tests/machine/x/typescript/update_stmt.error
@@ -1,2 +1,5 @@
-line 0: unsupported statement at line 14
-type Person {
+line 0: run: exit status 1
+[0m[1m[31merror[0m: Uncaught (in promise) Error: update adult status failed
+    at [0m[36mfile:///workspace/mochi/tests/machine/x/typescript/update_stmt.ts[0m:[0m[33m13[0m:[0m[33m202[0m
+
+type Person = { name: any; age: any; status: any; };

--- a/tests/machine/x/typescript/update_stmt.ts
+++ b/tests/machine/x/typescript/update_stmt.ts
@@ -1,0 +1,14 @@
+type Person = { name: any; age: any; status: any; };
+let people = [{name: "Alice", age: 17, status: "minor"}, {name: "Bob", age: 25, status: "unknown"}, {name: "Charlie", age: 18, status: "unknown"}, {name: "Diana", age: 16, status: "minor"}];
+for (let i = 0; i < people.length; i++) {
+  let _tmp1 = people[i];
+  let status = _tmp1.status;
+  let age = _tmp1.age;
+  if ((age >= 18)) {
+    _tmp1.status = "adult";
+    _tmp1.age = (age + 1);
+  }
+  people[i] = _tmp1;
+}
+if (!((people == [{name: "Alice", age: 17, status: "minor"}, {name: "Bob", age: 26, status: "adult"}, {name: "Charlie", age: 19, status: "adult"}, {name: "Diana", age: 16, status: "minor"}]))) { throw new Error("update adult status failed"); }
+console.log("ok");


### PR DESCRIPTION
## Summary
- regenerate machine output for the TypeScript backend
- mark programs that failed to compile or run

## Testing
- `go test ./compiler/x/typescript -tags slow -run TestCompilePrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686e275ed9908320b099d116bd245bd5