### PR TITLE
Add grouped join support in Rust compiler

### DIFF
--- a/tests/machine/x/rust/README.md
+++ b/tests/machine/x/rust/README.md
@@ -83,7 +83,7 @@ Checklist of programs that currently compile and run (84/97):
 - [x] group_by
 - [x] group_by_conditional_sum
 - [x] group_by_having
-- [ ] group_by_join
+- [x] group_by_join
 - [ ] group_by_left_join
 - [ ] group_by_multi_join
 - [ ] group_by_multi_join_sort

--- a/tests/machine/x/rust/group_by_join.error
+++ b/tests/machine/x/rust/group_by_join.error
@@ -1,2 +1,0 @@
-line 0: query features not supported
-// group_by_join.mochi

--- a/tests/machine/x/rust/group_by_join.out
+++ b/tests/machine/x/rust/group_by_join.out
@@ -1,0 +1,3 @@
+"--- Orders per customer ---"
+"Alice" "orders:" 2
+"Bob" "orders:" 1

--- a/tests/machine/x/rust/group_by_join.rs
+++ b/tests/machine/x/rust/group_by_join.rs
@@ -1,0 +1,39 @@
+#[derive(Default, Debug, Clone)]
+struct Customer {
+    id: i32,
+    name: &'static str,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Order {
+    id: i32,
+    customerId: i32,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Item {
+    o: Order,
+    c: Customer,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Group {
+    key: &'static str,
+    items: Vec<Item>,
+}
+
+#[derive(Default, Debug, Clone)]
+struct Result {
+    name: &'static str,
+    count: i32,
+}
+
+fn main() {
+    let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }];
+    let orders = vec![Order { id: 100, customerId: 1 }, Order { id: 101, customerId: 1 }, Order { id: 102, customerId: 2 }];
+    let stats = { let mut tmp1 = std::collections::HashMap::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } let key = c.name; tmp1.entry(key).or_insert_with(Vec::new).push(Item {o: o.clone(), c: c.clone() }); } } let mut tmp2 = Vec::<Group>::new(); for (k,v) in tmp1 { tmp2.push(Group { key: k, items: v }); } let mut result = Vec::new(); for g in tmp2 { result.push(Result { name: g.key, count: g.clone().items.len() as i32 }); } result };
+    println!("{:?}", "--- Orders per customer ---");
+    for s in stats {
+        println!("{:?} {:?} {:?}", s.name, "orders:", s.count);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `compileGroupByJoin` in Rust compiler and invoke for grouped joins
- cast results of `count`/`len` to `i32`
- track group structs so field types resolve correctly
- add machine output for `group_by_join` and update checklist

## Testing
- `go test -tags slow ./compiler/x/rust -run TestCompilePrograms/group_by_left_join -v`
- `go test -tags slow ./compiler/x/rust -run TestCompilePrograms -count=1 > /tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_686ec0f43c9c8320b5911510129094aa