### PR TITLE
Improve Swift join query handling

### DIFF
--- a/tests/machine/x/swift/inner_join.error
+++ b/tests/machine/x/swift/inner_join.error
@@ -1,2 +1,47 @@
-line: 0
-error: unsupported expression at line 13
+tests/machine/x/swift/inner_join.swift:7:25: warning: forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?
+ 5 | 	for o in orders {
+ 6 | 		for c in customers {
+ 7 | 			if !(o["customerId"] as! Int == c["id"] as! Int) { continue }
+   |                         `- warning: forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?
+ 8 | 			_res.append((orderId: o["id"] as! Int, customerName: c["name"] as! String, total: o["total"] as! Int))
+ 9 | 		}
+
+tests/machine/x/swift/inner_join.swift:8:34: warning: forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?
+ 6 | 		for c in customers {
+ 7 | 			if !(o["customerId"] as! Int == c["id"] as! Int) { continue }
+ 8 | 			_res.append((orderId: o["id"] as! Int, customerName: c["name"] as! String, total: o["total"] as! Int))
+   |                                  `- warning: forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?
+ 9 | 		}
+10 | 	}
+
+tests/machine/x/swift/inner_join.swift:8:97: warning: forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?
+ 6 | 		for c in customers {
+ 7 | 			if !(o["customerId"] as! Int == c["id"] as! Int) { continue }
+ 8 | 			_res.append((orderId: o["id"] as! Int, customerName: c["name"] as! String, total: o["total"] as! Int))
+   |                                                                                                 `- warning: forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?
+ 9 | 		}
+10 | 	}
+
+tests/machine/x/swift/inner_join.swift:15:25: error: value of type 'Any' has no subscripts
+13 | print("--- Orders with customer info ---")
+14 | for entry in result {
+15 |     print("Order", entry["orderId"], "by", entry["customerName"], "- $", entry["total"])
+   |                         `- error: value of type 'Any' has no subscripts
+16 | }
+17 | 
+
+tests/machine/x/swift/inner_join.swift:15:49: error: value of type 'Any' has no subscripts
+13 | print("--- Orders with customer info ---")
+14 | for entry in result {
+15 |     print("Order", entry["orderId"], "by", entry["customerName"], "- $", entry["total"])
+   |                                                 `- error: value of type 'Any' has no subscripts
+16 | }
+17 | 
+
+tests/machine/x/swift/inner_join.swift:15:79: error: value of type 'Any' has no subscripts
+13 | print("--- Orders with customer info ---")
+14 | for entry in result {
+15 |     print("Order", entry["orderId"], "by", entry["customerName"], "- $", entry["total"])
+   |                                                                               `- error: value of type 'Any' has no subscripts
+16 | }
+17 | 

--- a/tests/machine/x/swift/inner_join.swift
+++ b/tests/machine/x/swift/inner_join.swift
@@ -1,0 +1,16 @@
+let customers = [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"], ["id": 3, "name": "Charlie"]]
+let orders = [["id": 100, "customerId": 1, "total": 250], ["id": 101, "customerId": 2, "total": 125], ["id": 102, "customerId": 1, "total": 300], ["id": 103, "customerId": 4, "total": 80]]
+let result = ({
+	var _res: [Any] = []
+	for o in orders {
+		for c in customers {
+			if !(o["customerId"] as! Int == c["id"] as! Int) { continue }
+			_res.append((orderId: o["id"] as! Int, customerName: c["name"] as! String, total: o["total"] as! Int))
+		}
+	}
+	return _res
+}())
+print("--- Orders with customer info ---")
+for entry in result {
+    print("Order", entry["orderId"], "by", entry["customerName"], "- $", entry["total"])
+}


### PR DESCRIPTION
## Summary
- improve var type handling for join queries in Swift compiler
- compile `inner_join.mochi` to Swift and update error output

## Testing
- `go test ./compiler/x/swift -tags=slow` *(fails: Swift not fully working)*

------
https://chatgpt.com/codex/tasks/task_e_686ea7edc66883208438282b7c9cfd5c