### PR TITLE
Improve Lua compiler formatting

### DIFF
--- a/compiler/x/lua/compiler.go
+++ b/compiler/x/lua/compiler.go
@@ -123,6 +123,9 @@ func contains(list []string, s string) bool {
 }
 
 func checkLuaSyntax(code []byte) error {
+	if os.Getenv("MOCHI_SKIP_LUA_SYNTAX") == "1" {
+		return nil
+	}
 	if _, err := exec.LookPath("luac"); err != nil {
 		return nil
 	}

--- a/compiler/x/lua/tools.go
+++ b/compiler/x/lua/tools.go
@@ -180,7 +180,7 @@ func FormatLua(src []byte) []byte {
 		}
 	}
 	if path, err := exec.LookPath("luafmt"); err == nil {
-		cmd := exec.Command(path, "--stdin", "--indent-count", "4")
+		cmd := exec.Command(path, "--stdin", "--indent-count", "2")
 		cmd.Stdin = bytes.NewReader(src)
 		var out bytes.Buffer
 		cmd.Stdout = &out
@@ -192,7 +192,7 @@ func FormatLua(src []byte) []byte {
 			return res
 		}
 	}
-	src = bytes.ReplaceAll(src, []byte("\t"), []byte("    "))
+	src = bytes.ReplaceAll(src, []byte("\t"), []byte("  "))
 	if len(src) > 0 && src[len(src)-1] != '\n' {
 		src = append(src, '\n')
 	}

--- a/tests/machine/x/lua/README.md
+++ b/tests/machine/x/lua/README.md
@@ -1,109 +1,105 @@
-# Lua Machine Output
+# Lua Machine Translations
 
-This directory contains Lua source code generated from Mochi programs and the corresponding outputs or error information.
+This directory stores Lua code generated from the Mochi programs in `tests/vm/valid`.
+Each program was compiled and executed using the Lua compiler. Successful runs produce a `.out` file, while failures have a `.error` file.
 
-## Summary
+Compiled programs: 86/97
 
-- 86/97 programs compiled and executed successfully.
-- 11 programs failed to compile or run.
-
-### Successful
-append_builtin
-avg_builtin
-basic_compare
-binary_precedence
-bool_chain
-break_continue
-cast_string_to_int
-cast_struct
-closure
-count_builtin
-cross_join
-cross_join_filter
-cross_join_triple
-dataset_sort_take_limit
-dataset_where_filter
-exists_builtin
-for_list_collection
-for_loop
-for_map_collection
-fun_call
-fun_expr_in_let
-fun_three_args
-group_by
-group_by_having
-group_by_join
-group_by_left_join
-if_else
-if_then_else
-if_then_else_nested
-in_operator
-in_operator_extended
-inner_join
-join_multi
-json_builtin
-left_join
-left_join_multi
-len_builtin
-len_map
-len_string
-let_and_print
-list_assign
-list_index
-list_nested_assign
-map_assign
-map_in_operator
-map_index
-map_int_key
-map_literal_dynamic
-map_membership
-map_nested_assign
-match_expr
-match_full
-math_ops
-membership
-min_max_builtin
-nested_function
-outer_join
-partial_application
-print_hello
-pure_fold
-pure_global_fold
-query_sum_select
-record_assign
-right_join
-save_jsonl_stdout
-short_circuit
-str_builtin
-string_compare
-string_concat
-string_contains
-string_in_operator
-string_index
-string_prefix_slice
-substring_builtin
-sum_builtin
-tail_recursion
-test_block
-two-sum
-typed_let
-typed_var
-unary_neg
-update_stmt
-user_type_literal
-values_builtin
-var_assignment
-while_loop
-
-### Failed
-group_by_conditional_sum
-group_by_multi_join
-group_by_multi_join_sort
-group_by_sort
-group_items_iteration
-list_set_ops
-load_yaml
-order_by_map
-slice
-sort_stable
-tree_sum
+Checklist:
+- [x] append_builtin
+- [x] avg_builtin
+- [x] basic_compare
+- [x] binary_precedence
+- [x] bool_chain
+- [x] break_continue
+- [x] cast_string_to_int
+- [x] cast_struct
+- [x] closure
+- [x] count_builtin
+- [x] cross_join
+- [x] cross_join_filter
+- [x] cross_join_triple
+- [x] dataset_sort_take_limit
+- [x] dataset_where_filter
+- [x] exists_builtin
+- [x] for_list_collection
+- [x] for_loop
+- [x] for_map_collection
+- [x] fun_call
+- [x] fun_expr_in_let
+- [x] fun_three_args
+- [x] group_by
+- [x] group_by_having
+- [x] group_by_join
+- [x] group_by_left_join
+- [x] if_else
+- [x] if_then_else
+- [x] if_then_else_nested
+- [x] in_operator
+- [x] in_operator_extended
+- [x] inner_join
+- [x] join_multi
+- [x] json_builtin
+- [x] left_join
+- [x] left_join_multi
+- [x] len_builtin
+- [x] len_map
+- [x] len_string
+- [x] let_and_print
+- [x] list_assign
+- [x] list_index
+- [x] list_nested_assign
+- [x] map_assign
+- [x] map_in_operator
+- [x] map_index
+- [x] map_int_key
+- [x] map_literal_dynamic
+- [x] map_membership
+- [x] map_nested_assign
+- [x] match_expr
+- [x] match_full
+- [x] math_ops
+- [x] membership
+- [x] min_max_builtin
+- [x] nested_function
+- [x] outer_join
+- [x] partial_application
+- [x] print_hello
+- [x] pure_fold
+- [x] pure_global_fold
+- [x] query_sum_select
+- [x] record_assign
+- [x] right_join
+- [x] save_jsonl_stdout
+- [x] short_circuit
+- [x] str_builtin
+- [x] string_compare
+- [x] string_concat
+- [x] string_contains
+- [x] string_in_operator
+- [x] string_index
+- [x] string_prefix_slice
+- [x] substring_builtin
+- [x] sum_builtin
+- [x] tail_recursion
+- [x] test_block
+- [x] two-sum
+- [x] typed_let
+- [x] typed_var
+- [x] unary_neg
+- [x] update_stmt
+- [x] user_type_literal
+- [x] values_builtin
+- [x] var_assignment
+- [x] while_loop
+- [ ] group_by_conditional_sum
+- [ ] group_by_multi_join
+- [ ] group_by_multi_join_sort
+- [ ] group_by_sort
+- [ ] group_items_iteration
+- [ ] list_set_ops
+- [ ] load_yaml
+- [ ] order_by_map
+- [ ] slice
+- [ ] sort_stable
+- [ ] tree_sum


### PR DESCRIPTION
## Summary
- tweak Lua formatter to use two space indentation by default
- allow skipping `luac` syntax check via `MOCHI_SKIP_LUA_SYNTAX`
- regenerate Lua machine README with checkbox checklist

## Testing
- `go vet ./...`
- `go test ./compiler/x/lua -tags slow -run TestLuaCompiler_ValidPrograms -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_686e44cb97d883209567766eac970e61