### PR TITLE
Add left join support in Rust compiler

### DIFF
--- a/tests/compiler/rust/left_join.mochi
+++ b/tests/compiler/rust/left_join.mochi
@@ -1,0 +1,19 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 3, total: 80 }
+]
+let result = from o in orders
+             left join c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customer: c,
+               total: o.total
+             }
+print("--- Left Join ---")
+for entry in result {
+  print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+}

--- a/tests/compiler/rust/left_join.out
+++ b/tests/compiler/rust/left_join.out
@@ -1,0 +1,3 @@
+--- Left Join ---
+Order 100 customer map[id:1 name:Alice] total 250
+Order 101 customer null total 80

--- a/tests/compiler/rust/left_join.rs.out
+++ b/tests/compiler/rust/left_join.rs.out
@@ -1,0 +1,44 @@
+#[derive(Clone, Debug, Default)]
+struct Customer {
+    id: i64,
+    name: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct Order {
+    id: i64,
+    customerId: i64,
+    total: i64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PairInfo {
+    orderId: i64,
+    customer: Option<Customer>,
+    total: i64,
+}
+
+fn main() {
+    let mut customers = vec![Customer { id: 1, name: "Alice".to_string() }, Customer { id: 2, name: "Bob".to_string() }];
+    let mut orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 3, total: 80 }];
+    let mut result = {
+    let mut _res = Vec::new();
+    for o in orders.clone() {
+        let mut _matched = false;
+        for c in customers.clone() {
+            if !(o.customerId == c.id) { continue; }
+            _matched = true;
+            _res.push(PairInfo { orderId: o.id, customer: Some(c), total: o.total });
+        }
+        if !_matched {
+            let c = Option::<Customer>::None;
+            _res.push(PairInfo { orderId: o.id, customer: c, total: o.total });
+        }
+    }
+    _res
+};
+    println!("{}", "--- Left Join ---");
+    for entry in result {
+        println!("{} {} {} {:?} {} {}", "Order", entry.orderId, "customer", entry.customer, "total", entry.total);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `compileLeftJoinSimple` for the Rust backend
- call left join handler when using `left join`
- add regression test for left join

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e9ec74e248320bcd64f465a07af1d