### PR TITLE
Update Rust compiler pre-decls

### DIFF
--- a/tests/machine/x/rust/README.md
+++ b/tests/machine/x/rust/README.md
@@ -100,6 +100,6 @@ Checklist of programs that currently compile and run (84/97):
 - [ ] right_join
 - [ ] save_jsonl_stdout
 - [ ] sort_stable
-- [x] tree_sum
+- [ ] tree_sum
 - [ ] update_stmt
 


### PR DESCRIPTION
## Summary
- add enumDecls buffer to Rust compiler
- move type declarations out of main and generate before compiled code
- update TODO list for Rust machine outputs

## Testing
- `go test ./compiler/x/rust -run TestCompilePrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686ed6adb2088320a957dd2d5ac93239