### PR TITLE
Add join support for Racket compiler

### DIFF
--- a/tests/machine/x/racket/README.md
+++ b/tests/machine/x/racket/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Racket source code generated from the Mochi programs in `tests/vm/valid` using the Racket compiler. Each program was compiled and executed. Successful runs produced an `.out` file while failures produced an `.error` file.
 
-Compiled programs: 76/97
+Compiled programs: 82/97
 
 ## Checklist
 - [x] append_builtin
@@ -80,12 +80,12 @@ Compiled programs: 76/97
 - [ ] group_by_sort
 - [ ] group_items_iteration
 - [x] if_then_else_nested
-- [ ] in_operator_extended
-- [ ] inner_join
-- [ ] join_multi
+ - [ ] in_operator_extended
+ - [x] inner_join
+ - [x] join_multi
  - [x] json_builtin
-- [ ] left_join
-- [ ] left_join_multi
+ - [x] left_join
+ - [x] left_join_multi
 - [ ] load_yaml
 - [x] map_int_key
 - [x] map_membership
@@ -95,7 +95,7 @@ Compiled programs: 76/97
  - [x] partial_application
 - [ ] query_sum_select
  - [x] record_assign
-- [ ] right_join
+ - [x] right_join
 - [ ] save_jsonl_stdout
 - [x] string_contains
  - [x] test_block

--- a/tests/machine/x/racket/inner_join.error
+++ b/tests/machine/x/racket/inner_join.error
@@ -1,6 +1,0 @@
-run: exit status 1
-/workspace/mochi/tests/machine/x/racket/inner_join.rkt:4:95: c: unbound identifier
-  in: c
-  location...:
-   /workspace/mochi/tests/machine/x/racket/inner_join.rkt:4:95
-

--- a/tests/machine/x/racket/inner_join.out
+++ b/tests/machine/x/racket/inner_join.out
@@ -1,0 +1,4 @@
+--- Orders with customer info ---
+Order 100 by Alice - $ 250
+Order 101 by Bob - $ 125
+Order 102 by Alice - $ 300

--- a/tests/machine/x/racket/inner_join.rkt
+++ b/tests/machine/x/racket/inner_join.rkt
@@ -1,7 +1,7 @@
 #lang racket
 (define customers (list (hash 'id 1 'name "Alice") (hash 'id 2 'name "Bob") (hash 'id 3 'name "Charlie")))
 (define orders (list (hash 'id 100 'customerId 1 'total 250) (hash 'id 101 'customerId 2 'total 125) (hash 'id 102 'customerId 1 'total 300) (hash 'id 103 'customerId 4 'total 80)))
