### PR TITLE
Improve F# compiler group join support

### DIFF
--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -2,44 +2,42 @@
 
 This directory contains F# source code generated from Mochi programs and the corresponding outputs or error logs.
 
-## Summary
+## Checklist
 
-- 29/37 programs compiled and executed successfully.
-- 8 programs failed to compile or run.
+Checklist of programs that currently compile and run (29/37):
 
-### Successful
-- append_builtin
-- avg_builtin
-- basic_compare
-- binary_precedence
-- bool_chain
-- break_continue
-- cast_string_to_int
-- cast_struct
-- closure
-- count_builtin
-- exists_builtin
-- for_list_collection
-- for_loop
-- for_map_collection
-- fun_call
-- fun_expr_in_let
-- fun_three_args
-- if_else
-- if_then_else
-- if_then_else_nested
-- in_operator
-- cross_join
-- cross_join_filter
-- cross_join_triple
-- dataset_sort_take_limit
-- dataset_where_filter
+- [x] append_builtin
+- [x] avg_builtin
+- [x] basic_compare
+- [x] binary_precedence
+- [x] bool_chain
+- [x] break_continue
+- [x] cast_string_to_int
+- [x] cast_struct
+- [x] closure
+- [x] count_builtin
+- [x] exists_builtin
+- [x] for_list_collection
+- [x] for_loop
+- [x] for_map_collection
+- [x] fun_call
+- [x] fun_expr_in_let
+- [x] fun_three_args
+- [x] if_else
+- [x] if_then_else
+- [x] if_then_else_nested
+- [x] in_operator
+- [x] cross_join
+- [x] cross_join_filter
+- [x] cross_join_triple
+- [x] dataset_sort_take_limit
+- [x] dataset_where_filter
+- [x] group_by
+- [x] group_by_conditional_sum
+- [x] group_by_having
 
-- group_by
-- group_by_conditional_sum
-- group_by_having
+Remaining programs to implement:
 
-### Failed
 - group_by_join
 - group_by_left_join
 - group_by_multi_join

--- a/tests/machine/x/fs/group_by_join.fs
+++ b/tests/machine/x/fs/group_by_join.fs
@@ -3,9 +3,24 @@ open System
 exception Break
 exception Continue
 
-let customers = [dict [(id, 1); (name, "Alice")]; dict [(id, 2); (name, "Bob")]]
-let orders = [dict [(id, 100); (customerId, 1)]; dict [(id, 101); (customerId, 1)]; dict [(id, 102); (customerId, 2)]]
-let stats = [ for o in orders doyield dict [(name, g.key); (count, List.length g)] ]
+type Anon1 = {
+    id: int
+    name: string
+}
+type Anon2 = {
+    id: int
+    customerId: int
+}
+type Anon3 = {
+    name: obj
+    count: obj
+}
+let customers = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }]
+let orders = [{ id = 100; customerId = 1 }; { id = 101; customerId = 1 }; { id = 102; customerId = 2 }]
+let stats = [ for gKey, gItems in [ for o in orders do 
+  for c in customers do if o.customerId = c.id then yield (o, c) ] |> List.groupBy (fun (o, c) -> c.name) do
+    let g = {| key = gKey; items = gItems |}
+    yield { name = g.key; count = List.length g } ]
 printfn "%s" "--- Orders per customer ---"
 try
     for s in stats do

--- a/tests/machine/x/fs/group_by_left_join.fs
+++ b/tests/machine/x/fs/group_by_left_join.fs
@@ -3,9 +3,24 @@ open System
 exception Break
 exception Continue
 
-let customers = [dict [(id, 1); (name, "Alice")]; dict [(id, 2); (name, "Bob")]; dict [(id, 3); (name, "Charlie")]]
-let orders = [dict [(id, 100); (customerId, 1)]; dict [(id, 101); (customerId, 1)]; dict [(id, 102); (customerId, 2)]]
-let stats = [ for c in customers doyield dict [(name, g.key); (count, List.length [ for r in g do if r.o then yield r ])] ]
+type Anon1 = {
+    id: int
+    name: string
+}
+type Anon2 = {
+    id: int
+    customerId: int
+}
+type Anon3 = {
+    name: obj
+    count: obj
+}
+let customers = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }; { id = 3; name = "Charlie" }]
+let orders = [{ id = 100; customerId = 1 }; { id = 101; customerId = 1 }; { id = 102; customerId = 2 }]
+let stats = [ for gKey, gItems in [ for c in customers do 
+  for o in orders do if o.customerId = c.id then yield (c, o) ] |> List.groupBy (fun (c, o) -> c.name) do
+    let g = {| key = gKey; items = gItems |}
+    yield { name = g.key; count = List.length [ for r in g do if r.o then yield r ] } ]
 printfn "%s" "--- Group Left Join ---"
 try
     for s in stats do

