### PR TITLE
Add MOCHI_ROOT override

### DIFF
--- a/compiler/x/typescript/compiler.go
+++ b/compiler/x/typescript/compiler.go
@@ -17,6 +17,9 @@ import (
 )
 
 func findRepoRoot() string {
+	if root := os.Getenv("MOCHI_ROOT"); root != "" {
+		return root
+	}
 	dir, _ := os.Getwd()
 	for i := 0; i < 10; i++ {
 		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {


### PR DESCRIPTION
## Summary
- allow overriding the repository root for TypeScript compiler via `MOCHI_ROOT`

## Testing
- `go test ./compiler/x/typescript -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e5cb7ffa08320b3b6894aa13effa9