### PR TITLE
Add aggregate support to Scala compiler

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -72,7 +72,7 @@ This directory contains Scala source files generated from Mochi programs using t
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
 - [ ] pure_global_fold.mochi
-- [ ] query_sum_select.mochi
+- [x] query_sum_select.mochi
 - [x] record_assign.mochi
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi

--- a/tests/machine/x/scala/query_sum_select.scala
+++ b/tests/machine/x/scala/query_sum_select.scala
@@ -1,6 +1,6 @@
 object query_sum_select {
   val nums = List(1, 2, 3)
-  val result = for { n <- nums; if n > 1 } yield n.sum
+  val result = (for { n <- nums; if n > 1 } yield n).sum
   def main(args: Array[String]): Unit = {
     println((result))
   }


### PR DESCRIPTION
## Summary
- handle simple aggregations in Scala compiler's query expressions
- regenerate `query_sum_select.scala`
- mark compiled program in Scala machine README

## Testing
- `go test ./compiler/x/scala -run TestScalaCompilerGolden -count=1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686eab4d13bc8320ac987966647473be