### PR TITLE
Fix Zig map literal variable shadow

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -2028,7 +2028,8 @@ func (c *Compiler) compileMapLiteral(m *parser.MapLiteral) (string, error) {
 	}
 	var b strings.Builder
 	lbl := c.newLabel()
-	b.WriteString("(" + lbl + ": { var m = std.AutoHashMap(" + keyType + ", " + valType + ").init(std.heap.page_allocator); ")
+	tmpMap := c.newTmp()
+	b.WriteString("(" + lbl + ": { var " + tmpMap + " = std.AutoHashMap(" + keyType + ", " + valType + ").init(std.heap.page_allocator); ")
 	for _, it := range m.Items {
 		var keyExpr string
 		if k, ok := simpleStringKey(it.Key); ok {
@@ -2044,9 +2045,9 @@ func (c *Compiler) compileMapLiteral(m *parser.MapLiteral) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		b.WriteString("m.put(" + keyExpr + ", " + v + ") catch unreachable; ")
+		b.WriteString(tmpMap + ".put(" + keyExpr + ", " + v + ") catch unreachable; ")
 	}
-	b.WriteString("break :" + lbl + " m; })")
+	b.WriteString("break :" + lbl + " " + tmpMap + "; })")
 	return b.String(), nil
 }
 

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -96,3 +96,7 @@
 - [ ] values_builtin.mochi
 - [ ] var_assignment.mochi
 - [ ] while_loop.mochi
+
+## TODO
+- Regenerate outputs after fixing map literal temporary variable names
+- Support map literals in iterations by emitting `std.AutoHashMap` even when keys are simple


### PR DESCRIPTION
## Summary
- avoid reusing `m` inside Zig map literal compilation
- note remaining tasks in Zig machine README

## Testing
- `gofmt -w compiler/x/zig/compiler.go`


------
https://chatgpt.com/codex/tasks/task_e_686e4eb04ca88320b01c81ea9df301f3