### PR TITLE
Improve Fortran compiler program naming

### DIFF
--- a/compiler/x/fortran/compiler.go
+++ b/compiler/x/fortran/compiler.go
@@ -51,6 +51,10 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	name := "main"
 	if prog.Package != "" {
 		name = sanitize(prog.Package)
+	} else if prog != nil && prog.Pos.Filename != "" {
+		base := filepath.Base(prog.Pos.Filename)
+		base = strings.TrimSuffix(base, filepath.Ext(base))
+		name = sanitize(base)
 	}
 	c.writeln(fmt.Sprintf("program %s", name))
 	c.indent++


### PR DESCRIPTION
## Summary
- better Fortran output by naming the program after the source file when no package name is set

## Testing
- `go test ./compiler/x/fortran -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_686e4e8f171c832097833fe9004b1cdb