--- a/tests/machine/x/fs/group_by_multi_join.fs
+++ b/tests/machine/x/fs/group_by_multi_join.fs
@@ -3,9 +3,35 @@ open System
 exception Break
 exception Continue
 
-let nations = [dict [(id, 1); (name, "A")]; dict [(id, 2); (name, "B")]]
-let suppliers = [dict [(id, 1); (nation, 1)]; dict [(id, 2); (nation, 2)]]
-let partsupp = [dict [(part, 100); (supplier, 1); (cost, 10); (qty, 2)]; dict [(part, 100); (supplier, 2); (cost, 20); (qty, 1)]; dict [(part, 200); (supplier, 1); (cost, 5); (qty, 3)]]
-let filtered = [ for ps in partsupp do if n.name = "A" then yield dict [(part, ps.part); (value, ps.cost * ps.qty)] ]
-let grouped = [ for x in filtered doyield dict [(part, g.key); (total, sum [ for r in g doyield r.value ])] ]
+type Anon1 = {
+    id: int
+    name: string
+}
+type Anon2 = {
+    id: int
+    nation: int
+}
+type Anon3 = {
+    part: int
+    supplier: int
+    cost: float
+    qty: int
+}
+type Anon4 = {
+    part: obj
+    value: obj
+}
+type Anon5 = {
+    part: obj
+    total: obj
+}
+let nations = [{ id = 1; name = "A" }; { id = 2; name = "B" }]
+let suppliers = [{ id = 1; nation = 1 }; { id = 2; nation = 2 }]
+let partsupp = [{ part = 100; supplier = 1; cost = 10; qty = 2 }; { part = 100; supplier = 2; cost = 20; qty = 1 }; { part = 200; supplier = 1; cost = 5; qty = 3 }]
+let filtered = [ for ps in partsupp do 
+  for s in suppliers do 
+  for n in nations do if s.id = ps.supplier && n.id = s.nation && n.name = "A" then yield { part = ps.part; value = ps.cost * ps.qty } ]
+let grouped = [ for gKey, gItems in [ for x in filtered do yield x ] |> List.groupBy (fun x -> x.part) do
+    let g = {| key = gKey; items = gItems |}
+    yield { part = g.key; total = List.sum [ for r in g do yield r.value ] } ]
 printfn "%A" (grouped)

--- a/tests/machine/x/fs/group_by_multi_join_sort.fs
+++ b/tests/machine/x/fs/group_by_multi_join_sort.fs
@@ -3,11 +3,59 @@ open System
 exception Break
 exception Continue
 
