### PR TITLE
Add Rust compiler join support

### DIFF
--- a/tests/machine/x/rust/README.md
+++ b/tests/machine/x/rust/README.md
@@ -2,7 +2,7 @@
 
 This directory stores machine generated Rust translations of programs from `tests/vm/valid`. Each entry is compiled and executed during tests. If a program fails to compile or run, a `.error` file contains the diagnostic details.
 
-Checklist of programs that currently compile and run (80/97):
+Checklist of programs that currently compile and run (84/97):
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
@@ -89,10 +89,10 @@ Checklist of programs that currently compile and run (80/97):
 - [ ] group_by_multi_join_sort
 - [x] group_by_sort
 - [x] group_items_iteration
-- [ ] inner_join
-- [ ] join_multi
-- [ ] left_join
-- [ ] left_join_multi
+- [x] inner_join
+- [x] join_multi
+- [x] left_join
+- [x] left_join_multi
 - [ ] load_yaml
 - [ ] order_by_map
 - [ ] outer_join

--- a/tests/machine/x/rust/inner_join.error
+++ b/tests/machine/x/rust/inner_join.error
@@ -1,2 +1,0 @@
-line 0: query features not supported
-// inner_join.mochi

--- a/tests/machine/x/rust/inner_join.out
+++ b/tests/machine/x/rust/inner_join.out
@@ -1,0 +1,4 @@
+"--- Orders with customer info ---"
+"Order" 100 "by" "Alice" "- $" 250
+"Order" 101 "by" "Bob" "- $" 125
+"Order" 102 "by" "Alice" "- $" 300

--- a/tests/machine/x/rust/inner_join.rs
+++ b/tests/machine/x/rust/inner_join.rs
@@ -1,0 +1,29 @@
+#[derive(Default, Debug, Clone)]
+struct Customer {
+    id: i32,
+    name: &'static str,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Order {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Result {
+    orderId: i32,
+    customerName: &'static str,
+    total: i32,
+}
+
+fn main() {
+    let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }, Customer { id: 3, name: "Charlie" }];
+    let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 2, total: 125 }, Order { id: 102, customerId: 1, total: 300 }, Order { id: 103, customerId: 4, total: 80 }];
+    let result = { let mut tmp1 = Vec::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } tmp1.push(Result { orderId: o.id, customerName: c.name, total: o.total }); } } tmp1 };
+    println!("{:?}", "--- Orders with customer info ---");
+    for entry in result {
+        println!("{:?} {:?} {:?} {:?} {:?} {:?}", "Order", entry.orderId, "by", entry.customerName, "- $", entry.total);
+    }
+}

--- a/tests/machine/x/rust/join_multi.error
+++ b/tests/machine/x/rust/join_multi.error
@@ -1,2 +1,0 @@
-line 0: query features not supported
-let customers = [

--- a/tests/machine/x/rust/join_multi.out
+++ b/tests/machine/x/rust/join_multi.out
@@ -1,0 +1,3 @@
+"--- Multi Join ---"
+"Alice" "bought item" "a"
+"Bob" "bought item" "b"

--- a/tests/machine/x/rust/join_multi.rs
+++ b/tests/machine/x/rust/join_multi.rs
@@ -1,0 +1,34 @@
+#[derive(Default, Debug, Clone)]
+struct Customer {
+    id: i32,
+    name: &'static str,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Order {
+    id: i32,
+    customerId: i32,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Item {
+    orderId: i32,
+    sku: &'static str,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Result {
+    name: &'static str,
+    sku: &'static str,
+}
+
+fn main() {
+    let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }];
+    let orders = vec![Order { id: 100, customerId: 1 }, Order { id: 101, customerId: 2 }];
+    let items = vec![Item { orderId: 100, sku: "a" }, Item { orderId: 101, sku: "b" }];
+    let result = { let mut tmp1 = Vec::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } for i in &items { if !(o.id == i.orderId) { continue; } tmp1.push(Result { name: c.name, sku: i.sku }); } } } tmp1 };
+    println!("{:?}", "--- Multi Join ---");
+    for r in result {
+        println!("{:?} {:?} {:?}", r.name, "bought item", r.sku);
+    }
+}

