### PR TITLE
Add outer join support for Racket compiler

### DIFF
--- a/tests/machine/x/racket/README.md
+++ b/tests/machine/x/racket/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Racket source code generated from the Mochi programs in `tests/vm/valid` using the Racket compiler. Each program was compiled and executed. Successful runs produced an `.out` file while failures produced an `.error` file.
 
-Compiled programs: 82/97
+Compiled programs: 83/97
 
 ## Checklist
 - [x] append_builtin
@@ -91,7 +91,7 @@ Compiled programs: 82/97
 - [x] map_membership
  - [x] match_expr
  - [x] match_full
-- [ ] outer_join
+ - [x] outer_join
  - [x] partial_application
 - [ ] query_sum_select
  - [x] record_assign

--- a/tests/machine/x/racket/outer_join.error
+++ b/tests/machine/x/racket/outer_join.error
@@ -1,6 +1,0 @@
-run: exit status 1
-/workspace/mochi/tests/machine/x/racket/outer_join.rkt:4:64: c: unbound identifier
-  in: c
-  location...:
-   /workspace/mochi/tests/machine/x/racket/outer_join.rkt:4:64
-

--- a/tests/machine/x/racket/outer_join.out
+++ b/tests/machine/x/racket/outer_join.out
@@ -1,0 +1,7 @@
+--- Outer Join using syntax ---
+Order 100 by Alice - $ 250
+Order 101 by Bob - $ 125
+Order 102 by Alice - $ 300
+Order 103 by Unknown - $ 80
+Customer Charlie has no orders
+Customer Diana has no orders

--- a/tests/machine/x/racket/outer_join.rkt
+++ b/tests/machine/x/racket/outer_join.rkt
@@ -1,7 +1,8 @@
 #lang racket
+(require racket/list)
 (define customers (list (hash 'id 1 'name "Alice") (hash 'id 2 'name "Bob") (hash 'id 3 'name "Charlie") (hash 'id 4 'name "Diana")))
 (define orders (list (hash 'id 100 'customerId 1 'total 250) (hash 'id 101 'customerId 2 'total 125) (hash 'id 102 'customerId 1 'total 300) (hash 'id 103 'customerId 5 'total 80)))
-(define result (for*/list ([o orders]) (hash 'order o 'customer c)))
+(define result (append (for/list ([o orders]) (let ([c (findf (lambda (c) (equal? (hash-ref o 'customerId) (hash-ref c 'id))) customers)]) (hash 'order o 'customer c))) (for/list ([c customers] #:unless (for/or ([o orders]) (equal? (hash-ref o 'customerId) (hash-ref c 'id)))) (let ([o #f]) (hash 'order o 'customer c)))))
 (displayln "--- Outer Join using syntax ---")
 (for ([row (if (hash? result) (hash-keys result) result)])
 (if (hash-ref row 'order)


### PR DESCRIPTION
## Summary
- support `outer join` in Racket compiler
- update generated Racket code and outputs
- mark `outer_join` as compiled in the machine README

## Testing
- `go test ./compiler/x/racket -run TestRacketCompiler/outer_join -count=1 -tags=slow -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ec33cca448320806cb246f596620f