### PR TITLE
Add join handling to Racket compiler

### DIFF
--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -735,6 +735,20 @@ func (c *Compiler) compileQuery(q *parser.QueryExpr) (string, error) {
 		}
 		loops = append(loops, fmt.Sprintf("[%s %s]", f.Var, s))
 	}
+	for _, j := range q.Joins {
+		if j.Side != nil {
+			return "", fmt.Errorf("unsupported join type")
+		}
+		js, err := c.compileExpr(j.Src)
+		if err != nil {
+			return "", err
+		}
+		onExpr, err := c.compileExpr(j.On)
+		if err != nil {
+			return "", err
+		}
+		loops = append(loops, fmt.Sprintf("[%s %s #:when %s]", j.Var, js, onExpr))
+	}
 	cond := ""
 	if q.Where != nil {
 		ce, err := c.compileExpr(q.Where)


### PR DESCRIPTION
## Summary
- extend query compilation in `x/racket` to understand join clauses
- reject unsupported join types

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_686e97feb2848320a4b045313d7d7153