### PR TITLE
Add basic Prolog while loop support

### DIFF
--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -285,6 +285,8 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		return c.compileIf(s.If)
 	case s.For != nil:
 		return c.compileFor(s.For)
+	case s.While != nil:
+		return c.compileWhile(s.While)
 	case s.Break != nil:
 		c.writeln("throw(break),")
 		return nil
@@ -392,6 +394,39 @@ func (c *Compiler) compileFor(fs *parser.ForStmt) error {
 	c.writeln("; true")
 	c.indent--
 	c.writeln("), break, true),")
+	return nil
+}
+
+func (c *Compiler) compileWhile(ws *parser.WhileStmt) error {
+	c.writeln("catch(")
+	c.indent++
+	c.writeln("(")
+	c.indent++
+	c.writeln("repeat,")
+	cond, _, err := c.compileExpr(ws.Cond)
+	if err != nil {
+		return err
+	}
+	c.writeln(fmt.Sprintf("(%s ->", cond))
+	c.indent++
+	c.writeln("catch(")
+	c.indent++
+	c.writeln("(")
+	c.indent++
+	for _, st := range ws.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.writeln("true")
+	c.indent--
+	c.writeln("), continue, true),")
+	c.writeln("fail")
+	c.indent--
+	c.writeln("; true)")
+	c.indent--
+	c.writeln("), break, true),")
+	c.indent--
 	return nil
 }
 

--- a/tests/machine/x/pl/README.md
+++ b/tests/machine/x/pl/README.md
@@ -6,103 +6,101 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 
  - 58/97 programs compiled and executed successfully.
 
-### Successful
-- append_builtin
-- avg_builtin
-- basic_compare
-- binary_precedence
-- bool_chain
-- break_continue
-- count_builtin
-- exists_builtin
-- for_list_collection
-- for_loop
-- fun_call
-- fun_three_args
-- if_else
-- if_then_else
-- if_then_else_nested
-- len_builtin
-- len_string
-- let_and_print
-- math_ops
-- min_max_builtin
-- partial_application
-- print_hello
-- pure_fold
-- pure_global_fold
-- short_circuit
-- str_builtin
-- string_compare
-- string_concat
-- substring_builtin
-- sum_builtin
-- tail_recursion
-- typed_let
-- typed_var
-- unary_neg
-- var_assignment
-- list_index
-- slice
-- string_contains
-- string_index
-- string_prefix_slice
-- cast_string_to_int
-- cast_struct
-- membership
-- for_map_collection
-- len_map
-- list_assign
-- list_nested_assign
-- map_assign
-- map_in_operator
-- map_index
-- map_int_key
-- map_literal_dynamic
-- map_membership
-- map_nested_assign
-- in_operator
-- string_in_operator
-- values_builtin
-- user_type_literal
-
-### Failed
-- closure
-- cross_join
-- cross_join_filter
-- cross_join_triple
-- dataset_sort_take_limit
-- dataset_where_filter
-- fun_expr_in_let
-- group_by
-- group_by_conditional_sum
-- group_by_having
-- group_by_join
-- group_by_left_join
-- group_by_multi_join
-- group_by_multi_join_sort
-- group_by_sort
-- group_items_iteration
-- in_operator_extended
-- inner_join
-- join_multi
-- json_builtin
-- left_join
-- left_join_multi
-- list_set_ops
-- load_yaml
-- match_expr
-- match_full
-- nested_function
-- order_by_map
-- outer_join
-- query_sum_select
-- record_assign
-- right_join
-- save_jsonl_stdout
-- sort_stable
-- test_block
-- tree_sum
-- two-sum
-- update_stmt
-- while_loop
+### Checklist
+- [x] append_builtin
+- [x] avg_builtin
+- [x] basic_compare
+- [x] binary_precedence
+- [x] bool_chain
+- [x] break_continue
+- [x] count_builtin
+- [x] exists_builtin
+- [x] for_list_collection
+- [x] for_loop
+- [x] fun_call
+- [x] fun_three_args
+- [x] if_else
+- [x] if_then_else
+- [x] if_then_else_nested
+- [x] len_builtin
+- [x] len_string
+- [x] let_and_print
+- [x] math_ops
+- [x] min_max_builtin
+- [x] partial_application
+- [x] print_hello
+- [x] pure_fold
+- [x] pure_global_fold
+- [x] short_circuit
+- [x] str_builtin
+- [x] string_compare
+- [x] string_concat
+- [x] substring_builtin
+- [x] sum_builtin
+- [x] tail_recursion
+- [x] typed_let
+- [x] typed_var
+- [x] unary_neg
+- [x] var_assignment
+- [x] list_index
+- [x] slice
+- [x] string_contains
+- [x] string_index
+- [x] string_prefix_slice
+- [x] cast_string_to_int
+- [x] cast_struct
+- [x] membership
+- [x] for_map_collection
+- [x] len_map
+- [x] list_assign
+- [x] list_nested_assign
+- [x] map_assign
+- [x] map_in_operator
+- [x] map_index
+- [x] map_int_key
+- [x] map_literal_dynamic
+- [x] map_membership
+- [x] map_nested_assign
+- [x] in_operator
+- [x] string_in_operator
+- [x] values_builtin
+- [x] user_type_literal
+- [ ] closure
+- [ ] cross_join
+- [ ] cross_join_filter
+- [ ] cross_join_triple
+- [ ] dataset_sort_take_limit
+- [ ] dataset_where_filter
+- [ ] fun_expr_in_let
+- [ ] group_by
+- [ ] group_by_conditional_sum
+- [ ] group_by_having
+- [ ] group_by_join
+- [ ] group_by_left_join
+- [ ] group_by_multi_join
+- [ ] group_by_multi_join_sort
+- [ ] group_by_sort
+- [ ] group_items_iteration
+- [ ] in_operator_extended
+- [ ] inner_join
+- [ ] join_multi
+- [ ] json_builtin
+- [ ] left_join
+- [ ] left_join_multi
+- [ ] list_set_ops
+- [ ] load_yaml
+- [ ] match_expr
+- [ ] match_full
+- [ ] nested_function
+- [ ] order_by_map
+- [ ] outer_join
+- [ ] query_sum_select
+- [ ] record_assign
+- [ ] right_join
+- [ ] save_jsonl_stdout
+- [ ] sort_stable
+- [ ] test_block
+- [ ] tree_sum
+- [ ] two-sum
+- [ ] update_stmt
+- [ ] while_loop

