### PR TITLE
Add Smalltalk group-by support

### DIFF
--- a/tests/machine/x/st/README.md
+++ b/tests/machine/x/st/README.md
@@ -1,4 +1,4 @@
-# Mochi to Smalltalk Machine Outputs (83/97 compiled)
+# Mochi to Smalltalk Machine Outputs (86/97 compiled)
 
 This directory contains Smalltalk source code generated from the Mochi programs in `tests/vm/valid`. A checkbox indicates the program compiled and executed successfully during tests. Because the `gst` interpreter is not available, all programs currently fail at runtime.
 
@@ -102,7 +102,7 @@ This directory contains Smalltalk source code generated from the Mochi programs 
 - [ ] update_stmt.mochi
 
 ## TODO
-- [ ] implement query joins and grouping
+- [ ] implement query joins
 - [ ] handle load/save expressions
 - [ ] support update statements
 - [ ] support test blocks

--- a/tests/machine/x/st/group_by.error
+++ b/tests/machine/x/st/group_by.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: gst interpreter not available

--- a/tests/machine/x/st/group_by.st
+++ b/tests/machine/x/st/group_by.st
@@ -1,0 +1,28 @@
+| people stats s |
+people := {Dictionary newFrom: {name -> 'Alice'. age -> 30. city -> 'Paris'}. Dictionary newFrom: {name -> 'Bob'. age -> 15. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Charlie'. age -> 65. city -> 'Paris'}. Dictionary newFrom: {name -> 'Diana'. age -> 45. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Eve'. age -> 70. city -> 'Paris'}. Dictionary newFrom: {name -> 'Frank'. age -> 22. city -> 'Hanoi'}}.
+stats := [ | groups tmp |
+  groups := Dictionary new.
+  tmp := OrderedCollection new.
+  people do: [:person |
+    | g |
+    g := groups at: person.city ifAbsentPut:[OrderedCollection new].
+    g add: Dictionary newFrom: {#person->person}.
+  ].
+  groups keysAndValuesDo: [:k :grp |
+    | g |
+    g := Dictionary newFrom:{#key->k. #items->grp}.
+    tmp add: Dictionary newFrom: {city -> g.key. count -> (g size). avg_age -> avg value: [ | tmp |
+  tmp := OrderedCollection new.
+  g do: [:p |
+    tmp add: p.age.
+  ].
+  tmp
+] value}.
+  ].
+  tmp
+] value.
+Transcript show: ('--- People grouped by city ---') printString; cr.
+stats do: [:s |.
+Transcript show: (s at: 'city') printString; show: ' '; show: ': count ='; show: ' '; show: (s at: 'count') printString; show: ' '; show: ', avg_age ='; show: ' '; show: (s at: 'avg_age') printString; cr.
+].
+.

--- a/tests/machine/x/st/group_by_conditional_sum.error
+++ b/tests/machine/x/st/group_by_conditional_sum.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: gst interpreter not available

--- a/tests/machine/x/st/group_by_conditional_sum.st
+++ b/tests/machine/x/st/group_by_conditional_sum.st
@@ -1,0 +1,31 @@
+| items result |
+items := {Dictionary newFrom: {cat -> 'a'. val -> 10. flag -> true}. Dictionary newFrom: {cat -> 'a'. val -> 5. flag -> false}. Dictionary newFrom: {cat -> 'b'. val -> 20. flag -> true}}.
+result := [ | groups tmp |
+  groups := Dictionary new.
+  tmp := OrderedCollection new.
+  items do: [:i |
+    | g |
+    g := groups at: i.cat ifAbsentPut:[OrderedCollection new].
+    g add: Dictionary newFrom: {#i->i}.
+  ].
+  groups keysAndValuesDo: [:k :grp |
+    | g |
+    g := Dictionary newFrom:{#key->k. #items->grp}.
+    tmp add: Dictionary newFrom: {cat -> g.key. share -> (([ | tmp |
+  tmp := OrderedCollection new.
+  g do: [:x |
+    tmp add: (x.flag) ifTrue: [x.val] ifFalse: [0].
+  ].
+  tmp
+] value inject: 0 into: [:s :x | s + x]) / ([ | tmp |
+  tmp := OrderedCollection new.
+  g do: [:x |
+    tmp add: x.val.
+  ].
+  tmp
+] value inject: 0 into: [:s :x | s + x]))}.
+  ].
+  tmp := tmp asSortedCollection: [:a :b | g.key < g.key].
+  tmp
+] value.
+Transcript show: (result) printString; cr.

--- a/tests/machine/x/st/group_by_having.error
+++ b/tests/machine/x/st/group_by_having.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: gst interpreter not available

--- a/tests/machine/x/st/group_by_having.st
+++ b/tests/machine/x/st/group_by_having.st
@@ -1,0 +1,18 @@
+| people big |
+people := {Dictionary newFrom: {name -> 'Alice'. city -> 'Paris'}. Dictionary newFrom: {name -> 'Bob'. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Charlie'. city -> 'Paris'}. Dictionary newFrom: {name -> 'Diana'. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Eve'. city -> 'Paris'}. Dictionary newFrom: {name -> 'Frank'. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'George'. city -> 'Paris'}}.
+big := [ | groups tmp |
+  groups := Dictionary new.
+  tmp := OrderedCollection new.
+  people do: [:p |
+    | g |
+    g := groups at: p.city ifAbsentPut:[OrderedCollection new].
+    g add: Dictionary newFrom: {#p->p}.
+  ].
+  groups keysAndValuesDo: [:k :grp |
+    | g |
+    g := Dictionary newFrom:{#key->k. #items->grp}.
+    tmp add: Dictionary newFrom: {city -> g.key. num -> (g size)}.
+  ].
+  tmp
+] value.
+json value: big.

--- a/tests/machine/x/st/group_by_join.error
+++ b/tests/machine/x/st/group_by_join.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: join clauses not supported

--- a/tests/machine/x/st/group_by_left_join.error
+++ b/tests/machine/x/st/group_by_left_join.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: join clauses not supported

--- a/tests/machine/x/st/group_by_multi_join.error
+++ b/tests/machine/x/st/group_by_multi_join.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: join clauses not supported

--- a/tests/machine/x/st/group_by_multi_join_sort.error
+++ b/tests/machine/x/st/group_by_multi_join_sort.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: join clauses not supported

--- a/tests/machine/x/st/group_by_sort.error
+++ b/tests/machine/x/st/group_by_sort.error
@@ -1,2 +1,2 @@
 line: 0
-error: query features not supported
+error: gst interpreter not available

--- a/tests/machine/x/st/group_by_sort.st
+++ b/tests/machine/x/st/group_by_sort.st
@@ -1,0 +1,37 @@
+| grouped items |
+items := {Dictionary newFrom: {cat -> 'a'. val -> 3}. Dictionary newFrom: {cat -> 'a'. val -> 1}. Dictionary newFrom: {cat -> 'b'. val -> 5}. Dictionary newFrom: {cat -> 'b'. val -> 2}}.
+grouped := [ | groups tmp |
+  groups := Dictionary new.
+  tmp := OrderedCollection new.
+  items do: [:i |
+    | g |
+    g := groups at: i.cat ifAbsentPut:[OrderedCollection new].
+    g add: Dictionary newFrom: {#i->i}.
+  ].
+  groups keysAndValuesDo: [:k :grp |
+    | g |
+    g := Dictionary newFrom:{#key->k. #items->grp}.
+    tmp add: Dictionary newFrom: {cat -> g.key. total -> ([ | tmp |
+  tmp := OrderedCollection new.
+  g do: [:x |
+    tmp add: x.val.
+  ].
+  tmp
+] value inject: 0 into: [:s :x | s + x])}.
+  ].
+  tmp := tmp asSortedCollection: [:a :b | -([ | tmp |
+  tmp := OrderedCollectaon new.
+  g do: [:x |
+    tmp add: x.val.
+  ].
+  tmp
+] value anject: 0 anto: [:s :x | s + x]) < -([ | tmp |
+  tmp := OrderedCollectbon new.
+  g do: [:x |
+    tmp add: x.val.
+  ].
+  tmp
+] value bnject: 0 bnto: [:s :x | s + x])].
+  tmp
+] value.
+Transcript show: (grouped) printString; cr.

--- a/tests/machine/x/st/load_yaml.st
+++ b/tests/machine/x/st/load_yaml.st
@@ -1,0 +1,15 @@
+| people adults a |
+people := load value: "../interpreter/valid/people.yaml" value: Dictionary newFrom: {format -> 'yaml'}.
+adults := [ | tmp |
+  tmp := OrderedCollection new.
+  people do: [:p |
+    ((p.age >= 18)) ifTrue: [
+      tmp add: Dictionary newFrom: {name -> p.name. email -> p.email}.
+    ].
+  ].
+  tmp
+] value.
+adults do: [:a |.
+Transcript show: (a at: 'name') printString; show: ' '; show: (a at: 'email') printString; cr.
+].
+.

--- a/tests/machine/x/st/save_jsonl_stdout.st
+++ b/tests/machine/x/st/save_jsonl_stdout.st
@@ -1,0 +1,3 @@
+| people |
+people := {Dictionary newFrom: {name -> 'Alice'. age -> 30}. Dictionary newFrom: {name -> 'Bob'. age -> 25}}.
+save value: people value: "-" value: Dictionary newFrom: {format -> 'jsonl'}.

--- a/tests/machine/x/st/test_block.st
+++ b/tests/machine/x/st/test_block.st
@@ -1,0 +1,3 @@
+x := (1 + 2).
+((x = 3)) ifTrue: [Transcript show:'ok'; cr] ifFalse: [Transcript show:'fail'; cr].
+Transcript show: ('ok') printString; cr.

--- a/tests/machine/x/st/update_stmt.st
+++ b/tests/machine/x/st/update_stmt.st
@@ -1,0 +1,10 @@
+| people |
+people := {Dictionary newFrom: {#name->'Alice'. #age->17. #status->'minor'}. Dictionary newFrom: {#name->'Bob'. #age->25. #status->'unknown'}. Dictionary newFrom: {#name->'Charlie'. #age->18. #status->'unknown'}. Dictionary newFrom: {#name->'Diana'. #age->16. #status->'minor'}}.
+people do: [:it |.
+((age >= 18)) ifTrue: [.
+it at: 'status' put: 'adult'.
+it at: 'age' put: (age + 1).
+].
+].
+((people = {Dictionary newFrom: {#name->'Alice'. #age->17. #status->'minor'}. Dictionary newFrom: {#name->'Bob'. #age->26. #status->'adult'}. Dictionary newFrom: {#name->'Charlie'. #age->19. #status->'adult'}. Dictionary newFrom: {#name->'Diana'. #age->16. #status->'minor'}})) ifTrue: [Transcript show:'ok'; cr] ifFalse: [Transcript show:'fail'; cr].
+Transcript show: ('ok') printString; cr.


### PR DESCRIPTION
## Summary
- implement simple group by handling in the Smalltalk compiler
- regenerate Smalltalk machine outputs for group by examples
- note new compile count in the Smalltalk machine README

## Testing
- `go test -tags slow ./compiler/x/st -run TestCompilePrograms/group_by -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e4897df788320bf51286157b12c1a