### PR TITLE
Improve Pascal map typing

### DIFF
--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -1880,9 +1880,11 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		keyType := "string"
 		valType := "integer"
 		if len(p.Map.Items) > 0 {
-			keyType = typeString(types.TypeOfExpr(p.Map.Items[0].Key, c.env))
-			if _, ok := selectorName(p.Map.Items[0].Key); ok {
+			kt := typeString(types.TypeOfExpr(p.Map.Items[0].Key, c.env))
+			if _, ok := stringKey(p.Map.Items[0].Key); ok {
 				keyType = "string"
+			} else {
+				keyType = kt
 			}
 			valType = typeString(types.TypeOfExpr(p.Map.Items[0].Value, c.env))
 			if valType != "integer" {

--- a/tests/machine/x/pascal/README.md
+++ b/tests/machine/x/pascal/README.md
@@ -103,3 +103,8 @@ Checklist:
 - [ ] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining Tasks
+
+The Pascal backend currently skips many programs that rely on dataset query features, complex join operations and advanced pattern matching. Extending `compileQueryExpr` and related helpers to fully cover these constructs will allow the remaining examples to compile.
+


### PR DESCRIPTION
## Summary
- fix Pascal map literal key typing using `stringKey`
- note remaining Pascal backend tasks

## Testing
- `go test -tags slow ./compiler/x/pascal -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e52f7ad708320a5d4ee0aca9c5917