### PR TITLE
Improve Pascal compiler variable inference

### DIFF
--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -962,7 +962,7 @@ func collectVars(stmts []*parser.Statement, env *types.Env, vars map[string]stri
 				typ = typeString(resolveSimpleTypeRef(s.Let.Type))
 			}
 			if typ == "integer" && s.Let.Value != nil {
-				typT := types.TypeOfExpr(s.Let.Value, env)
+				typT := types.TypeOfExprBasic(s.Let.Value, env)
 				typ = typeString(typT)
 				if typ == "integer" && isStringSliceExpr(s.Let.Value, env, vars) {
 					typ = "string"
@@ -987,7 +987,7 @@ func collectVars(stmts []*parser.Statement, env *types.Env, vars map[string]stri
 				typ = typeString(resolveSimpleTypeRef(s.Var.Type))
 			}
 			if typ == "integer" && s.Var.Value != nil {
-				typT := types.TypeOfExpr(s.Var.Value, env)
+				typT := types.TypeOfExprBasic(s.Var.Value, env)
 				typ = typeString(typT)
 				if typ == "integer" && isStringSliceExpr(s.Var.Value, env, vars) {
 					typ = "string"
@@ -1011,7 +1011,7 @@ func collectVars(stmts []*parser.Statement, env *types.Env, vars map[string]stri
 					}
 				}
 				if typ == "integer" {
-					typT := types.TypeOfExpr(s.For.Source, env)
+					typT := types.TypeOfExprBasic(s.For.Source, env)
 					typ = typeString(typT)
 				}
 				if strings.HasPrefix(typ, "specialize TArray<") {


### PR DESCRIPTION
## Summary
- use `types.TypeOfExprBasic` in Pascal compiler when inferring types for `let`, `var`, and `for` statements

## Testing
- `go test ./compiler/x/pascal -run TestCompileValidPrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e33032a3c832098c0ab2171695fc0