### PR TITLE
Add TPCH q1 Go compiler test

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -2602,26 +2602,12 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 
 	var sel string
 	var retElem string
-	if ml := mapLiteral(q.Select); ml != nil {
-		if st, ok := c.inferStructFromMap(ml, "Result"); ok {
-			c.env.SetStruct(st.Name, st)
-			c.compileStructType(st)
-			sel, err = c.compileExprHint(q.Select, st)
-			if err != nil {
-				c.env = original
-				return "", err
-			}
-			retElem = goType(st)
-		}
+	sel, err = c.compileExpr(q.Select)
+	if err != nil {
+		c.env = original
+		return "", err
 	}
-	if sel == "" {
-		sel, err = c.compileExpr(q.Select)
-		if err != nil {
-			c.env = original
-			return "", err
-		}
-		retElem = goType(c.inferExprType(q.Select))
-	}
+	retElem = goType(c.inferExprType(q.Select))
 	if retElem == "" {
 		retElem = "any"
 	}

--- a/compiler/x/go/tpch_golden_test.go
+++ b/compiler/x/go/tpch_golden_test.go
@@ -1,0 +1,123 @@
+//go:build slow
+
+package gocode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	gocode "mochi/compiler/x/go"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func normalizeOutput(root string, b []byte) []byte {
+	out := string(b)
+	out = strings.ReplaceAll(out, filepath.ToSlash(root)+"/", "")
+	out = strings.ReplaceAll(out, filepath.ToSlash(root), "")
+	out = strings.ReplaceAll(out, "github.com/mochi-lang/mochi/", "")
+	out = strings.ReplaceAll(out, "mochi/tests/", "tests/")
+	durRE := regexp.MustCompile(`\([0-9]+(\.[0-9]+)?(ns|µs|ms|s)\)`)
+	out = durRE.ReplaceAllString(out, "(X)")
+	out = strings.TrimSpace(out)
+	return []byte(out)
+}
+
+func TestGoCompiler_TPCH_Q1(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not installed")
+	}
+	root := repoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "tpc-h", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := gocode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	wantCodePath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "go", "q1.go.out")
+	wantCode, err := os.ReadFile(wantCodePath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	got := bytes.TrimSpace(code)
+	if !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q1.go.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(wantCode))
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("go", "run", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run error: %v\n%s", err, out)
+	}
+	gotOut := bytes.TrimSpace(out)
+	if idx := bytes.IndexByte(gotOut, '\n'); idx >= 0 {
+		gotOut = gotOut[:idx]
+	}
+
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		t.Fatalf("vm compile error: %v", err)
+	}
+	var vmBuf bytes.Buffer
+	m := vm.New(p, &vmBuf)
+	if err := m.Run(); err != nil {
+		t.Fatalf("vm run error: %v", err)
+	}
+	vmOut := bytes.TrimSpace(vmBuf.Bytes())
+	if idx := bytes.IndexByte(vmOut, '\n'); idx >= 0 {
+		vmOut = vmOut[:idx]
+	}
+	if !bytes.Equal(normalizeOutput(root, gotOut), normalizeOutput(root, vmOut)) {
+		t.Errorf("vm mismatch\n\n--- Go ---\n%s\n\n--- VM ---\n%s\n", gotOut, vmOut)
+	}
+
+	wantOutPath := filepath.Join(root, "tests", "dataset", "tpc-h", "out", "q1.out")
+	wantOut, err := os.ReadFile(wantOutPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	wantOut = bytes.TrimSpace(wantOut)
+	if idx := bytes.IndexByte(wantOut, '\n'); idx >= 0 {
+		wantOut = wantOut[:idx]
+	}
+	if !bytes.Equal(normalizeOutput(root, gotOut), normalizeOutput(root, wantOut)) {
+		t.Errorf("output mismatch for q1.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", gotOut, wantOut)
+	}
+}

--- a/tests/dataset/tpc-h/compiler/go/q1.go.out
+++ b/tests/dataset/tpc-h/compiler/go/q1.go.out
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (
@@ -5,6 +7,7 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"strconv"
 	"time"
 )
 
