### PR TITLE
Improve C backend variable initialization

### DIFF
--- a/tests/machine/x/c/typed_let.c
+++ b/tests/machine/x/c/typed_let.c
@@ -12,7 +12,7 @@ static list_int list_int_create(int len) {
   return l;
 }
 int main() {
-  int y;
+  int y = 0;
   printf("%d\n", y);
   return 0;
 }

--- a/tests/machine/x/c/typed_let.error
+++ b/tests/machine/x/c/typed_let.error
@@ -1,7 +1,7 @@
 line: 0
 error: output mismatch
 -- got --
-32766
+0
 -- want --
 <nil>
    1: #include <stdio.h>

--- a/tests/machine/x/c/typed_var.c
+++ b/tests/machine/x/c/typed_var.c
@@ -12,7 +12,7 @@ static list_int list_int_create(int len) {
   return l;
 }
 int main() {
-  int x;
+  int x = 0;
   printf("%d\n", x);
   return 0;
 }

--- a/tests/machine/x/c/typed_var.error
+++ b/tests/machine/x/c/typed_var.error
@@ -1,7 +1,7 @@
 line: 0
 error: output mismatch
 -- got --
-32767
+0
 -- want --
 <nil>
    1: #include <stdio.h>


### PR DESCRIPTION
## Summary
- initialize `let` and `var` declarations with a zero value
- update machine generated C for typed variable tests

## Testing
- `go test -tags slow -run TestCCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e375c47b8832099f463a3aa22059d