### PR TITLE
Extend F# compiler

### DIFF
--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -3,7 +3,7 @@
 This directory contains F# source code generated from Mochi programs in `tests/vm/valid`.
 Generated with `compiler/x/fs`. Programs that compile successfully have a `.fs` file, and if compilation fails an `.error` file captures the reason.
 
-Compiled programs: 91/97
+Compiled programs: 97/97
 
 Checklist:
 - [x] append_builtin
@@ -55,7 +55,7 @@ Checklist:
 - [x] list_index
 - [x] list_nested_assign
 - [x] list_set_ops
-- [ ] load_yaml
+ - [x] load_yaml
 - [x] map_assign
 - [x] map_in_operator
 - [x] map_index
@@ -70,7 +70,7 @@ Checklist:
 - [x] min_max_builtin
 - [x] nested_function
 - [x] order_by_map
-- [ ] outer_join
+ - [x] outer_join
 - [x] partial_application
 - [x] print_hello
 - [x] pure_fold
@@ -78,7 +78,7 @@ Checklist:
 - [x] query_sum_select
 - [x] record_assign
 - [x] right_join
-- [ ] save_jsonl_stdout
+ - [x] save_jsonl_stdout
 - [x] short_circuit
 - [x] slice
 - [x] sort_stable
@@ -92,13 +92,13 @@ Checklist:
 - [x] substring_builtin
 - [x] sum_builtin
 - [x] tail_recursion
-- [ ] test_block
-- [ ] tree_sum
+ - [x] test_block
+ - [x] tree_sum
 - [x] two-sum
 - [x] typed_let
 - [x] typed_var
 - [x] unary_neg
-- [ ] update_stmt
+ - [x] update_stmt
 - [x] user_type_literal
 - [x] values_builtin
 - [x] var_assignment

--- a/tests/machine/x/fs/load_yaml.error
+++ b/tests/machine/x/fs/load_yaml.error
@@ -1,1 +1,0 @@
-unsupported expression at line 7

--- a/tests/machine/x/fs/load_yaml.fs
+++ b/tests/machine/x/fs/load_yaml.fs
@@ -1,0 +1,26 @@
+open System
+open System.IO
+open YamlDotNet.Serialization
+
+exception Break
+exception Continue
+
+type Anon1 = {
+    name: obj
+    email: obj
+}
+type Person = {
+    mutable name: string
+    mutable age: int
+    mutable email: string
+}
+let people = (let deserializer = DeserializerBuilder().Build()
+    let yamlText = File.ReadAllText("../interpreter/valid/people.yaml")
+    deserializer.Deserialize<Person list>(yamlText))
+let adults = [ for p in people do if p.age >= 18 then yield { name = p.name; email = p.email } ]
+try
+    for a in adults do
+        try
+            printfn "%s" (String.concat " " [string a.name; string a.email])
+        with Continue -> ()
+with Break -> ()

--- a/tests/machine/x/fs/outer_join.error
+++ b/tests/machine/x/fs/outer_join.error
@@ -1,2 +1,0 @@
-unsupported join type
-

--- a/tests/machine/x/fs/outer_join.fs
+++ b/tests/machine/x/fs/outer_join.fs
@@ -12,14 +12,15 @@ type Anon2 = {
     customerId: int
     total: int
 }
-type Anon3 = {
-    order: obj
-    customer: obj
-}
 let customers = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }; { id = 3; name = "Charlie" }; { id = 4; name = "Diana" }]
 let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId = 2; total = 125 }; { id = 102; customerId = 1; total = 300 }; { id = 103; customerId = 5; total = 80 }]
-let result = [ for o in orders do 
-  for c in customers do if o.customerId = c.id then yield { order = o; customer = c } ]
+let result = (let orderPart = [ for o in orders do
+    let c = customers |> List.tryFind (fun c -> o.customerId = c.id)
+    yield { order = Some o; customer = c } ]
+ let customerPart = [ for c in customers do
+    if orders |> List.exists (fun o -> o.customerId = c.id) |> not then
+        yield { order = None; customer = Some c } ]
+ orderPart @ customerPart)
 printfn "%s" "--- Outer Join using syntax ---"
 try
     for row in result do

--- a/tests/machine/x/fs/save_jsonl_stdout.error
+++ b/tests/machine/x/fs/save_jsonl_stdout.error
@@ -1,1 +1,0 @@
-unsupported expression at line 6

--- a/tests/machine/x/fs/save_jsonl_stdout.fs
+++ b/tests/machine/x/fs/save_jsonl_stdout.fs
@@ -1,0 +1,12 @@
+open System
+open System.Text.Json
+
+exception Break
+exception Continue
+
+type Anon1 = {
+    name: string
+    age: int
+}
+let people = [{ name = "Alice"; age = 30 }; { name = "Bob"; age = 25 }]
+(List.iter (fun row -> printfn "%s" (JsonSerializer.Serialize(row))) people)

--- a/tests/machine/x/fs/test_block.error
+++ b/tests/machine/x/fs/test_block.error
@@ -1,1 +1,0 @@
-unsupported statement at line 1

--- a/tests/machine/x/fs/test_block.fs
+++ b/tests/machine/x/fs/test_block.fs
@@ -1,0 +1,8 @@
+open System
+
+exception Break
+exception Continue
+
+let x = 1 + 2
+assert (x = 3)
+printfn "%s" "ok"

--- a/tests/machine/x/fs/tree_sum.error
+++ b/tests/machine/x/fs/tree_sum.error
@@ -1,1 +1,0 @@
-variant types not supported

--- a/tests/machine/x/fs/tree_sum.fs
+++ b/tests/machine/x/fs/tree_sum.fs
@@ -1,0 +1,14 @@
+open System
+
+exception Break
+exception Continue
+
+type Tree =
+    | Leaf
+    | Node of Tree * int * Tree
+let sum_tree (t) =
+    (match t with
+    | Leaf -> 0
+    | Node left value right -> sum_tree left + value + sum_tree right)
+let t = Node(Leaf, 1, Node(Leaf, 2, Leaf))
+printfn "%A" (sum_tree t)

--- a/tests/machine/x/fs/update_stmt.error
+++ b/tests/machine/x/fs/update_stmt.error
@@ -1,1 +1,0 @@
-unsupported type

--- a/tests/machine/x/fs/update_stmt.fs
+++ b/tests/machine/x/fs/update_stmt.fs
@@ -1,0 +1,17 @@
+open System
+
+exception Break
+exception Continue
+
+type Person = {
+    mutable name: string
+    mutable age: int
+    mutable status: string
+}
+let people = [{ name = "Alice"; age = 17; status = "minor" }; { name = "Bob"; age = 25; status = "unknown" }; { name = "Charlie"; age = 18; status = "unknown" }; { name = "Diana"; age = 16; status = "minor" }]
+for item in people do
+    if item.age >= 18 then
+        item.status <- "adult"
+        item.age <- item.age + 1
+assert (people = [{ name = "Alice"; age = 17; status = "minor" }; { name = "Bob"; age = 26; status = "adult" }; { name = "Charlie"; age = 19; status = "adult" }; { name = "Diana"; age = 16; status = "minor" }])
+printfn "%s" "ok"


### PR DESCRIPTION
## Summary
- expand F# codegen with load/save, test blocks, update, outer join
- support variant types and mutable fields
- regenerate machine outputs for F# examples

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ecdb632e08320ae09eb3494303b18