### PR TITLE
Update Zig compiler and machine output

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -122,6 +122,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		if s.Let != nil && c.constGlobals[sanitizeName(s.Let.Name)] {
 			continue
 		}
+		if s.Var != nil && c.constGlobals[sanitizeName(s.Var.Name)] {
+			continue
+		}
 		if err := c.compileStmt(s, false); err != nil {
 			return nil, err
 		}
@@ -321,7 +324,7 @@ func (c *Compiler) compileGlobalDecls(prog *parser.Program) error {
 				}
 				c.constGlobals[name] = true
 			} else {
-				c.writeln(fmt.Sprintf("var %s: %s = undefined;", name, zigTypeOf(typ)))
+				c.writeln(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), zeroValue(typ)))
 				c.constGlobals[name] = true
 			}
 			continue
@@ -361,7 +364,7 @@ func (c *Compiler) compileGlobalDecls(prog *parser.Program) error {
 					}
 				}
 			} else {
-				c.writeln(fmt.Sprintf("var %s: %s = undefined;", name, zigTypeOf(typ)))
+				c.writeln(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), zeroValue(typ)))
 			}
 			c.constGlobals[name] = true
 			continue

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -1,4 +1,4 @@
-# Mochi to Zig Machine Outputs (31/97 compiled)
+# Mochi to Zig Machine Outputs (32/97 compiled)
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -89,7 +89,7 @@
 - [ ] tree_sum.mochi
 - [ ] two-sum.mochi
 - [ ] typed_let.mochi
-- [ ] typed_var.mochi
+- [x] typed_var.mochi
 - [ ] unary_neg.mochi
 - [ ] update_stmt.mochi
 - [ ] user_type_literal.mochi

--- a/tests/machine/x/zig/typed_var.zig
+++ b/tests/machine/x/zig/typed_var.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+var x: i32 = 0;
+
+pub fn main() void {
+    std.debug.print("{d}\n", .{x});
+}


### PR DESCRIPTION
## Summary
- skip global `var` declarations when generating `main`
- provide zero-value initialization for uninitialized globals
- add zero-value helper
- compile `typed_var.mochi` successfully
- document progress in Zig machine README

## Testing
- `go run -tags slow /tmp/gen.go`

------
https://chatgpt.com/codex/tasks/task_e_686e9207dd908320a668465fe4844cf6