### PR TITLE
Add join side support to Swift compiler

### DIFF
--- a/tests/compiler/swift/left_join.mochi
+++ b/tests/compiler/swift/left_join.mochi
@@ -1,0 +1,19 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 3, total: 80 }
+]
+let result = from o in orders
+             left join c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customer: c,
+               total: o.total
+             }
+print("--- Left Join ---")
+for entry in result {
+  print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+}

--- a/tests/compiler/swift/left_join.out
+++ b/tests/compiler/swift/left_join.out
@@ -1,0 +1,3 @@
+--- Left Join ---
+Order 100 customer map[id:1 name:Alice] total 250
+Order 101 customer <nil> total 80

--- a/tests/compiler/swift/left_join.swift.out
+++ b/tests/compiler/swift/left_join.swift.out
@@ -1,0 +1,24 @@
+let customers = [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"]]
+let orders = [["id": 100, "customerId": 1, "total": 250], ["id": 101, "customerId": 3, "total": 80]]
+let result = ({
+	var _res: [Any] = []
+	let _src = orders
+	let _join = customers
+	for o in _src {
+		var _m = false
+		for c in _join {
+			if !(o.customerId == c.id) { continue }
+			_m = true
+			_res.append(["orderId": o["id"] as! Int, "customer": c, "total": o["total"] as! Int])
+		}
+		if !_m {
+			let c: Any? = nil
+			_res.append(["orderId": o["id"] as! Int, "customer": c, "total": o["total"] as! Int])
+		}
+	}
+	return _res
+}())
+print("--- Left Join ---")
+for entry in result {
+    print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+}


### PR DESCRIPTION
## Summary
- enhance Swift compiler with join-side support (`left`, `right`, `outer`)
- generate Swift code for `left_join` example
- add new test files for Swift `left_join`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ea056f1c083209d63af5341b936e0