### PR TITLE
Add join support for cpp compiler

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -1582,15 +1582,12 @@ func extractVectorElemType(expr string) string {
 		return ""
 	}
 	typ := inner[:idx]
-	if strings.Contains(typ, "std::string") {
-		return "std::string"
-	}
-	if strings.Contains(typ, "bool") {
-		return "bool"
-	}
 	if strings.HasPrefix(typ, "decltype(") {
 		texpr := strings.TrimSuffix(strings.TrimPrefix(typ, "decltype("), ")")
 		if strings.HasPrefix(texpr, "__struct") {
+			if idx := strings.Index(texpr, "{"); idx != -1 {
+				return texpr[:idx]
+			}
 			return texpr
 		}
 		if strings.Contains(texpr, "std::string") {
@@ -1602,6 +1599,12 @@ func extractVectorElemType(expr string) string {
 		if _, err := strconv.Atoi(texpr); err == nil {
 			return "int"
 		}
+	}
+	if strings.Contains(typ, "std::string") {
+		return "std::string"
+	}
+	if strings.Contains(typ, "bool") {
+		return "bool"
 	}
 	return ""
 }

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -2,7 +2,7 @@
 
 This directory contains C++ source code generated from Mochi programs and the corresponding outputs or errors.
 
-Compiled programs: 72/97
+Compiled programs: 74/97
 
 ## Checklist
 
@@ -81,8 +81,8 @@ Compiled programs: 72/97
 - [ ] group_by_sort
 - [ ] group_items_iteration
 - [ ] in_operator_extended
-- [ ] inner_join
-- [ ] join_multi
+- [x] inner_join
+- [x] join_multi
 - [ ] json_builtin
 - [ ] left_join
 - [ ] left_join_multi
@@ -116,8 +116,8 @@ Compiled programs: 72/97
 - [ ] group_by_sort
 - [ ] group_items_iteration
 - [ ] in_operator_extended
-- [ ] inner_join
-- [ ] join_multi
+- [x] inner_join
+- [x] join_multi
 - [ ] json_builtin
 - [ ] left_join
 - [ ] left_join_multi

--- a/tests/machine/x/cpp/inner_join.cpp
+++ b/tests/machine/x/cpp/inner_join.cpp
@@ -1,0 +1,64 @@
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+struct __struct1 {
+  decltype(1) id;
+  decltype(std::string("Alice")) name;
+};
+struct __struct2 {
+  decltype(100) id;
+  decltype(1) customerId;
+  decltype(250) total;
+};
+struct __struct3 {
+  decltype(std::declval<__struct2>().id) orderId;
+  decltype(std::declval<__struct1>().name) customerName;
+  decltype(std::declval<__struct2>().total) total;
+};
+int main() {
+  std::vector<__struct1> customers =
+      std::vector<decltype(__struct1{1, std::string("Alice")})>{
+          __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
+          __struct1{3, std::string("Charlie")}};
+  std::vector<__struct2> orders = std::vector<decltype(__struct2{100, 1, 250})>{
+      __struct2{100, 1, 250}, __struct2{101, 2, 125}, __struct2{102, 1, 300},
+      __struct2{103, 4, 80}};
+  auto result = ([&]() {
+    std::vector<__struct3> __items;
+    for (auto o : orders) {
+      for (auto c : customers) {
+        if (!((o.customerId == c.id)))
+          continue;
+        __items.push_back(__struct3{o.id, c.name, o.total});
+      }
+    }
+    return __items;
+  })();
+  {
+    std::cout << std::boolalpha
+              << std::string("--- Orders with customer info ---");
+    std::cout << std::endl;
+  }
+  for (auto entry : result) {
+    {
+      std::cout << std::boolalpha << std::string("Order");
+      std::cout << ' ';
+      std::cout << std::boolalpha << entry.orderId;
+      std::cout << ' ';
+      std::cout << std::boolalpha << std::string("by");
+      std::cout << ' ';
+      std::cout << std::boolalpha << entry.customerName;
+      std::cout << ' ';
+      std::cout << std::boolalpha << std::string("- $");
+      std::cout << ' ';
+      std::cout << std::boolalpha << entry.total;
+      std::cout << std::endl;
+    }
+  }
+  return 0;
+}

--- a/tests/machine/x/cpp/inner_join.error
+++ b/tests/machine/x/cpp/inner_join.error
@@ -1,1 +1,0 @@
-line 0: compile error: query features not supported

--- a/tests/machine/x/cpp/inner_join.out
+++ b/tests/machine/x/cpp/inner_join.out
@@ -1,0 +1,4 @@
+--- Orders with customer info ---
+Order 100 by Alice - $ 250
+Order 101 by Bob - $ 125
+Order 102 by Alice - $ 300

--- a/tests/machine/x/cpp/join_multi.cpp
+++ b/tests/machine/x/cpp/join_multi.cpp
@@ -1,0 +1,64 @@
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+struct __struct1 {
+  decltype(1) id;
+  decltype(std::string("Alice")) name;
+};
+struct __struct2 {
+  decltype(100) id;
+  decltype(1) customerId;
+};
+struct __struct3 {
+  decltype(100) orderId;
+  decltype(std::string("a")) sku;
+};
+struct __struct4 {
+  decltype(std::declval<__struct1>().name) name;
+  decltype(std::declval<__struct3>().sku) sku;
+};
+int main() {
+  std::vector<__struct1> customers =
+      std::vector<decltype(__struct1{1, std::string("Alice")})>{
+          __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")}};
+  std::vector<__struct2> orders = std::vector<decltype(__struct2{100, 1})>{
+      __struct2{100, 1}, __struct2{101, 2}};
+  std::vector<__struct3> items =
+      std::vector<decltype(__struct3{100, std::string("a")})>{
+          __struct3{100, std::string("a")}, __struct3{101, std::string("b")}};
+  auto result = ([&]() {
+    std::vector<__struct4> __items;
+    for (auto o : orders) {
+      for (auto c : customers) {
+        if (!((o.customerId == c.id)))
+          continue;
+        for (auto i : items) {
+          if (!((o.id == i.orderId)))
+            continue;
+          __items.push_back(__struct4{c.name, i.sku});
+        }
+      }
+    }
+    return __items;
+  })();
+  {
+    std::cout << std::boolalpha << std::string("--- Multi Join ---");
+    std::cout << std::endl;
+  }
+  for (auto r : result) {
+    {
+      std::cout << std::boolalpha << r.name;
+      std::cout << ' ';
+      std::cout << std::boolalpha << std::string("bought item");
+      std::cout << ' ';
+      std::cout << std::boolalpha << r.sku;
+      std::cout << std::endl;
+    }
+  }
+  return 0;
+}

--- a/tests/machine/x/cpp/join_multi.error
+++ b/tests/machine/x/cpp/join_multi.error
@@ -1,1 +1,0 @@
-line 0: compile error: query features not supported

--- a/tests/machine/x/cpp/join_multi.out
+++ b/tests/machine/x/cpp/join_multi.out
@@ -1,0 +1,3 @@
+--- Multi Join ---
+Alice bought item a
+Bob bought item b


### PR DESCRIPTION
## Summary
- update C++ compiler to infer element types for vectors containing struct literals
- regenerate machine outputs for `inner_join` and `join_multi`
- update C++ machine README checklist

## Testing
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms/inner_join -v`
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms/join_multi -v`
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ec0a9f50083208bc458d51dac1947