### PR TITLE
Improve C# group by handling

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -1199,7 +1199,8 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			srcParts = append(srcParts, fmt.Sprintf("Where(%s => %s)", v, cond))
 		}
 		filtered := strings.Join(srcParts, ".")
-		expr := fmt.Sprintf("%s.GroupBy(%s => %s)", filtered, v, keyExpr)
+		c.use("_group_by")
+		expr := fmt.Sprintf("_group_by(%s, %s => %s)", filtered, v, keyExpr)
 		if havingExpr != "" {
 			expr = fmt.Sprintf("%s.Where(%s => %s)", expr, sanitizeName(q.Group.Name), havingExpr)
 		}

--- a/tests/machine/x/cs/group_by.cs
+++ b/tests/machine/x/cs/group_by.cs
@@ -3,24 +3,50 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-public class Program {
-    public static void Main() {
-        var people = new Dictionary<string, dynamic>[] { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Eve" }, { "age", 70 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Frank" }, { "age", 22 }, { "city", "Hanoi" } } };
-        var stats = people.GroupBy(person => person["city"]).Select(g => new Dictionary<string, dynamic> { { "city", g.Key }, { "count", Enumerable.Count(g) }, { "avg_age", _avg(g.Select(p => p["age"])) } }).ToList();
+public class Program
+{
+    public static void Main()
+    {
+        var people = new dynamic[] { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Eve" }, { "age", 70 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Frank" }, { "age", 22 }, { "city", "Hanoi" } } };
+        var stats = _group_by(people, person => person["city"]).Select(g => new Dictionary<string, dynamic> { { "city", g.Key }, { "count", Enumerable.Count(g) }, { "avg_age", _avg(g.Items.Select(p => p["age"])) } }).ToList();
         Console.WriteLine("--- People grouped by city ---");
-        foreach (var s in stats) {
-            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(s["city"]), Convert.ToString(": count ="), Convert.ToString(s["count"]), Convert.ToString(", avg_age ="), Convert.ToString(s["avg_age"]) }));
+        foreach (var s in stats)
+        {
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(s["city"]), Convert.ToString(": count ="), Convert.ToString(s["count"]), Convert.ToString(", avg_age ="), Convert.ToString(s["avg_age"]) }));
         }
     }
-    static double _avg(dynamic v) {
+    static double _avg(dynamic v)
+    {
         if (v == null) return 0.0;
         int _n = 0;
         double _sum = 0;
-        foreach (var it in v) {
+        foreach (var it in v)
+        {
             _sum += Convert.ToDouble(it);
             _n++;
         }
         return _n == 0 ? 0.0 : _sum / _n;
     }
-    
+
+    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn)
+    {
+        var groups = new Dictionary<string, _Group>();
+        var order = new List<string>();
+        foreach (var it in src)
+        {
+            var key = keyfn(it);
+            var ks = Convert.ToString(key);
+            if (!groups.TryGetValue(ks, out var g))
+            {
+                g = new _Group(key);
+                groups[ks] = g;
+                order.Add(ks);
+            }
+            g.Items.Add(it);
+        }
+        var res = new List<_Group>();
+        foreach (var k in order) res.Add(groups[k]);
+        return res;
+    }
+
 }


### PR DESCRIPTION
## Summary
- support group by queries via the `_group_by` runtime helper
- update generated C# code for `group_by.mochi`

## Testing
- `go test -tags slow ./compiler/x/cs -run TestCompileValidPrograms -count=1` *(fails: dotnet not installed, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686ecc00c09c8320a29154548a0f8595