### PR TITLE
Reduce TypeScript avg helper

### DIFF
--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -1726,6 +1726,8 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		return fmt.Sprintf("_exists(%s)", argStr), nil
 	case "avg":
 		c.use("_avg")
+		c.use("_count")
+		c.use("_sum")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
 	case "reduce":
 		if len(args) != 3 {

--- a/compiler/x/ts/runtime.go
+++ b/compiler/x/ts/runtime.go
@@ -53,16 +53,8 @@ const (
 		"}\n"
 
 	helperAvg = "function _avg(v: any): number {\n" +
-		"  let list: any[] | null = null;\n" +
-		"  if (Array.isArray(v)) list = v;\n" +
-		"  else if (v && typeof v === 'object') {\n" +
-		"    if (Array.isArray((v as any).items)) list = (v as any).items;\n" +
-		"    else if (Array.isArray((v as any).Items)) list = (v as any).Items;\n" +
-		"  }\n" +
-		"  if (!list || list.length === 0) return 0;\n" +
-		"  let sum = 0;\n" +
-		"  for (const n of list) sum += Number(n);\n" +
-		"  return sum / list.length;\n" +
+		"  const c = _count(v);\n" +
+		"  return c ? _sum(v) / c : 0;\n" +
 		"}\n"
 
 	helperReduce = "function _reduce(src: any[], fn: (a: any, b: any) => any, acc: any): any {\n" +


### PR DESCRIPTION
## Summary
- simplify `_avg` helper in TypeScript runtime
- ensure the compiler includes `_count` and `_sum` when emitting `_avg`

## Testing
- `go test ./compiler/x/ts -tags slow -run TestTSCompiler_SubsetPrograms/avg_builtin -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e38e65740832083e4be77aeb957fc