### PR TITLE
Improve Smalltalk map literals

### DIFF
--- a/tests/machine/x/st/README.md
+++ b/tests/machine/x/st/README.md
@@ -5,7 +5,8 @@ in `tests/vm/valid`. A checkbox indicates the program compiled and executed
 successfully during tests. The CI environment now installs `gst`, so all
 programs run to completion.  The Smalltalk compiler supports `join` and
 `group by` queries, allowing the examples below to execute as in the reference
-implementations.
+implementations. Dictionary keys now emit Smalltalk symbols to more closely
+match the hand written examples in `tests/human/x/st`.
 
 ## Checklist
 - [x] append_builtin.mochi

--- a/tests/machine/x/st/basic_compare.st
+++ b/tests/machine/x/st/basic_compare.st
@@ -1,4 +1,4 @@
-| a b |
+| b a |
 a := (10 - 3).
 b := (2 + 2).
 Transcript show: (a) printString; cr.

--- a/tests/machine/x/st/break_continue.st
+++ b/tests/machine/x/st/break_continue.st
@@ -1,4 +1,4 @@
-| numbers n |
+| n numbers |
 Object subclass: #BreakSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!.
 Object subclass: #ContinueSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!.
 numbers := {1. 2. 3. 4. 5. 6. 7. 8. 9}.

--- a/tests/machine/x/st/cast_struct.st
+++ b/tests/machine/x/st/cast_struct.st
@@ -1,3 +1,3 @@
 | todo |
-todo := Dictionary newFrom: {'title' -> 'hi'}.
+todo := Dictionary newFrom:{'title'->'hi'}.
 Transcript show: (todo at: 'title') printString; cr.

