### PR TITLE
Improve Python backend inference

### DIFF
--- a/compiler/x/python/runtime.go
+++ b/compiler/x/python/runtime.go
@@ -114,7 +114,7 @@ var helperGroupBy = "def _group_by(src: list[T], keyfn: Callable[[T], K]) -> lis
 	"        g.Items.append(it)\n" +
 	"    return [ groups[k] for k in order ]\n"
 
-var helperFetch = "def _fetch(url, opts):\n" +
+var helperFetch = "def _fetch(url: str, opts: dict[str, Any] | None) -> Any:\n" +
 	"    import urllib.request, urllib.parse, json\n" +
 	"    method = 'GET'\n" +
 	"    data = None\n" +
@@ -137,7 +137,7 @@ var helperFetch = "def _fetch(url, opts):\n" +
 	"        text = resp.read()\n" +
 	"    return json.loads(text)\n"
 
-var helperLoad = "def _load(path, opts):\n" +
+var helperLoad = "def _load(path: str | None, opts: dict[str, Any] | None) -> list[dict[str, Any]]:\n" +
 	"    import csv, json, sys, os\n" +
 	"    fmt = 'csv'\n" +
 	"    header = True\n" +


### PR DESCRIPTION
## Summary
- infer struct types for lists of map literals so generated Python has tighter element types
- annotate runtime `fetch` and `load` helpers with explicit typing information

## Testing
- `make test` *(fails: exceeded time or requires network)*

------
https://chatgpt.com/codex/tasks/task_e_686e9718224c8320bbe77e249ee36f3e