### PR TITLE
Improve Haskell build tooling

### DIFF
--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -1543,7 +1543,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			res = fmt.Sprintf("drop %s %s", sk, res)
+			res = fmt.Sprintf("drop %s (%s)", sk, res)
 			c.usesList = true
 		}
 		if q.Take != nil {
@@ -1551,7 +1551,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			res = fmt.Sprintf("take %s %s", tk, res)
+			res = fmt.Sprintf("take %s (%s)", tk, res)
 			c.usesList = true
 		}
 		c.usesMap = true
@@ -1581,7 +1581,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		res = fmt.Sprintf("drop %s %s", sk, res)
+		res = fmt.Sprintf("drop %s (%s)", sk, res)
 		c.usesList = true
 	}
 	if q.Take != nil {
@@ -1589,7 +1589,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		res = fmt.Sprintf("take %s %s", tk, res)
+		res = fmt.Sprintf("take %s (%s)", tk, res)
 		c.usesList = true
 	}
 	return res, nil

--- a/compiler/x/hs/tools.go
+++ b/compiler/x/hs/tools.go
@@ -80,7 +80,7 @@ func EnsureHaskell() error {
 			if err := cmd.Run(); err != nil {
 				return err
 			}
-			cmd = exec.Command("apt-get", "install", "-y", "ghc")
+			cmd = exec.Command("apt-get", "install", "-y", "ghc", "libghc-aeson-dev")
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err == nil {


### PR DESCRIPTION
## Summary
- install Aeson library along with ghc
- ensure query `skip`/`take` code uses parentheses

## Testing
- `gofmt -w compiler/x/hs/tools.go`
- `gofmt -w compiler/x/hs/compiler.go`
- `go test -tags slow ./compiler/x/hs -run TestHSCompiler_ValidPrograms/cross_join -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e412ff3908320ae837ea4cbd7c2f4