### PR TITLE
Add from/join support in Pascal compiler

### DIFF
--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -1970,13 +1970,6 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		}
 		genv := types.NewEnv(child)
 		genv.SetVar(q.Group.Name, types.AnyType{}, true)
-		c.env = genv
-		valExpr, err := c.compileExpr(q.Select)
-		if err != nil {
-			c.env = orig
-			return "", err
-		}
-		c.env = orig
 		elemType := typeString(types.TypeOfExpr(q.Select, genv))
 		if elemType == "" {
 			elemType = "integer"
@@ -2003,6 +1996,13 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		c.writeln(fmt.Sprintf("for %s in %s do", sanitizeName(q.Group.Name), tmpGrp))
 		c.writeln("begin")
 		c.indent++
+		c.env = genv
+		valExpr, err := c.compileExpr(q.Select)
+		if err != nil {
+			c.env = orig
+			return "", err
+		}
+		c.env = orig
 		c.writeln(fmt.Sprintf("%s := Concat(%s, [%s]);", tmpRes, tmpRes, valExpr))
 		c.indent--
 		c.writeln("end;")


### PR DESCRIPTION
## Summary
- update Pascal query compiler to emit select code inside loops
- ensure grouped query results handle select expressions correctly

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e97bcafcc8320ba219fda4715327d