### PR TITLE
Add env-aware PHP update compiler

### DIFF
--- a/tests/machine/x/php/update_stmt.out
+++ b/tests/machine/x/php/update_stmt.out
@@ -1,5 +1,1 @@
-PHP Warning:  Undefined variable $age in /workspace/mochi/tests/machine/x/php/update_stmt.php on line 14
-PHP Warning:  Undefined variable $age in /workspace/mochi/tests/machine/x/php/update_stmt.php on line 14
-PHP Warning:  Undefined variable $age in /workspace/mochi/tests/machine/x/php/update_stmt.php on line 14
-PHP Warning:  Undefined variable $age in /workspace/mochi/tests/machine/x/php/update_stmt.php on line 14
 string(2) "ok"

--- a/tests/machine/x/php/update_stmt.php
+++ b/tests/machine/x/php/update_stmt.php
@@ -11,6 +11,9 @@ class Person {
 }
 $people = [new Person(['name' => "Alice", 'age' => 17, 'status' => "minor"]), new Person(['name' => "Bob", 'age' => 25, 'status' => "unknown"]), new Person(['name' => "Charlie", 'age' => 18, 'status' => "unknown"]), new Person(['name' => "Diana", 'age' => 16, 'status' => "minor"])];
 foreach ($people as $_tmp0 => $_tmp1) {
+    $name = $_tmp1->name;
+    $age = $_tmp1->age;
+    $status = $_tmp1->status;
     if ($age >= 18) {
         $_tmp1->status = "adult";
         $_tmp1->age = $age + 1;


### PR DESCRIPTION
## Summary
- fix update statement code generation for PHP backend
- regenerate `update_stmt` PHP output

## Testing
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_ValidPrograms/update_stmt -count=1`
- `php tests/machine/x/php/update_stmt.php`


------
https://chatgpt.com/codex/tasks/task_e_686eafba0d548320bfafac94662637e3