### PR TITLE
Optimize Clojure query helpers

### DIFF
--- a/compiler/x/clj/runtime.go
+++ b/compiler/x/clj/runtime.go
@@ -79,17 +79,20 @@ const (
 `
 
 	helperGroupBy = `(defn _group_by [src keyfn]
-  (let [groups (atom {})
-        order (atom [])]
+  (let [groups (transient {})
+        order (transient [])]
     (doseq [it src]
       (let [k (keyfn it)
-            ks (str k)]
-        (when-not (contains? @groups ks)
-          (swap! groups assoc ks (_Group. k []))
-          (swap! order conj ks))
-        (swap! groups update ks (fn [g] (assoc g :Items (conj (:Items g) it)))))
-    )
-    (map (fn [k] (@groups k)) @order)))
+            ks (str k)
+            g (get groups ks)]
+        (if g
+          (assoc! groups ks (assoc g :Items (conj (:Items g) it)))
+          (do
+            (assoc! groups ks (_Group. k [it]))
+            (conj! order ks))))
+    (let [g (persistent! groups)
+          o (persistent! order)]
+      (mapv #(get g %) o))) )
 `
 
 	helperParseCSV = `(defn _parse_csv [text header delim]
@@ -287,53 +290,71 @@ const (
   (let [items (atom (mapv vector src))]
     (doseq [j joins]
       (let [joined (atom [])]
-        (cond
-          (and (:right j) (:left j))
-            (let [matched (boolean-array (count (:items j)))]
-              (doseq [left @items]
-                (let [m (atom false)]
-                  (doseq [[ri right] (map-indexed vector (:items j))]
-                    (let [keep (if-let [f (:on j)]
-                                 (apply f (conj left right))
-                                 true)]
-                      (when keep
-                        (reset! m true)
-                        (aset matched ri true)
-                        (swap! joined conj (conj left right))))
-                  (when-not @m
-                    (swap! joined conj (conj left nil))))
-              (doseq [[ri right] (map-indexed vector (:items j))]
-                (when-not (aget matched ri)
-                  (swap! joined conj (vec (concat (repeat (count (first (or @items []))) nil) [right])))))
-            (reset! items @joined)
-          (:right j)
-            (do
+        (if (and (:leftKey j) (:rightKey j))
+          (let [idx (group-by (:rightKey j) (:items j))
+                seen (atom #{})]
+            (doseq [left @items]
+              (let [k ((:leftKey j) left)
+                    rs (get idx k)]
+                (if rs
+                  (do
+                    (swap! seen conj k)
+                    (doseq [right rs]
+                      (swap! joined conj (conj left right))))
+                  (when (:left j)
+                    (swap! joined conj (conj left nil)))))
+            (when (:right j)
               (doseq [right (:items j)]
-                (let [m (atom false)]
-                  (doseq [left @items]
-                    (let [keep (if-let [f (:on j)]
-                                 (apply f (conj left right))
-                                 true)]
-                      (when keep
-                        (reset! m true)
-                        (swap! joined conj (conj left right))))
-                  (when-not @m
+                (when-not (contains? @seen ((:rightKey j) right))
+                  (swap! joined conj (vec (concat (repeat (count (first (or @items []))) nil) [right]))))))
+            (reset! items @joined))
+          (cond
+            (and (:right j) (:left j))
+              (let [matched (boolean-array (count (:items j)))]
+                (doseq [left @items]
+                  (let [m (atom false)]
+                    (doseq [[ri right] (map-indexed vector (:items j))]
+                      (let [keep (if-let [f (:on j)]
+                                   (apply f (conj left right))
+                                   true)]
+                        (when keep
+                          (reset! m true)
+                          (aset matched ri true)
+                          (swap! joined conj (conj left right))))
+                    (when-not @m
+                      (swap! joined conj (conj left nil))))
+                (doseq [[ri right] (map-indexed vector (:items j))]
+                  (when-not (aget matched ri)
                     (swap! joined conj (vec (concat (repeat (count (first (or @items []))) nil) [right])))))
-              (reset! items @joined))
-          :else
-            (do
-              (doseq [left @items]
-                (let [m (atom false)]
-                  (doseq [right (:items j)]
-                    (let [keep (if-let [f (:on j)]
-                                 (apply f (conj left right))
-                                 true)]
-                      (when keep
-                        (reset! m true)
-                        (swap! joined conj (conj left right))))
-                  (when (and (:left j) (not @m))
-                    (swap! joined conj (conj left nil))))
-              (reset! items @joined))))
+              (reset! items @joined)
+            (:right j)
+              (do
+                (doseq [right (:items j)]
+                  (let [m (atom false)]
+                    (doseq [left @items]
+                      (let [keep (if-let [f (:on j)]
+                                   (apply f (conj left right))
+                                   true)]
+                        (when keep
+                          (reset! m true)
+                          (swap! joined conj (conj left right))))
+                    (when-not @m
+                      (swap! joined conj (vec (concat (repeat (count (first (or @items []))) nil) [right])))))
+                (reset! items @joined))
+            :else
+              (do
+                (doseq [left @items]
+                  (let [m (atom false)]
+                    (doseq [right (:items j)]
+                      (let [keep (if-let [f (:on j)]
+                                   (apply f (conj left right))
+                                   true)]
+                        (when keep
+                          (reset! m true)
+                          (swap! joined conj (conj left right))))
+                    (when (and (:left j) (not @m))
+                      (swap! joined conj (conj left nil))))
+                (reset! items @joined)))))
     (let [it @items
           it (if-let [w (:where opts)] (vec (filter #(apply w %) it)) it)
           it (if-let [sk (:sortKey opts)]


### PR DESCRIPTION
## Summary
- add helpers for extracting join key expressions
- emit join key functions in Clojure query compiler
- speed up `_group_by` using transients
- use hash join when key functions are provided in `_query`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ebd073530832087825b793466ef82