### PR TITLE
Improve Haskell compiler print handling

### DIFF
--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -1265,7 +1265,7 @@ func (c *Compiler) compilePrint(ca callArgs) (string, error) {
 		if strings.HasPrefix(a, "\"") || strings.HasPrefix(a, "_indexString") || c.isStringExpr(ca.exprs[i]) {
 			parts[i] = a
 		} else {
-			parts[i] = fmt.Sprintf("show %s", a)
+			parts[i] = fmt.Sprintf("show (%s)", a)
 		}
 	}
 	return fmt.Sprintf("putStrLn (unwords [%s])", strings.Join(parts, ", ")), nil


### PR DESCRIPTION
## Summary
- fix the Haskell compiler `compilePrint` function to wrap non-string
  arguments with parentheses before applying `show`

## Testing
- `go test -tags slow ./compiler/x/hs -run 'TestHSCompiler_ValidPrograms/print_hello$' -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e32f6372c8320bef405d75ea89d5c