### PR TITLE
Add query helper to Clojure compiler

### DIFF
--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -1574,7 +1574,7 @@ func (c *Compiler) compileQuery(q *parser.QueryExpr) (string, error) {
 	}
 
 	useHelper := false
-	if q.Group != nil {
+	if q.Group != nil || len(q.Froms) > 0 || len(q.Joins) > 0 {
 		useHelper = true
 	}
 	for _, j := range q.Joins {


### PR DESCRIPTION
## Summary
- update the Clojure query compiler to use the helper whenever a `from` or `join` clause is present

## Testing
- `go test -tags slow ./compiler/x/clj -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686e95d9145c832098a588c7fbef1842