### PR TITLE
Fix Go compiler boolean condition casting

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -1062,6 +1062,10 @@ func (c *Compiler) compileWhile(stmt *parser.WhileStmt) error {
 	if err != nil {
 		return err
 	}
+	ct := c.inferExprType(stmt.Cond)
+	if !isBool(ct) {
+		cond = c.castExpr(cond, ct, types.BoolType{})
+	}
 	c.writeIndent()
 	c.buf.WriteString("if !(" + cond + ") {\n")
 	c.indent++
@@ -2390,6 +2394,10 @@ func (c *Compiler) compileIfExpr(ie *parser.IfExpr) (string, error) {
 	cond, err := c.compileExpr(ie.Cond)
 	if err != nil {
 		return "", err
+	}
+	ct := c.inferExprType(ie.Cond)
+	if !isBool(ct) {
+		cond = c.castExpr(cond, ct, types.BoolType{})
 	}
 	thenExpr, err := c.compileExpr(ie.Then)
 	if err != nil {


### PR DESCRIPTION
## Summary
- ensure conditions are boolean in `compileIfExpr` and `compileWhile`

## Testing
- `go test ./...`
- `go test -tags slow -run TestGoCompiler_ValidPrograms/dataset_where_filter -v -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e329f3a248320a380ca5218bc6094