### PR TITLE
Add partial Swift query compilation

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,6 +1,6 @@
 # Machine-generated Swift Outputs
 
-Compiled programs: 76/97
+Compiled programs: 80/97
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -37,7 +37,7 @@ Compiled programs: 76/97
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
 - [x] in_operator.mochi
-- [ ] in_operator_extended.mochi
+- [x] in_operator_extended.mochi
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi
 - [x] json_builtin.mochi
@@ -71,7 +71,7 @@ Compiled programs: 76/97
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
-- [ ] query_sum_select.mochi
+- [x] query_sum_select.mochi
 - [x] record_assign.mochi
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
@@ -88,8 +88,8 @@ Compiled programs: 76/97
 - [x] substring_builtin.mochi
 - [x] sum_builtin.mochi
 - [x] tail_recursion.mochi
-- [ ] test_block.mochi
-- [ ] tree_sum.mochi
+- [x] test_block.mochi
+- [x] tree_sum.mochi
 - [x] two-sum.mochi
 - [x] typed_let.mochi
 - [x] typed_var.mochi

--- a/tests/machine/x/swift/group_by.swift
+++ b/tests/machine/x/swift/group_by.swift
@@ -1,0 +1,10 @@
+let people = [["name": "Alice", "age": 30, "city": "Paris"], ["name": "Bob", "age": 15, "city": "Hanoi"], ["name": "Charlie", "age": 65, "city": "Paris"], ["name": "Diana", "age": 45, "city": "Hanoi"], ["name": "Eve", "age": 70, "city": "Paris"], ["name": "Frank", "age": 22, "city": "Hanoi"]]
+let stats = { () -> [Any] in
+    let _groups = Dictionary(grouping: people) { person in person["city"] as! String }
+    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    return _tmp.map { g in ["city": g.key, "count": g.items.count, "avg_age": (g.items.map { p in p.age }.reduce(0, +) / g.items.map { p in p.age }.count)] }
+}()
+print("--- People grouped by city ---")
+for s in stats {
+    print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}

--- a/tests/machine/x/swift/group_by_conditional_sum.swift
+++ b/tests/machine/x/swift/group_by_conditional_sum.swift
@@ -1,0 +1,8 @@
+let items = [["cat": "a", "val": 10, "flag": true], ["cat": "a", "val": 5, "flag": false], ["cat": "b", "val": 20, "flag": true]]
+let result = { () -> [Any] in
+    let _groups = Dictionary(grouping: items) { i in i["cat"] as! String }
+    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    _tmp.sort { $0.key < $1.key }
+    return _tmp.map { g in ["cat": g.key, "share": g.items.map { x in x.flag ? x.val : 0 }.reduce(0, +) / g.items.map { x in x.val }.reduce(0, +)] }
+}()
+print(result)

--- a/tests/machine/x/swift/group_by_having.swift
+++ b/tests/machine/x/swift/group_by_having.swift
@@ -1,0 +1,8 @@
+let people = [["name": "Alice", "city": "Paris"], ["name": "Bob", "city": "Hanoi"], ["name": "Charlie", "city": "Paris"], ["name": "Diana", "city": "Hanoi"], ["name": "Eve", "city": "Paris"], ["name": "Frank", "city": "Hanoi"], ["name": "George", "city": "Paris"]]
+let big = { () -> [Any] in
+    let _groups = Dictionary(grouping: people) { p in p["city"] as! String }
+    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    _tmp = _tmp.filter { g in g.items.count >= 4 }
+    return _tmp.map { g in ["city": g.key, "num": g.items.count] }
+}()
+json(big)

--- a/tests/machine/x/swift/group_by_sort.swift
+++ b/tests/machine/x/swift/group_by_sort.swift
@@ -1,0 +1,8 @@
+let items = [["cat": "a", "val": 3], ["cat": "a", "val": 1], ["cat": "b", "val": 5], ["cat": "b", "val": 2]]
+let grouped = { () -> [Any] in
+    let _groups = Dictionary(grouping: items) { i in i["cat"] as! String }
+    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    _tmp.sort { $0.items.map { x in x.val }.reduce(0, +) > $1.items.map { x in x.val }.reduce(0, +) }
+    return _tmp.map { g in ["cat": g.key, "total": g.items.map { x in x.val }.reduce(0, +)] }
+}()
+print(grouped)

--- a/tests/machine/x/swift/group_items_iteration.swift
+++ b/tests/machine/x/swift/group_items_iteration.swift
@@ -1,0 +1,16 @@
+let data = [["tag": "a", "val": 1], ["tag": "a", "val": 2], ["tag": "b", "val": 3]]
+let groups = { () -> [Any] in
+    let _groups = Dictionary(grouping: data) { d in d["tag"] as! String }
+    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    return _tmp.map { g in g }
+}()
+var tmp = []
+for g in groups {
+    var total = 0
+    for x in g.items {
+        total = total + x.val
+    }
+    tmp = tmp + [["tag": g.key, "total": total]]
+}
+let result = tmp.map { r in (value: r, key: r.tag) }.sorted { $0.key < $1.key }.map { $0.value }
+print(result)

--- a/tests/machine/x/swift/in_operator_extended.out
+++ b/tests/machine/x/swift/in_operator_extended.out
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false

--- a/tests/machine/x/swift/in_operator_extended.swift
+++ b/tests/machine/x/swift/in_operator_extended.swift
@@ -1,0 +1,10 @@
+let xs = [1, 2, 3]
+let ys = xs.compactMap { x in x % 2 == 1 ? (x) : nil }
+print(ys.contains(1))
+print(ys.contains(2))
+let m = ["a": 1]
+print(m.keys.contains("a"))
+print(m.keys.contains("b"))
+let s = "hello"
+print(s.contains("ell"))
+print(s.contains("foo"))

--- a/tests/machine/x/swift/query_sum_select.error
+++ b/tests/machine/x/swift/query_sum_select.error
@@ -1,2 +1,0 @@
-line: 0
-error: unsupported expression at line 2

--- a/tests/machine/x/swift/query_sum_select.swift
+++ b/tests/machine/x/swift/query_sum_select.swift
@@ -1,0 +1,3 @@
+let nums = [1, 2, 3]
+let result = nums.compactMap { n in n > 1 ? (n.reduce(0, +)) : nil }
+print(result)

--- a/tests/machine/x/swift/update_stmt.swift
+++ b/tests/machine/x/swift/update_stmt.swift
@@ -1,0 +1,16 @@
+struct Person {
+    var name: String
+    var age: Int
+    var status: String
+}
+let people: [Person] = [Person(name: "Alice", age: 17, status: "minor"), Person(name: "Bob", age: 25, status: "unknown"), Person(name: "Charlie", age: 18, status: "unknown"), Person(name: "Diana", age: 16, status: "minor")]
+for i in 0..<people.count {
+    var elem = people[i]
+    if elem.age >= 18 {
+        elem.status = "adult"
+        elem.age = elem.age + 1
+    }
+    people[i] = elem
+}
+assert(people == [Person(name: "Alice", age: 17, status: "minor"), Person(name: "Bob", age: 26, status: "adult"), Person(name: "Charlie", age: 19, status: "adult"), Person(name: "Diana", age: 16, status: "minor")])
+print("ok")


### PR DESCRIPTION
## Summary
- enhance Swift compiler with initial group query support and group-aware builtins
- generate machine outputs for several programs
- update Swift machine README progress

## Testing
- `go test -tags slow ./compiler/x/swift -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e924801fc8320ac5ad9fa4c90d594