### PR TITLE
Improve Pascal compiler var handling

### DIFF
--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -107,6 +107,11 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		}
 	}
 
+	// Pre-collect variables so that later statements can be
+	// compiled with type information available.
+	preVars := map[string]string{}
+	collectVars(prog.Statements, c.env, preVars)
+
 	// Compile main body first to gather temporaries
 	var body bytes.Buffer
 	prevBuf := c.buf

--- a/compiler/x/pascal/helpers.go
+++ b/compiler/x/pascal/helpers.go
@@ -74,7 +74,7 @@ func inferQueryType(q *parser.QueryExpr, env *types.Env) types.Type {
 	child.SetVar(q.Var, elem, true)
 	for _, f := range q.Froms {
 		ft := types.TypeOfExprBasic(f.Src, env)
-		fe := types.AnyType{}
+		var fe types.Type = types.AnyType{}
 		if lt, ok := ft.(types.ListType); ok {
 			fe = lt.Elem
 		}
@@ -82,7 +82,7 @@ func inferQueryType(q *parser.QueryExpr, env *types.Env) types.Type {
 	}
 	for _, j := range q.Joins {
 		jt := types.TypeOfExprBasic(j.Src, env)
-		je := types.AnyType{}
+		var je types.Type = types.AnyType{}
 		if lt, ok := jt.(types.ListType); ok {
 			je = lt.Elem
 		}


### PR DESCRIPTION
## Summary
- collect variable types before compiling the program so expressions know about earlier declarations
- fix query type inference in helper to use generic `types.Type`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ed1080ce08320847c7bfa769ea1fd