### PR TITLE
Add OCaml match/union support

### DIFF
--- a/tests/machine/x/ocaml/README.md
+++ b/tests/machine/x/ocaml/README.md
@@ -75,17 +75,17 @@ runs produce a `.out` file while failures generate a `.error` report.
 - [x] user_type_literal
 - [x] var_assignment
 - [x] while_loop
+- [x] match_expr
+- [x] match_full
+- [x] tree_sum
 
 ## Failed to build or run
 
 - [ ] group_items_iteration
 - [ ] load_yaml
-- [ ] match_expr
-- [ ] match_full
 - [ ] nested_function
 - [ ] save_jsonl_stdout
 - [ ] test_block
-- [ ] tree_sum
 - [ ] two-sum
 - [ ] update_stmt
 

--- a/tests/machine/x/ocaml/match_expr.error
+++ b/tests/machine/x/ocaml/match_expr.error
@@ -1,1 +1,0 @@
-unsupported expression at line 3

--- a/tests/machine/x/ocaml/match_expr.ml
+++ b/tests/machine/x/ocaml/match_expr.ml
@@ -1,0 +1,64 @@
+let rec __show v =
+  let open Obj in
+  let rec list_aux o =
+    if is_int o && (magic (obj o) : int) = 0 then "" else
+     let hd = field o 0 in
+     let tl = field o 1 in
+     let rest = list_aux tl in
+     if rest = "" then __show (obj hd) else __show (obj hd) ^ "; " ^ rest
+  in
+  let r = repr v in
+  if is_int r then string_of_int (magic v) else
+  match tag r with
+    | 0 -> if size r = 0 then "[]" else "[" ^ list_aux r ^ "]"
+    | 252 -> (magic v : string)
+    | 253 -> string_of_float (magic v)
+    | _ -> "<value>"
+
+exception Break
+exception Continue
+
+let string_contains s sub =
+  let len_s = String.length s and len_sub = String.length sub in
+  let rec aux i =
+    if i + len_sub > len_s then false
+    else if String.sub s i len_sub = sub then true
+    else aux (i + 1)
+  in aux 0
+
+let slice lst i j =
+  lst |> List.mapi (fun idx x -> idx, x)
+      |> List.filter (fun (idx, _) -> idx >= i && idx < j)
+      |> List.map snd
+
+let string_slice s i j = String.sub s i (j - i)
+
+let list_set lst idx value =
+  List.mapi (fun i v -> if i = idx then value else v) lst
+
+let rec map_set m k v =
+  match m with
+    | [] -> [(k,Obj.repr v)]
+    | (k2,v2)::tl -> if k2 = k then (k,Obj.repr v)::tl else (k2,v2)::map_set tl k v
+
+let map_get m k = Obj.obj (List.assoc k m)
+
+let list_union a b = List.sort_uniq compare (a @ b)
+let list_except a b = List.filter (fun x -> not (List.mem x b)) a
+let list_intersect a b = List.filter (fun x -> List.mem x b) a |> List.sort_uniq compare
+let list_union_all a b = a @ b
+let sum lst = List.fold_left (+) 0 lst
+type ('k,'v) group = { key : 'k; items : 'v list }
+let group_by lst keyfn =
+  let add acc it =
+    let k = keyfn it in
+    let cur = try List.assoc k acc with Not_found -> [] in
+    (k, cur @ [it]) :: List.remove_assoc k acc
+  in
+  lst |> List.fold_left add [] |> List.rev |> List.map (fun (k,items) -> { key = k; items = items })
+
+let x = 2
+let label = (match x with | 1 -> "one" | 2 -> "two" | 3 -> "three" | _ -> "unknown")
+
+let () =
+  print_endline (__show (label));

--- a/tests/machine/x/ocaml/match_full.error
+++ b/tests/machine/x/ocaml/match_full.error
@@ -1,1 +1,0 @@
-unsupported expression at line 3