--- a/tests/machine/x/pl/two-sum.pl
+++ b/tests/machine/x/pl/two-sum.pl
@@ -1,0 +1,55 @@
+:- style_check(-singleton).
+get_item(Container, Key, Val) :-
+    is_dict(Container), !, (string(Key) -> atom_string(A, Key) ; A = Key), get_dict(A, Container, Val).
+get_item(Container, Index, Val) :-
+    string(Container), !, string_chars(Container, Chars), nth0(Index, Chars, Val).
+get_item(List, Index, Val) :- nth0(Index, List, Val).
+
+len_any(Value, Len) :-
+    string(Value), !, string_length(Value, Len).
+len_any(Value, Len) :-
+    is_dict(Value), !, dict_pairs(Value, _, Pairs), length(Pairs, Len).
+len_any(Value, Len) :- length(Value, Len).
+
+TwoSum(Nums, Target, _Res) :-
+    len_any(Nums, _V0),
+    N is _V0,
+    catch(
+        (
+            _V1 is N - 1,
+            between(0, _V1, I),
+                catch(
+                    (
+                        catch(
+                            (
+                                _V2 is N - 1,
+                                between((I + 1), _V2, J),
+                                    catch(
+                                        (
+                                            get_item(Nums, I, _V3),
+                                            get_item(Nums, J, _V4),
+                                            (((_V3 + _V4) == Target) ->
+                                                _Res = [I, J].
+                                            ; true
+                                            ),
+                                            true
+                                        ), continue, true),
+                                        fail
+                                    ; true
+                                ), break, true),
+                                true
+                            ), continue, true),
+                            fail
+                        ; true
+                    ), break, true),
+                    _Res = [(-1), (-1)].
+                
+                :- initialization(main, main).
+                main :-
+                    TwoSum([2, 7, 11, 15], 9, _V0),
+                    Result = _V0,
+                    get_item(Result, 0, _V1),
+                    writeln(_V1),
+                    get_item(Result, 1, _V2),
+                    writeln(_V2),
+                    true.

--- a/tests/machine/x/pl/while_loop.error
+++ b/tests/machine/x/pl/while_loop.error
@@ -1,1 +1,4 @@
-unsupported statement
+run: exit status 2
+0
+ERROR: /workspace/mochi/tests/machine/x/pl/while_loop.pl:2: user:main is/2: Arguments are not sufficiently instantiated
+

--- a/tests/machine/x/pl/while_loop.pl
+++ b/tests/machine/x/pl/while_loop.pl
@@ -1,0 +1,18 @@
+:- style_check(-singleton).
+:- initialization(main, main).
+main :-
+    I is 0,
+    catch(
+        (
+            repeat,
+            ((I < 3) ->
+                catch(
+                    (
+                        writeln(I),
+                        I_0 is (I_0 + 1),
+                        true
+                    ), continue, true),
+                    fail
+                ; true)
+            ), break, true),
+        true.


### PR DESCRIPTION
## Summary
- add compileWhile to Prolog backend
- update machine generated Prolog files
- convert Prolog README to checklist format

## Testing
- `go test ./compiler/x/pl -tags slow` *(fails: unsupported statements and runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e974ab0a08320b9df3bd128e5cc2a