### PR TITLE
Add unary not support to Prolog compiler

### DIFF
--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -460,6 +460,11 @@ func (c *Compiler) compileUnary(u *parser.Unary) (string, bool, error) {
 		if op == "-" {
 			val = fmt.Sprintf("(-%s)", val)
 			arith = true
+		} else if op == "!" {
+			tmp := c.newTmp()
+			c.writeln(fmt.Sprintf("(%s -> %s = false ; %s = true),", val, tmp, tmp))
+			val = tmp
+			arith = false
 		} else {
 			return "", false, fmt.Errorf("unsupported unary op")
 		}

--- a/tests/machine/x/pl/README.md
+++ b/tests/machine/x/pl/README.md
@@ -4,7 +4,7 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 
 ## Summary
 
-- 57/97 programs compiled and executed successfully.
+ - 58/97 programs compiled and executed successfully.
 
 ### Successful
 - append_builtin
@@ -61,6 +61,7 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 - map_literal_dynamic
 - map_membership
 - map_nested_assign
+- in_operator
 - string_in_operator
 - values_builtin
 - user_type_literal
@@ -82,7 +83,6 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 - group_by_multi_join_sort
 - group_by_sort
 - group_items_iteration
-- in_operator
 - in_operator_extended
 - inner_join
 - join_multi

--- a/tests/machine/x/pl/in_operator.error
+++ b/tests/machine/x/pl/in_operator.error
@@ -1,1 +1,0 @@
-unsupported op

--- a/tests/machine/x/pl/in_operator.out
+++ b/tests/machine/x/pl/in_operator.out
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/machine/x/pl/in_operator.pl
+++ b/tests/machine/x/pl/in_operator.pl
@@ -1,0 +1,16 @@
+:- style_check(-singleton).
+contains(Container, Item, Res) :-
+    is_dict(Container), !, (string(Item) -> atom_string(A, Item) ; A = Item), (get_dict(A, Container, _) -> Res = true ; Res = false).
+contains(List, Item, Res) :-
+    string(List), !, (sub_string(List, _, _, _, Item) -> Res = true ; Res = false).
+contains(List, Item, Res) :- (member(Item, List) -> Res = true ; Res = false).
+
+:- initialization(main, main).
+main :-
+    Xs = [1, 2, 3],
+    contains(Xs, 2, _V0),
+    writeln(_V0),
+    contains(Xs, 5, _V1),
+    (_V1 -> _V2 = false ; _V2 = true),
+    writeln(_V2),
+    true.


### PR DESCRIPTION
## Summary
- implement unary `!` operator in Prolog compiler
- recompile `in_operator.mochi` successfully
- update machine output README for Prolog

## Testing
- `go vet ./...`
- `go test ./compiler/x/pl -run TestPrologCompiler/in_operator$ -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e945164b08320a0fc37ff9d7f679a