### PR TITLE
Improve C# type resolution

### DIFF
--- a/compiler/x/cs/helpers.go
+++ b/compiler/x/cs/helpers.go
@@ -53,9 +53,17 @@ func csTypeOf(t types.Type) string {
 	case types.MapType:
 		return fmt.Sprintf("Dictionary<%s, %s>", csTypeOf(tt.Key), csTypeOf(tt.Value))
 	case types.StructType:
-		return sanitizeName(tt.Name)
+		name := sanitizeName(tt.Name)
+		if name == "" {
+			return "dynamic"
+		}
+		return name
 	case types.UnionType:
-		return sanitizeName(tt.Name)
+		name := sanitizeName(tt.Name)
+		if name == "" {
+			return "dynamic"
+		}
+		return name
 	case types.FuncType:
 		params := make([]string, len(tt.Params))
 		for i, p := range tt.Params {


### PR DESCRIPTION
## Summary
- adjust `csTypeOf` to return `dynamic` when a struct or union type lacks a name

## Testing
- `go test ./compiler/x/cs -run TestDummy -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686ea6d5cbcc83208e567ce49fa92a1d