### PR TITLE
Fix Zig compiler anonymous struct formatting

### DIFF
--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -35,7 +35,7 @@ func zigTypeOf(t types.Type) string {
 		if tt.Name == "" {
 			fields := make([]string, len(tt.Order))
 			for i, f := range tt.Order {
-				fields[i] = fmt.Sprintf("%s: %s", sanitizeName(f), zigTypeOf(tt.Fields[f]))
+				fields[i] = fmt.Sprintf("%s: %s,", sanitizeName(f), zigTypeOf(tt.Fields[f]))
 			}
 			return fmt.Sprintf("struct { %s }", strings.Join(fields, " "))
 		}


### PR DESCRIPTION
## Summary
- add commas when emitting anonymous struct field types in zig helpers

## Testing
- `go test ./compiler/x/zig -run TestZigCompiler_ValidPrograms/cross_join -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f1cd75e288320b6f43c0a9143770d