### PR TITLE
Add status section in clj machine README

### DIFF
--- a/tests/machine/x/clj/README.md
+++ b/tests/machine/x/clj/README.md
@@ -100,3 +100,10 @@ Compiled programs: 97/97 successful.
 - [x] right_join.mochi
 - [x] save_jsonl_stdout.mochi
 - [x] values_builtin.mochi
+
+## Status
+All example programs compile and run successfully.
+
+## Remaining tasks
+None
+


### PR DESCRIPTION
## Summary
- document that all clojure examples compile and run

## Testing
- `go test ./compiler/x/clj -tags slow -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ea6ebef64832091a596a16a95a4a3