### PR TITLE
Implement partial join support for Pascal

### DIFF
--- a/compiler/x/pascal/helpers.go
+++ b/compiler/x/pascal/helpers.go
@@ -489,3 +489,10 @@ func stringKey(e *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+func asMapLiteral(e *parser.Expr) *parser.MapLiteral {
+	if e == nil || e.Binary == nil || e.Binary.Left == nil || e.Binary.Left.Value == nil || e.Binary.Left.Value.Target == nil {
+		return nil
+	}
+	return e.Binary.Left.Value.Target.Map
+}

--- a/tests/machine/x/pascal/cross_join.error
+++ b/tests/machine/x/pascal/cross_join.error
@@ -4,20 +4,12 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/cross_join.pas
-cross_join.pas(36,16) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" to "TArray$1$crcE0B4E8C7"
-cross_join.pas(49,13) Error: Illegal type conversion: "{Array Of Const/Constant Open} Array of TFPGMap$2$crcDFB44C97" to "TArray$1$crc7ED07D64"
-cross_join.pas(51,35) Error: identifier idents no member "id"
-cross_join.pas(52,43) Error: identifier idents no member "customerId"
-cross_join.pas(53,46) Error: identifier idents no member "name"
-cross_join.pas(54,38) Error: identifier idents no member "total"
-cross_join.pas(60,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcA49C6E68" expected "TArray$1$crcE0B4E8C7"
-cross_join.pas(60,35) Error: Incompatible types: got "TFPGMap<System.Variant,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
 cross_join.pas(63,14) Error: Incompatible types: got "TArray$1$crcE0B4E8C7" expected "TArray$1$crc7ED07D64"
 cross_join.pas(67,35) Error: identifier idents no member "orderId"
 cross_join.pas(67,76) Error: identifier idents no member "orderCustomerId"
 cross_join.pas(68,40) Error: identifier idents no member "orderTotal"
 cross_join.pas(69,15) Error: identifier idents no member "pairedCustomerName"
-cross_join.pas(72) Fatal: There were 13 errors compiling module, stopping
+cross_join.pas(72) Fatal: There were 5 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/cross_join.pas
+++ b/tests/machine/x/pascal/cross_join.pas
@@ -8,14 +8,14 @@ type
   generic TArray<T> = array of T;
 
 var
-  _tmp0: specialize TFPGMap<Variant, Variant>;
-  _tmp1: specialize TFPGMap<Variant, Variant>;
-  _tmp2: specialize TFPGMap<Variant, Variant>;
-  _tmp3: specialize TFPGMap<Variant, integer>;
-  _tmp4: specialize TFPGMap<Variant, integer>;
-  _tmp5: specialize TFPGMap<Variant, integer>;
-  _tmp6: specialize TFPGMap<Variant, Variant>;
-  _tmp7: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp0: specialize TFPGMap<string, Variant>;
+  _tmp1: specialize TFPGMap<string, Variant>;
+  _tmp2: specialize TFPGMap<string, Variant>;
+  _tmp3: specialize TFPGMap<string, integer>;
+  _tmp4: specialize TFPGMap<string, integer>;
+  _tmp5: specialize TFPGMap<string, integer>;
+  _tmp6: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp7: specialize TFPGMap<string, Variant>;
   c: specialize TFPGMap<string, Variant>;
   customers: specialize TArray<specialize TFPGMap<string, Variant>>;
   entry: specialize TFPGMap<string, integer>;
@@ -24,43 +24,43 @@ var
   _result: specialize TArray<specialize TFPGMap<string, integer>>;
 
 begin
-  _tmp0 := specialize TFPGMap<Variant, Variant>.Create;
+  _tmp0 := specialize TFPGMap<string, Variant>.Create;
   _tmp0.AddOrSetData('id', 1);
   _tmp0.AddOrSetData('name', 'Alice');
-  _tmp1 := specialize TFPGMap<Variant, Variant>.Create;
+  _tmp1 := specialize TFPGMap<string, Variant>.Create;
   _tmp1.AddOrSetData('id', 2);
   _tmp1.AddOrSetData('name', 'Bob');
-  _tmp2 := specialize TFPGMap<Variant, Variant>.Create;
+  _tmp2 := specialize TFPGMap<string, Variant>.Create;
   _tmp2.AddOrSetData('id', 3);
   _tmp2.AddOrSetData('name', 'Charlie');
   customers := specialize TArray<specialize TFPGMap<string, Variant>>([_tmp0, _tmp1, _tmp2]);
-  _tmp3 := specialize TFPGMap<Variant, integer>.Create;
+  _tmp3 := specialize TFPGMap<string, integer>.Create;
   _tmp3.AddOrSetData('id', 100);
   _tmp3.AddOrSetData('customerId', 1);
   _tmp3.AddOrSetData('total', 250);
-  _tmp4 := specialize TFPGMap<Variant, integer>.Create;
+  _tmp4 := specialize TFPGMap<string, integer>.Create;
   _tmp4.AddOrSetData('id', 101);
   _tmp4.AddOrSetData('customerId', 2);
   _tmp4.AddOrSetData('total', 125);
-  _tmp5 := specialize TFPGMap<Variant, integer>.Create;
+  _tmp5 := specialize TFPGMap<string, integer>.Create;
   _tmp5.AddOrSetData('id', 102);
   _tmp5.AddOrSetData('customerId', 1);
   _tmp5.AddOrSetData('total', 300);
   orders := specialize TArray<specialize TFPGMap<string, integer>>([_tmp3, _tmp4, _tmp5]);
-  _tmp6 := specialize TFPGMap<Variant, Variant>.Create;
-  _tmp6.AddOrSetData('orderId', o.id);
-  _tmp6.AddOrSetData('orderCustomerId', o.customerId);
-  _tmp6.AddOrSetData('pairedCustomerName', c.name);
-  _tmp6.AddOrSetData('orderTotal', o.total);
-  SetLength(_tmp7, 0);
+  SetLength(_tmp6, 0);
   for o in orders do
     begin
       for c in customers do
         begin
-          _tmp7 := Concat(_tmp7, [_tmp6]);
+          _tmp7 := specialize TFPGMap<string, Variant>.Create;
+          _tmp7.AddOrSetData('orderId', o.KeyData['id']);
+          _tmp7.AddOrSetData('orderCustomerId', o.KeyData['customerId']);
+          _tmp7.AddOrSetData('pairedCustomerName', c.KeyData['name']);
+          _tmp7.AddOrSetData('orderTotal', o.KeyData['total']);
+          _tmp6 := Concat(_tmp6, [_tmp7]);
         end;
     end;
-  _result := _tmp7;
+  _result := _tmp6;
   writeln('--- Cross Join: All order-customer pairs ---');
   for entry in _result do
     begin

--- a/tests/machine/x/pascal/cross_join_filter.error
+++ b/tests/machine/x/pascal/cross_join_filter.error
@@ -4,13 +4,9 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/cross_join_filter.pas
-cross_join_filter.pas(24,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
-cross_join_filter.pas(25,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
-cross_join_filter.pas(32,41) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcB529B9ED" expected "TArray$1$crcE0B4E8C7"
-cross_join_filter.pas(32,35) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
 cross_join_filter.pas(39,17) Error: identifier idents no member "n"
 cross_join_filter.pas(39,27) Error: identifier idents no member "l"
-cross_join_filter.pas(42) Fatal: There were 6 errors compiling module, stopping
+cross_join_filter.pas(42) Fatal: There were 2 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/cross_join_filter.pas
+++ b/tests/machine/x/pascal/cross_join_filter.pas
@@ -8,8 +8,8 @@ type
   generic TArray<T> = array of T;
 
 var
-  _tmp0: specialize TFPGMap<integer, Variant>;
-  _tmp1: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp0: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp1: specialize TFPGMap<string, Variant>;
   l: string;
   letters: specialize TArray<string>;
   n: integer;
@@ -20,19 +20,19 @@ var
 begin
   nums := specialize TArray<integer>([1, 2, 3]);
   letters := specialize TArray<string>(['A', 'B']);
-  _tmp0 := specialize TFPGMap<integer, Variant>.Create;
-  _tmp0.AddOrSetData('n', n);
-  _tmp0.AddOrSetData('l', l);
-  SetLength(_tmp1, 0);
+  SetLength(_tmp0, 0);
   for n in nums do
     begin
       for l in letters do
         begin
           if not ((n mod 2 = 0)) then continue;
-          _tmp1 := Concat(_tmp1, [_tmp0]);
+          _tmp1 := specialize TFPGMap<string, Variant>.Create;
+          _tmp1.AddOrSetData('n', n);
+          _tmp1.AddOrSetData('l', l);
+          _tmp0 := Concat(_tmp0, [_tmp1]);
         end;
     end;
-  pairs := _tmp1;
+  pairs := _tmp0;
   writeln('--- Even pairs ---');
   for p in pairs do
     begin

--- a/tests/machine/x/pascal/cross_join_triple.error
+++ b/tests/machine/x/pascal/cross_join_triple.error
@@ -4,15 +4,10 @@ Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
 Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /workspace/mochi/tests/machine/x/pascal/cross_join_triple.pas
-cross_join_triple.pas(27,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
-cross_join_triple.pas(28,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
-cross_join_triple.pas(29,25) Error: Incompatible type for arg no. 1: Got "Char", expected "LongInt"
-cross_join_triple.pas(37,45) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of TFPGMap$2$crcB529B9ED" expected "TArray$1$crcE0B4E8C7"
-cross_join_triple.pas(37,39) Error: Incompatible types: got "TFPGMap<System.LongInt,System.Variant>" expected "TFPGMap<System.ShortString,System.Variant>"
 cross_join_triple.pas(45,17) Error: identifier idents no member "n"
 cross_join_triple.pas(45,27) Error: identifier idents no member "l"
 cross_join_triple.pas(45,37) Error: identifier idents no member "b"
-cross_join_triple.pas(48) Fatal: There were 8 errors compiling module, stopping
+cross_join_triple.pas(48) Fatal: There were 3 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode
 

--- a/tests/machine/x/pascal/cross_join_triple.pas
+++ b/tests/machine/x/pascal/cross_join_triple.pas
@@ -8,8 +8,8 @@ type
   generic TArray<T> = array of T;
 
 var
-  _tmp0: specialize TFPGMap<integer, Variant>;
-  _tmp1: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp0: specialize TArray<specialize TFPGMap<string, Variant>>;
+  _tmp1: specialize TFPGMap<string, Variant>;
   b: boolean;
   bools: specialize TArray<boolean>;
   c: specialize TFPGMap<string, Variant>;
@@ -23,22 +23,22 @@ begin
   nums := specialize TArray<integer>([1, 2]);
   letters := specialize TArray<string>(['A', 'B']);
   bools := specialize TArray<boolean>([True, False]);
-  _tmp0 := specialize TFPGMap<integer, Variant>.Create;
-  _tmp0.AddOrSetData('n', n);
-  _tmp0.AddOrSetData('l', l);
-  _tmp0.AddOrSetData('b', b);
-  SetLength(_tmp1, 0);
+  SetLength(_tmp0, 0);
   for n in nums do
     begin
       for l in letters do
         begin
           for b in bools do
             begin
-              _tmp1 := Concat(_tmp1, [_tmp0]);
+              _tmp1 := specialize TFPGMap<string, Variant>.Create;
+              _tmp1.AddOrSetData('n', n);
+              _tmp1.AddOrSetData('l', l);
+              _tmp1.AddOrSetData('b', b);
+              _tmp0 := Concat(_tmp0, [_tmp1]);
             end;
         end;
     end;
-  combos := _tmp1;
+  combos := _tmp0;
   writeln('--- Cross Join of three lists ---');
   for c in combos do
     begin


### PR DESCRIPTION
## Summary
- begin adding join capabilities in the Pascal backend
- restructure query compilation with source info and left/right join handling
- add simple map literal detection helper
- regenerate Pascal outputs for cross join samples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686ebb3b2ed483209c47b97d3ffc3222