### PR TITLE
Add Swift query sort support

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,6 +1,6 @@
 # Machine-generated Swift Outputs
 
-Compiled programs: 74/97
+Compiled programs: 77/97
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -15,7 +15,7 @@ Compiled programs: 74/97
 - [x] cross_join.mochi
 - [x] cross_join_filter.mochi
 - [x] cross_join_triple.mochi
-- [ ] dataset_sort_take_limit.mochi
+- [x] dataset_sort_take_limit.mochi
 - [x] dataset_where_filter.mochi
 - [x] exists_builtin.mochi
 - [x] for_list_collection.mochi
@@ -65,7 +65,7 @@ Compiled programs: 74/97
 - [x] membership.mochi
 - [x] min_max_builtin.mochi
 - [x] nested_function.mochi
-- [ ] order_by_map.mochi
+- [x] order_by_map.mochi
 - [ ] outer_join.mochi
 - [x] partial_application.mochi
 - [x] print_hello.mochi
@@ -77,7 +77,7 @@ Compiled programs: 74/97
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
 - [x] slice.mochi
-- [ ] sort_stable.mochi
+- [x] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi

--- a/tests/machine/x/swift/dataset_sort_take_limit.error
+++ b/tests/machine/x/swift/dataset_sort_take_limit.error
@@ -1,2 +1,0 @@
-line: 0
-error: unsupported expression at line 11

--- a/tests/machine/x/swift/dataset_sort_take_limit.swift
+++ b/tests/machine/x/swift/dataset_sort_take_limit.swift
@@ -1,0 +1,6 @@
+let products = [["name": "Laptop", "price": 1500], ["name": "Smartphone", "price": 900], ["name": "Tablet", "price": 600], ["name": "Monitor", "price": 300], ["name": "Keyboard", "price": 100], ["name": "Mouse", "price": 50], ["name": "Headphones", "price": 200]]
+let expensive = products.map { p in (value: p, key: p.price) }.sorted { $0.key > $1.key }.dropFirst(1).prefix(3).map { $0.value }
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+    print(item.name, "costs $", item.price)
+}

--- a/tests/machine/x/swift/order_by_map.error
+++ b/tests/machine/x/swift/order_by_map.error
@@ -1,2 +1,0 @@
-line: 0
-error: unsupported expression at line 7

--- a/tests/machine/x/swift/order_by_map.swift
+++ b/tests/machine/x/swift/order_by_map.swift
@@ -1,0 +1,3 @@
+let data = [["a": 1, "b": 2], ["a": 1, "b": 1], ["a": 0, "b": 5]]
+let sorted = data.map { x in (value: x, key: (a: x.a, b: x.b)) }.sorted { $0.key < $1.key }.map { $0.value }
+print(sorted)

--- a/tests/machine/x/swift/sort_stable.error
+++ b/tests/machine/x/swift/sort_stable.error
@@ -1,2 +1,0 @@
-line: 0
-error: unsupported expression at line 6

--- a/tests/machine/x/swift/sort_stable.swift
+++ b/tests/machine/x/swift/sort_stable.swift
@@ -1,0 +1,3 @@
+let items = [["n": 1, "v": "a"], ["n": 1, "v": "b"], ["n": 2, "v": "c"]]
+let result = items.map { i in (value: i.v, key: i.n) }.sorted { $0.key < $1.key }.map { $0.value }
+print(result)


### PR DESCRIPTION
## Summary
- extend the Swift compiler with basic query sort/skip/take handling
- replace identifiers correctly when generating sort expressions
- regenerate Swift outputs for dataset_sort_take_limit, order_by_map, and sort_stable
- update compilation checklist

## Testing
- `go test ./compiler/x/swift -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686e489b54148320bd41e11ef7620cb7