-let nation = [dict [(n_nationkey, 1); (n_name, "BRAZIL")]]
-let customer = [dict [(c_custkey, 1); (c_name, "Alice"); (c_acctbal, 100); (c_nationkey, 1); (c_address, "123 St"); (c_phone, "123-456"); (c_comment, "Loyal")]]
-let orders = [dict [(o_orderkey, 1000); (o_custkey, 1); (o_orderdate, "1993-10-15")]; dict [(o_orderkey, 2000); (o_custkey, 1); (o_orderdate, "1994-01-02")]]
-let lineitem = [dict [(l_orderkey, 1000); (l_returnflag, "R"); (l_extendedprice, 1000); (l_discount, 0.1)]; dict [(l_orderkey, 2000); (l_returnflag, "N"); (l_extendedprice, 500); (l_discount, 0)]]
-let start_date = "1993-10-01"
-let end_date = "1994-01-01"
-let result = [ for c in customer do if o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag = "R" then yield dict [(c_custkey, g.key.c_custkey); (c_name, g.key.c_name); (revenue, sum [ for x in g doyield x.l.l_extendedprice * (1 - x.l.l_discount) ]); (c_acctbal, g.key.c_acctbal); (n_name, g.key.n_name); (c_address, g.key.c_address); (c_phone, g.key.c_phone); (c_comment, g.key.c_comment)] ] |> List.sortByDescending (fun _ -> sum [ for x in g doyield x.l.l_extendedprice * (1 - x.l.l_discount) ])
+type Anon1 = {
+    n_nationkey: int
+    n_name: string
+}
+type Anon2 = {
+    c_custkey: int
+    c_name: string
+    c_acctbal: float
+    c_nationkey: int
+    c_address: string
+    c_phone: string
+    c_comment: string
+}
+type Anon3 = {
+    o_orderkey: int
+    o_custkey: int
+    o_orderdate: string
+}
+type Anon4 = {
+    l_orderkey: int
+    l_returnflag: string
+    l_extendedprice: float
+    l_discount: float
+}
+type Anon5 = {
+    c_custkey: obj
+    c_name: obj
+    revenue: obj
+    c_acctbal: obj
+    n_name: obj
+    c_address: obj
+    c_phone: obj
+    c_comment: obj
+}
+type Anon6 = {
+    c_custkey: obj
+    c_name: obj
+    c_acctbal: obj
+    c_address: obj
+    c_phone: obj
+    c_comment: obj
+    n_name: obj
+}
+let nation = [{ n_nationkey = 1; n_name = "BRAZIL" }]
+let customer = [{ c_custkey = 1; c_name = "Alice"; c_acctbal = 100; c_nationkey = 1; c_address = "123 St"; c_phone = "123-456"; c_comment = "Loyal" }]
+let orders = [{ o_orderkey = 1000; o_custkey = 1; o_orderdate = "1993-10-15" }; { o_orderkey = 2000; o_custkey = 1; o_orderdate = "1994-01-02" }]
+let lineitem = [{ l_orderkey = 1000; l_returnflag = "R"; l_extendedprice = 1000; l_discount = 0.1 }; { l_orderkey = 2000; l_returnflag = "N"; l_extendedprice = 500; l_discount = 0 }]
+let start_date: string = "1993-10-01"
+let end_date: string = "1994-01-01"
+let result = [ for gKey, gItems in [ for c in customer do 
+  for o in orders do 
+  for l in lineitem do 
+  for n in nation do if o.o_custkey = c.c_custkey && l.l_orderkey = o.o_orderkey && n.n_nationkey = c.c_nationkey && o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag = "R" then yield (c, o, l, n) ] |> List.groupBy (fun (c, o, l, n) -> { c_custkey = c.c_custkey; c_name = c.c_name; c_acctbal = c.c_acctbal; c_address = c.c_address; c_phone = c.c_phone; c_comment = c.c_comment; n_name = n.n_name }) |> List.sortByDescending (fun (gKey, gItems) -> let g = {| key = gKey; items = gItems |} in List.sum [ for x in g do yield x.l.l_extendedprice * (1 - x.l.l_discount) ]) do
+    let g = {| key = gKey; items = gItems |}
+    yield { c_custkey = g.key.c_custkey; c_name = g.key.c_name; revenue = List.sum [ for x in g do yield x.l.l_extendedprice * (1 - x.l.l_discount) ]; c_acctbal = g.key.c_acctbal; n_name = g.key.n_name; c_address = g.key.c_address; c_phone = g.key.c_phone; c_comment = g.key.c_comment } ]
 printfn "%A" (result)

--- a/tests/machine/x/fs/group_by_sort.fs
+++ b/tests/machine/x/fs/group_by_sort.fs
@@ -3,6 +3,16 @@ open System
 exception Break
 exception Continue
 
-let items = [dict [(cat, "a"); (val, 3)]; dict [(cat, "a"); (val, 1)]; dict [(cat, "b"); (val, 5)]; dict [(cat, "b"); (val, 2)]]
-let grouped = [ for i in items doyield dict [(cat, g.key); (total, sum [ for x in g doyield x.val ])] ] |> List.sortByDescending (fun _ -> sum [ for x in g doyield x.val ])
+type Anon1 = {
+    cat: string
+    val: int
+}
+type Anon2 = {
+    cat: obj
+    total: obj
+}
+let items = [{ cat = "a"; val = 3 }; { cat = "a"; val = 1 }; { cat = "b"; val = 5 }; { cat = "b"; val = 2 }]
+let grouped = [ for gKey, gItems in [ for i in items do yield i ] |> List.groupBy (fun i -> i.cat) |> List.sortByDescending (fun (gKey, gItems) -> let g = {| key = gKey; items = gItems |} in List.sum [ for x in g do yield x.val ]) do
+    let g = {| key = gKey; items = gItems |}
+    yield { cat = g.key; total = List.sum [ for x in g do yield x.val ] } ]
 printfn "%A" (grouped)

