### PR TITLE
Add right join support to Smalltalk compiler

### DIFF
--- a/tests/machine/x/st/README.md
+++ b/tests/machine/x/st/README.md
@@ -103,5 +103,6 @@ This directory contains Smalltalk source code generated from the Mochi programs 
 
 ## TODO
 - [x] full outer join semantics
+- [x] right join semantics
 
 All programs executed successfully with GNU Smalltalk.

--- a/tests/machine/x/st/right_join.st
+++ b/tests/machine/x/st/right_join.st
@@ -3,12 +3,10 @@ customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom
 orders := {Dictionary newFrom: {id -> 100. customerId -> 1. total -> 250}. Dictionary newFrom: {id -> 101. customerId -> 2. total -> 125}. Dictionary newFrom: {id -> 102. customerId -> 1. total -> 300}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
-  customers do: [:c |
-    orders do: [:o |
-      ((o.customerId = c.id)) ifTrue: [
-        tmp add: Dictionary newFrom: {customerName -> c.name. order -> o}.
-      ].
-    ].
+  orders do: [:o |
+    | c |
+    c := customers detect: [:c | ((o.customerId = c.id)) ] ifAbsent:[nil].
+    tmp add: Dictionary newFrom: {customerName -> c.name. order -> o}.
   ].
   tmp
 ] value.


### PR DESCRIPTION
## Summary
- support simple right join queries in the Smalltalk compiler
- regenerate machine output for `right_join` example
- document right join capability in the Smalltalk machine README

## Testing
- `go test -tags slow ./compiler/x/st -run TestCompilePrograms/right_join -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686ecba9fec0832089315982075930f3