--- a/tests/machine/x/ocaml/match_full.ml
+++ b/tests/machine/x/ocaml/match_full.ml
@@ -1,0 +1,75 @@
+let rec __show v =
+  let open Obj in
+  let rec list_aux o =
+    if is_int o && (magic (obj o) : int) = 0 then "" else
+     let hd = field o 0 in
+     let tl = field o 1 in
+     let rest = list_aux tl in
+     if rest = "" then __show (obj hd) else __show (obj hd) ^ "; " ^ rest
+  in
+  let r = repr v in
+  if is_int r then string_of_int (magic v) else
+  match tag r with
+    | 0 -> if size r = 0 then "[]" else "[" ^ list_aux r ^ "]"
+    | 252 -> (magic v : string)
+    | 253 -> string_of_float (magic v)
+    | _ -> "<value>"
+
+exception Break
+exception Continue
+
+let string_contains s sub =
+  let len_s = String.length s and len_sub = String.length sub in
+  let rec aux i =
+    if i + len_sub > len_s then false
+    else if String.sub s i len_sub = sub then true
+    else aux (i + 1)
+  in aux 0
+
+let slice lst i j =
+  lst |> List.mapi (fun idx x -> idx, x)
+      |> List.filter (fun (idx, _) -> idx >= i && idx < j)
+      |> List.map snd
+
+let string_slice s i j = String.sub s i (j - i)
+
+let list_set lst idx value =
+  List.mapi (fun i v -> if i = idx then value else v) lst
+
+let rec map_set m k v =
+  match m with
+    | [] -> [(k,Obj.repr v)]
+    | (k2,v2)::tl -> if k2 = k then (k,Obj.repr v)::tl else (k2,v2)::map_set tl k v
+
+let map_get m k = Obj.obj (List.assoc k m)
+
+let list_union a b = List.sort_uniq compare (a @ b)
+let list_except a b = List.filter (fun x -> not (List.mem x b)) a
+let list_intersect a b = List.filter (fun x -> List.mem x b) a |> List.sort_uniq compare
+let list_union_all a b = a @ b
+let sum lst = List.fold_left (+) 0 lst
+type ('k,'v) group = { key : 'k; items : 'v list }
+let group_by lst keyfn =
+  let add acc it =
+    let k = keyfn it in
+    let cur = try List.assoc k acc with Not_found -> [] in
+    (k, cur @ [it]) :: List.remove_assoc k acc
+  in
+  lst |> List.fold_left add [] |> List.rev |> List.map (fun (k,items) -> { key = k; items = items })
+
+let x = 2
+let label = (match x with | 1 -> "one" | 2 -> "two" | 3 -> "three" | _ -> "unknown")
+let day = "sun"
+let mood = (match day with | "mon" -> "tired" | "fri" -> "excited" | "sun" -> "relaxed" | _ -> "normal")
+let ok = true
+let status = (match ok with | true -> "confirmed" | false -> "denied")
+let rec classify (n : int) : string =
+  (match n with | 0 -> "zero" | 1 -> "one" | _ -> "many")
+
+
+let () =
+  print_endline (__show (label));
+  print_endline (__show (mood));
+  print_endline (__show (status));
+  print_endline (__show (classify 0));
+  print_endline (__show (classify 5));

--- a/tests/machine/x/ocaml/tree_sum.error
+++ b/tests/machine/x/ocaml/tree_sum.error
@@ -1,1 +1,0 @@
-unsupported expression at line 10

--- a/tests/machine/x/ocaml/tree_sum.ml
+++ b/tests/machine/x/ocaml/tree_sum.ml
@@ -1,0 +1,67 @@
+let rec __show v =
+  let open Obj in
+  let rec list_aux o =
+    if is_int o && (magic (obj o) : int) = 0 then "" else
+     let hd = field o 0 in
+     let tl = field o 1 in
+     let rest = list_aux tl in
+     if rest = "" then __show (obj hd) else __show (obj hd) ^ "; " ^ rest
+  in
+  let r = repr v in
+  if is_int r then string_of_int (magic v) else
+  match tag r with
+    | 0 -> if size r = 0 then "[]" else "[" ^ list_aux r ^ "]"
+    | 252 -> (magic v : string)
+    | 253 -> string_of_float (magic v)
+    | _ -> "<value>"
+
+exception Break
+exception Continue
+
+let string_contains s sub =
+  let len_s = String.length s and len_sub = String.length sub in
+  let rec aux i =
+    if i + len_sub > len_s then false
+    else if String.sub s i len_sub = sub then true
+    else aux (i + 1)
+  in aux 0
+
+let slice lst i j =
+  lst |> List.mapi (fun idx x -> idx, x)
+      |> List.filter (fun (idx, _) -> idx >= i && idx < j)
+      |> List.map snd
+
+let string_slice s i j = String.sub s i (j - i)
+
+let list_set lst idx value =
+  List.mapi (fun i v -> if i = idx then value else v) lst
+
+let rec map_set m k v =
+  match m with
+    | [] -> [(k,Obj.repr v)]
+    | (k2,v2)::tl -> if k2 = k then (k,Obj.repr v)::tl else (k2,v2)::map_set tl k v
+
+let map_get m k = Obj.obj (List.assoc k m)
+
+let list_union a b = List.sort_uniq compare (a @ b)
+let list_except a b = List.filter (fun x -> not (List.mem x b)) a
+let list_intersect a b = List.filter (fun x -> List.mem x b) a |> List.sort_uniq compare
+let list_union_all a b = a @ b
+let sum lst = List.fold_left (+) 0 lst
+type ('k,'v) group = { key : 'k; items : 'v list }
+let group_by lst keyfn =
+  let add acc it =
+    let k = keyfn it in
+    let cur = try List.assoc k acc with Not_found -> [] in
+    (k, cur @ [it]) :: List.remove_assoc k acc
+  in
+  lst |> List.fold_left add [] |> List.rev |> List.map (fun (k,items) -> { key = k; items = items })
+
+type tree = Leaf | Node of tree * int * tree
+let rec sum_tree (t : tree) : int =
+  (match t with | Leaf -> 0 | Node (left, value, right) -> ((sum_tree left + value) + sum_tree right))
+
+let t = Node (Leaf, 1, Node (Leaf, 2, Leaf))
+
+let () =
+  print_endline (__show (sum_tree t));


### PR DESCRIPTION
## Summary
- support union type declarations in the OCaml compiler
- implement pattern matching compilation
- emit OCaml variants when constructing union values
- generate source for `match_expr`, `match_full` and `tree_sum`
- update OCaml machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ec8f4099483209d09dc53b04ef87e