### PR TITLE
Improve Haskell compiler output formatting

### DIFF
--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -1329,12 +1329,17 @@ func (c *Compiler) compilePrint(ca callArgs) (string, error) {
 		if strings.HasPrefix(arg, "\"") || strings.HasPrefix(arg, "show(") || strings.HasPrefix(arg, "show ") || strings.HasPrefix(arg, "show") || strings.HasPrefix(arg, "_indexString") || c.isStringExpr(ca.exprs[0]) {
 			return fmt.Sprintf("putStrLn (%s)", arg), nil
 		}
+		if _, ok := c.inferExprType(ca.exprs[0]).(types.AnyType); ok {
+			return fmt.Sprintf("putStrLn (_showAny (%s))", arg), nil
+		}
 		return fmt.Sprintf("print (%s)", arg), nil
 	}
 	parts := make([]string, len(ca.args))
 	for i, a := range ca.args {
 		if strings.HasPrefix(a, "\"") || strings.HasPrefix(a, "_indexString") || c.isStringExpr(ca.exprs[i]) {
 			parts[i] = a
+		} else if _, ok := c.inferExprType(ca.exprs[i]).(types.AnyType); ok {
+			parts[i] = fmt.Sprintf("_showAny (%s)", a)
 		} else {
 			parts[i] = fmt.Sprintf("show (%s)", a)
 		}

--- a/compiler/x/hs/runtime.go
+++ b/compiler/x/hs/runtime.go
@@ -166,6 +166,12 @@ _asBool :: AnyValue -> Bool
 _asBool (VBool b) = b
 _asBool v = error ("expected bool, got " ++ show v)
 
+_showAny :: AnyValue -> String
+_showAny (VInt n) = show n
+_showAny (VDouble d) = show d
+_showAny (VString s) = s
+_showAny (VBool b) = if b then "true" else "false"
+
 _parseJSON :: String -> [Map.Map String String]
 _parseJSON text =
   case Aeson.decode (BSL.pack text) of

--- a/tests/machine/x/hs/README.md
+++ b/tests/machine/x/hs/README.md
@@ -107,3 +107,4 @@ This directory contains Haskell code generated from the Mochi programs in `tests
 - [ ] Implement support for dataset and join queries.
 - [ ] Add map and struct operations needed for JSON helpers.
 - [ ] Finish runtime features for update statements and YAML loading.
+- [ ] Improve query output formatting beyond `_showAny` helpers.

--- a/tests/machine/x/hs/dataset_sort_take_limit.hs
+++ b/tests/machine/x/hs/dataset_sort_take_limit.hs
@@ -132,6 +132,12 @@ _asBool :: AnyValue -> Bool
 _asBool (VBool b) = b
 _asBool v = error ("expected bool, got " ++ show v)
 
+_showAny :: AnyValue -> String
+_showAny (VInt n) = show n
+_showAny (VDouble d) = show d
+_showAny (VString s) = s
+_showAny (VBool b) = if b then "true" else "false"
+
 _parseJSON :: String -> [Map.Map String String]
 _parseJSON text =
   case Aeson.decode (BSL.pack text) of
@@ -183,4 +189,4 @@ expensive = take 3 (drop 1 (map snd (List.sortOn fst [((-(_asInt (fromMaybe (err
 main :: IO ()
 main = do
   putStrLn ("--- Top products (excluding most expensive) ---")
-  mapM_ (\item -> putStrLn (unwords [show (fromMaybe (error "missing") (Map.lookup "name" item)), "costs $", show (fromMaybe (error "missing") (Map.lookup "price" item))])) expensive
+  mapM_ (\item -> putStrLn (unwords [_showAny (fromMaybe (error "missing") (Map.lookup "name" item)), "costs $", _showAny (fromMaybe (error "missing") (Map.lookup "price" item))])) expensive

--- a/tests/machine/x/hs/dataset_sort_take_limit.out
+++ b/tests/machine/x/hs/dataset_sort_take_limit.out
@@ -1,4 +1,3 @@
---- Top products (excluding most expensive) ---
-VString "Smartphone" costs $ VInt 900
-VString "Tablet" costs $ VInt 600
-VString "Monitor" costs $ VInt 300
+--- Top products (excluding most expensive) ---Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- improve `compilePrint` to use `_showAny` for `AnyValue` expressions
- add `_showAny` helper to Haskell runtime
- regenerate Haskell output for `dataset_sort_take_limit`
- note formatting task in `tests/machine/x/hs/README.md`

## Testing
- `go test -tags slow ./compiler/x/hs -run TestHSCompiler_ValidPrograms/dataset_sort_take_limit -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ed2b1d27c8320b1c3526e9848a115