### PR TITLE
Improve Pascal compiler variable tracking

### DIFF
--- a/compiler/x/pascal/helpers.go
+++ b/compiler/x/pascal/helpers.go
@@ -59,6 +59,9 @@ func (c *Compiler) newTypedVar(typ string) string {
 		c.tempVars = make(map[string]string)
 	}
 	c.tempVars[name] = typ
+	if c.varTypes != nil {
+		c.varTypes[name] = typ
+	}
 	return name
 }
 


### PR DESCRIPTION
## Summary
- ensure variable types are available while compiling main/test blocks
- record types for temporary variables
- handle anonymous struct results in query expressions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ed04f8e808320a131fef17c25e285