### PR TITLE
Improve Swift compiler group handling

### DIFF
--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -30,14 +30,15 @@ type Compiler struct {
 // New creates a new Compiler instance.
 func New(env *types.Env) *Compiler {
 	return &Compiler{compiler: compiler{
-		structs:    make(map[string][]string),
-		variants:   make(map[string]string),
-		inout:      make(map[string][]bool),
-		funcArgs:   make(map[string][]string),
-		varTypes:   make(map[string]string),
-		swiftTypes: make(map[string]string),
-		mapFields:  make(map[string]map[string]string),
-		groups:     make(map[string]bool),
+		structs:      make(map[string][]string),
+		variants:     make(map[string]string),
+		inout:        make(map[string][]bool),
+		funcArgs:     make(map[string][]string),
+		varTypes:     make(map[string]string),
+		swiftTypes:   make(map[string]string),
+		mapFields:    make(map[string]map[string]string),
+		groups:       make(map[string]bool),
+		groupSources: make(map[string]*parser.Expr),
 	}}
 }
 
@@ -52,17 +53,18 @@ func (c *Compiler) Compile(p *parser.Program) ([]byte, error) {
 }
 
 type compiler struct {
-	buf        strings.Builder
-	indent     int
-	structs    map[string][]string
-	variants   map[string]string
-	inout      map[string][]bool
-	funcArgs   map[string][]string
-	varTypes   map[string]string
-	swiftTypes map[string]string
-	mapFields  map[string]map[string]string
-	groups     map[string]bool
-	tupleMap   bool
+	buf          strings.Builder
+	indent       int
+	structs      map[string][]string
+	variants     map[string]string
+	inout        map[string][]bool
+	funcArgs     map[string][]string
+	varTypes     map[string]string
+	swiftTypes   map[string]string
+	mapFields    map[string]map[string]string
+	groups       map[string]bool
+	groupSources map[string]*parser.Expr
+	tupleMap     bool
 }
 
 func (c *compiler) program(p *parser.Program) error {
@@ -1434,8 +1436,9 @@ func (c *compiler) groupQuery(q *parser.QueryExpr) (string, error) {
 	}
 	gname := q.Group.Name
 	c.varTypes[gname] = ""
-	c.mapFields[gname] = nil
+	c.mapFields[gname] = map[string]string{"key": "Any", "items": "list"}
 	c.groups[gname] = true
+	c.groupSources[gname] = q.Source
 	var having string
 	if q.Group.Having != nil {
 		hv, err := c.expr(q.Group.Having)
@@ -1446,15 +1449,15 @@ func (c *compiler) groupQuery(q *parser.QueryExpr) (string, error) {
 		}
 		having = hv
 	}
-       prevTuple := c.tupleMap
-       c.tupleMap = true
-       sel, err := c.expr(q.Select)
-       c.tupleMap = prevTuple
-       if err != nil {
-               c.varTypes = savedVars
-               c.mapFields = savedFields
-               return "", err
-       }
+	prevTuple := c.tupleMap
+	c.tupleMap = true
+	sel, err := c.expr(q.Select)
+	c.tupleMap = prevTuple
+	if err != nil {
+		c.varTypes = savedVars
+		c.mapFields = savedFields
+		return "", err
+	}
 	sortExpr := ""
 	if q.Sort != nil {
 		prev := c.tupleMap
@@ -1519,6 +1522,7 @@ func (c *compiler) groupQuery(q *parser.QueryExpr) (string, error) {
 	b.WriteString("    return _tmp.map { " + gname + " in " + sel + " }\n")
 	b.WriteString("}()")
 	delete(c.groups, gname)
+	delete(c.groupSources, gname)
 	return b.String(), nil
 }
 
@@ -1535,18 +1539,18 @@ func (c *compiler) joinQuery(q *parser.QueryExpr) (string, error) {
 		}
 		fromSrcs[i] = fs
 	}
-       joinSrcs := make([]string, len(q.Joins))
-       joinSides := make([]string, len(q.Joins))
-       for i, j := range q.Joins {
-               js, err := c.expr(j.Src)
-               if err != nil {
-                       return "", err
-               }
-               joinSrcs[i] = js
-               if j.Side != nil {
-                       joinSides[i] = *j.Side
-               }
-       }
+	joinSrcs := make([]string, len(q.Joins))
+	joinSides := make([]string, len(q.Joins))
+	for i, j := range q.Joins {
+		js, err := c.expr(j.Src)
+		if err != nil {
+			return "", err
+		}
+		joinSrcs[i] = js
+		if j.Side != nil {
+			joinSides[i] = *j.Side
+		}
+	}
 	savedVars := c.varTypes
 	savedFields := c.mapFields
 	c.varTypes = copyMap(c.varTypes)
@@ -1562,29 +1566,29 @@ func (c *compiler) joinQuery(q *parser.QueryExpr) (string, error) {
 		}
 		_ = fromSrcs[i]
 	}
-       for i, j := range q.Joins {
-               c.varTypes[j.Var] = c.elementType(j.Src)
-               if fields := c.elementFieldTypes(j.Src); fields != nil {
-                       c.mapFields[j.Var] = fields
-               }
-               _ = joinSrcs[i]
-       }
+	for i, j := range q.Joins {
+		c.varTypes[j.Var] = c.elementType(j.Src)
+		if fields := c.elementFieldTypes(j.Src); fields != nil {
+			c.mapFields[j.Var] = fields
+		}
+		_ = joinSrcs[i]
+	}
 
-       joinOns := make([]string, len(q.Joins))
-       for i, j := range q.Joins {
-               on, err := c.expr(j.On)
-               if err != nil {
-                       c.varTypes = savedVars
-                       c.mapFields = savedFields
-                       return "", err
-               }
-               joinOns[i] = on
-       }
-       if len(q.Froms) == 0 && len(q.Joins) == 1 && q.Group == nil && q.Sort == nil && q.Skip == nil && q.Take == nil && q.Where == nil && joinSides[0] != "" {
-               c.varTypes = savedVars
-               c.mapFields = savedFields
-               return c.joinSingleSide(q, src, joinSrcs[0], joinOns[0], joinSides[0])
-       }
+	joinOns := make([]string, len(q.Joins))
+	for i, j := range q.Joins {
+		on, err := c.expr(j.On)
+		if err != nil {
+			c.varTypes = savedVars
+			c.mapFields = savedFields
+			return "", err
+		}
+		joinOns[i] = on
+	}
+	if len(q.Froms) == 0 && len(q.Joins) == 1 && q.Group == nil && q.Sort == nil && q.Skip == nil && q.Take == nil && q.Where == nil && joinSides[0] != "" {
+		c.varTypes = savedVars
+		c.mapFields = savedFields
+		return c.joinSingleSide(q, src, joinSrcs[0], joinOns[0], joinSides[0])
+	}
 	cond := ""
 	if q.Where != nil {
 		ccond, err := c.expr(q.Where)
@@ -1595,15 +1599,15 @@ func (c *compiler) joinQuery(q *parser.QueryExpr) (string, error) {
 		}
 		cond = ccond
 	}
-       prevTuple := c.tupleMap
-       c.tupleMap = true
-       sel, err := c.expr(q.Select)
-       c.tupleMap = prevTuple
-       if err != nil {
-               c.varTypes = savedVars
-               c.mapFields = savedFields
-               return "", err
-       }
+	prevTuple := c.tupleMap
+	c.tupleMap = true
+	sel, err := c.expr(q.Select)
+	c.tupleMap = prevTuple
+	if err != nil {
+		c.varTypes = savedVars
+		c.mapFields = savedFields
+		return "", err
+	}
 	c.varTypes = savedVars
 	c.mapFields = savedFields
 
@@ -1983,6 +1987,14 @@ func (c *compiler) elementFieldTypes(e *parser.Expr) map[string]string {
 	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
 		if t, ok := c.mapFields[p.Target.Selector.Root]; ok {
 			return t
+		}
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 1 {
+		root := p.Target.Selector.Root
+		if c.groups[root] && p.Target.Selector.Tail[0] == "items" {
+			if src, ok := c.groupSources[root]; ok {
+				return c.elementFieldTypes(src)
+			}
 		}
 	}
 	if p.Target.List != nil && len(p.Target.List.Elems) > 0 {


### PR DESCRIPTION
## Summary
- extend Swift compiler to track group variable sources
- update `elementFieldTypes` to infer fields from group sources
- store and remove groupSources in `groupQuery`

## Testing
- `go build -tags slow ./...`

------
https://chatgpt.com/codex/tasks/task_e_686eabfa09208320937d77d1cb630d31