### PR TITLE
Improve TypeScript map typing

### DIFF
--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -534,8 +534,8 @@ func (c *Compiler) compileVar(s *parser.VarStmt) error {
 		if ml := s.Value.Binary.Left.Value.Target.Map; ml != nil && len(ml.Items) == 0 {
 			if c.env != nil {
 				if t, err := c.env.GetVar(s.Name); err == nil {
-					if mt, ok := t.(types.MapType); ok {
-						value = fmt.Sprintf("{} as Record<%s, %s>", tsType(mt.Key), tsType(mt.Value))
+					if _, ok := t.(types.MapType); ok {
+						value = "{}"
 					}
 				}
 			}

--- a/compiler/x/ts/helpers.go
+++ b/compiler/x/ts/helpers.go
@@ -230,7 +230,7 @@ func tsType(t types.Type) string {
 		}
 		return elem + "[]"
 	case types.MapType:
-		return "Record<" + tsType(tt.Key) + ", " + tsType(tt.Value) + ">"
+		return "{ [key: " + tsType(tt.Key) + "]: " + tsType(tt.Value) + " }"
 	case types.StructType:
 		name := sanitizeName(tt.Name)
 		if name != "" {

--- a/compiler/x/ts/runtime.go
+++ b/compiler/x/ts/runtime.go
@@ -152,7 +152,7 @@ const (
 		"  return false;\n" +
 		"}\n"
 
-	helperValues = "function _values<T>(m: Record<string, T>): T[] {\n" +
+	helperValues = "function _values<T>(m: { [key: string]: T }): T[] {\n" +
 		"  if (m && typeof m === 'object' && !Array.isArray(m)) {\n" +
 		"    return Object.values(m);\n" +
 		"  }\n" +
@@ -164,7 +164,7 @@ const (
 		"  return v === null ? '' : v;\n" +
 		"}\n"
 
-	helperIter = "function _iter<T>(v: Iterable<T> | Record<string, T> | any): Iterable<T | string> {\n" +
+	helperIter = "function _iter<T>(v: Iterable<T> | { [key: string]: T } | any): Iterable<T | string> {\n" +
 		"  if (v && typeof v === 'object' && !Array.isArray(v) && !(Symbol.iterator in v)) {\n" +
 		"    return Object.keys(v);\n" +
 		"  }\n" +
@@ -239,8 +239,8 @@ const (
 		"  try { return JSON.parse(text); } catch { return text; }\n" +
 		"}\n"
 
-	helperToAnyMap = "function _toAnyMap(m: any): Record<string, any> {\n" +
-		"  return m as Record<string, any>;\n" +
+	helperToAnyMap = "function _toAnyMap(m: any): { [key: string]: any } {\n" +
+		"  return m as { [key: string]: any };\n" +
 		"}\n"
 
 	helperUnionAll = "function _union_all<T>(a: T[], b: T[]): T[] {\n" +
@@ -297,9 +297,9 @@ const (
 
 	helperAgent = "class Agent {\n" +
 		"  name: string;\n" +
-		"  handlers: Record<string, (ev: any) => any | Promise<any>> = {};\n" +
-		"  intents: Record<string, (...args: any[]) => any> = {};\n" +
-		"  state: Record<string, any> = {};\n" +
+		"  handlers: { [key: string]: (ev: any) => any | Promise<any> } = {};\n" +
+		"  intents: { [key: string]: (...args: any[]) => any } = {};\n" +
+		"  state: { [key: string]: any } = {};\n" +
 		"  constructor(name: string) {\n" +
 		"    this.name = name;\n" +
 		"  }\n" +
@@ -424,7 +424,7 @@ const (
 		"  for (let i=start; i<lines.length; i++) {\n" +
 		"    if (!lines[i]) continue;\n" +
 		"    const parts = lines[i].split(delim);\n" +
-		"    const m: Record<string, any> = {};\n" +
+		"    const m: { [key: string]: any } = {};\n" +
 		"    for (let j=0; j<headers.length; j++) {\n" +
 		"      const val = parts[j] ?? '';\n" +
 		"      if (/^-?\\d+$/.test(val)) m[headers[j]] = parseInt(val,10);\n" +


### PR DESCRIPTION
## Summary
- infer map type using index signatures
- initialize empty maps without `Record` cast
- update runtime helpers to use index notation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e9519a95c83208fbb00417b114d9e