### PR TITLE
Improve Pascal compiler query handling

### DIFF
--- a/tests/machine/x/pascal/README.md
+++ b/tests/machine/x/pascal/README.md
@@ -103,3 +103,9 @@ Checklist:
 - [ ] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining tasks
+
+- Re-run the compiler with a working FreePascal installation to
+  generate `.out` files for programs marked as incomplete.
+- Verify join and group by queries compile and execute correctly.

--- a/types/check.go
+++ b/types/check.go
@@ -1690,6 +1690,8 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 				valT = vt
 			} else if !unify(valT, vt, nil) {
 				valT = AnyType{}
+			} else if _, ok := vt.(AnyType); ok {
+				valT = AnyType{}
 			}
 		}
 		if keyT == nil {


### PR DESCRIPTION
## Summary
- capture variable types before compiling the main body so map field access uses KeyData
- restore var type map after compiling functions
- treat `Any` values in map literals as `Variant` to avoid overly strict typing
- note remaining tasks in Pascal machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686eca4b00d48320a097d66039991b94