### PR TITLE
Enhance C++ compiler join support

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -1556,29 +1556,32 @@ func extractVectorElemType(expr string) string {
 	if idx == -1 {
 		return ""
 	}
-	typ := inner[:idx]
-	if strings.Contains(typ, "std::string") {
-		return "std::string"
-	}
-	if strings.Contains(typ, "bool") {
-		return "bool"
-	}
-	if strings.HasPrefix(typ, "decltype(") {
-		texpr := strings.TrimSuffix(strings.TrimPrefix(typ, "decltype("), ")")
-		if strings.HasPrefix(texpr, "__struct") {
-			return texpr
-		}
-		if strings.Contains(texpr, "std::string") {
-			return "std::string"
-		}
-		if strings.Contains(texpr, "true") || strings.Contains(texpr, "false") {
-			return "bool"
-		}
-		if _, err := strconv.Atoi(texpr); err == nil {
-			return "int"
-		}
-	}
-	return ""
+        typ := inner[:idx]
+        if strings.HasPrefix(typ, "decltype(") {
+                texpr := strings.TrimSuffix(strings.TrimPrefix(typ, "decltype("), ")")
+                if strings.HasPrefix(texpr, "__struct") {
+                        if idx := strings.Index(texpr, "{"); idx != -1 {
+                                texpr = texpr[:idx]
+                        }
+                        return texpr
+                }
+                if strings.Contains(texpr, "std::string") {
+                        return "std::string"
+                }
+                if strings.Contains(texpr, "true") || strings.Contains(texpr, "false") {
+                        return "bool"
+                }
+                if _, err := strconv.Atoi(texpr); err == nil {
+                        return "int"
+                }
+        }
+        if strings.Contains(typ, "std::string") {
+                return "std::string"
+        }
+        if strings.Contains(typ, "bool") {
+                return "bool"
+        }
+        return ""
 }
 
 func structLiteralType(expr string) string {

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -2,7 +2,7 @@
 
 This directory contains C++ source code generated from Mochi programs and the corresponding outputs or errors.
 
-Compiled programs: 70/97
+Compiled programs: 72/97
 
 ## Checklist
 
@@ -81,8 +81,8 @@ Compiled programs: 70/97
 - [ ] group_by_sort
 - [ ] group_items_iteration
 - [ ] in_operator_extended
-- [ ] inner_join
-- [ ] join_multi
+- [x] inner_join
+- [x] join_multi
 - [ ] json_builtin
 - [ ] left_join
 - [ ] left_join_multi
@@ -116,8 +116,8 @@ Compiled programs: 70/97
 - [ ] group_by_sort
 - [ ] group_items_iteration
 - [ ] in_operator_extended
-- [ ] inner_join
-- [ ] join_multi
+- [x] inner_join
+- [x] join_multi
 - [ ] json_builtin
 - [ ] left_join
 - [ ] left_join_multi

--- a/tests/machine/x/cpp/append_builtin.cpp
+++ b/tests/machine/x/cpp/append_builtin.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto a = std::vector<decltype(1)>{1, 2};
+  std::vector<int> a = std::vector<decltype(1)>{1, 2};
   {
     auto __tmp1 = ([&](auto v) {
       v.push_back(3);

--- a/tests/machine/x/cpp/break_continue.cpp
+++ b/tests/machine/x/cpp/break_continue.cpp
@@ -7,7 +7,8 @@
 #include <vector>
 
 int main() {
-  auto numbers = std::vector<decltype(1)>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<int> numbers =
+      std::vector<decltype(1)>{1, 2, 3, 4, 5, 6, 7, 8, 9};
   for (auto n : numbers) {
     if (((n % 2) == 0)) {
       continue;

--- a/tests/machine/x/cpp/cross_join_filter.cpp
+++ b/tests/machine/x/cpp/cross_join_filter.cpp
@@ -11,9 +11,9 @@ struct __struct1 {
   std::string l;
 };
 int main() {
-  auto nums = std::vector<decltype(1)>{1, 2, 3};
-  auto letters = std::vector<decltype(std::string("A"))>{std::string("A"),
-                                                         std::string("B")};
+  std::vector<int> nums = std::vector<decltype(1)>{1, 2, 3};
+  std::vector<std::string> letters = std::vector<decltype(std::string("A"))>{
+      std::string("A"), std::string("B")};
   auto pairs = ([&]() {
     std::vector<__struct1> __items;
     for (auto n : nums) {

--- a/tests/machine/x/cpp/cross_join_triple.cpp
+++ b/tests/machine/x/cpp/cross_join_triple.cpp
@@ -12,10 +12,10 @@ struct __struct1 {
   bool b;
 };
 int main() {
-  auto nums = std::vector<decltype(1)>{1, 2};
-  auto letters = std::vector<decltype(std::string("A"))>{std::string("A"),
-                                                         std::string("B")};
-  auto bools = std::vector<decltype(true)>{true, false};
+  std::vector<int> nums = std::vector<decltype(1)>{1, 2};
+  std::vector<std::string> letters = std::vector<decltype(std::string("A"))>{
+      std::string("A"), std::string("B")};
+  std::vector<bool> bools = std::vector<decltype(true)>{true, false};
   auto combos = ([&]() {
     std::vector<__struct1> __items;
     for (auto n : nums) {

--- a/tests/machine/x/cpp/dataset_sort_take_limit.cpp
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.cpp
@@ -11,14 +11,15 @@ struct __struct1 {
   decltype(1500) price;
 };
 int main() {
-  auto products = std::vector<decltype(__struct1{std::string("Laptop"), 1500})>{
-      __struct1{std::string("Laptop"), 1500},
-      __struct1{std::string("Smartphone"), 900},
-      __struct1{std::string("Tablet"), 600},
-      __struct1{std::string("Monitor"), 300},
-      __struct1{std::string("Keyboard"), 100},
-      __struct1{std::string("Mouse"), 50},
-      __struct1{std::string("Headphones"), 200}};
+  std::vector<__struct1> products =
+      std::vector<decltype(__struct1{std::string("Laptop"), 1500})>{
+          __struct1{std::string("Laptop"), 1500},
+          __struct1{std::string("Smartphone"), 900},
+          __struct1{std::string("Tablet"), 600},
+          __struct1{std::string("Monitor"), 300},
+          __struct1{std::string("Keyboard"), 100},
+          __struct1{std::string("Mouse"), 50},
+          __struct1{std::string("Headphones"), 200}};
   auto expensive = ([&]() {
     std::vector<std::pair<decltype(std::declval<__struct1>().price), __struct1>>
         __items;

--- a/tests/machine/x/cpp/dataset_where_filter.cpp
+++ b/tests/machine/x/cpp/dataset_where_filter.cpp
@@ -16,10 +16,12 @@ struct __struct2 {
   bool is_senior;
 };
 int main() {
-  auto people = std::vector<decltype(__struct1{std::string("Alice"), 30})>{
-      __struct1{std::string("Alice"), 30}, __struct1{std::string("Bob"), 15},
-      __struct1{std::string("Charlie"), 65},
-      __struct1{std::string("Diana"), 45}};
+  std::vector<__struct1> people =
+      std::vector<decltype(__struct1{std::string("Alice"), 30})>{
+          __struct1{std::string("Alice"), 30},
+          __struct1{std::string("Bob"), 15},
+          __struct1{std::string("Charlie"), 65},
+          __struct1{std::string("Diana"), 45}};
   auto adults = ([&]() {
     std::vector<__struct2> __items;
     for (auto person : people) {

--- a/tests/machine/x/cpp/exists_builtin.cpp
+++ b/tests/machine/x/cpp/exists_builtin.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto data = std::vector<decltype(1)>{1, 2};
+  std::vector<int> data = std::vector<decltype(1)>{1, 2};
   auto flag = (!([&]() {
                   std::vector<int> __items;
                   for (auto x : data) {

--- a/tests/machine/x/cpp/for_map_collection.cpp
+++ b/tests/machine/x/cpp/for_map_collection.cpp
@@ -7,8 +7,8 @@
 #include <vector>
 
 int main() {
-  auto m = std::unordered_map<std::string, int>{{std::string("a"), 1},
-                                                {std::string("b"), 2}};
+  auto m = std::unordered_map<std::string, decltype(1)>{{std::string("a"), 1},
+                                                        {std::string("b"), 2}};
   for (auto k : m) {
     {
       std::cout << std::boolalpha << k.first << ' ' << k.second;

--- a/tests/machine/x/cpp/in_operator.cpp
+++ b/tests/machine/x/cpp/in_operator.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto xs = std::vector<decltype(1)>{1, 2, 3};
+  std::vector<int> xs = std::vector<decltype(1)>{1, 2, 3};
   {
     std::cout << std::boolalpha
               << (std::find(xs.begin(), xs.end(), 2) != xs.end());

--- a/tests/machine/x/cpp/in_operator_extended.cpp
+++ b/tests/machine/x/cpp/in_operator_extended.cpp
@@ -10,9 +10,9 @@ struct __struct1 {
   decltype(1) a;
 };
 int main() {
-  auto xs = std::vector<decltype(1)>{1, 2, 3};
+  std::vector<int> xs = std::vector<decltype(1)>{1, 2, 3};
   auto ys = ([&]() {
-    std::vector<decltype(x)> __items;
+    std::vector<int> __items;
     for (auto x : xs) {
       if (!(((x % 2) == 1)))
         continue;

--- a/tests/machine/x/cpp/in_operator_extended.error
+++ b/tests/machine/x/cpp/in_operator_extended.error
@@ -1,34 +1,4 @@
-line 15: ../../../tests/machine/x/cpp/in_operator_extended.cpp: In lambda function:
-../../../tests/machine/x/cpp/in_operator_extended.cpp:15:26: error: ‘x’ was not declared in this scope; did you mean ‘xs’?
-   15 |     std::vector<decltype(x)> __items;
-      |                          ^
-      |                          xs
-../../../tests/machine/x/cpp/in_operator_extended.cpp:15:28: error: template argument 1 is invalid
-   15 |     std::vector<decltype(x)> __items;
-      |                            ^
-../../../tests/machine/x/cpp/in_operator_extended.cpp:15:28: error: template argument 2 is invalid
-../../../tests/machine/x/cpp/in_operator_extended.cpp:19:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
-   19 |       __items.push_back(x);
-      |               ^~~~~~~~~
-../../../tests/machine/x/cpp/in_operator_extended.cpp: In function ‘int main()’:
-../../../tests/machine/x/cpp/in_operator_extended.cpp:25:32: error: request for member ‘begin’ in ‘ys’, which is of non-class type ‘int’
-   25 |               << (std::find(ys.begin(), ys.end(), 1) != ys.end());
-      |                                ^~~~~
-../../../tests/machine/x/cpp/in_operator_extended.cpp:25:44: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
-   25 |               << (std::find(ys.begin(), ys.end(), 1) != ys.end());
-      |                                            ^~~
-../../../tests/machine/x/cpp/in_operator_extended.cpp:25:60: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
-   25 |               << (std::find(ys.begin(), ys.end(), 1) != ys.end());
-      |                                                            ^~~
-../../../tests/machine/x/cpp/in_operator_extended.cpp:30:32: error: request for member ‘begin’ in ‘ys’, which is of non-class type ‘int’
-   30 |               << (std::find(ys.begin(), ys.end(), 2) != ys.end());
-      |                                ^~~~~
-../../../tests/machine/x/cpp/in_operator_extended.cpp:30:44: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
-   30 |               << (std::find(ys.begin(), ys.end(), 2) != ys.end());
-      |                                            ^~~
-../../../tests/machine/x/cpp/in_operator_extended.cpp:30:60: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
-   30 |               << (std::find(ys.begin(), ys.end(), 2) != ys.end());
-      |                                                            ^~~
+line 36: ../../../tests/machine/x/cpp/in_operator_extended.cpp: In function ‘int main()’:
 ../../../tests/machine/x/cpp/in_operator_extended.cpp:36:31: error: ‘struct __struct1’ has no member named ‘begin’
    36 |               << (std::find(m.begin(), m.end(), std::string("a")) != m.end());
       |                               ^~~~~
@@ -48,6 +18,6 @@ line 15: ../../../tests/machine/x/cpp/in_operator_extended.cpp: In lambda functi
    41 |               << (std::find(m.begin(), m.end(), std::string("b")) != m.end());
       |                                                                        ^~~
 
- 14 |   auto ys = ([&]() {
- 15 |     std::vector<decltype(x)> __items;
- 16 |     for (auto x : xs) {
+ 35 |     std::cout << std::boolalpha
+ 36 |               << (std::find(m.begin(), m.end(), std::string("a")) != m.end());
+ 37 |     std::cout << std::endl;

--- a/tests/machine/x/cpp/inner_join.cpp
+++ b/tests/machine/x/cpp/inner_join.cpp
@@ -17,9 +17,8 @@ struct __struct2 {
 };
 struct __struct3 {
   decltype(std::declval<__struct2>().id) orderId;
-  decltype(std::declval<__struct2>().customerId) orderCustomerId;
-  decltype(std::declval<__struct1>().name) pairedCustomerName;
-  decltype(std::declval<__struct2>().total) orderTotal;
+  decltype(std::declval<__struct1>().name) customerName;
+  decltype(std::declval<__struct2>().total) total;
 };
 int main() {
   std::vector<__struct1> customers =
@@ -27,19 +26,22 @@ int main() {
           __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
           __struct1{3, std::string("Charlie")}};
   std::vector<__struct2> orders = std::vector<decltype(__struct2{100, 1, 250})>{
-      __struct2{100, 1, 250}, __struct2{101, 2, 125}, __struct2{102, 1, 300}};
+      __struct2{100, 1, 250}, __struct2{101, 2, 125}, __struct2{102, 1, 300},
+      __struct2{103, 4, 80}};
   auto result = ([&]() {
     std::vector<__struct3> __items;
     for (auto o : orders) {
       for (auto c : customers) {
-        __items.push_back(__struct3{o.id, o.customerId, c.name, o.total});
+        if (!((o.customerId == c.id)))
+          continue;
+        __items.push_back(__struct3{o.id, c.name, o.total});
       }
     }
     return __items;
   })();
   {
     std::cout << std::boolalpha
-              << std::string("--- Cross Join: All order-customer pairs ---");
+              << std::string("--- Orders with customer info ---");
     std::cout << std::endl;
   }
   for (auto entry : result) {
@@ -48,17 +50,13 @@ int main() {
       std::cout << ' ';
       std::cout << std::boolalpha << entry.orderId;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("(customerId:");
+      std::cout << std::boolalpha << std::string("by");
       std::cout << ' ';
-      std::cout << std::boolalpha << entry.orderCustomerId;
+      std::cout << std::boolalpha << entry.customerName;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string(", total: $");
+      std::cout << std::boolalpha << std::string("- $");
       std::cout << ' ';
-      std::cout << std::boolalpha << entry.orderTotal;
-      std::cout << ' ';
-      std::cout << std::boolalpha << std::string(") paired with");
-      std::cout << ' ';
-      std::cout << std::boolalpha << entry.pairedCustomerName;
+      std::cout << std::boolalpha << entry.total;
       std::cout << std::endl;
     }
   }

--- a/tests/machine/x/cpp/inner_join.error
+++ b/tests/machine/x/cpp/inner_join.error
@@ -1,1 +1,0 @@
-line 0: compile error: query features not supported

--- a/tests/machine/x/cpp/inner_join.out
+++ b/tests/machine/x/cpp/inner_join.out
@@ -1,0 +1,4 @@
+--- Orders with customer info ---
+Order 100 by Alice - $ 250
+Order 101 by Bob - $ 125
+Order 102 by Alice - $ 300

--- a/tests/machine/x/cpp/join_multi.cpp
+++ b/tests/machine/x/cpp/join_multi.cpp
@@ -1,0 +1,64 @@
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+struct __struct1 {
+  decltype(1) id;
+  decltype(std::string("Alice")) name;
+};
+struct __struct2 {
+  decltype(100) id;
+  decltype(1) customerId;
+};
+struct __struct3 {
+  decltype(100) orderId;
+  decltype(std::string("a")) sku;
+};
+struct __struct4 {
+  decltype(std::declval<__struct1>().name) name;
+  decltype(std::declval<__struct3>().sku) sku;
+};
+int main() {
+  std::vector<__struct1> customers =
+      std::vector<decltype(__struct1{1, std::string("Alice")})>{
+          __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")}};
+  std::vector<__struct2> orders = std::vector<decltype(__struct2{100, 1})>{
+      __struct2{100, 1}, __struct2{101, 2}};
+  std::vector<__struct3> items =
+      std::vector<decltype(__struct3{100, std::string("a")})>{
+          __struct3{100, std::string("a")}, __struct3{101, std::string("b")}};
+  auto result = ([&]() {
+    std::vector<__struct4> __items;
+    for (auto o : orders) {
+      for (auto c : customers) {
+        if (!((o.customerId == c.id)))
+          continue;
+        for (auto i : items) {
+          if (!((o.id == i.orderId)))
+            continue;
+          __items.push_back(__struct4{c.name, i.sku});
+        }
+      }
+    }
+    return __items;
+  })();
+  {
+    std::cout << std::boolalpha << std::string("--- Multi Join ---");
+    std::cout << std::endl;
+  }
+  for (auto r : result) {
+    {
+      std::cout << std::boolalpha << r.name;
+      std::cout << ' ';
+      std::cout << std::boolalpha << std::string("bought item");
+      std::cout << ' ';
+      std::cout << std::boolalpha << r.sku;
+      std::cout << std::endl;
+    }
+  }
+  return 0;
+}

--- a/tests/machine/x/cpp/join_multi.error
+++ b/tests/machine/x/cpp/join_multi.error
@@ -1,1 +1,0 @@
-line 0: compile error: query features not supported

--- a/tests/machine/x/cpp/join_multi.out
+++ b/tests/machine/x/cpp/join_multi.out
@@ -1,0 +1,3 @@
+--- Multi Join ---
+Alice bought item a
+Bob bought item b

--- a/tests/machine/x/cpp/left_join.error
+++ b/tests/machine/x/cpp/left_join.error
@@ -1,1 +1,1 @@
-line 0: compile error: query features not supported
+line 0: compile error: join side not supported

--- a/tests/machine/x/cpp/left_join_multi.error
+++ b/tests/machine/x/cpp/left_join_multi.error
@@ -1,1 +1,1 @@
-line 0: compile error: query features not supported
+line 0: compile error: join side not supported

--- a/tests/machine/x/cpp/len_map.cpp
+++ b/tests/machine/x/cpp/len_map.cpp
@@ -8,10 +8,11 @@
 
 int main() {
   {
-    std::cout << std::boolalpha
-              << std::unordered_map<std::string, int>{{std::string("a"), 1},
-                                                      {std::string("b"), 2}}
-                     .size();
+    std::cout
+        << std::boolalpha
+        << std::unordered_map<std::string, decltype(1)>{{std::string("a"), 1},
+                                                        {std::string("b"), 2}}
+               .size();
     std::cout << std::endl;
   }
   return 0;

--- a/tests/machine/x/cpp/list_assign.cpp
+++ b/tests/machine/x/cpp/list_assign.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<decltype(1)>{1, 2};
+  std::vector<int> nums = std::vector<decltype(1)>{1, 2};
   nums[1] = 3;
   {
     std::cout << std::boolalpha << nums[1];

--- a/tests/machine/x/cpp/list_index.cpp
+++ b/tests/machine/x/cpp/list_index.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto xs = std::vector<decltype(10)>{10, 20, 30};
+  std::vector<int> xs = std::vector<decltype(10)>{10, 20, 30};
   {
     std::cout << std::boolalpha << xs[1];
     std::cout << std::endl;

--- a/tests/machine/x/cpp/map_assign.cpp
+++ b/tests/machine/x/cpp/map_assign.cpp
@@ -7,7 +7,8 @@
 #include <vector>
 
 int main() {
-  auto scores = std::unordered_map<std::string, int>{{std::string("alice"), 1}};
+  auto scores =
+      std::unordered_map<std::string, decltype(1)>{{std::string("alice"), 1}};
   scores[std::string("bob")] = 2;
   {
     std::cout << std::boolalpha << scores[std::string("bob")];

--- a/tests/machine/x/cpp/map_index.cpp
+++ b/tests/machine/x/cpp/map_index.cpp
@@ -7,8 +7,8 @@
 #include <vector>
 
 int main() {
-  auto m = std::unordered_map<std::string, int>{{std::string("a"), 1},
-                                                {std::string("b"), 2}};
+  auto m = std::unordered_map<std::string, decltype(1)>{{std::string("a"), 1},
+                                                        {std::string("b"), 2}};
   {
     std::cout << std::boolalpha << m[std::string("b")];
     std::cout << std::endl;

--- a/tests/machine/x/cpp/map_literal_dynamic.cpp
+++ b/tests/machine/x/cpp/map_literal_dynamic.cpp
@@ -9,8 +9,8 @@
 int main() {
   auto x = 3;
   auto y = 4;
-  auto m = std::unordered_map<std::string, int>{{std::string("a"), x},
-                                                {std::string("b"), y}};
+  auto m = std::unordered_map<std::string, decltype(x)>{{std::string("a"), x},
+                                                        {std::string("b"), y}};
   {
     std::cout << std::boolalpha << m[std::string("a")];
     std::cout << ' ';

--- a/tests/machine/x/cpp/map_membership.cpp
+++ b/tests/machine/x/cpp/map_membership.cpp
@@ -7,8 +7,8 @@
 #include <vector>
 
 int main() {
-  auto m = std::unordered_map<std::string, int>{{std::string("a"), 1},
-                                                {std::string("b"), 2}};
+  auto m = std::unordered_map<std::string, decltype(1)>{{std::string("a"), 1},
+                                                        {std::string("b"), 2}};
   {
     std::cout << std::boolalpha << (m.count(std::string("a")) > 0);
     std::cout << std::endl;

--- a/tests/machine/x/cpp/membership.cpp
+++ b/tests/machine/x/cpp/membership.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<decltype(1)>{1, 2, 3};
+  std::vector<int> nums = std::vector<decltype(1)>{1, 2, 3};
   {
     std::cout << std::boolalpha
               << (std::find(nums.begin(), nums.end(), 2) != nums.end());

--- a/tests/machine/x/cpp/min_max_builtin.cpp
+++ b/tests/machine/x/cpp/min_max_builtin.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<decltype(3)>{3, 1, 4};
+  std::vector<int> nums = std::vector<decltype(3)>{3, 1, 4};
   {
     std::cout << std::boolalpha
               << (*std::min_element(nums.begin(), nums.end()));

--- a/tests/machine/x/cpp/order_by_map.cpp
+++ b/tests/machine/x/cpp/order_by_map.cpp
@@ -11,7 +11,7 @@ struct __struct1 {
   decltype(2) b;
 };
 int main() {
-  auto data = std::vector<decltype(__struct1{1, 2})>{
+  std::vector<__struct1> data = std::vector<decltype(__struct1{1, 2})>{
       __struct1{1, 2}, __struct1{1, 1}, __struct1{0, 5}};
   auto sorted = ([&]() {
     std::vector<std::pair<decltype(std::declval<__struct1>().a), __struct1>>
@@ -27,7 +27,12 @@ int main() {
     return __res;
   })();
   {
-    std::cout << std::boolalpha << sorted;
+    auto __tmp1 = sorted;
+    for (size_t i = 0; i < __tmp1.size(); ++i) {
+      if (i)
+        std::cout << ' ';
+      std::cout << std::boolalpha << __tmp1[i];
+    }
     std::cout << std::endl;
   }
   return 0;

--- a/tests/machine/x/cpp/order_by_map.error
+++ b/tests/machine/x/cpp/order_by_map.error
@@ -17,121 +17,117 @@ In file included from /usr/include/c++/13/vector:66,
  1298 |       push_back(value_type&& __x)
       |                 ~~~~~~~~~~~~~^~~
 ../../../tests/machine/x/cpp/order_by_map.cpp: In function ‘int main()’:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:33: error: no match for ‘operator<<’ (operand types are ‘std::basic_ostream<char>::__ostream_type’ {aka ‘std::basic_ostream<char>’} and ‘std::vector<__struct1>’)
-   30 |     std::cout << std::boolalpha << sorted;
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~ ~~~~~~
-      |               |                    |
-      |               |                    std::vector<__struct1>
-      |               std::basic_ostream<char>::__ostream_type {aka std::basic_ostream<char>}
+../../../tests/machine/x/cpp/order_by_map.cpp:34:35: error: no match for ‘operator<<’ (operand types are ‘std::basic_ostream<char>::__ostream_type’ {aka ‘std::basic_ostream<char>’} and ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’})
+   34 |       std::cout << std::boolalpha << __tmp1[i];
 In file included from /usr/include/c++/13/iostream:41,
                  from ../../../tests/machine/x/cpp/order_by_map.cpp:2:
 /usr/include/c++/13/ostream:110:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ostream_type& (*)(__ostream_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   110 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:110:36: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘std::basic_ostream<char>::__ostream_type& (*)(std::basic_ostream<char>::__ostream_type&)’ {aka ‘std::basic_ostream<char>& (*)(std::basic_ostream<char>&)’}
+/usr/include/c++/13/ostream:110:36: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘std::basic_ostream<char>::__ostream_type& (*)(std::basic_ostream<char>::__ostream_type&)’ {aka ‘std::basic_ostream<char>& (*)(std::basic_ostream<char>&)’}
   110 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
       |                  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
 /usr/include/c++/13/ostream:119:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ios_type& (*)(__ios_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>; __ios_type = std::basic_ios<char>]’
   119 |       operator<<(__ios_type& (*__pf)(__ios_type&))
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:119:32: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘std::basic_ostream<char>::__ios_type& (*)(std::basic_ostream<char>::__ios_type&)’ {aka ‘std::basic_ios<char>& (*)(std::basic_ios<char>&)’}
+/usr/include/c++/13/ostream:119:32: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘std::basic_ostream<char>::__ios_type& (*)(std::basic_ostream<char>::__ios_type&)’ {aka ‘std::basic_ios<char>& (*)(std::basic_ios<char>&)’}
   119 |       operator<<(__ios_type& (*__pf)(__ios_type&))
       |                  ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
 /usr/include/c++/13/ostream:129:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(std::ios_base& (*)(std::ios_base&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   129 |       operator<<(ios_base& (*__pf) (ios_base&))
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:129:30: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘std::ios_base& (*)(std::ios_base&)’
+/usr/include/c++/13/ostream:129:30: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘std::ios_base& (*)(std::ios_base&)’
   129 |       operator<<(ios_base& (*__pf) (ios_base&))
       |                  ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
 /usr/include/c++/13/ostream:168:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   168 |       operator<<(long __n)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:168:23: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘long int’
+/usr/include/c++/13/ostream:168:23: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘long int’
   168 |       operator<<(long __n)
       |                  ~~~~~^~~
 /usr/include/c++/13/ostream:172:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   172 |       operator<<(unsigned long __n)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:172:32: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘long unsigned int’
+/usr/include/c++/13/ostream:172:32: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘long unsigned int’
   172 |       operator<<(unsigned long __n)
       |                  ~~~~~~~~~~~~~~^~~
 /usr/include/c++/13/ostream:176:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(bool) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   176 |       operator<<(bool __n)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:176:23: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘bool’
+/usr/include/c++/13/ostream:176:23: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘bool’
   176 |       operator<<(bool __n)
       |                  ~~~~~^~~
 In file included from /usr/include/c++/13/ostream:880:
 /usr/include/c++/13/bits/ostream.tcc:96:5: note: candidate: ‘std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(short int) [with _CharT = char; _Traits = std::char_traits<char>]’
    96 |     basic_ostream<_CharT, _Traits>::
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/usr/include/c++/13/bits/ostream.tcc:97:22: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘short int’
+/usr/include/c++/13/bits/ostream.tcc:97:22: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘short int’
    97 |     operator<<(short __n)
       |                ~~~~~~^~~
 /usr/include/c++/13/ostream:183:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(short unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   183 |       operator<<(unsigned short __n)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:183:33: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘short unsigned int’
+/usr/include/c++/13/ostream:183:33: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘short unsigned int’
   183 |       operator<<(unsigned short __n)
       |                  ~~~~~~~~~~~~~~~^~~
 /usr/include/c++/13/bits/ostream.tcc:110:5: note: candidate: ‘std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char; _Traits = std::char_traits<char>]’
   110 |     basic_ostream<_CharT, _Traits>::
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/usr/include/c++/13/bits/ostream.tcc:111:20: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘int’
+/usr/include/c++/13/bits/ostream.tcc:111:20: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘int’
   111 |     operator<<(int __n)
       |                ~~~~^~~
 /usr/include/c++/13/ostream:194:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   194 |       operator<<(unsigned int __n)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:194:31: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘unsigned int’
+/usr/include/c++/13/ostream:194:31: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘unsigned int’
   194 |       operator<<(unsigned int __n)
       |                  ~~~~~~~~~~~~~^~~
 /usr/include/c++/13/ostream:203:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long long int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   203 |       operator<<(long long __n)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:203:28: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘long long int’
+/usr/include/c++/13/ostream:203:28: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘long long int’
   203 |       operator<<(long long __n)
       |                  ~~~~~~~~~~^~~
 /usr/include/c++/13/ostream:207:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long long unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   207 |       operator<<(unsigned long long __n)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:207:37: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘long long unsigned int’
+/usr/include/c++/13/ostream:207:37: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘long long unsigned int’
   207 |       operator<<(unsigned long long __n)
       |                  ~~~~~~~~~~~~~~~~~~~^~~
 /usr/include/c++/13/ostream:222:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(double) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   222 |       operator<<(double __f)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:222:25: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘double’
+/usr/include/c++/13/ostream:222:25: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘double’
   222 |       operator<<(double __f)
       |                  ~~~~~~~^~~
 /usr/include/c++/13/ostream:226:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(float) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   226 |       operator<<(float __f)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:226:24: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘float’
+/usr/include/c++/13/ostream:226:24: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘float’
   226 |       operator<<(float __f)
       |                  ~~~~~~^~~
 /usr/include/c++/13/ostream:234:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long double) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   234 |       operator<<(long double __f)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:234:30: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘long double’
+/usr/include/c++/13/ostream:234:30: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘long double’
   234 |       operator<<(long double __f)
       |                  ~~~~~~~~~~~~^~~
 /usr/include/c++/13/ostream:292:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(const void*) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   292 |       operator<<(const void* __p)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:292:30: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘const void*’
+/usr/include/c++/13/ostream:292:30: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘const void*’
   292 |       operator<<(const void* __p)
       |                  ~~~~~~~~~~~~^~~
 /usr/include/c++/13/ostream:297:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(std::nullptr_t) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>; std::nullptr_t = std::nullptr_t]’
   297 |       operator<<(nullptr_t)
       |       ^~~~~~~~
-/usr/include/c++/13/ostream:297:18: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘std::nullptr_t’
+/usr/include/c++/13/ostream:297:18: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘std::nullptr_t’
   297 |       operator<<(nullptr_t)
       |                  ^~~~~~~~~
 /usr/include/c++/13/bits/ostream.tcc:124:5: note: candidate: ‘std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(__streambuf_type*) [with _CharT = char; _Traits = std::char_traits<char>; __streambuf_type = std::basic_streambuf<char>]’
   124 |     basic_ostream<_CharT, _Traits>::
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/usr/include/c++/13/bits/ostream.tcc:125:34: note:   no known conversion for argument 1 from ‘std::vector<__struct1>’ to ‘std::basic_ostream<char>::__streambuf_type*’ {aka ‘std::basic_streambuf<char>*’}
+/usr/include/c++/13/bits/ostream.tcc:125:34: note:   no known conversion for argument 1 from ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} to ‘std::basic_ostream<char>::__streambuf_type*’ {aka ‘std::basic_streambuf<char>*’}
   125 |     operator<<(__streambuf_type* __sbin)
       |                ~~~~~~~~~~~~~~~~~~^~~~~~
 In file included from /usr/include/c++/13/bits/basic_string.h:47,
@@ -144,109 +140,109 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   761 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:761:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   ‘std::vector<__struct1>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   ‘__struct1’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/bits/basic_string.h:4032:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  4032 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:4032:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   ‘std::vector<__struct1>’ is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 In file included from /usr/include/c++/13/bits/memory_resource.h:38,
                  from /usr/include/c++/13/string:58:
 /usr/include/c++/13/cstddef:124:5: note: candidate: ‘template<class _IntegerType> constexpr std::__byte_op_t<_IntegerType> std::operator<<(byte, _IntegerType)’
   124 |     operator<<(byte __b, _IntegerType __shift) noexcept
       |     ^~~~~~~~
 /usr/include/c++/13/cstddef:124:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:15: note:   cannot convert ‘std::cout.std::basic_ostream<char>::operator<<(std::boolalpha)’ (type ‘std::basic_ostream<char>::__ostream_type’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
-   30 |     std::cout << std::boolalpha << sorted;
-      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:17: note:   cannot convert ‘std::cout.std::basic_ostream<char>::operator<<(std::boolalpha)’ (type ‘std::basic_ostream<char>::__ostream_type’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |       ~~~~~~~~~~^~~~~~~~~~~~~~~~~
 In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/system_error:339:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const error_code&)’
   339 |     operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
       |     ^~~~~~~~
 /usr/include/c++/13/system_error:339:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘const std::error_code&’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘const std::error_code&’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:554:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, _CharT)’
   554 |     operator<<(basic_ostream<_CharT, _Traits>& __out, _CharT __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:554:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘std::vector<__struct1>’)
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘__struct1’)
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:564:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, char)’
   564 |     operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:564:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘char’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘char’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:570:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, char)’
   570 |     operator<<(basic_ostream<char, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:570:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘char’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘char’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:581:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, signed char)’
   581 |     operator<<(basic_ostream<char, _Traits>& __out, signed char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:581:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘signed char’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘signed char’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:586:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, unsigned char)’
   586 |     operator<<(basic_ostream<char, _Traits>& __out, unsigned char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:586:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘unsigned char’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘unsigned char’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:645:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const _CharT*)’
   645 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const _CharT* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:645:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   mismatched types ‘const _CharT*’ and ‘std::vector<__struct1>’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   mismatched types ‘const _CharT*’ and ‘__struct1’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/bits/ostream.tcc:307:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const char*)’
   307 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/ostream.tcc:307:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘const char*’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘const char*’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:662:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const char*)’
   662 |     operator<<(basic_ostream<char, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:662:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘const char*’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘const char*’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:675:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const signed char*)’
   675 |     operator<<(basic_ostream<char, _Traits>& __out, const signed char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:675:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘const signed char*’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘const signed char*’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:680:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const unsigned char*)’
   680 |     operator<<(basic_ostream<char, _Traits>& __out, const unsigned char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:680:5: note:   template argument deduction/substitution failed:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36: note:   cannot convert ‘sorted’ (type ‘std::vector<__struct1>’) to type ‘const unsigned char*’
-   30 |     std::cout << std::boolalpha << sorted;
-      |                                    ^~~~~~
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46: note:   cannot convert ‘__tmp1.std::vector<__struct1>::operator[](i)’ (type ‘__gnu_cxx::__alloc_traits<std::allocator<__struct1>, __struct1>::value_type’ {aka ‘std::allocator_traits<std::allocator<__struct1> >::value_type’}) to type ‘const unsigned char*’
+   34 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                              ^
 /usr/include/c++/13/ostream:801:5: note: candidate: ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&)’
   801 |     operator<<(_Ostream&& __os, const _Tp& __x)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:801:5: note:   template argument deduction/substitution failed:
-/usr/include/c++/13/ostream: In substitution of ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&) [with _Ostream = std::basic_ostream<char>&; _Tp = std::vector<__struct1>]’:
-../../../tests/machine/x/cpp/order_by_map.cpp:30:36:   required from here
+/usr/include/c++/13/ostream: In substitution of ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&) [with _Ostream = std::basic_ostream<char>&; _Tp = __struct1]’:
+../../../tests/machine/x/cpp/order_by_map.cpp:34:46:   required from here
 /usr/include/c++/13/ostream:801:5: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’
 
  19 |     for (auto x : data) {

--- a/tests/machine/x/cpp/outer_join.error
+++ b/tests/machine/x/cpp/outer_join.error
@@ -1,1 +1,1 @@
-line 0: compile error: query features not supported
+line 0: compile error: join side not supported

--- a/tests/machine/x/cpp/query_sum_select.cpp
+++ b/tests/machine/x/cpp/query_sum_select.cpp
@@ -7,18 +7,26 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<decltype(1)>{1, 2, 3};
+  std::vector<int> nums = std::vector<decltype(1)>{1, 2, 3};
   auto result = ([&]() {
-    std::vector<decltype(std::accumulate(n.begin(), n.end(), 0))> __items;
+    std::vector<decltype((
+        [&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n))>
+        __items;
     for (auto n : nums) {
       if (!((n > 1)))
         continue;
-      __items.push_back(std::accumulate(n.begin(), n.end(), 0));
+      __items.push_back(
+          ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n));
     }
     return __items;
   })();
   {
-    std::cout << std::boolalpha << result;
+    auto __tmp1 = result;
+    for (size_t i = 0; i < __tmp1.size(); ++i) {
+      if (i)
+        std::cout << ' ';
+      std::cout << std::boolalpha << __tmp1[i];
+    }
     std::cout << std::endl;
   }
   return 0;

--- a/tests/machine/x/cpp/query_sum_select.error
+++ b/tests/machine/x/cpp/query_sum_select.error
@@ -1,21 +1,33 @@
-line 12: ../../../tests/machine/x/cpp/query_sum_select.cpp: In lambda function:
-../../../tests/machine/x/cpp/query_sum_select.cpp:12:42: error: ‘n’ was not declared in this scope
-   12 |     std::vector<decltype(std::accumulate(n.begin(), n.end(), 0))> __items;
-      |                                          ^
-../../../tests/machine/x/cpp/query_sum_select.cpp:12:65: error: template argument 1 is invalid
-   12 |     std::vector<decltype(std::accumulate(n.begin(), n.end(), 0))> __items;
-      |                                                                 ^
-../../../tests/machine/x/cpp/query_sum_select.cpp:12:65: error: template argument 2 is invalid
-../../../tests/machine/x/cpp/query_sum_select.cpp:16:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
-   16 |       __items.push_back(std::accumulate(n.begin(), n.end(), 0));
+line 13: ../../../tests/machine/x/cpp/query_sum_select.cpp: In lambda function:
+../../../tests/machine/x/cpp/query_sum_select.cpp:13:9: error: lambda-expression in unevaluated context only available with ‘-std=c++20’ or ‘-std=gnu++20’
+   13 |         [&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n))>
+      |         ^
+../../../tests/machine/x/cpp/query_sum_select.cpp:13:73: error: ‘n’ was not declared in this scope
+   13 |         [&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n))>
+      |                                                                         ^
+../../../tests/machine/x/cpp/query_sum_select.cpp:13:76: error: template argument 1 is invalid
+   13 |         [&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n))>
+      |                                                                            ^
+../../../tests/machine/x/cpp/query_sum_select.cpp:13:76: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/query_sum_select.cpp:18:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   18 |       __items.push_back(
       |               ^~~~~~~~~
-../../../tests/machine/x/cpp/query_sum_select.cpp:16:43: error: request for member ‘begin’ in ‘n’, which is of non-class type ‘int’
-   16 |       __items.push_back(std::accumulate(n.begin(), n.end(), 0));
-      |                                           ^~~~~
-../../../tests/machine/x/cpp/query_sum_select.cpp:16:54: error: request for member ‘end’ in ‘n’, which is of non-class type ‘int’
-   16 |       __items.push_back(std::accumulate(n.begin(), n.end(), 0));
-      |                                                      ^~~
+../../../tests/machine/x/cpp/query_sum_select.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+../../../tests/machine/x/cpp/query_sum_select.cpp:19:75:   required from here
+../../../tests/machine/x/cpp/query_sum_select.cpp:19:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   19 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n));
+      |                                                 ~~^~~~~
+../../../tests/machine/x/cpp/query_sum_select.cpp:19:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   19 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n));
+      |                                                            ~~^~~
+../../../tests/machine/x/cpp/query_sum_select.cpp: In function ‘int main()’:
+../../../tests/machine/x/cpp/query_sum_select.cpp:25:35: error: request for member ‘size’ in ‘__tmp1’, which is of non-class type ‘int’
+   25 |     for (size_t i = 0; i < __tmp1.size(); ++i) {
+      |                                   ^~~~
+../../../tests/machine/x/cpp/query_sum_select.cpp:28:44: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
+   28 |       std::cout << std::boolalpha << __tmp1[i];
+      |                                            ^
 
- 11 |   auto result = ([&]() {
- 12 |     std::vector<decltype(std::accumulate(n.begin(), n.end(), 0))> __items;
- 13 |     for (auto n : nums) {
+ 12 |     std::vector<decltype((
+ 13 |         [&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(n))>
+ 14 |         __items;

--- a/tests/machine/x/cpp/right_join.error
+++ b/tests/machine/x/cpp/right_join.error
@@ -1,1 +1,1 @@
-line 0: compile error: query features not supported
+line 0: compile error: join side not supported

--- a/tests/machine/x/cpp/slice.cpp
+++ b/tests/machine/x/cpp/slice.cpp
@@ -8,25 +8,20 @@
 
 int main() {
   {
-    auto __tmp1 = std::vector<decltype(1)>{1, 2, 3}[1];
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
-        std::cout << ' ';
-      std::cout << std::boolalpha << __tmp1[i];
-    }
+    std::cout
+        << std::boolalpha
+        << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(1, (3) - (1));
     std::cout << std::endl;
   }
   {
-    auto __tmp2 = std::vector<decltype(1)>{1, 2, 3}[0];
-    for (size_t i = 0; i < __tmp2.size(); ++i) {
-      if (i)
-        std::cout << ' ';
-      std::cout << std::boolalpha << __tmp2[i];
-    }
+    std::cout
+        << std::boolalpha
+        << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(0, (2) - (0));
     std::cout << std::endl;
   }
   {
-    std::cout << std::boolalpha << std::string("hello")[1];
+    std::cout << std::boolalpha
+              << std::string(std::string("hello")).substr(1, (4) - (1));
     std::cout << std::endl;
   }
   return 0;

--- a/tests/machine/x/cpp/slice.error
+++ b/tests/machine/x/cpp/slice.error
@@ -1,17 +1,204 @@
-line 12: ../../../tests/machine/x/cpp/slice.cpp: In function ‘int main()’:
-../../../tests/machine/x/cpp/slice.cpp:12:35: error: request for member ‘size’ in ‘__tmp1’, which is of non-class type ‘int’
-   12 |     for (size_t i = 0; i < __tmp1.size(); ++i) {
-      |                                   ^~~~
-../../../tests/machine/x/cpp/slice.cpp:15:44: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
-   15 |       std::cout << std::boolalpha << __tmp1[i];
-      |                                            ^
-../../../tests/machine/x/cpp/slice.cpp:21:35: error: request for member ‘size’ in ‘__tmp2’, which is of non-class type ‘int’
-   21 |     for (size_t i = 0; i < __tmp2.size(); ++i) {
-      |                                   ^~~~
-../../../tests/machine/x/cpp/slice.cpp:24:44: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
-   24 |       std::cout << std::boolalpha << __tmp2[i];
-      |                                            ^
+line 13: ../../../tests/machine/x/cpp/slice.cpp: In function ‘int main()’:
+../../../tests/machine/x/cpp/slice.cpp:13:57: error: no matching function for call to ‘std::__cxx11::basic_string<char>::basic_string(std::vector<int>)’
+   13 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(1, (3) - (1));
+      |                                                         ^
+In file included from /usr/include/c++/13/string:54,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from ../../../tests/machine/x/cpp/slice.cpp:2:
+/usr/include/c++/13/bits/basic_string.h:795:9: note: candidate: ‘template<class _Tp, class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _Tp&, const _Alloc&) [with <template-parameter-2-2> = _Tp; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  795 |         basic_string(const _Tp& __t, const _Alloc& __a = _Alloc())
+      |         ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:795:9: note:   template argument deduction/substitution failed:
+In file included from /usr/include/c++/13/bits/stl_pair.h:60,
+                 from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60,
+                 from ../../../tests/machine/x/cpp/slice.cpp:1:
+/usr/include/c++/13/type_traits: In substitution of ‘template<bool _Cond, class _Tp> using std::enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp = void]’:
+/usr/include/c++/13/bits/basic_string.h:144:8:   required by substitution of ‘template<class _CharT, class _Traits, class _Alloc> template<class _Tp, class _Res> using std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_If_sv = std::enable_if_t<std::__and_<std::is_convertible<const _Tp&, std::basic_string_view<_CharT, _Traits> >, std::__not_<std::is_convertible<const _Tp*, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>*> >, std::__not_<std::is_convertible<const _Tp&, const _CharT*> > >::value, _Res> [with _Tp = std::vector<int>; _Res = void; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+/usr/include/c++/13/bits/basic_string.h:792:30:   required from here
+/usr/include/c++/13/type_traits:2610:11: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’
+ 2610 |     using enable_if_t = typename enable_if<_Cond, _Tp>::type;
+      |           ^~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:783:9: note: candidate: ‘template<class _Tp, class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _Tp&, size_type, size_type, const _Alloc&) [with <template-parameter-2-2> = _Tp; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  783 |         basic_string(const _Tp& __t, size_type __pos, size_type __n,
+      |         ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:783:9: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:13:57: note:   candidate expects 4 arguments, 1 provided
+   13 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(1, (3) - (1));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:760:9: note: candidate: ‘template<class _InputIterator, class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(_InputIterator, _InputIterator, const _Alloc&) [with <template-parameter-2-2> = _InputIterator; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  760 |         basic_string(_InputIterator __beg, _InputIterator __end,
+      |         ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:760:9: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:13:57: note:   candidate expects 3 arguments, 1 provided
+   13 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(1, (3) - (1));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:664:7: note: candidate: ‘template<class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(size_type, _CharT, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  664 |       basic_string(size_type __n, _CharT __c, const _Alloc& __a = _Alloc())
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:664:7: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:13:57: note:   candidate expects 3 arguments, 1 provided
+   13 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(1, (3) - (1));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:641:7: note: candidate: ‘template<class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  641 |       basic_string(const _CharT* __s, const _Alloc& __a = _Alloc())
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:641:7: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:13:29: note:   cannot convert ‘std::vector<int>(std::initializer_list<int>{((const int*)(& const int [3]{1, 2, 3})), 3}, std::allocator<int>())’ (type ‘std::vector<int>’) to type ‘const char*’
+   13 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(1, (3) - (1));
+      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:716:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&&, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  716 |       basic_string(basic_string&& __str, const _Alloc& __a)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:716:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:711:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  711 |       basic_string(const basic_string& __str, const _Alloc& __a)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:711:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:706:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::initializer_list<_Tp>, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  706 |       basic_string(initializer_list<_CharT> __l, const _Alloc& __a = _Alloc())
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:706:45: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘std::initializer_list<char>’
+  706 |       basic_string(initializer_list<_CharT> __l, const _Alloc& __a = _Alloc())
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/basic_string.h:677:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  677 |       basic_string(basic_string&& __str) noexcept
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:677:35: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘std::__cxx11::basic_string<char>&&’
+  677 |       basic_string(basic_string&& __str) noexcept
+      |                    ~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:619:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  619 |       basic_string(const _CharT* __s, size_type __n,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:619:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:599:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, size_type, size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  599 |       basic_string(const basic_string& __str, size_type __pos,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:599:7: note:   candidate expects 4 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:581:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, size_type, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  581 |       basic_string(const basic_string& __str, size_type __pos,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:581:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:564:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  564 |       basic_string(const basic_string& __str, size_type __pos,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:564:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:547:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  547 |       basic_string(const basic_string& __str)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:547:40: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘const std::__cxx11::basic_string<char>&’
+  547 |       basic_string(const basic_string& __str)
+      |                    ~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:535:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  535 |       basic_string(const _Alloc& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:535:34: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘const std::allocator<char>&’
+  535 |       basic_string(const _Alloc& __a) _GLIBCXX_NOEXCEPT
+      |                    ~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/basic_string.h:522:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  522 |       basic_string()
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:522:7: note:   candidate expects 0 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:176:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(__sv_wrapper, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  176 |       basic_string(__sv_wrapper __svw, const _Alloc& __a)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:176:7: note:   candidate expects 2 arguments, 1 provided
+../../../tests/machine/x/cpp/slice.cpp:19:57: error: no matching function for call to ‘std::__cxx11::basic_string<char>::basic_string(std::vector<int>)’
+   19 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(0, (2) - (0));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:795:9: note: candidate: ‘template<class _Tp, class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _Tp&, const _Alloc&) [with <template-parameter-2-2> = _Tp; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  795 |         basic_string(const _Tp& __t, const _Alloc& __a = _Alloc())
+      |         ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:795:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/basic_string.h:783:9: note: candidate: ‘template<class _Tp, class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _Tp&, size_type, size_type, const _Alloc&) [with <template-parameter-2-2> = _Tp; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  783 |         basic_string(const _Tp& __t, size_type __pos, size_type __n,
+      |         ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:783:9: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:19:57: note:   candidate expects 4 arguments, 1 provided
+   19 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(0, (2) - (0));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:760:9: note: candidate: ‘template<class _InputIterator, class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(_InputIterator, _InputIterator, const _Alloc&) [with <template-parameter-2-2> = _InputIterator; _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  760 |         basic_string(_InputIterator __beg, _InputIterator __end,
+      |         ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:760:9: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:19:57: note:   candidate expects 3 arguments, 1 provided
+   19 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(0, (2) - (0));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:664:7: note: candidate: ‘template<class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(size_type, _CharT, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  664 |       basic_string(size_type __n, _CharT __c, const _Alloc& __a = _Alloc())
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:664:7: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:19:57: note:   candidate expects 3 arguments, 1 provided
+   19 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(0, (2) - (0));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:641:7: note: candidate: ‘template<class> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  641 |       basic_string(const _CharT* __s, const _Alloc& __a = _Alloc())
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:641:7: note:   template argument deduction/substitution failed:
+../../../tests/machine/x/cpp/slice.cpp:19:29: note:   cannot convert ‘std::vector<int>(std::initializer_list<int>{((const int*)(& const int [3]{1, 2, 3})), 3}, std::allocator<int>())’ (type ‘std::vector<int>’) to type ‘const char*’
+   19 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(0, (2) - (0));
+      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:716:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&&, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  716 |       basic_string(basic_string&& __str, const _Alloc& __a)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:716:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:711:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  711 |       basic_string(const basic_string& __str, const _Alloc& __a)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:711:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:706:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::initializer_list<_Tp>, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  706 |       basic_string(initializer_list<_CharT> __l, const _Alloc& __a = _Alloc())
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:706:45: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘std::initializer_list<char>’
+  706 |       basic_string(initializer_list<_CharT> __l, const _Alloc& __a = _Alloc())
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/basic_string.h:677:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  677 |       basic_string(basic_string&& __str) noexcept
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:677:35: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘std::__cxx11::basic_string<char>&&’
+  677 |       basic_string(basic_string&& __str) noexcept
+      |                    ~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:619:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _CharT*, size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  619 |       basic_string(const _CharT* __s, size_type __n,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:619:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:599:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, size_type, size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  599 |       basic_string(const basic_string& __str, size_type __pos,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:599:7: note:   candidate expects 4 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:581:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, size_type, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  581 |       basic_string(const basic_string& __str, size_type __pos,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:581:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:564:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, size_type, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]’
+  564 |       basic_string(const basic_string& __str, size_type __pos,
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:564:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:547:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  547 |       basic_string(const basic_string& __str)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:547:40: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘const std::__cxx11::basic_string<char>&’
+  547 |       basic_string(const basic_string& __str)
+      |                    ~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:535:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  535 |       basic_string(const _Alloc& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:535:34: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘const std::allocator<char>&’
+  535 |       basic_string(const _Alloc& __a) _GLIBCXX_NOEXCEPT
+      |                    ~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/basic_string.h:522:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  522 |       basic_string()
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:522:7: note:   candidate expects 0 arguments, 1 provided
+/usr/include/c++/13/bits/basic_string.h:176:7: note: candidate: ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(__sv_wrapper, const _Alloc&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
+  176 |       basic_string(__sv_wrapper __svw, const _Alloc& __a)
+      |       ^~~~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:176:7: note:   candidate expects 2 arguments, 1 provided
 
- 11 |     auto __tmp1 = std::vector<decltype(1)>{1, 2, 3}[1];
- 12 |     for (size_t i = 0; i < __tmp1.size(); ++i) {
- 13 |       if (i)
+ 12 |         << std::boolalpha
+ 13 |         << std::string(std::vector<decltype(1)>{1, 2, 3}).substr(1, (3) - (1));
+ 14 |     std::cout << std::endl;

--- a/tests/machine/x/cpp/sort_stable.cpp
+++ b/tests/machine/x/cpp/sort_stable.cpp
@@ -11,9 +11,10 @@ struct __struct1 {
   decltype(std::string("a")) v;
 };
 int main() {
-  auto items = std::vector<decltype(__struct1{1, std::string("a")})>{
-      __struct1{1, std::string("a")}, __struct1{1, std::string("b")},
-      __struct1{2, std::string("c")}};
+  std::vector<__struct1> items =
+      std::vector<decltype(__struct1{1, std::string("a")})>{
+          __struct1{1, std::string("a")}, __struct1{1, std::string("b")},
+          __struct1{2, std::string("c")}};
   auto result = ([&]() {
     std::vector<std::pair<decltype(std::declval<__struct1>().n),
                           decltype(std::declval<__struct1>().v)>>

--- a/tests/machine/x/cpp/test_block.cpp
+++ b/tests/machine/x/cpp/test_block.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 int main() {
+  // test addition works
   auto x = (1 + 2);
   {
     std::cout << std::boolalpha << std::string("ok");

--- a/tests/machine/x/cpp/test_block.error
+++ b/tests/machine/x/cpp/test_block.error
@@ -1,1 +1,0 @@
-line 0: compile error: unsupported statement at 1:1

--- a/tests/machine/x/cpp/update_stmt.cpp
+++ b/tests/machine/x/cpp/update_stmt.cpp
@@ -29,6 +29,7 @@ int main() {
       __tmp1.age = (__tmp1.age + 1);
     }
   }
+  // test update adult status
   {
     std::cout << std::boolalpha << std::string("ok");
     std::cout << std::endl;

--- a/tests/machine/x/cpp/values_builtin.cpp
+++ b/tests/machine/x/cpp/values_builtin.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-  auto m = std::unordered_map<std::string, int>{
+  auto m = std::unordered_map<std::string, decltype(1)>{
       {std::string("a"), 1}, {std::string("b"), 2}, {std::string("c"), 3}};
   {
     auto __tmp1 = ([&]() {


### PR DESCRIPTION
## Summary
- improve element type inference for vectors in the C++ compiler
- regenerate machine generated C++ sources and outputs
- mark `inner_join` and `join_multi` as passing

## Testing
- `go test -tags slow -run TestCompilePrograms -timeout=0`

------
https://chatgpt.com/codex/tasks/task_e_686ebc3916c48320b3ede2e8ad2e1b12