### PR TITLE
Improve Scheme backend

### DIFF
--- a/compiler/x/scheme/util.go
+++ b/compiler/x/scheme/util.go
@@ -52,6 +52,15 @@ func simpleStringKey(e *parser.Expr) (string, bool) {
 	return "", false
 }
 
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 func identName(e *parser.Expr) (string, bool) {
 	if e == nil || len(e.Binary.Right) != 0 {
 		return "", false


### PR DESCRIPTION
## Summary
- support YAML in `_load`
- add `_parse_yaml` helper for Scheme backend
- implement binary operator precedence

## Testing
- `go test ./compiler/x/scheme -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f1cf2e0588320b9d62639e9cf5891