### PR TITLE
Enhance Erlang compiler join support

### DIFF
--- a/tests/machine/x/erlang/README.md
+++ b/tests/machine/x/erlang/README.md
@@ -105,5 +105,6 @@ Compiled programs: 39/97
 ## Remaining tasks
 
 - [x] Implement `exists` query compilation
-- [ ] Support joins and group-by queries
+- [x] Basic join support
+- [ ] Support group-by queries
 - [ ] Add code generation for remaining Mochi examples


### PR DESCRIPTION
## Summary
- support simple join clauses in the Erlang compiler
- note progress on join support in Erlang machine README

## Testing
- `gofmt -w compiler/x/erlang/compiler.go`

------
https://chatgpt.com/codex/tasks/task_e_686e5d4545d08320a1dc950c58dd14e1