--- a/tests/machine/x/rust/left_join.error
+++ b/tests/machine/x/rust/left_join.error
@@ -1,2 +1,0 @@
-line 0: query features not supported
-let customers = [

--- a/tests/machine/x/rust/left_join.out
+++ b/tests/machine/x/rust/left_join.out
@@ -1,0 +1,3 @@
+"--- Left Join ---"
+"Order" 100 "customer" Customer { id: 1, name: "Alice" } "total" 250
+"Order" 101 "customer" Customer { id: 0, name: "" } "total" 80

--- a/tests/machine/x/rust/left_join.rs
+++ b/tests/machine/x/rust/left_join.rs
@@ -1,0 +1,29 @@
+#[derive(Default, Debug, Clone)]
+struct Customer {
+    id: i32,
+    name: &'static str,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Order {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Result {
+    orderId: i32,
+    customer: Customer,
+    total: i32,
+}
+
+fn main() {
+    let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }];
+    let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 3, total: 80 }];
+    let result = { let mut tmp1 = Vec::new();for o in &orders { let mut _matched = false; for c in &customers { if !(o.customerId == c.id) { continue; } _matched = true; tmp1.push(Result { orderId: o.id, customer: c.clone(), total: o.total }); } if !_matched { let c: Customer = Default::default(); tmp1.push(Result { orderId: o.id, customer: c.clone(), total: o.total }); } } tmp1 };
+    println!("{:?}", "--- Left Join ---");
+    for entry in result {
+        println!("{:?} {:?} {:?} {:?} {:?} {:?}", "Order", entry.orderId, "customer", entry.customer, "total", entry.total);
+    }
+}

--- a/tests/machine/x/rust/left_join_multi.error
+++ b/tests/machine/x/rust/left_join_multi.error
@@ -1,2 +1,0 @@
-line 0: query features not supported
-let customers = [

--- a/tests/machine/x/rust/left_join_multi.out
+++ b/tests/machine/x/rust/left_join_multi.out
@@ -1,0 +1,3 @@
+"--- Left Join Multi ---"
+100 "Alice" Item { orderId: 100, sku: "a" }
+101 "Bob" Item { orderId: 0, sku: "" }

--- a/tests/machine/x/rust/left_join_multi.rs
+++ b/tests/machine/x/rust/left_join_multi.rs
@@ -1,0 +1,35 @@
+#[derive(Default, Debug, Clone)]
+struct Customer {
+    id: i32,
+    name: &'static str,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Order {
+    id: i32,
+    customerId: i32,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Item {
+    orderId: i32,
+    sku: &'static str,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Result {
+    orderId: i32,
+    name: &'static str,
+    item: Item,
+}
+
+fn main() {
+    let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }];
+    let orders = vec![Order { id: 100, customerId: 1 }, Order { id: 101, customerId: 2 }];
+    let items = vec![Item { orderId: 100, sku: "a" }];
+    let result = { let mut tmp1 = Vec::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } let mut _matched = false; for i in &items { if !(o.id == i.orderId) { continue; } _matched = true; tmp1.push(Result { orderId: o.id, name: c.name, item: i.clone() }); } if !_matched { let i: Item = Default::default(); tmp1.push(Result { orderId: o.id, name: c.name, item: i.clone() }); } } } tmp1 };
+    println!("{:?}", "--- Left Join Multi ---");
+    for r in result {
+        println!("{:?} {:?} {:?}", r.orderId, r.name, r.item);
+    }
+}


### PR DESCRIPTION
## Summary
- handle left joins including multi-join queries
- emit struct defaults and clones when needed
- generate code for join examples in machine outputs
- update Rust machine README with new successes

## Testing
- `go test ./compiler/x/rust -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ebb875b68832088b9be6a28c5d75b