-(define result (for*/list ([o orders]) (hash 'orderId (hash-ref o 'id) 'customerName (hash-ref c 'name) 'total (hash-ref o 'total))))
+(define result (for*/list ([o orders] [c customers] #:when (and (equal? (hash-ref o 'customerId) (hash-ref c 'id)))) (hash 'orderId (hash-ref o 'id) 'customerName (hash-ref c 'name) 'total (hash-ref o 'total))))
 (displayln "--- Orders with customer info ---")
 (for ([entry (if (hash? result) (hash-keys result) result)])
 (displayln (string-join (map ~a (list "Order" (hash-ref entry 'orderId) "by" (hash-ref entry 'customerName) "- $" (hash-ref entry 'total))) " "))

--- a/tests/machine/x/racket/join_multi.error
+++ b/tests/machine/x/racket/join_multi.error
@@ -1,6 +1,0 @@
-run: exit status 1
-/workspace/mochi/tests/machine/x/racket/join_multi.rkt:5:61: c: unbound identifier
-  in: c
-  location...:
-   /workspace/mochi/tests/machine/x/racket/join_multi.rkt:5:61
-

--- a/tests/machine/x/racket/join_multi.out
+++ b/tests/machine/x/racket/join_multi.out
@@ -1,0 +1,3 @@
+--- Multi Join ---
+Alice bought item a
+Bob bought item b

--- a/tests/machine/x/racket/join_multi.rkt
+++ b/tests/machine/x/racket/join_multi.rkt
@@ -2,7 +2,7 @@
 (define customers (list (hash 'id 1 'name "Alice") (hash 'id 2 'name "Bob")))
 (define orders (list (hash 'id 100 'customerId 1) (hash 'id 101 'customerId 2)))
 (define items (list (hash 'orderId 100 'sku "a") (hash 'orderId 101 'sku "b")))
-(define result (for*/list ([o orders]) (hash 'name (hash-ref c 'name) 'sku (hash-ref i 'sku))))
+(define result (for*/list ([o orders] [c customers] [i items] #:when (and (equal? (hash-ref o 'customerId) (hash-ref c 'id)) (equal? (hash-ref o 'id) (hash-ref i 'orderId)))) (hash 'name (hash-ref c 'name) 'sku (hash-ref i 'sku))))
 (displayln "--- Multi Join ---")
 (for ([r (if (hash? result) (hash-keys result) result)])
 (displayln (string-join (map ~a (list (hash-ref r 'name) "bought item" (hash-ref r 'sku))) " "))

--- a/tests/machine/x/racket/left_join.error
+++ b/tests/machine/x/racket/left_join.error
@@ -1,6 +1,0 @@
-run: exit status 1
-/workspace/mochi/tests/machine/x/racket/left_join.rkt:4:81: c: unbound identifier
-  in: c
-  location...:
-   /workspace/mochi/tests/machine/x/racket/left_join.rkt:4:81
-

--- a/tests/machine/x/racket/left_join.out
+++ b/tests/machine/x/racket/left_join.out
@@ -1,0 +1,3 @@
+--- Left Join ---
+Order 100 customer #hash((id . 1) (name . Alice)) total 250
+Order 101 customer #f total 80

--- a/tests/machine/x/racket/left_join.rkt
+++ b/tests/machine/x/racket/left_join.rkt
@@ -1,7 +1,8 @@
 #lang racket
+(require racket/list)
 (define customers (list (hash 'id 1 'name "Alice") (hash 'id 2 'name "Bob")))
 (define orders (list (hash 'id 100 'customerId 1 'total 250) (hash 'id 101 'customerId 3 'total 80)))
-(define result (for*/list ([o orders]) (hash 'orderId (hash-ref o 'id) 'customer c 'total (hash-ref o 'total))))
+(define result (for*/list ([o orders]) (let ((c (findf (lambda (c) (equal? (hash-ref o 'customerId) (hash-ref c 'id))) customers))) (hash 'orderId (hash-ref o 'id) 'customer c 'total (hash-ref o 'total)))))
 (displayln "--- Left Join ---")
 (for ([entry (if (hash? result) (hash-keys result) result)])
 (displayln (string-join (map ~a (list "Order" (hash-ref entry 'orderId) "customer" (hash-ref entry 'customer) "total" (hash-ref entry 'total))) " "))

--- a/tests/machine/x/racket/left_join_multi.error
+++ b/tests/machine/x/racket/left_join_multi.error
@@ -1,6 +1,0 @@
-run: exit status 1
-/workspace/mochi/tests/machine/x/racket/left_join_multi.rkt:5:87: c: unbound identifier
-  in: c
-  location...:
-   /workspace/mochi/tests/machine/x/racket/left_join_multi.rkt:5:87
-

--- a/tests/machine/x/racket/left_join_multi.out
+++ b/tests/machine/x/racket/left_join_multi.out
@@ -1,0 +1,3 @@
+--- Left Join Multi ---
+100 Alice #hash((orderId . 100) (sku . a))
+101 Bob #f

--- a/tests/machine/x/racket/left_join_multi.rkt
+++ b/tests/machine/x/racket/left_join_multi.rkt
@@ -1,8 +1,9 @@
 #lang racket
+(require racket/list)
 (define customers (list (hash 'id 1 'name "Alice") (hash 'id 2 'name "Bob")))
 (define orders (list (hash 'id 100 'customerId 1) (hash 'id 101 'customerId 2)))
 (define items (list (hash 'orderId 100 'sku "a")))
-(define result (for*/list ([o orders]) (hash 'orderId (hash-ref o 'id) 'name (hash-ref c 'name) 'item i)))
+(define result (for*/list ([o orders] [c customers] #:when (and (equal? (hash-ref o 'customerId) (hash-ref c 'id)))) (let ((i (findf (lambda (i) (equal? (hash-ref o 'id) (hash-ref i 'orderId))) items))) (hash 'orderId (hash-ref o 'id) 'name (hash-ref c 'name) 'item i))))
 (displayln "--- Left Join Multi ---")
 (for ([r (if (hash? result) (hash-keys result) result)])
 (displayln (string-join (map ~a (list (hash-ref r 'orderId) (hash-ref r 'name) (hash-ref r 'item))) " "))

--- a/tests/machine/x/racket/right_join.error
+++ b/tests/machine/x/racket/right_join.error
@@ -1,6 +1,0 @@
-run: exit status 1
-/workspace/mochi/tests/machine/x/racket/right_join.rkt:4:88: o: unbound identifier
-  in: o
-  location...:
-   /workspace/mochi/tests/machine/x/racket/right_join.rkt:4:88
-

--- a/tests/machine/x/racket/right_join.out
+++ b/tests/machine/x/racket/right_join.out
@@ -1,0 +1,4 @@
+--- Right Join using syntax ---
+Customer Alice has order 100 - $ 250
+Customer Bob has order 101 - $ 125
+Customer Alice has order 102 - $ 300

--- a/tests/machine/x/racket/right_join.rkt
+++ b/tests/machine/x/racket/right_join.rkt
@@ -1,7 +1,8 @@
 #lang racket
+(require racket/list)
 (define customers (list (hash 'id 1 'name "Alice") (hash 'id 2 'name "Bob") (hash 'id 3 'name "Charlie") (hash 'id 4 'name "Diana")))
 (define orders (list (hash 'id 100 'customerId 1 'total 250) (hash 'id 101 'customerId 2 'total 125) (hash 'id 102 'customerId 1 'total 300)))
-(define result (for*/list ([c customers]) (hash 'customerName (hash-ref c 'name) 'order o)))
+(define result (for*/list ([o orders]) (let ((c (findf (lambda (c) (equal? (hash-ref o 'customerId) (hash-ref c 'id))) customers))) (hash 'customerName (hash-ref c 'name) 'order o))))
 (displayln "--- Right Join using syntax ---")
 (for ([entry (if (hash? result) (hash-keys result) result)])
 (if (hash-ref entry 'order)


### PR DESCRIPTION
## Summary
- implement joins in the Racket compiler
- update machine generated Racket code for join programs
- mark additional programs as working in the Racket README

## Testing
- `go test -tags slow -run TestRacketCompiler -count=1 -timeout 0`


------
https://chatgpt.com/codex/tasks/task_e_686ebe0d9f60832093822e245be65a21