### PR TITLE
Add group-by join support for Zig compiler

### DIFF
--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -101,3 +101,4 @@
 - [x] Regenerate outputs after fixing map literal temporary variable names
 - [x] Support map literals in iterations by emitting `std.AutoHashMap` even when keys are simple
 - [x] Support right and outer join queries
+- [x] Support join queries with grouping, having clauses, and sorting


### PR DESCRIPTION
## Summary
- support sorting, having, skipping and taking in group-by queries for Zig backend
- note new feature in Zig machine README

## Testing
- `go vet ./...`
- `go test -tags slow ./compiler/x/zig -run TestZigCompiler_ValidPrograms/group_by_sort -count=1`
- `go test -tags slow ./compiler/x/zig -run TestZigCompiler_ValidPrograms/group_by_having -count=1`
- `go test -tags slow ./compiler/x/zig -run TestZigCompiler_ValidPrograms/group_by_conditional_sum -count=1`
- `go test -tags slow ./compiler/x/zig -run TestZigCompiler_ValidPrograms/group_by_multi_join_sort -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686ecb7298048320bbffccb9f38a34ef