### PR TITLE
Add left/right join for F# compiler

### DIFF
--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -3,7 +3,7 @@
 This directory contains F# source code generated from Mochi programs in `tests/vm/valid`.
 Generated with `compiler/x/fs`. Programs that compile successfully have a `.fs` file, and if compilation fails an `.error` file captures the reason.
 
-Compiled programs: 90/97
+Compiled programs: 89/97
 
 Checklist:
 - [x] append_builtin
@@ -70,7 +70,7 @@ Checklist:
 - [x] min_max_builtin
 - [x] nested_function
 - [x] order_by_map
-- [x] outer_join
+- [ ] outer_join
 - [x] partial_application
 - [x] print_hello
 - [x] pure_fold

--- a/tests/machine/x/fs/group_by_left_join.fs
+++ b/tests/machine/x/fs/group_by_left_join.fs
@@ -18,7 +18,7 @@ type Anon3 = {
 let customers = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }; { id = 3; name = "Charlie" }]
 let orders = [{ id = 100; customerId = 1 }; { id = 101; customerId = 1 }; { id = 102; customerId = 2 }]
 let stats = [ for gKey, gItems in [ for c in customers do 
-  for o in orders do if o.customerId = c.id then yield (c, o) ] |> List.groupBy (fun (c, o) -> c.name) do
+  let o = List.tryFind (fun o -> o.customerId = c.id) orders yield (c, o) ] |> List.groupBy (fun (c, o) -> c.name) do
     let g = {| key = gKey; items = gItems |}
     yield { name = g.key; count = List.length [ for r in g do if r.o then yield r ] } ]
 printfn "%s" "--- Group Left Join ---"

--- a/tests/machine/x/fs/left_join.fs
+++ b/tests/machine/x/fs/left_join.fs
@@ -20,7 +20,7 @@ type Anon3 = {
 let customers = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }]
 let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId = 3; total = 80 }]
 let result = [ for o in orders do 
-  for c in customers do if o.customerId = c.id then yield { orderId = o.id; customer = c; total = o.total } ]
+  let c = List.tryFind (fun c -> o.customerId = c.id) customers yield { orderId = o.id; customer = c; total = o.total } ]
 printfn "%s" "--- Left Join ---"
 try
     for entry in result do

--- a/tests/machine/x/fs/left_join_multi.fs
+++ b/tests/machine/x/fs/left_join_multi.fs
@@ -25,7 +25,7 @@ let orders = [{ id = 100; customerId = 1 }; { id = 101; customerId = 2 }]
 let items = [{ orderId = 100; sku = "a" }]
 let result = [ for o in orders do 
   for c in customers do 
-  for i in items do if o.customerId = c.id && o.id = i.orderId then yield { orderId = o.id; name = c.name; item = i } ]
+  let i = List.tryFind (fun i -> o.id = i.orderId) items if o.customerId = c.id then yield { orderId = o.id; name = c.name; item = i } ]
 printfn "%s" "--- Left Join Multi ---"
 try
     for r in result do

--- a/tests/machine/x/fs/outer_join.error
+++ b/tests/machine/x/fs/outer_join.error
@@ -1,0 +1,2 @@
+unsupported join type
+

--- a/tests/machine/x/fs/right_join.fs
+++ b/tests/machine/x/fs/right_join.fs
@@ -18,8 +18,8 @@ type Anon3 = {
 }
 let customers = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }; { id = 3; name = "Charlie" }; { id = 4; name = "Diana" }]
 let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId = 2; total = 125 }; { id = 102; customerId = 1; total = 300 }]
-let result = [ for c in customers do 
-  for o in orders do if o.customerId = c.id then yield { customerName = c.name; order = o } ]
+let result = [ for o in orders do 
+  let c = List.tryFind (fun c -> o.customerId = c.id) customers yield { customerName = c.name; order = o } ]
 printfn "%s" "--- Right Join using syntax ---"
 try
     for entry in result do


### PR DESCRIPTION
## Summary
- implement join clause handling in `compiler/x/fs`
- update F# machine output for join examples
- mark outer join unsupported

## Testing
- `go vet ./...`
- `go test -tags slow ./compiler/x/fs -run TestFSCompiler/right_join` *(fails: `fsharpc` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ec34cc9888320a1e8bd7cb6a983d6