### PR TITLE
Fix Elixir group-by join rows

### DIFF
--- a/compiler/x/ex/compiler.go
+++ b/compiler/x/ex/compiler.go
@@ -964,9 +964,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		}
 		b.WriteString(" })\n")
 		b.WriteString(fmt.Sprintf("\tgroups = _group_by(rows, fn [%s] -> %s end)\n", allParams, keyExpr))
-		if len(paramCopy) > 1 {
-			b.WriteString(fmt.Sprintf("\tgroups = Enum.map(groups, fn g -> %%{g | items: Enum.map(g.items, fn [%s] -> %s end)} end)\n", allParams, sanitizeName(q.Var)))
-		}
+		// Keep full rows in group items to support nested queries
 		b.WriteString("\titems = groups\n")
 		if sortExpr != "" {
 			b.WriteString(fmt.Sprintf("\titems = Enum.sort_by(items, fn %s -> %s end)\n", sanitizeName(q.Group.Name), sortExpr))


### PR DESCRIPTION
## Summary
- fix Elixir compiler to keep full rows in `group by` results when joins are present

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e95fa7cb08320b8288cb00cf4c202