### PR TITLE
Add update statement support in PHP compiler

### DIFF
--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -3,6 +3,7 @@
 package phpcode
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -123,4 +124,10 @@ func (c *Compiler) emitRuntime() {
 			c.buf.WriteString(code)
 		}
 	}
+}
+
+func (c *Compiler) newTmp() string {
+	name := fmt.Sprintf("$_tmp%d", c.tmpCount)
+	c.tmpCount++
+	return name
 }


### PR DESCRIPTION
## Summary
- extend PHP compiler `Compiler` struct with temp variable counter
- add helper to generate temporary variable names
- implement `compileUpdate` to handle `update` statements
- wire new function into `compileStmt`

## Testing
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_ValidPrograms`

------
https://chatgpt.com/codex/tasks/task_e_686e4e9adf988320b263513924c0636c