@@ -107,7 +110,12 @@ func main() {
 					groups[ks] = g
 					order = append(order, ks)
 				}
-				g.Items = append(g.Items, row)
+				_item := map[string]any{}
+				for k, v := range _cast[map[string]any](row) {
+					_item[k] = v
+				}
+				_item["row"] = row
+				g.Items = append(g.Items, _item)
 			}
 		}
 		items := []*data.Group{}
@@ -168,7 +176,7 @@ func main() {
 					}
 					return _res
 				}()),
-				"count_order": _count(g),
+				"count_order": len(g.Items),
 			})
 		}
 		return _res
@@ -207,24 +215,24 @@ func _avg(v any) float64 {
 		case []any:
 			items = s
 		case []int:
-			items = make([]any, len(s))
-			for i, v := range s {
-				items[i] = v
+			items = []any{}
+			for _, v := range s {
+				items = append(items, v)
 			}
 		case []float64:
-			items = make([]any, len(s))
-			for i, v := range s {
-				items[i] = v
+			items = []any{}
+			for _, v := range s {
+				items = append(items, v)
 			}
 		case []string:
-			items = make([]any, len(s))
-			for i, v := range s {
-				items[i] = v
+			items = []any{}
+			for _, v := range s {
+				items = append(items, v)
 			}
 		case []bool:
-			items = make([]any, len(s))
-			for i, v := range s {
-				items[i] = v
+			items = []any{}
+			for _, v := range s {
+				items = append(items, v)
 			}
 		default:
 			panic("avg() expects list or group")
@@ -263,6 +271,9 @@ func _cast[T any](v any) T {
 			return any(int(vv)).(T)
 		case float32:
 			return any(int(vv)).(T)
+		case string:
+			n, _ := strconv.Atoi(vv)
+			return any(n).(T)
 		}
 	case float64:
 		switch vv := v.(type) {
@@ -307,35 +318,6 @@ func _convertMapAny(m map[any]any) map[string]any {
 		}
 	}
 	return out
-}
-
-func _count(v any) int {
-	if g, ok := v.(*data.Group); ok {
-		return len(g.Items)
-	}
-	switch s := v.(type) {
-	case []any:
-		return len(s)
-	case []int:
-		return len(s)
-	case []float64:
-		return len(s)
-	case []string:
-		return len(s)
-	case []bool:
-		return len(s)
-	case []map[string]any:
-		return len(s)
-	case map[string]any:
-		return len(s)
-	case string:
-		return len([]rune(s))
-	}
-	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
-		return rv.Len()
-	}
-	panic("count() expects list or group")
 }
 
 func _equal(a, b any) bool {
@@ -383,14 +365,14 @@ func _sum(v any) float64 {
 		case []any:
 			items = s
 		case []int:
-			items = make([]any, len(s))
-			for i, v := range s {
-				items[i] = v
+			items = []any{}
+			for _, v := range s {
+				items = append(items, v)
 			}
 		case []float64:
-			items = make([]any, len(s))
-			for i, v := range s {
-				items[i] = v
+			items = []any{}
+			for _, v := range s {
+				items = append(items, v)
 			}
 		case []string, []bool:
 			panic("sum() expects numbers")

--- a/tests/dataset/tpc-h/compiler/go/q1.out
+++ b/tests/dataset/tpc-h/compiler/go/q1.out
@@ -1,2 +1,2 @@
 [{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]
-   test Q1 aggregates revenue and quantity by returnflag + linestatus ... ok (6.0µs)
+   test Q1 aggregates revenue and quantity by returnflag + linestatus ... ok (10.0µs)


### PR DESCRIPTION
## Summary
- update Go compiler query handling
- provide TPCH q1 golden output for Go backend
- add golden test exercising compilation and execution of TPCH q1

## Testing
- `go test ./compiler/x/go -run TestGoCompiler_TPCH_Q1 -tags slow -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e5f4bd31083209eb52c6b0c452e07