### PR TITLE
Improve Lua compiler tool lookup

### DIFF
--- a/compiler/x/lua/compiler.go
+++ b/compiler/x/lua/compiler.go
@@ -126,8 +126,13 @@ func checkLuaSyntax(code []byte) error {
 	if os.Getenv("MOCHI_SKIP_LUA_SYNTAX") == "1" {
 		return nil
 	}
-	if _, err := exec.LookPath("luac"); err != nil {
-		return nil
+	luac := os.Getenv("MOCHI_LUAC")
+	if luac == "" {
+		if path, err := exec.LookPath("luac"); err == nil {
+			luac = path
+		} else {
+			return nil
+		}
 	}
 	tmp, err := os.CreateTemp("", "mochi_*.lua")
 	if err != nil {
@@ -139,7 +144,7 @@ func checkLuaSyntax(code []byte) error {
 		return err
 	}
 	tmp.Close()
-	cmd := exec.Command("luac", "-p", tmp.Name())
+	cmd := exec.Command(luac, "-p", tmp.Name())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("luac error: %v\n%s", err, out)
 	}

--- a/tests/machine/x/lua/README.md
+++ b/tests/machine/x/lua/README.md
@@ -5,6 +5,9 @@ Each program was compiled and executed using the Lua compiler. Successful runs p
 
 Compiled programs: 86/97
 
+Set `MOCHI_LUAC` to the path of the Lua bytecode compiler if `luac` is not on
+the PATH. The compiler uses this tool for a basic syntax check.
+
 Checklist:
 - [x] append_builtin
 - [x] avg_builtin


### PR DESCRIPTION
## Summary
- make Lua syntax checker configurable via `MOCHI_LUAC`
- document `MOCHI_LUAC` environment variable used during tests

## Testing
- `gofmt -w compiler/x/lua/compiler.go`


------
https://chatgpt.com/codex/tasks/task_e_686e488a51848320a40443e5135b4740