### PR TITLE
Add load/save support to Smalltalk compiler

### DIFF
--- a/tests/machine/x/st/README.md
+++ b/tests/machine/x/st/README.md
@@ -1,4 +1,4 @@
-# Mochi to Smalltalk Machine Outputs (86/97 compiled)
+# Mochi to Smalltalk Machine Outputs (88/97 compiled)
 
 This directory contains Smalltalk source code generated from the Mochi programs in `tests/vm/valid`. A checkbox indicates the program compiled and executed successfully during tests. Because the `gst` interpreter is not available, all programs currently fail at runtime.
 
@@ -91,11 +91,11 @@ This directory contains Smalltalk source code generated from the Mochi programs 
 - [x] json_builtin.mochi
 - [ ] left_join.mochi
 - [ ] left_join_multi.mochi
-- [ ] load_yaml.mochi
+ - [x] load_yaml.mochi
 - [ ] outer_join.mochi
 - [x] query_sum_select.mochi
 - [ ] right_join.mochi
-- [ ] save_jsonl_stdout.mochi
+ - [x] save_jsonl_stdout.mochi
 - [ ] test_block.mochi
 - [x] tree_sum.mochi
 - [x] two-sum.mochi
@@ -103,7 +103,6 @@ This directory contains Smalltalk source code generated from the Mochi programs 
 
 ## TODO
 - [ ] implement query joins
-- [ ] handle load/save expressions
 - [ ] support update statements
 - [ ] support test blocks
 

--- a/tests/machine/x/st/load_yaml.error
+++ b/tests/machine/x/st/load_yaml.error
@@ -1,5 +1,2 @@
-line: 1
-error: unsupported statement at line 1
-   1: type Person {
-   2:   name: string
-   3:   age: int
+line: 0
+error: gst interpreter not available

--- a/tests/machine/x/st/load_yaml.st
+++ b/tests/machine/x/st/load_yaml.st
@@ -1,5 +1,5 @@
-| people adults a |
-people := load value: "../interpreter/valid/people.yaml" value: Dictionary newFrom: {format -> 'yaml'}.
+| adults people |
+people := ((Main _load: '../interpreter/valid/people.yaml' opts: Dictionary newFrom: {format -> 'yaml'}) collect: [:it | Person newFrom: it]).
 adults := [ | tmp |
   tmp := OrderedCollection new.
   people do: [:p |
@@ -9,7 +9,7 @@ adults := [ | tmp |
   ].
   tmp
 ] value.
-adults do: [:a |.
-Transcript show: (a at: 'name') printString; show: ' '; show: (a at: 'email') printString; cr.
-].
+adults do: [:a |
+  Transcript show: (a.name) printString; show: ' '; show: (a.email) printString; cr.
+]
 .

--- a/tests/machine/x/st/save_jsonl_stdout.error
+++ b/tests/machine/x/st/save_jsonl_stdout.error
@@ -1,6 +1,2 @@
-line: 6
-error: unsupported expression at line 6
-   4: ]
-   5: 
-   6: save people to "-" with { format: "jsonl" }
-   7: 
+line: 0
+error: gst interpreter not available

--- a/tests/machine/x/st/save_jsonl_stdout.st
+++ b/tests/machine/x/st/save_jsonl_stdout.st
@@ -1,3 +1,3 @@
 | people |
 people := {Dictionary newFrom: {name -> 'Alice'. age -> 30}. Dictionary newFrom: {name -> 'Bob'. age -> 25}}.
-save value: people value: "-" value: Dictionary newFrom: {format -> 'jsonl'}.
+(Main _save: people path: '-' opts: Dictionary newFrom: {format -> 'jsonl'}).


### PR DESCRIPTION
## Summary
- support `load`, `save` and `fetch` expressions in the Smalltalk backend
- regenerate machine outputs for `load_yaml` and `save_jsonl_stdout`
- update checklist in Smalltalk README

## Testing
- `go test ./compiler/x/smalltalk -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686e4eac9388832095376cdd5a9c6c42