--- a/tests/machine/x/fs/group_items_iteration.fs
+++ b/tests/machine/x/fs/group_items_iteration.fs
@@ -3,9 +3,19 @@ open System
 exception Break
 exception Continue
 
-let data = [dict [(tag, "a"); (val, 1)]; dict [(tag, "a"); (val, 2)]; dict [(tag, "b"); (val, 3)]]
-let groups = [ for d in data doyield g ]
-let mutable tmp = []
+type Anon1 = {
+    tag: string
+    val: int
+}
+type Anon2 = {
+    tag: obj
+    total: obj
+}
+let data = [{ tag = "a"; val = 1 }; { tag = "a"; val = 2 }; { tag = "b"; val = 3 }]
+let groups = [ for gKey, gItems in [ for d in data do yield d ] |> List.groupBy (fun d -> d.tag) do
+    let g = {| key = gKey; items = gItems |}
+    yield g ]
+let mutable tmp = [||]
 try
     for g in groups do
         try
@@ -16,8 +26,8 @@ try
                         total <- total + x.val
                     with Continue -> ()
             with Break -> ()
-            tmp <- tmp @ [dict [(tag, g.key); (total, total)]]
+            tmp <- tmp @ [{ tag = g.key; total = total }]
         with Continue -> ()
 with Break -> ()
-let result = [ for r in tmp doyield r ] |> List.sortBy (fun _ -> r.tag)
+let result = [ for r in tmp do yield r ] |> List.sortBy (fun r -> r.tag)
 printfn "%A" (result)

--- a/tests/machine/x/fs/in_operator_extended.fs
+++ b/tests/machine/x/fs/in_operator_extended.fs
@@ -3,13 +3,16 @@ open System
 exception Break
 exception Continue
 
+type Anon1 = {
+    a: int
+}
 let xs = [1; 2; 3]
 let ys = [ for x in xs do if x % 2 = 1 then yield x ]
-printfn "%A" (List.contains 1 ys)
-printfn "%A" (List.contains 2 ys)
-let m = dict [(a, 1)]
-printfn "%A" (List.contains "a" m)
-printfn "%A" (List.contains "b" m)
-let s = "hello"
-printfn "%A" (List.contains "ell" s)
-printfn "%A" (List.contains "foo" s)
+printfn "%b" (List.contains 1 ys)
+printfn "%b" (List.contains 2 ys)
+let m = { a = 1 }
+printfn "%s" List.contains "a" m
+printfn "%s" List.contains "b" m
+let s: string = "hello"
+printfn "%s" List.contains "ell" s
+printfn "%s" List.contains "foo" s

--- a/tests/machine/x/fs/inner_join.fs
+++ b/tests/machine/x/fs/inner_join.fs
@@ -3,9 +3,24 @@ open System
 exception Break
 exception Continue
 
-let customers = [dict [(id, 1); (name, "Alice")]; dict [(id, 2); (name, "Bob")]; dict [(id, 3); (name, "Charlie")]]
-let orders = [dict [(id, 100); (customerId, 1); (total, 250)]; dict [(id, 101); (customerId, 2); (total, 125)]; dict [(id, 102); (customerId, 1); (total, 300)]; dict [(id, 103); (customerId, 4); (total, 80)]]
-let result = [ for o in orders doyield dict [(orderId, o.id); (customerName, c.name); (total, o.total)] ]
+type Anon1 = {
+    id: int
+    name: string
+}
+type Anon2 = {
+    id: int
+    customerId: int
+    total: int
+}
+type Anon3 = {
+    orderId: obj
+    customerName: obj
+    total: obj
+}
+let customers = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }; { id = 3; name = "Charlie" }]
+let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId = 2; total = 125 }; { id = 102; customerId = 1; total = 300 }; { id = 103; customerId = 4; total = 80 }]
+let result = [ for o in orders do 
+  for c in customers do if o.customerId = c.id then yield { orderId = o.id; customerName = c.name; total = o.total } ]
 printfn "%s" "--- Orders with customer info ---"
 try
     for entry in result do


### PR DESCRIPTION
## Summary
- expand F# compiler to support query joins when grouping
- regenerate F# machine output for queries using joins
- update README with checklist format

## Testing
- `go test ./...`
- `go test -tags slow ./compiler/x/fs` *(fails: fsharpc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea71d63348320b75f887d99a12355