### PR TITLE
Improve Swift compiler map field inference

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -103,4 +103,4 @@ Compiled programs: 87/97
 ## TODO
 - [x] implement join queries
 - [x] handle load/save dataset operations
-- [ ] preserve map field information in queries
+- [x] preserve map field information in queries


### PR DESCRIPTION
## Summary
- enhance the Swift compiler so `elementFieldTypes` handles query expressions
- add helper `queryFieldTypes` to infer field types within queries
- mark TODO in machine-generated Swift README as complete

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f26caf42c8320b03c336c17e6ccbf