### PR TITLE
Add break/continue to Smalltalk compiler

### DIFF
--- a/tests/machine/x/st/README.md
+++ b/tests/machine/x/st/README.md
@@ -1,4 +1,4 @@
-# Mochi to Smalltalk Machine Outputs (82/97 compiled)
+# Mochi to Smalltalk Machine Outputs (83/97 compiled)
 
 This directory contains Smalltalk source code generated from the Mochi programs in `tests/vm/valid`. A checkbox indicates the program compiled and executed successfully during tests. Because the `gst` interpreter is not available, all programs currently fail at runtime.
 
@@ -8,7 +8,7 @@ This directory contains Smalltalk source code generated from the Mochi programs 
 - [x] basic_compare.mochi
 - [x] binary_precedence.mochi
 - [x] bool_chain.mochi
-- [ ] break_continue.mochi
+- [x] break_continue.mochi
 - [x] cast_string_to_int.mochi
 - [x] cast_struct.mochi
 - [x] closure.mochi

--- a/tests/machine/x/st/break_continue.error
+++ b/tests/machine/x/st/break_continue.error
@@ -1,7 +1,2 @@
-line: 5
-error: unsupported statement at line 5
-   3: for n in numbers {
-   4:   if n % 2 == 0 {
-   5:     continue
-   6:   }
-   7:   if n > 7 {
+line: 0
+error: gst interpreter not available

--- a/tests/machine/x/st/break_continue.st
+++ b/tests/machine/x/st/break_continue.st
@@ -1,0 +1,17 @@
+| numbers n |
+Object subclass: #BreakSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!.
+Object subclass: #ContinueSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!.
+numbers := {1. 2. 3. 4. 5. 6. 7. 8. 9}.
+[.
+numbers do: [:n |.
+[.
+(((n % 2) = 0)) ifTrue: [
+ContinueSignal signal.
+].
+((n > 7)) ifTrue: [
+BreakSignal signal.
+].
+Transcript show: 'odd number:'; show: ' '; show: (n) printString; cr.
+] on: ContinueSignal do: [:ex | ].
+].
+] on: BreakSignal do: [:ex | ].


### PR DESCRIPTION
## Summary
- extend the Smalltalk (st) compiler with break/continue support
- regenerate machine outputs for break_continue program
- update checklist to mark the program compiled

## Testing
- `go test ./compiler/x/st -tags=slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e3313932483209d8a5f5f11ef26c5