### PR TITLE
Fix struct 'in' operator for Ruby compiler

### DIFF
--- a/compiler/x/rb/compiler.go
+++ b/compiler/x/rb/compiler.go
@@ -1265,7 +1265,7 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 			var expr string
 			switch op {
 			case "in":
-				if types.IsMapType(rt) {
+				if types.IsMapType(rt) || types.IsStructType(rt) {
 					expr = fmt.Sprintf("(%s.to_h.key?(%s))", r, l)
 				} else {
 					expr = fmt.Sprintf("(%s.include?(%s))", r, l)

--- a/types/infer.go
+++ b/types/infer.go
@@ -926,6 +926,9 @@ func TypeOfPrimaryBasic(p *parser.Primary, env *Env) Type {
 // IsListType reports whether t is a list type.
 func IsListType(t Type) bool { return isList(t) }
 
+// IsStructType reports whether t is a struct type.
+func IsStructType(t Type) bool { _, ok := t.(StructType); return ok }
+
 // IsMapType reports whether t is a map type.
 func IsMapType(t Type) bool { _, ok := t.(MapType); return ok }
 


### PR DESCRIPTION
## Summary
- add helper to check struct types
- handle `in` operator for structs in Ruby compiler

## Testing
- `go test ./compiler/x/rb -run '^TestCompileValidPrograms$/in_operator_extended$' -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686e3b4080208320acf1b457393a0474