### PR TITLE
Add v0.10.21 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # 📦 CHANGELOG.md
+## [0.10.21] – 2025-07-10T09:38:20+07:00
+
+### Added
+
+* Join and group-by support across C, C++, Pascal, Kotlin, Swift and more
+* String map handling and group-by string support for the C backend
+* Java compiler load/save and update/test features
+* Map size, max and json builtins for Haskell, Zig and Kotlin
+* YAML loading capability for the Scheme compiler
+
+### Changed
+
+* Improved type inference and runtime helper reuse across compilers
+* Optimized join queries with captured closure support
+
+### Fixed
+
+* Refresh machine outputs and examples across languages
+* Minor dataset and YAML test corrections
 
 ## [0.10.20] – 2025-07-09T10:05:52+07:00
 

--- a/releases/v0.10.21.md
+++ b/releases/v0.10.21.md
@@ -1,0 +1,24 @@
+# Jul 2025 (v0.10.21)
+
+Released on Thu Jul 10 09:38:20 2025 +0700.
+
+Mochi v0.10.21 expands join and aggregation capabilities across compilers, introduces new map utilities and builtins, and updates test suites across the project.
+
+## Compilers
+
+- Group-by and join operations implemented across C, C++, Pascal, Kotlin, Swift, Racket and other backends
+- C backend gains string map handling and group-by string support
+- Java compiler adds basic load/save and update/test features
+- Haskell, Zig and Kotlin compilers extend builtin support (map size, max, json)
+- Scheme compiler can load YAML files with improved precedence rules
+- OCaml, Rust and C# compilers improve type inference and runtime helpers
+
+## Runtime
+
+- Values builtin for the C runtime and helper deduplication
+- Optimized join queries and captured closure support
+
+## Tests
+
+- Machine outputs refreshed across languages with updated READMEs
+- Additional examples for join queries and dataset operations


### PR DESCRIPTION
## Summary
- document v0.10.21 changes in CHANGELOG
- add release notes for v0.10.21

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f2801c70883208aecd337a2630d6c