### PR TITLE
Support query free variable capture for PHP

### DIFF
--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -182,3 +182,162 @@ func (c *Compiler) newTmp() string {
 	c.tmpCount++
 	return name
 }
+
+func scanStmt(s *parser.Statement, vars map[string]struct{}) {
+	switch {
+	case s.Let != nil:
+		scanExpr(s.Let.Value, vars)
+	case s.Var != nil:
+		scanExpr(s.Var.Value, vars)
+	case s.Expect != nil:
+		scanExpr(s.Expect.Value, vars)
+	case s.Test != nil:
+		for _, st := range s.Test.Body {
+			scanStmt(st, vars)
+		}
+	case s.Assign != nil:
+		scanExpr(s.Assign.Value, vars)
+	case s.Return != nil:
+		scanExpr(s.Return.Value, vars)
+	case s.Expr != nil:
+		scanExpr(s.Expr.Expr, vars)
+	case s.For != nil:
+		scanExpr(s.For.Source, vars)
+		scanExpr(s.For.RangeEnd, vars)
+		for _, st := range s.For.Body {
+			scanStmt(st, vars)
+		}
+	case s.While != nil:
+		scanExpr(s.While.Cond, vars)
+		for _, st := range s.While.Body {
+			scanStmt(st, vars)
+		}
+	case s.If != nil:
+		scanExpr(s.If.Cond, vars)
+		for _, st := range s.If.Then {
+			scanStmt(st, vars)
+		}
+		if s.If.ElseIf != nil {
+			scanStmt(&parser.Statement{If: s.If.ElseIf}, vars)
+		}
+		for _, st := range s.If.Else {
+			scanStmt(st, vars)
+		}
+	}
+}
+
+func scanExpr(e *parser.Expr, vars map[string]struct{}) {
+	if e == nil {
+		return
+	}
+	scanUnary(e.Binary.Left, vars)
+	for _, op := range e.Binary.Right {
+		scanPostfix(op.Right, vars)
+	}
+}
+
+func scanUnary(u *parser.Unary, vars map[string]struct{}) {
+	if u == nil {
+		return
+	}
+	scanPostfix(u.Value, vars)
+}
+
+func scanPostfix(p *parser.PostfixExpr, vars map[string]struct{}) {
+	if p == nil {
+		return
+	}
+	scanPrimary(p.Target, vars)
+	for _, op := range p.Ops {
+		if op.Index != nil {
+			scanExpr(op.Index.Start, vars)
+			scanExpr(op.Index.End, vars)
+		}
+		if op.Call != nil {
+			for _, a := range op.Call.Args {
+				scanExpr(a, vars)
+			}
+		}
+	}
+}
+
+func scanPrimary(p *parser.Primary, vars map[string]struct{}) {
+	if p == nil {
+		return
+	}
+	if p.Selector != nil {
+		vars[p.Selector.Root] = struct{}{}
+	}
+	if p.Group != nil {
+		scanExpr(p.Group, vars)
+	}
+	if p.FunExpr != nil {
+		scanExpr(p.FunExpr.ExprBody, vars)
+		for _, st := range p.FunExpr.BlockBody {
+			scanStmt(st, vars)
+		}
+	}
+	if p.List != nil {
+		for _, e := range p.List.Elems {
+			scanExpr(e, vars)
+		}
+	}
+	if p.Map != nil {
+		for _, it := range p.Map.Items {
+			if _, ok := types.SimpleStringKey(it.Key); !ok {
+				scanExpr(it.Key, vars)
+			}
+			scanExpr(it.Value, vars)
+		}
+	}
+	if p.Call != nil {
+		for _, a := range p.Call.Args {
+			scanExpr(a, vars)
+		}
+	}
+}
+
+func queryFreeVars(q *parser.QueryExpr, env *types.Env) []string {
+	vars := map[string]struct{}{}
+	scanExpr(q.Source, vars)
+	for _, f := range q.Froms {
+		scanExpr(f.Src, vars)
+	}
+	for _, j := range q.Joins {
+		scanExpr(j.Src, vars)
+		scanExpr(j.On, vars)
+	}
+	if q.Group != nil {
+		scanExpr(q.Group.Exprs[0], vars)
+	}
+	scanExpr(q.Select, vars)
+	scanExpr(q.Where, vars)
+	scanExpr(q.Sort, vars)
+	scanExpr(q.Skip, vars)
+	scanExpr(q.Take, vars)
+	delete(vars, q.Var)
+	for _, f := range q.Froms {
+		delete(vars, f.Var)
+	}
+	for _, j := range q.Joins {
+		delete(vars, j.Var)
+	}
+	if q.Group != nil {
+		delete(vars, q.Group.Name)
+	}
+	outMap := map[string]struct{}{}
+	for k := range vars {
+		if env != nil {
+			if _, err := env.GetVar(k); err != nil {
+				continue
+			}
+		}
+		outMap["$"+sanitizeName(k)] = struct{}{}
+	}
+	out := make([]string, 0, len(outMap))
+	for k := range outMap {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## Summary
- handle free variables in PHP query compiler
- add helper routines for scanning expressions and collecting free variables

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e97d6e80883209ff8ef2184af0174