### PR TITLE
Improve OCaml compiler map handling

### DIFF
--- a/tests/machine/x/ocaml/README.md
+++ b/tests/machine/x/ocaml/README.md
@@ -4,8 +4,8 @@ This directory contains OCaml source code generated from Mochi programs and the 
 
 ## Summary
 
-- 51/97 programs compiled and executed successfully.
-- 46 programs failed to compile or run.
+- 54/97 programs compiled and executed successfully.
+- 43 programs failed to compile or run.
 
 ### Successful
 - append_builtin
@@ -56,11 +56,11 @@ This directory contains OCaml source code generated from Mochi programs and the 
 - if_then_else_nested
 - list_assign
 - record_assign
-
-### Failed
 - cross_join
 - cross_join_filter
 - cross_join_triple
+
+### Failed
 - dataset_sort_take_limit
 - dataset_where_filter
 - exists_builtin
@@ -107,3 +107,9 @@ This directory contains OCaml source code generated from Mochi programs and the 
 - update_stmt
 - user_type_literal
 - values_builtin
+
+## Remaining Tasks
+
+- [ ] Implement support for advanced query joins and aggregation.
+- [ ] Handle nested map updates and struct patterns.
+- [ ] Add runtime to run compiled programs during tests.


### PR DESCRIPTION
## Summary
- add Obj-based map storage so mixed-type maps compile
- support map field selection with List.assoc
- update OCaml machine results summary and checklist

## Testing
- `go test ./compiler/x/ocaml -run TestPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686e5f39e2bc8320809f44876895cba7