--- a/tests/machine/x/st/cross_join.st
+++ b/tests/machine/x/st/cross_join.st
@@ -1,11 +1,11 @@
-| orders result entry customers |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}. Dictionary newFrom: {id -> 3. name -> 'Charlie'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1. total -> 250}. Dictionary newFrom: {id -> 101. customerId -> 2. total -> 125}. Dictionary newFrom: {id -> 102. customerId -> 1. total -> 300}}.
+| customers orders result entry |
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}. Dictionary newFrom:{#id->3. #name->'Charlie'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->2. #total->125}. Dictionary newFrom:{#id->102. #customerId->1. #total->300}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   orders do: [:o |
     customers do: [:c |
-      tmp add: Dictionary newFrom: {orderId -> o.id. orderCustomerId -> o.customerId. pairedCustomerName -> c.name. orderTotal -> o.total}.
+      tmp add: Dictionary newFrom:{#orderId->o.id. #orderCustomerId->o.customerId. #pairedCustomerName->c.name. #orderTotal->o.total}.
     ].
   ].
   tmp

--- a/tests/machine/x/st/cross_join_filter.st
+++ b/tests/machine/x/st/cross_join_filter.st
@@ -1,4 +1,4 @@
-| p nums letters pairs |
+| nums letters pairs p |
 nums := {1. 2. 3}.
 letters := {'A'. 'B'}.
 pairs := [ | tmp |
@@ -6,7 +6,7 @@ pairs := [ | tmp |
   nums do: [:n |
     letters do: [:l |
       (((n % 2) = 0)) ifTrue: [
-        tmp add: Dictionary newFrom: {n -> n. l -> l}.
+        tmp add: Dictionary newFrom:{#n->n. #l->l}.
       ].
     ].
   ].

--- a/tests/machine/x/st/cross_join_triple.st
+++ b/tests/machine/x/st/cross_join_triple.st
@@ -1,4 +1,4 @@
-| nums letters bools combos c |
+| combos c nums letters bools |
 nums := {1. 2}.
 letters := {'A'. 'B'}.
 bools := {true. false}.
@@ -7,7 +7,7 @@ combos := [ | tmp |
   nums do: [:n |
     letters do: [:l |
       bools do: [:b |
-        tmp add: Dictionary newFrom: {n -> n. l -> l. b -> b}.
+        tmp add: Dictionary newFrom:{#n->n. #l->l. #b->b}.
       ].
     ].
   ].

--- a/tests/machine/x/st/dataset_sort_take_limit.st
+++ b/tests/machine/x/st/dataset_sort_take_limit.st
@@ -1,5 +1,5 @@
-| expensive item products |
-products := {Dictionary newFrom: {name -> 'Laptop'. price -> 1500}. Dictionary newFrom: {name -> 'Smartphone'. price -> 900}. Dictionary newFrom: {name -> 'Tablet'. price -> 600}. Dictionary newFrom: {name -> 'Monitor'. price -> 300}. Dictionary newFrom: {name -> 'Keyboard'. price -> 100}. Dictionary newFrom: {name -> 'Mouse'. price -> 50}. Dictionary newFrom: {name -> 'Headphones'. price -> 200}}.
+| products expensive item |
+products := {Dictionary newFrom:{#name->'Laptop'. #price->1500}. Dictionary newFrom:{#name->'Smartphone'. #price->900}. Dictionary newFrom:{#name->'Tablet'. #price->600}. Dictionary newFrom:{#name->'Monitor'. #price->300}. Dictionary newFrom:{#name->'Keyboard'. #price->100}. Dictionary newFrom:{#name->'Mouse'. #price->50}. Dictionary newFrom:{#name->'Headphones'. #price->200}}.
 expensive := [ | tmp |
   tmp := OrderedCollection new.
   products do: [:p |

--- a/tests/machine/x/st/dataset_where_filter.st
+++ b/tests/machine/x/st/dataset_where_filter.st
@@ -1,10 +1,10 @@
-| people adults person |
-people := {Dictionary newFrom: {name -> 'Alice'. age -> 30}. Dictionary newFrom: {name -> 'Bob'. age -> 15}. Dictionary newFrom: {name -> 'Charlie'. age -> 65}. Dictionary newFrom: {name -> 'Diana'. age -> 45}}.
+| person people adults |
+people := {Dictionary newFrom:{#name->'Alice'. #age->30}. Dictionary newFrom:{#name->'Bob'. #age->15}. Dictionary newFrom:{#name->'Charlie'. #age->65}. Dictionary newFrom:{#name->'Diana'. #age->45}}.
 adults := [ | tmp |
   tmp := OrderedCollection new.
   people do: [:person |
     ((person.age >= 18)) ifTrue: [
-      tmp add: Dictionary newFrom: {name -> person.name. age -> person.age. is_senior -> (person.age >= 60)}.
+      tmp add: Dictionary newFrom:{#name->person.name. #age->person.age. #is_senior->(person.age >= 60)}.
     ].
   ].
   tmp

--- a/tests/machine/x/st/exists_builtin.st
+++ b/tests/machine/x/st/exists_builtin.st
@@ -1,4 +1,4 @@
-| flag data |
+| data flag |
 data := {1. 2}.
 flag := exists value: [ | tmp |
   tmp := OrderedCollection new.

--- a/tests/machine/x/st/for_map_collection.st
+++ b/tests/machine/x/st/for_map_collection.st
@@ -1,5 +1,5 @@
 | m k |
-m := Dictionary newFrom: {'a' -> 1. 'b' -> 2}.
+m := Dictionary newFrom:{'a'->1. 'b'->2}.
 m do: [:k |.
 Transcript show: (k) printString; cr.
 ].

--- a/tests/machine/x/st/group_by.st
+++ b/tests/machine/x/st/group_by.st
@@ -1,5 +1,5 @@
-| people stats s |
-people := {Dictionary newFrom: {name -> 'Alice'. age -> 30. city -> 'Paris'}. Dictionary newFrom: {name -> 'Bob'. age -> 15. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Charlie'. age -> 65. city -> 'Paris'}. Dictionary newFrom: {name -> 'Diana'. age -> 45. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Eve'. age -> 70. city -> 'Paris'}. Dictionary newFrom: {name -> 'Frank'. age -> 22. city -> 'Hanoi'}}.
+| stats s people |
+people := {Dictionary newFrom:{#name->'Alice'. #age->30. #city->'Paris'}. Dictionary newFrom:{#name->'Bob'. #age->15. #city->'Hanoi'}. Dictionary newFrom:{#name->'Charlie'. #age->65. #city->'Paris'}. Dictionary newFrom:{#name->'Diana'. #age->45. #city->'Hanoi'}. Dictionary newFrom:{#name->'Eve'. #age->70. #city->'Paris'}. Dictionary newFrom:{#name->'Frank'. #age->22. #city->'Hanoi'}}.
 stats := [ | groups tmp |
   groups := Dictionary new.
   tmp := OrderedCollection new.
@@ -11,7 +11,7 @@ stats := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {city -> g.key. count -> (g size). avg_age -> avg value: [ | tmp |
+    tmp add: Dictionary newFrom:{#city->g.key. #count->(g size). #avg_age->avg value: [ | tmp |
   tmp := OrderedCollection new.
   g do: [:p |
     tmp add: p.age.

--- a/tests/machine/x/st/group_by_conditional_sum.st
+++ b/tests/machine/x/st/group_by_conditional_sum.st
@@ -1,5 +1,5 @@
 | items result |
-items := {Dictionary newFrom: {cat -> 'a'. val -> 10. flag -> true}. Dictionary newFrom: {cat -> 'a'. val -> 5. flag -> false}. Dictionary newFrom: {cat -> 'b'. val -> 20. flag -> true}}.
+items := {Dictionary newFrom:{#cat->'a'. #val->10. #flag->true}. Dictionary newFrom:{#cat->'a'. #val->5. #flag->false}. Dictionary newFrom:{#cat->'b'. #val->20. #flag->true}}.
 result := [ | groups tmp |
   groups := Dictionary new.
   tmp := OrderedCollection new.
@@ -11,7 +11,7 @@ result := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {cat -> g.key. share -> (([ | tmp |
+    tmp add: Dictionary newFrom:{#cat->g.key. #share->(([ | tmp |
   tmp := OrderedCollection new.
   g do: [:x |
     tmp add: (x.flag) ifTrue: [x.val] ifFalse: [0].

--- a/tests/machine/x/st/group_by_having.st
+++ b/tests/machine/x/st/group_by_having.st
@@ -1,5 +1,5 @@
 | people big |
-people := {Dictionary newFrom: {name -> 'Alice'. city -> 'Paris'}. Dictionary newFrom: {name -> 'Bob'. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Charlie'. city -> 'Paris'}. Dictionary newFrom: {name -> 'Diana'. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'Eve'. city -> 'Paris'}. Dictionary newFrom: {name -> 'Frank'. city -> 'Hanoi'}. Dictionary newFrom: {name -> 'George'. city -> 'Paris'}}.
+people := {Dictionary newFrom:{#name->'Alice'. #city->'Paris'}. Dictionary newFrom:{#name->'Bob'. #city->'Hanoi'}. Dictionary newFrom:{#name->'Charlie'. #city->'Paris'}. Dictionary newFrom:{#name->'Diana'. #city->'Hanoi'}. Dictionary newFrom:{#name->'Eve'. #city->'Paris'}. Dictionary newFrom:{#name->'Frank'. #city->'Hanoi'}. Dictionary newFrom:{#name->'George'. #city->'Paris'}}.
 big := [ | groups tmp |
   groups := Dictionary new.
   tmp := OrderedCollection new.
@@ -11,7 +11,7 @@ big := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {city -> g.key. num -> (g size)}.
+    tmp add: Dictionary newFrom:{#city->g.key. #num->(g size)}.
   ].
   tmp
 ] value.

--- a/tests/machine/x/st/group_by_join.st
+++ b/tests/machine/x/st/group_by_join.st
@@ -1,6 +1,6 @@
 | customers orders stats s |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1}. Dictionary newFrom: {id -> 101. customerId -> 1}. Dictionary newFrom: {id -> 102. customerId -> 2}}.
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1}. Dictionary newFrom:{#id->101. #customerId->1}. Dictionary newFrom:{#id->102. #customerId->2}}.
 stats := [ | groups tmp |
   groups := Dictionary new.
   tmp := OrderedCollection new.
@@ -16,7 +16,7 @@ stats := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {name -> g.key. count -> (g size)}.
+    tmp add: Dictionary newFrom:{#name->g.key. #count->(g size)}.
   ].
   tmp
 ] value.

--- a/tests/machine/x/st/group_by_left_join.st
+++ b/tests/machine/x/st/group_by_left_join.st
@@ -1,6 +1,6 @@
-| s customers orders stats |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}. Dictionary newFrom: {id -> 3. name -> 'Charlie'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1}. Dictionary newFrom: {id -> 101. customerId -> 1}. Dictionary newFrom: {id -> 102. customerId -> 2}}.
+| customers orders stats s |
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}. Dictionary newFrom:{#id->3. #name->'Charlie'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1}. Dictionary newFrom:{#id->101. #customerId->1}. Dictionary newFrom:{#id->102. #customerId->2}}.
 stats := [ | groups tmp |
   groups := Dictionary new.
   tmp := OrderedCollection new.
@@ -16,7 +16,7 @@ stats := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {name -> g.key. count -> ([ | tmp |
+    tmp add: Dictionary newFrom:{#name->g.key. #count->([ | tmp |
   tmp := OrderedCollection new.
   g do: [:r |
     (r.o) ifTrue: [

--- a/tests/machine/x/st/group_by_multi_join.st
+++ b/tests/machine/x/st/group_by_multi_join.st
@@ -1,14 +1,14 @@
-| nations suppliers partsupp filtered grouped |
-nations := {Dictionary newFrom: {id -> 1. name -> 'A'}. Dictionary newFrom: {id -> 2. name -> 'B'}}.
-suppliers := {Dictionary newFrom: {id -> 1. nation -> 1}. Dictionary newFrom: {id -> 2. nation -> 2}}.
-partsupp := {Dictionary newFrom: {part -> 100. supplier -> 1. cost -> 10. qty -> 2}. Dictionary newFrom: {part -> 100. supplier -> 2. cost -> 20. qty -> 1}. Dictionary newFrom: {part -> 200. supplier -> 1. cost -> 5. qty -> 3}}.
+| partsupp filtered grouped nations suppliers |
+nations := {Dictionary newFrom:{#id->1. #name->'A'}. Dictionary newFrom:{#id->2. #name->'B'}}.
+suppliers := {Dictionary newFrom:{#id->1. #nation->1}. Dictionary newFrom:{#id->2. #nation->2}}.
+partsupp := {Dictionary newFrom:{#part->100. #supplier->1. #cost->10. #qty->2}. Dictionary newFrom:{#part->100. #supplier->2. #cost->20. #qty->1}. Dictionary newFrom:{#part->200. #supplier->1. #cost->5. #qty->3}}.
 filtered := [ | tmp |
   tmp := OrderedCollection new.
   partsupp do: [:ps |
     suppliers do: [:s |
       nations do: [:n |
         ((((n.name = 'A') and: [(s.id = ps.supplier)]) and: [(n.id = s.nation)])) ifTrue: [
-          tmp add: Dictionary newFrom: {part -> ps.part. value -> (ps.cost * ps.qty)}.
+          tmp add: Dictionary newFrom:{#part->ps.part. #value->(ps.cost * ps.qty)}.
         ].
       ].
     ].
@@ -26,7 +26,7 @@ grouped := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {part -> g.key. total -> ([ | tmp |
+    tmp add: Dictionary newFrom:{#part->g.key. #total->([ | tmp |
   tmp := OrderedCollection new.
   g do: [:r |
     tmp add: r.value.

--- a/tests/machine/x/st/group_by_multi_join_sort.st
+++ b/tests/machine/x/st/group_by_multi_join_sort.st
@@ -1,8 +1,8 @@
-| lineitem start_date end_date result nation customer orders |
-nation := {Dictionary newFrom: {n_nationkey -> 1. n_name -> 'BRAZIL'}}.
-customer := {Dictionary newFrom: {c_custkey -> 1. c_name -> 'Alice'. c_acctbal -> 100. c_nationkey -> 1. c_address -> '123 St'. c_phone -> '123-456'. c_comment -> 'Loyal'}}.
-orders := {Dictionary newFrom: {o_orderkey -> 1000. o_custkey -> 1. o_orderdate -> '1993-10-15'}. Dictionary newFrom: {o_orderkey -> 2000. o_custkey -> 1. o_orderdate -> '1994-01-02'}}.
-lineitem := {Dictionary newFrom: {l_orderkey -> 1000. l_returnflag -> 'R'. l_extendedprice -> 1000. l_discount -> 0.1}. Dictionary newFrom: {l_orderkey -> 2000. l_returnflag -> 'N'. l_extendedprice -> 500. l_discount -> 0}}.
+| start_date end_date result nation customer orders lineitem |
+nation := {Dictionary newFrom:{#n_nationkey->1. #n_name->'BRAZIL'}}.
+customer := {Dictionary newFrom:{#c_custkey->1. #c_name->'Alice'. #c_acctbal->100. #c_nationkey->1. #c_address->'123 St'. #c_phone->'123-456'. #c_comment->'Loyal'}}.
+orders := {Dictionary newFrom:{#o_orderkey->1000. #o_custkey->1. #o_orderdate->'1993-10-15'}. Dictionary newFrom:{#o_orderkey->2000. #o_custkey->1. #o_orderdate->'1994-01-02'}}.
+lineitem := {Dictionary newFrom:{#l_orderkey->1000. #l_returnflag->'R'. #l_extendedprice->1000. #l_discount->0.1}. Dictionary newFrom:{#l_orderkey->2000. #l_returnflag->'N'. #l_extendedprice->500. #l_discount->0}}.
 start_date := '1993-10-01'.
 end_date := '1994-01-01'.
 result := [ | groups tmp |
@@ -14,7 +14,7 @@ result := [ | groups tmp |
         nation do: [:n |
           (((((((o.o_orderdate >= start_date) and: [(o.o_orderdate < end_date)]) and: [(l.l_returnflag = 'R')]) and: [(o.o_custkey = c.c_custkey)]) and: [(l.l_orderkey = o.o_orderkey)]) and: [(n.n_nationkey = c.c_nationkey)])) ifTrue: [
             | g |
-            g := groups at: Dictionary newFrom: {c_custkey -> c.c_custkey. c_name -> c.c_name. c_acctbal -> c.c_acctbal. c_address -> c.c_address. c_phone -> c.c_phone. c_comment -> c.c_comment. n_name -> n.n_name} ifAbsentPut:[OrderedCollection new].
+            g := groups at: Dictionary newFrom:{#c_custkey->c.c_custkey. #c_name->c.c_name. #c_acctbal->c.c_acctbal. #c_address->c.c_address. #c_phone->c.c_phone. #c_comment->c.c_comment. #n_name->n.n_name} ifAbsentPut:[OrderedCollection new].
             g add: Dictionary newFrom: {#c->c. #o->o. #l->l. #n->n}.
           ].
         ].
@@ -24,13 +24,13 @@ result := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {c_custkey -> g.key.c_custkey. c_name -> g.key.c_name. revenue -> ([ | tmp |
+    tmp add: Dictionary newFrom:{#c_custkey->g.key.c_custkey. #c_name->g.key.c_name. #revenue->([ | tmp |
   tmp := OrderedCollection new.
   g do: [:x |
     tmp add: (x.l.l_extendedprice * (1 - x.l.l_discount)).
   ].
   tmp
-] value inject: 0 into: [:s :x | s + x]). c_acctbal -> g.key.c_acctbal. n_name -> g.key.n_name. c_address -> g.key.c_address. c_phone -> g.key.c_phone. c_comment -> g.key.c_comment}.
+] value inject: 0 into: [:s :x | s + x]). #c_acctbal->g.key.c_acctbal. #n_name->g.key.n_name. #c_address->g.key.c_address. #c_phone->g.key.c_phone. #c_comment->g.key.c_comment}.
   ].
   tmp := tmp asSortedCollection: [:a :b | -([ | tmp |
   tmp := OrderedColleation new.

--- a/tests/machine/x/st/group_by_sort.st
+++ b/tests/machine/x/st/group_by_sort.st
@@ -1,5 +1,5 @@
 | items grouped |
-items := {Dictionary newFrom: {cat -> 'a'. val -> 3}. Dictionary newFrom: {cat -> 'a'. val -> 1}. Dictionary newFrom: {cat -> 'b'. val -> 5}. Dictionary newFrom: {cat -> 'b'. val -> 2}}.
+items := {Dictionary newFrom:{#cat->'a'. #val->3}. Dictionary newFrom:{#cat->'a'. #val->1}. Dictionary newFrom:{#cat->'b'. #val->5}. Dictionary newFrom:{#cat->'b'. #val->2}}.
 grouped := [ | groups tmp |
   groups := Dictionary new.
   tmp := OrderedCollection new.
@@ -11,7 +11,7 @@ grouped := [ | groups tmp |
   groups keysAndValuesDo: [:k :grp |
     | g |
     g := Dictionary newFrom:{#key->k. #items->grp}.
-    tmp add: Dictionary newFrom: {cat -> g.key. total -> ([ | tmp |
+    tmp add: Dictionary newFrom:{#cat->g.key. #total->([ | tmp |
   tmp := OrderedCollection new.
   g do: [:x |
     tmp add: x.val.

--- a/tests/machine/x/st/group_items_iteration.st
+++ b/tests/machine/x/st/group_items_iteration.st
@@ -1,5 +1,5 @@
-| total x result data groups tmp g |
-data := {Dictionary newFrom: {tag -> 'a'. val -> 1}. Dictionary newFrom: {tag -> 'a'. val -> 2}. Dictionary newFrom: {tag -> 'b'. val -> 3}}.
+| data groups tmp g total x result |
+data := {Dictionary newFrom:{#tag->'a'. #val->1}. Dictionary newFrom:{#tag->'a'. #val->2}. Dictionary newFrom:{#tag->'b'. #val->3}}.
 groups := [ | groups tmp |
   groups := Dictionary new.
   tmp := OrderedCollection new.
@@ -22,7 +22,7 @@ g at: 'items' do: [:x |.
 total := (total + x at: 'val').
 ].
 .
-tmp := tmp copyWith: Dictionary newFrom: {tag -> g at: 'key'. total -> total}.
+tmp := tmp copyWith: Dictionary newFrom:{#tag->g at: 'key'. total->total}.
 ].
 .
 result := [ | tmp |

--- a/tests/machine/x/st/in_operator_extended.st
+++ b/tests/machine/x/st/in_operator_extended.st
@@ -1,4 +1,4 @@
-| ys m s xs |
+| xs ys m s |
 xs := {1. 2. 3}.
 ys := [ | tmp |
   tmp := OrderedCollection new.
@@ -11,7 +11,7 @@ ys := [ | tmp |
 ] value.
 Transcript show: ((1 in ys)) printString; cr.
 Transcript show: ((2 in ys)) printString; cr.
-m := Dictionary newFrom: {a -> 1}.
+m := Dictionary newFrom:{#a->1}.
 Transcript show: (('a' in m)) printString; cr.
 Transcript show: (('b' in m)) printString; cr.
 s := 'hello'.

--- a/tests/machine/x/st/inner_join.st
+++ b/tests/machine/x/st/inner_join.st
@@ -1,12 +1,12 @@
 | result entry customers orders |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}. Dictionary newFrom: {id -> 3. name -> 'Charlie'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1. total -> 250}. Dictionary newFrom: {id -> 101. customerId -> 2. total -> 125}. Dictionary newFrom: {id -> 102. customerId -> 1. total -> 300}. Dictionary newFrom: {id -> 103. customerId -> 4. total -> 80}}.
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}. Dictionary newFrom:{#id->3. #name->'Charlie'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->2. #total->125}. Dictionary newFrom:{#id->102. #customerId->1. #total->300}. Dictionary newFrom:{#id->103. #customerId->4. #total->80}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   orders do: [:o |
     customers do: [:c |
       ((o.customerId = c.id)) ifTrue: [
-        tmp add: Dictionary newFrom: {orderId -> o.id. customerName -> c.name. total -> o.total}.
+        tmp add: Dictionary newFrom:{#orderId->o.id. #customerName->c.name. #total->o.total}.
       ].
     ].
   ].

--- a/tests/machine/x/st/join_multi.st
+++ b/tests/machine/x/st/join_multi.st
@@ -1,14 +1,14 @@
-| customers orders items result r |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1}. Dictionary newFrom: {id -> 101. customerId -> 2}}.
-items := {Dictionary newFrom: {orderId -> 100. sku -> 'a'}. Dictionary newFrom: {orderId -> 101. sku -> 'b'}}.
+| r customers orders items result |
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1}. Dictionary newFrom:{#id->101. #customerId->2}}.
+items := {Dictionary newFrom:{#orderId->100. #sku->'a'}. Dictionary newFrom:{#orderId->101. #sku->'b'}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   orders do: [:o |
     customers do: [:c |
       items do: [:i |
         (((o.customerId = c.id) and: [(o.id = i.orderId)])) ifTrue: [
-          tmp add: Dictionary newFrom: {name -> c.name. sku -> i.sku}.
+          tmp add: Dictionary newFrom:{#name->c.name. #sku->i.sku}.
         ].
       ].
     ].

--- a/tests/machine/x/st/json_builtin.st
+++ b/tests/machine/x/st/json_builtin.st
@@ -1,3 +1,3 @@
 | m |
-m := Dictionary newFrom: {a -> 1. b -> 2}.
+m := Dictionary newFrom:{#a->1. #b->2}.
 json value: m.

--- a/tests/machine/x/st/left_join.st
+++ b/tests/machine/x/st/left_join.st
@@ -1,6 +1,6 @@
-| orders result entry customers |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1. total -> 250}. Dictionary newFrom: {id -> 101. customerId -> 3. total -> 80}}.
+| result entry customers orders |
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->3. #total->80}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   orders do: [:o |
@@ -9,12 +9,12 @@ result := [ | tmp |
     customers do: [:c |
       ((o.customerId = c.id)) ifTrue: [
         matched := true.
-        tmp add: Dictionary newFrom: {orderId -> o.id. customer -> c. total -> o.total}.
+        tmp add: Dictionary newFrom:{#orderId->o.id. #customer->c. #total->o.total}.
       ].
     ].
     matched ifFalse: [
       c := nil.
-      tmp add: Dictionary newFrom: {orderId -> o.id. customer -> c. total -> o.total}.
+      tmp add: Dictionary newFrom:{#orderId->o.id. #customer->c. #total->o.total}.
     ].
   ].
   tmp

--- a/tests/machine/x/st/left_join_multi.st
+++ b/tests/machine/x/st/left_join_multi.st
@@ -1,14 +1,14 @@
 | customers orders items result r |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1}. Dictionary newFrom: {id -> 101. customerId -> 2}}.
-items := {Dictionary newFrom: {orderId -> 100. sku -> 'a'}}.
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1}. Dictionary newFrom:{#id->101. #customerId->2}}.
+items := {Dictionary newFrom:{#orderId->100. #sku->'a'}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   orders do: [:o |
     customers do: [:c |
       items do: [:i |
         (((o.customerId = c.id) and: [(o.id = i.orderId)])) ifTrue: [
-          tmp add: Dictionary newFrom: {orderId -> o.id. name -> c.name. item -> i}.
+          tmp add: Dictionary newFrom:{#orderId->o.id. #name->c.name. #item->i}.
         ].
       ].
     ].

--- a/tests/machine/x/st/len_map.st
+++ b/tests/machine/x/st/len_map.st
@@ -1,1 +1,1 @@
-Transcript show: ((Dictionary newFrom: {'a' -> 1. 'b' -> 2} size)) printString; cr.
+Transcript show: ((Dictionary newFrom:{'a'->1. 'b'->2} size)) printString; cr.

--- a/tests/machine/x/st/load_yaml.st
+++ b/tests/machine/x/st/load_yaml.st
@@ -1,10 +1,10 @@
 | people adults a |
-people := load value: "../interpreter/valid/people.yaml" value: Dictionary newFrom: {format -> 'yaml'}.
+people := load value: "../interpreter/valid/people.yaml" value: Dictionary newFrom:{#format->'yaml'}.
 adults := [ | tmp |
   tmp := OrderedCollection new.
   people do: [:p |
     ((p.age >= 18)) ifTrue: [
-      tmp add: Dictionary newFrom: {name -> p.name. email -> p.email}.
+      tmp add: Dictionary newFrom:{#name->p.name. #email->p.email}.
     ].
   ].
   tmp

--- a/tests/machine/x/st/map_assign.st
+++ b/tests/machine/x/st/map_assign.st
@@ -1,4 +1,4 @@
 | scores |
-scores := Dictionary newFrom: {'alice' -> 1}.
+scores := Dictionary newFrom:{'alice'->1}.
 scores at: 'bob' put: 2.
 Transcript show: (scores at: 'bob') printString; cr.

--- a/tests/machine/x/st/map_in_operator.st
+++ b/tests/machine/x/st/map_in_operator.st
@@ -1,4 +1,4 @@
 | m |
-m := Dictionary newFrom: {1 -> 'a'. 2 -> 'b'}.
+m := Dictionary newFrom:{1->'a'. 2->'b'}.
 Transcript show: ((1 in m)) printString; cr.
 Transcript show: ((3 in m)) printString; cr.

--- a/tests/machine/x/st/map_index.st
+++ b/tests/machine/x/st/map_index.st
@@ -1,3 +1,3 @@
 | m |
-m := Dictionary newFrom: {'a' -> 1. 'b' -> 2}.
+m := Dictionary newFrom:{'a'->1. 'b'->2}.
 Transcript show: (m at: 'b') printString; cr.

--- a/tests/machine/x/st/map_int_key.st
+++ b/tests/machine/x/st/map_int_key.st
@@ -1,3 +1,3 @@
 | m |
-m := Dictionary newFrom: {1 -> 'a'. 2 -> 'b'}.
+m := Dictionary newFrom:{1->'a'. 2->'b'}.
 Transcript show: (m at: 1) printString; cr.

--- a/tests/machine/x/st/map_literal_dynamic.st
+++ b/tests/machine/x/st/map_literal_dynamic.st
@@ -1,5 +1,5 @@
-| y m x |
+| x y m |
 x := 3.
 y := 4.
-m := Dictionary newFrom: {'a' -> x. 'b' -> y}.
+m := Dictionary newFrom:{'a'->x. 'b'->y}.
 Transcript show: (m at: 'a') printString; show: ' '; show: (m at: 'b') printString; cr.

--- a/tests/machine/x/st/map_membership.st
+++ b/tests/machine/x/st/map_membership.st
@@ -1,4 +1,4 @@
 | m |
-m := Dictionary newFrom: {'a' -> 1. 'b' -> 2}.
+m := Dictionary newFrom:{'a'->1. 'b'->2}.
 Transcript show: (('a' in m)) printString; cr.
 Transcript show: (('c' in m)) printString; cr.

--- a/tests/machine/x/st/map_nested_assign.st
+++ b/tests/machine/x/st/map_nested_assign.st
@@ -1,4 +1,4 @@
 | data |
-data := Dictionary newFrom: {'outer' -> Dictionary newFrom: {'inner' -> 1}}.
+data := Dictionary newFrom:{'outer'->Dictionary newFrom:{'inner'->1}}.
 data at: 'outer' at: 'inner' put: 2.
 Transcript show: (data at: 'outer' at: 'inner') printString; cr.

--- a/tests/machine/x/st/match_expr.st
+++ b/tests/machine/x/st/match_expr.st
@@ -1,4 +1,4 @@
-| x label |
+| label x |
 x := 2.
 label := (x = 1) ifTrue: ['one'] ifFalse: [(x = 2) ifTrue: ['two'] ifFalse: [(x = 3) ifTrue: ['three'] ifFalse: ['unknown']]].
 Transcript show: (label) printString; cr.

--- a/tests/machine/x/st/match_full.st
+++ b/tests/machine/x/st/match_full.st
@@ -1,4 +1,4 @@
-| label day mood ok status classify x |
+| x label day mood ok status classify |
 x := 2.
 label := (x = 1) ifTrue: ['one'] ifFalse: [(x = 2) ifTrue: ['two'] ifFalse: [(x = 3) ifTrue: ['three'] ifFalse: ['unknown']]].
 Transcript show: (label) printString; cr.

--- a/tests/machine/x/st/order_by_map.st
+++ b/tests/machine/x/st/order_by_map.st
@@ -1,11 +1,11 @@
 | data sorted |
-data := {Dictionary newFrom: {a -> 1. b -> 2}. Dictionary newFrom: {a -> 1. b -> 1}. Dictionary newFrom: {a -> 0. b -> 5}}.
+data := {Dictionary newFrom:{#a->1. #b->2}. Dictionary newFrom:{#a->1. #b->1}. Dictionary newFrom:{#a->0. #b->5}}.
 sorted := [ | tmp |
   tmp := OrderedCollection new.
   data do: [:x |
     tmp add: x.
   ].
-  tmp := tmp asSortedCollection: [:a :b | Dictionary newFrom: {a -> a.a. b -> a.b} < Dictionary newFrom: {a -> b.a. b -> b.b}].
+  tmp := tmp asSortedCollection: [:a :b | Dictionary newFrom:{#a->a.a. #b->a.b} < Dictionary newFrom:{#a->b.a. #b->b.b}].
   tmp
 ] value.
 Transcript show: (sorted) printString; cr.

--- a/tests/machine/x/st/outer_join.st
+++ b/tests/machine/x/st/outer_join.st
@@ -1,18 +1,18 @@
 | customers orders result row |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}. Dictionary newFrom: {id -> 3. name -> 'Charlie'}. Dictionary newFrom: {id -> 4. name -> 'Diana'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1. total -> 250}. Dictionary newFrom: {id -> 101. customerId -> 2. total -> 125}. Dictionary newFrom: {id -> 102. customerId -> 1. total -> 300}. Dictionary newFrom: {id -> 103. customerId -> 5. total -> 80}}.
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}. Dictionary newFrom:{#id->3. #name->'Charlie'}. Dictionary newFrom:{#id->4. #name->'Diana'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->2. #total->125}. Dictionary newFrom:{#id->102. #customerId->1. #total->300}. Dictionary newFrom:{#id->103. #customerId->5. #total->80}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   orders do: [:o |
     | c |
     c := customers detect: [:c | ((o.customerId = c.id)) ] ifAbsent:[nil].
-    tmp add: Dictionary newFrom: {order -> o. customer -> c}.
+    tmp add: Dictionary newFrom:{#order->o. #customer->c}.
   ].
   customers do: [:c |
     (orders anySatisfy: [:o | ((o.customerId = c.id)) ]) ifFalse:[
       | o |
       o := nil.
-      tmp add: Dictionary newFrom: {order -> o. customer -> c}.
+      tmp add: Dictionary newFrom:{#order->o. #customer->c}.
     ].
   ].
   tmp

--- a/tests/machine/x/st/right_join.st
+++ b/tests/machine/x/st/right_join.st
@@ -1,12 +1,12 @@
-| orders result entry customers |
-customers := {Dictionary newFrom: {id -> 1. name -> 'Alice'}. Dictionary newFrom: {id -> 2. name -> 'Bob'}. Dictionary newFrom: {id -> 3. name -> 'Charlie'}. Dictionary newFrom: {id -> 4. name -> 'Diana'}}.
-orders := {Dictionary newFrom: {id -> 100. customerId -> 1. total -> 250}. Dictionary newFrom: {id -> 101. customerId -> 2. total -> 125}. Dictionary newFrom: {id -> 102. customerId -> 1. total -> 300}}.
+| result entry customers orders |
+customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}. Dictionary newFrom:{#id->3. #name->'Charlie'}. Dictionary newFrom:{#id->4. #name->'Diana'}}.
+orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->2. #total->125}. Dictionary newFrom:{#id->102. #customerId->1. #total->300}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   orders do: [:o |
     | c |
     c := customers detect: [:c | ((o.customerId = c.id)) ] ifAbsent:[nil].
-    tmp add: Dictionary newFrom: {customerName -> c.name. order -> o}.
+    tmp add: Dictionary newFrom:{#customerName->c.name. #order->o}.
   ].
   tmp
 ] value.

--- a/tests/machine/x/st/save_jsonl_stdout.st
+++ b/tests/machine/x/st/save_jsonl_stdout.st
@@ -1,3 +1,3 @@
 | people |
-people := {Dictionary newFrom: {name -> 'Alice'. age -> 30}. Dictionary newFrom: {name -> 'Bob'. age -> 25}}.
-save value: people value: "-" value: Dictionary newFrom: {format -> 'jsonl'}.
+people := {Dictionary newFrom:{#name->'Alice'. #age->30}. Dictionary newFrom:{#name->'Bob'. #age->25}}.
+save value: people value: "-" value: Dictionary newFrom:{#format->'jsonl'}.

--- a/tests/machine/x/st/sort_stable.st
+++ b/tests/machine/x/st/sort_stable.st
@@ -1,5 +1,5 @@
 | items result |
-items := {Dictionary newFrom: {n -> 1. v -> 'a'}. Dictionary newFrom: {n -> 1. v -> 'b'}. Dictionary newFrom: {n -> 2. v -> 'c'}}.
+items := {Dictionary newFrom:{#n->1. #v->'a'}. Dictionary newFrom:{#n->1. #v->'b'}. Dictionary newFrom:{#n->2. #v->'c'}}.
 result := [ | tmp |
   tmp := OrderedCollection new.
   items do: [:i |

--- a/tests/machine/x/st/string_prefix_slice.st
+++ b/tests/machine/x/st/string_prefix_slice.st
@@ -1,4 +1,4 @@
-| prefix s1 s2 |
+| s1 s2 prefix |
 prefix := 'fore'.
 s1 := 'forest'.
 Transcript show: ((s1 at: 0 = prefix)) printString; cr.

--- a/tests/machine/x/st/tree_sum.st
+++ b/tests/machine/x/st/tree_sum.st
@@ -1,4 +1,4 @@
-| t sum_tree |
+| sum_tree t |
 sum_tree := [:t | ^(t = Leaf) ifTrue: [0] ifFalse: [(t = Node value: left value: value value: right) ifTrue: [((sum_tree value: left + value) + sum_tree value: right)] ifFalse: [nil]]. ].
 t := Dictionary newFrom: {#left->Leaf. #value->1. #right->Dictionary newFrom: {#left->Leaf. #value->2. #right->Leaf}}.
 Transcript show: (sum_tree value: t) printString; cr.

--- a/tests/machine/x/st/two-sum.st
+++ b/tests/machine/x/st/two-sum.st
@@ -1,4 +1,4 @@
-| result twoSum n i j |
+| n i j result twoSum |
 twoSum := [:nums :target | n := (nums size).
 0 to: n do: [:i |.
 (i + 1) to: n do: [:j |.

--- a/tests/machine/x/st/values_builtin.st
+++ b/tests/machine/x/st/values_builtin.st
@@ -1,3 +1,3 @@
 | m |
-m := Dictionary newFrom: {'a' -> 1. 'b' -> 2. 'c' -> 3}.
+m := Dictionary newFrom:{'a'->1. 'b'->2. 'c'->3}.
 Transcript show: ((m values)) printString; cr.


### PR DESCRIPTION
## Summary
- improve Smalltalk compiler: emit symbol keys in map literals
- regenerate machine outputs for Smalltalk examples
- document new behavior in Smalltalk machine README

## Testing
- `go test ./compiler/x/st -run TestCompilePrograms -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ed18556ac8320a7f797320badb5e0