### PR TITLE
Improve COBOL compiler print handling

### DIFF
--- a/compiler/x/cobol/compiler.go
+++ b/compiler/x/cobol/compiler.go
@@ -420,7 +420,7 @@ func (c *Compiler) compilePrint(call *parser.CallExpr) error {
 		if err != nil {
 			return err
 		}
-		if isSimpleExpr(arg) {
+		if isSimpleExpr(arg) || types.IsStringType(types.TypeOfExpr(arg, c.env)) {
 			c.writeln(fmt.Sprintf("DISPLAY %s", expr))
 			return nil
 		}

--- a/tests/machine/x/cobol/README.md
+++ b/tests/machine/x/cobol/README.md
@@ -1,4 +1,4 @@
-# Mochi to COBOL Machine Translations (24/97 compiled)
+# Mochi to COBOL Machine Translations (25/97 compiled)
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -78,7 +78,7 @@
 - [ ] sort_stable.mochi
  - [x] str_builtin.mochi
 - [x] string_compare.mochi
-- [ ] string_concat.mochi
+- [x] string_concat.mochi
 - [ ] string_contains.mochi
 - [ ] string_in_operator.mochi
 - [ ] string_index.mochi


### PR DESCRIPTION
## Summary
- update COBOL compiler to print complex string expressions directly
- refresh machine translation checklist for COBOL

## Testing
- `go test ./...`
- `go test ./compiler/x/cobol -tags slow -run TestCobolCompiler_Programs/string_concat -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e3ba0df3c8320ad0e2352eadc0c1c