### PR TITLE
Update Swift compiler map handling

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -99,3 +99,8 @@ Compiled programs: 80/97
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## TODO
+- [ ] implement join queries
+- [ ] handle load/save dataset operations
+- [ ] preserve map field information in queries


### PR DESCRIPTION
## Summary
- improve Swift compiler type inference for query results
- allow field access on variables without explicit map type
- detect map fields for query expressions
- document remaining tasks in Swift machine output README

## Testing
- `go test -tags=slow ./compiler/x/swift -run TestCompileValidPrograms/dataset_sort_take_limit -v`

------
https://chatgpt.com/codex/tasks/task_e_686e991d8af883209cbf80e37a41d925