### PR TITLE
Improve Swift compiler inference

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,6 +1,6 @@
 # Machine-generated Swift Outputs
 
-Compiled programs: 86/97
+Compiled programs: 87/97
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -94,7 +94,7 @@ Compiled programs: 86/97
 - [x] typed_let.mochi
 - [x] typed_var.mochi
 - [x] unary_neg.mochi
-- [ ] update_stmt.mochi
+- [x] update_stmt.mochi
 - [x] user_type_literal.mochi
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi


### PR DESCRIPTION
## Summary
- enhance Swift compiler with generic type inference
- declare list constants as mutable if updated
- update machine README for Swift

## Testing
- `go test -tags slow ./compiler/x/swift -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f1ce38cb08320b9dc5f4086e5667e