### PR TITLE
Improve Zig codegen formatting

### DIFF
--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -102,4 +102,4 @@
 - [x] Support map literals in iterations by emitting `std.AutoHashMap` even when keys are simple
 - [x] Support right and outer join queries
 - [x] Support join queries with grouping, having clauses, and sorting
-- [ ] Format struct and list literals on multiple lines for readability
+- [x] Format struct and list literals on multiple lines for readability

--- a/tests/machine/x/zig/append_builtin.zig
+++ b/tests/machine/x/zig/append_builtin.zig
@@ -16,7 +16,10 @@ fn _print_list(comptime T: type, v: []const T) void {
     std.debug.print("\n", .{});
 }
 
-const a = &[_]i32{1, 2};
+const a = &[_]i32{
+    1,
+    2,
+};
 
 pub fn main() void {
     _print_list(i32, _append(i32, a, 3));

--- a/tests/machine/x/zig/avg_builtin.zig
+++ b/tests/machine/x/zig/avg_builtin.zig
@@ -8,5 +8,9 @@ fn _avg_int(v: []const i32) i32 {
 }
 
 pub fn main() void {
-    std.debug.print("{any}\n", .{_avg_int(&[_]i32{1, 2, 3})});
+    std.debug.print("{any}\n", .{_avg_int(&[_]i32{
+    1,
+    2,
+    3,
+})});
 }

--- a/tests/machine/x/zig/break_continue.zig
+++ b/tests/machine/x/zig/break_continue.zig
@@ -1,6 +1,16 @@
 const std = @import("std");
 
-const numbers = &[_]i32{1, 2, 3, 4, 5, 6, 7, 8, 9};
+const numbers = &[_]i32{
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+};
 
 pub fn main() void {
     for (numbers) |n| {

--- a/tests/machine/x/zig/count_builtin.zig
+++ b/tests/machine/x/zig/count_builtin.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("{d}\n", .{(&[_]i32{1, 2, 3}).len});
+    std.debug.print("{d}\n", .{(&[_]i32{
+    1,
+    2,
+    3,
+}).len});
 }

--- a/tests/machine/x/zig/cross_join.zig
+++ b/tests/machine/x/zig/cross_join.zig
@@ -1,8 +1,59 @@
 const std = @import("std");
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }, _tmp0{ .id = 3, .name = "Charlie" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, total: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1, .total = 250 }, _tmp1{ .id = 101, .customerId = 2, .total = 125 }, _tmp1{ .id = 102, .customerId = 1, .total = 300 }}; break :blk1 _arr; });
-const result = blk2: { var _tmp2 = std.ArrayList(struct { orderId: i32, orderCustomerId: i32, pairedCustomerName: []const u8, orderTotal: i32, }).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { _tmp2.append(struct { orderId: i32, orderCustomerId: i32, pairedCustomerName: []const u8, orderTotal: i32, }{ .orderId = o.id, .orderCustomerId = o.customerId, .pairedCustomerName = c.name, .orderTotal = o.total }) catch unreachable; } } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk2 _tmp3; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+    _tmp0{
+    .id = 3,
+    .name = "Charlie",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+    .total = 250,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 2,
+    .total = 125,
+},
+    _tmp1{
+    .id = 102,
+    .customerId = 1,
+    .total = 300,
+},
+}; break :blk1 _arr; });
+const result = blk2: { var _tmp2 = std.ArrayList(struct {
+    orderId: i32,
+    orderCustomerId: i32,
+    pairedCustomerName: []const u8,
+    orderTotal: i32,
+}).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { _tmp2.append(struct {
+    orderId: i32,
+    orderCustomerId: i32,
+    pairedCustomerName: []const u8,
+    orderTotal: i32,
+}{
+    .orderId = o.id,
+    .orderCustomerId = o.customerId,
+    .pairedCustomerName = c.name,
+    .orderTotal = o.total,
+}) catch unreachable; } } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk2 _tmp3; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Cross Join: All order-customer pairs ---"});

--- a/tests/machine/x/zig/cross_join_filter.zig
+++ b/tests/machine/x/zig/cross_join_filter.zig
@@ -1,8 +1,24 @@
 const std = @import("std");
 
-const nums = &[_]i32{1, 2, 3};
-const letters = &[_][]const u8{"A", "B"};
-const pairs = blk0: { var _tmp0 = std.ArrayList(struct { n: i32, l: []const u8, }).init(std.heap.page_allocator); for (nums) |n| { for (letters) |l| { if (!((@mod(n, 2) == 0))) continue; _tmp0.append(struct { n: i32, l: []const u8, }{ .n = n, .l = l }) catch unreachable; } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
+const nums = &[_]i32{
+    1,
+    2,
+    3,
+};
+const letters = &[_][]const u8{
+    "A",
+    "B",
+};
+const pairs = blk0: { var _tmp0 = std.ArrayList(struct {
+    n: i32,
+    l: []const u8,
+}).init(std.heap.page_allocator); for (nums) |n| { for (letters) |l| { if (!((@mod(n, 2) == 0))) continue; _tmp0.append(struct {
+    n: i32,
+    l: []const u8,
+}{
+    .n = n,
+    .l = l,
+}) catch unreachable; } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Even pairs ---"});

--- a/tests/machine/x/zig/cross_join_triple.zig
+++ b/tests/machine/x/zig/cross_join_triple.zig
@@ -1,9 +1,30 @@
 const std = @import("std");
 
-const nums = &[_]i32{1, 2};
-const letters = &[_][]const u8{"A", "B"};
-const bools = &[_]bool{true, false};
-const combos = blk0: { var _tmp0 = std.ArrayList(struct { n: i32, l: []const u8, b: bool, }).init(std.heap.page_allocator); for (nums) |n| { for (letters) |l| { for (bools) |b| { _tmp0.append(struct { n: i32, l: []const u8, b: bool, }{ .n = n, .l = l, .b = b }) catch unreachable; } } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
+const nums = &[_]i32{
+    1,
+    2,
+};
+const letters = &[_][]const u8{
+    "A",
+    "B",
+};
+const bools = &[_]bool{
+    true,
+    false,
+};
+const combos = blk0: { var _tmp0 = std.ArrayList(struct {
+    n: i32,
+    l: []const u8,
+    b: bool,
+}).init(std.heap.page_allocator); for (nums) |n| { for (letters) |l| { for (bools) |b| { _tmp0.append(struct {
+    n: i32,
+    l: []const u8,
+    b: bool,
+}{
+    .n = n,
+    .l = l,
+    .b = b,
+}) catch unreachable; } } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Cross Join of three lists ---"});

--- a/tests/machine/x/zig/dataset_sort_take_limit.zig
+++ b/tests/machine/x/zig/dataset_sort_take_limit.zig
@@ -21,8 +21,49 @@ fn _slice_list(comptime T: type, v: []const T, start: i32, end: i32, step: i32) 
     return res.toOwnedSlice() catch unreachable;
 }
 
-const products = (blk0: { const _tmp0 = struct { name: []const u8, price: i32, }; const _arr = &[_]_tmp0{_tmp0{ .name = "Laptop", .price = 1500 }, _tmp0{ .name = "Smartphone", .price = 900 }, _tmp0{ .name = "Tablet", .price = 600 }, _tmp0{ .name = "Monitor", .price = 300 }, _tmp0{ .name = "Keyboard", .price = 100 }, _tmp0{ .name = "Mouse", .price = 50 }, _tmp0{ .name = "Headphones", .price = 200 }}; break :blk0 _arr; });
-const expensive = blk1: { var _tmp1 = std.ArrayList(struct { item: struct { name: []const u8, price: i32, }, key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp1.append(.{ .item = p, .key = -p.price }) catch unreachable; } for (0.._tmp1.items.len) |i| { for (i+1.._tmp1.items.len) |j| { if (_tmp1.items[j].key < _tmp1.items[i].key) { const t = _tmp1.items[i]; _tmp1.items[i] = _tmp1.items[j]; _tmp1.items[j] = t; } } } var _tmp2 = std.ArrayList(struct { name: []const u8, price: i32, }).init(std.heap.page_allocator);for (_tmp1.items) |p| { _tmp2.append(p.item) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; _tmp3 = _slice_list(struct { name: []const u8, price: i32, }, _tmp3, 1, (1 + 3), 1); break :blk1 _tmp3; };
+const products = (blk0: { const _tmp0 = struct {
+    name: []const u8,
+    price: i32,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .name = "Laptop",
+    .price = 1500,
+},
+    _tmp0{
+    .name = "Smartphone",
+    .price = 900,
+},
+    _tmp0{
+    .name = "Tablet",
+    .price = 600,
+},
+    _tmp0{
+    .name = "Monitor",
+    .price = 300,
+},
+    _tmp0{
+    .name = "Keyboard",
+    .price = 100,
+},
+    _tmp0{
+    .name = "Mouse",
+    .price = 50,
+},
+    _tmp0{
+    .name = "Headphones",
+    .price = 200,
+},
+}; break :blk0 _arr; });
+const expensive = blk1: { var _tmp1 = std.ArrayList(struct { item: struct {
+    name: []const u8,
+    price: i32,
+}, key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp1.append(.{ .item = p, .key = -p.price }) catch unreachable; } for (0.._tmp1.items.len) |i| { for (i+1.._tmp1.items.len) |j| { if (_tmp1.items[j].key < _tmp1.items[i].key) { const t = _tmp1.items[i]; _tmp1.items[i] = _tmp1.items[j]; _tmp1.items[j] = t; } } } var _tmp2 = std.ArrayList(struct {
+    name: []const u8,
+    price: i32,
+}).init(std.heap.page_allocator);for (_tmp1.items) |p| { _tmp2.append(p.item) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; _tmp3 = _slice_list(struct {
+    name: []const u8,
+    price: i32,
+}, _tmp3, 1, (1 + 3), 1); break :blk1 _tmp3; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Top products (excluding most expensive) ---"});

--- a/tests/machine/x/zig/dataset_where_filter.zig
+++ b/tests/machine/x/zig/dataset_where_filter.zig
@@ -1,7 +1,39 @@
 const std = @import("std");
 
-const people = (blk0: { const _tmp0 = struct { name: []const u8, age: i32, }; const _arr = &[_]_tmp0{_tmp0{ .name = "Alice", .age = 30 }, _tmp0{ .name = "Bob", .age = 15 }, _tmp0{ .name = "Charlie", .age = 65 }, _tmp0{ .name = "Diana", .age = 45 }}; break :blk0 _arr; });
-const adults = blk1: { var _tmp1 = std.ArrayList(struct { name: []const u8, age: i32, is_senior: bool, }).init(std.heap.page_allocator); for (people) |person| { if (!((person.age >= 18))) continue; _tmp1.append(struct { name: []const u8, age: i32, is_senior: bool, }{ .name = person.name, .age = person.age, .is_senior = (person.age >= 60) }) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; };
+const people = (blk0: { const _tmp0 = struct {
+    name: []const u8,
+    age: i32,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .name = "Alice",
+    .age = 30,
+},
+    _tmp0{
+    .name = "Bob",
+    .age = 15,
+},
+    _tmp0{
+    .name = "Charlie",
+    .age = 65,
+},
+    _tmp0{
+    .name = "Diana",
+    .age = 45,
+},
+}; break :blk0 _arr; });
+const adults = blk1: { var _tmp1 = std.ArrayList(struct {
+    name: []const u8,
+    age: i32,
+    is_senior: bool,
+}).init(std.heap.page_allocator); for (people) |person| { if (!((person.age >= 18))) continue; _tmp1.append(struct {
+    name: []const u8,
+    age: i32,
+    is_senior: bool,
+}{
+    .name = person.name,
+    .age = person.age,
+    .is_senior = (person.age >= 60),
+}) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Adults ---"});

--- a/tests/machine/x/zig/exists_builtin.zig
+++ b/tests/machine/x/zig/exists_builtin.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 
-const data = &[_]i32{1, 2};
+const data = &[_]i32{
+    1,
+    2,
+};
 const flag = (blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (data) |x| { if (!((x == 1))) continue; _tmp0.append(x) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }).len != 0;
 
 pub fn main() void {

--- a/tests/machine/x/zig/for_list_collection.zig
+++ b/tests/machine/x/zig/for_list_collection.zig
@@ -1,7 +1,11 @@
 const std = @import("std");
 
 pub fn main() void {
-    for (&[_]i32{1, 2, 3}) |n| {
+    for (&[_]i32{
+    1,
+    2,
+    3,
+}) |n| {
         std.debug.print("{d}\n", .{n});
     }
 }

--- a/tests/machine/x/zig/for_map_collection.zig
+++ b/tests/machine/x/zig/for_map_collection.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 
-var m: struct { a: i32, b: i32, } = undefined;
+var m: struct {
+    a: i32,
+    b: i32,
+} = undefined;
 
 pub fn main() void {
     for (m) |k| {

--- a/tests/machine/x/zig/group_by.zig
+++ b/tests/machine/x/zig/group_by.zig
@@ -15,8 +15,71 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const people = (blk0: { const _tmp0 = struct { name: []const u8, age: i32, city: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .name = "Alice", .age = 30, .city = "Paris" }, _tmp0{ .name = "Bob", .age = 15, .city = "Hanoi" }, _tmp0{ .name = "Charlie", .age = 65, .city = "Paris" }, _tmp0{ .name = "Diana", .age = 45, .city = "Hanoi" }, _tmp0{ .name = "Eve", .age = 70, .city = "Paris" }, _tmp0{ .name = "Frank", .age = 22, .city = "Hanoi" }}; break :blk0 _arr; });
-const stats = blk2: { var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { name: []const u8, age: i32, city: []const u8, }) }).init(std.heap.page_allocator); var _tmp4 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (people) |person| { const _tmp5 = person.city; if (_tmp4.get(_tmp5)) |idx| { _tmp3.items[idx].Items.append(person) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct { name: []const u8, age: i32, city: []const u8, }) }{ .key = _tmp5, .Items = std.ArrayList(struct { name: []const u8, age: i32, city: []const u8, }).init(std.heap.page_allocator) }; g.Items.append(person) catch unreachable; _tmp3.append(g) catch unreachable; _tmp4.put(_tmp5, _tmp3.items.len - 1) catch unreachable; } } var _tmp6 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { name: []const u8, age: i32, city: []const u8, }) }).init(std.heap.page_allocator);for (_tmp3.items) |g| { _tmp6.append(g) catch unreachable; } var _tmp7 = std.ArrayList(struct { city: i32, count: i32, avg_age: f64, }).init(std.heap.page_allocator);for (_tmp6.items) |g| { _tmp7.append(struct { city: i32, count: i32, avg_age: f64, }{ .city = g.key, .count = (g.Items.len), .avg_age = _avg_int(blk1: { var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |p| { _tmp1.append(p.age) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; }) }) catch unreachable; } const _tmp7Slice = _tmp7.toOwnedSlice() catch unreachable; break :blk2 _tmp7Slice; };
+const people = (blk0: { const _tmp0 = struct {
+    name: []const u8,
+    age: i32,
+    city: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .name = "Alice",
+    .age = 30,
+    .city = "Paris",
+},
+    _tmp0{
+    .name = "Bob",
+    .age = 15,
+    .city = "Hanoi",
+},
+    _tmp0{
+    .name = "Charlie",
+    .age = 65,
+    .city = "Paris",
+},
+    _tmp0{
+    .name = "Diana",
+    .age = 45,
+    .city = "Hanoi",
+},
+    _tmp0{
+    .name = "Eve",
+    .age = 70,
+    .city = "Paris",
+},
+    _tmp0{
+    .name = "Frank",
+    .age = 22,
+    .city = "Hanoi",
+},
+}; break :blk0 _arr; });
+const stats = blk2: { var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    name: []const u8,
+    age: i32,
+    city: []const u8,
+}) }).init(std.heap.page_allocator); var _tmp4 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (people) |person| { const _tmp5 = person.city; if (_tmp4.get(_tmp5)) |idx| { _tmp3.items[idx].Items.append(person) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+    name: []const u8,
+    age: i32,
+    city: []const u8,
+}) }{ .key = _tmp5, .Items = std.ArrayList(struct {
+    name: []const u8,
+    age: i32,
+    city: []const u8,
+}).init(std.heap.page_allocator) }; g.Items.append(person) catch unreachable; _tmp3.append(g) catch unreachable; _tmp4.put(_tmp5, _tmp3.items.len - 1) catch unreachable; } } var _tmp6 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    name: []const u8,
+    age: i32,
+    city: []const u8,
+}) }).init(std.heap.page_allocator);for (_tmp3.items) |g| { _tmp6.append(g) catch unreachable; } var _tmp7 = std.ArrayList(struct {
+    city: i32,
+    count: i32,
+    avg_age: f64,
+}).init(std.heap.page_allocator);for (_tmp6.items) |g| { _tmp7.append(struct {
+    city: i32,
+    count: i32,
+    avg_age: f64,
+}{
+    .city = g.key,
+    .count = (g.Items.len),
+    .avg_age = _avg_int(blk1: { var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |p| { _tmp1.append(p.age) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; }),
+}) catch unreachable; } const _tmp7Slice = _tmp7.toOwnedSlice() catch unreachable; break :blk2 _tmp7Slice; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- People grouped by city ---"});

--- a/tests/machine/x/zig/group_by_conditional_sum.zig
+++ b/tests/machine/x/zig/group_by_conditional_sum.zig
@@ -22,8 +22,61 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const items = (blk0: { const _tmp0 = struct { cat: []const u8, val: i32, flag: bool, }; const _arr = &[_]_tmp0{_tmp0{ .cat = "a", .val = 10, .flag = true }, _tmp0{ .cat = "a", .val = 5, .flag = false }, _tmp0{ .cat = "b", .val = 20, .flag = true }}; break :blk0 _arr; });
-const result = blk3: { var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, flag: bool, }) }).init(std.heap.page_allocator); var _tmp6 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (items) |i| { const _tmp7 = i.cat; if (_tmp6.get(_tmp7)) |idx| { _tmp5.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, flag: bool, }) }{ .key = _tmp7, .Items = std.ArrayList(struct { cat: []const u8, val: i32, flag: bool, }).init(std.heap.page_allocator) }; g.Items.append(i) catch unreachable; _tmp5.append(g) catch unreachable; _tmp6.put(_tmp7, _tmp5.items.len - 1) catch unreachable; } } var _tmp8 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, flag: bool, }) }).init(std.heap.page_allocator);for (_tmp5.items) |g| { _tmp8.append(g) catch unreachable; } var _tmp9 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, flag: bool, }) }, key: i32 }).init(std.heap.page_allocator);for (_tmp8.items) |g| { _tmp9.append(.{ .item = g, .key = g.key }) catch unreachable; } for (0.._tmp9.items.len) |i| { for (i+1.._tmp9.items.len) |j| { if (_tmp9.items[j].key < _tmp9.items[i].key) { const t = _tmp9.items[i]; _tmp9.items[i] = _tmp9.items[j]; _tmp9.items[j] = t; } } } var _tmp10 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, flag: bool, }) }).init(std.heap.page_allocator);for (_tmp9.items) |p| { _tmp10.append(p.item) catch unreachable; } var _tmp11 = std.ArrayList(struct { cat: i32, share: f64, }).init(std.heap.page_allocator);for (_tmp10.items) |g| { _tmp11.append(struct { cat: i32, share: f64, }{ .cat = g.key, .share = (_sum_int(blk1: { var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp1.append(if (x.flag) (x.val) else (0)) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; }) / _sum_int(blk2: { var _tmp3 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp3.append(x.val) catch unreachable; } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk2 _tmp4; })) }) catch unreachable; } const _tmp11Slice = _tmp11.toOwnedSlice() catch unreachable; break :blk3 _tmp11Slice; };
+const items = (blk0: { const _tmp0 = struct {
+    cat: []const u8,
+    val: i32,
+    flag: bool,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .cat = "a",
+    .val = 10,
+    .flag = true,
+},
+    _tmp0{
+    .cat = "a",
+    .val = 5,
+    .flag = false,
+},
+    _tmp0{
+    .cat = "b",
+    .val = 20,
+    .flag = true,
+},
+}; break :blk0 _arr; });
+const result = blk3: { var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+    flag: bool,
+}) }).init(std.heap.page_allocator); var _tmp6 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (items) |i| { const _tmp7 = i.cat; if (_tmp6.get(_tmp7)) |idx| { _tmp5.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+    flag: bool,
+}) }{ .key = _tmp7, .Items = std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+    flag: bool,
+}).init(std.heap.page_allocator) }; g.Items.append(i) catch unreachable; _tmp5.append(g) catch unreachable; _tmp6.put(_tmp7, _tmp5.items.len - 1) catch unreachable; } } var _tmp8 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+    flag: bool,
+}) }).init(std.heap.page_allocator);for (_tmp5.items) |g| { _tmp8.append(g) catch unreachable; } var _tmp9 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+    flag: bool,
+}) }, key: i32 }).init(std.heap.page_allocator);for (_tmp8.items) |g| { _tmp9.append(.{ .item = g, .key = g.key }) catch unreachable; } for (0.._tmp9.items.len) |i| { for (i+1.._tmp9.items.len) |j| { if (_tmp9.items[j].key < _tmp9.items[i].key) { const t = _tmp9.items[i]; _tmp9.items[i] = _tmp9.items[j]; _tmp9.items[j] = t; } } } var _tmp10 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+    flag: bool,
+}) }).init(std.heap.page_allocator);for (_tmp9.items) |p| { _tmp10.append(p.item) catch unreachable; } var _tmp11 = std.ArrayList(struct {
+    cat: i32,
+    share: f64,
+}).init(std.heap.page_allocator);for (_tmp10.items) |g| { _tmp11.append(struct {
+    cat: i32,
+    share: f64,
+}{
+    .cat = g.key,
+    .share = (_sum_int(blk1: { var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp1.append(if (x.flag) (x.val) else (0)) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; }) / _sum_int(blk2: { var _tmp3 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp3.append(x.val) catch unreachable; } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk2 _tmp4; })),
+}) catch unreachable; } const _tmp11Slice = _tmp11.toOwnedSlice() catch unreachable; break :blk3 _tmp11Slice; };
 
 pub fn main() void {
     _print_list(std.StringHashMap(i32), result);

--- a/tests/machine/x/zig/group_by_having.zig
+++ b/tests/machine/x/zig/group_by_having.zig
@@ -15,8 +15,61 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const people = (blk0: { const _tmp0 = struct { name: []const u8, city: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .name = "Alice", .city = "Paris" }, _tmp0{ .name = "Bob", .city = "Hanoi" }, _tmp0{ .name = "Charlie", .city = "Paris" }, _tmp0{ .name = "Diana", .city = "Hanoi" }, _tmp0{ .name = "Eve", .city = "Paris" }, _tmp0{ .name = "Frank", .city = "Hanoi" }, _tmp0{ .name = "George", .city = "Paris" }}; break :blk0 _arr; });
-const big = blk1: { var _tmp1 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { name: []const u8, city: []const u8, }) }).init(std.heap.page_allocator); var _tmp2 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (people) |p| { const _tmp3 = p.city; if (_tmp2.get(_tmp3)) |idx| { _tmp1.items[idx].Items.append(p) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct { name: []const u8, city: []const u8, }) }{ .key = _tmp3, .Items = std.ArrayList(struct { name: []const u8, city: []const u8, }).init(std.heap.page_allocator) }; g.Items.append(p) catch unreachable; _tmp1.append(g) catch unreachable; _tmp2.put(_tmp3, _tmp1.items.len - 1) catch unreachable; } } var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { name: []const u8, city: []const u8, }) }).init(std.heap.page_allocator);for (_tmp1.items) |g| { if (!(((g.Items.len) >= 4))) continue; _tmp4.append(g) catch unreachable; } var _tmp5 = std.ArrayList(struct { city: i32, num: i32, }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp5.append(struct { city: i32, num: i32, }{ .city = g.key, .num = (g.Items.len) }) catch unreachable; } const _tmp5Slice = _tmp5.toOwnedSlice() catch unreachable; break :blk1 _tmp5Slice; };
+const people = (blk0: { const _tmp0 = struct {
+    name: []const u8,
+    city: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .name = "Alice",
+    .city = "Paris",
+},
+    _tmp0{
+    .name = "Bob",
+    .city = "Hanoi",
+},
+    _tmp0{
+    .name = "Charlie",
+    .city = "Paris",
+},
+    _tmp0{
+    .name = "Diana",
+    .city = "Hanoi",
+},
+    _tmp0{
+    .name = "Eve",
+    .city = "Paris",
+},
+    _tmp0{
+    .name = "Frank",
+    .city = "Hanoi",
+},
+    _tmp0{
+    .name = "George",
+    .city = "Paris",
+},
+}; break :blk0 _arr; });
+const big = blk1: { var _tmp1 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    name: []const u8,
+    city: []const u8,
+}) }).init(std.heap.page_allocator); var _tmp2 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (people) |p| { const _tmp3 = p.city; if (_tmp2.get(_tmp3)) |idx| { _tmp1.items[idx].Items.append(p) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+    name: []const u8,
+    city: []const u8,
+}) }{ .key = _tmp3, .Items = std.ArrayList(struct {
+    name: []const u8,
+    city: []const u8,
+}).init(std.heap.page_allocator) }; g.Items.append(p) catch unreachable; _tmp1.append(g) catch unreachable; _tmp2.put(_tmp3, _tmp1.items.len - 1) catch unreachable; } } var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    name: []const u8,
+    city: []const u8,
+}) }).init(std.heap.page_allocator);for (_tmp1.items) |g| { if (!(((g.Items.len) >= 4))) continue; _tmp4.append(g) catch unreachable; } var _tmp5 = std.ArrayList(struct {
+    city: i32,
+    num: i32,
+}).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp5.append(struct {
+    city: i32,
+    num: i32,
+}{
+    .city = g.key,
+    .num = (g.Items.len),
+}) catch unreachable; } const _tmp5Slice = _tmp5.toOwnedSlice() catch unreachable; break :blk1 _tmp5Slice; };
 
 pub fn main() void {
     _json(big);

--- a/tests/machine/x/zig/group_by_join.zig
+++ b/tests/machine/x/zig/group_by_join.zig
@@ -8,9 +8,58 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1 }, _tmp1{ .id = 101, .customerId = 1 }, _tmp1{ .id = 102, .customerId = 2 }}; break :blk1 _arr; });
-const stats = blk2: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { id: i32, customerId: i32, }) }).init(std.heap.page_allocator); var _tmp3 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; const _tmp4 = c.name; if (_tmp3.get(_tmp4)) |idx| { _tmp2.items[idx].Items.append(o) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct { id: i32, customerId: i32, }) }{ .key = _tmp4, .Items = std.ArrayList(struct { id: i32, customerId: i32, }).init(std.heap.page_allocator) }; g.Items.append(o) catch unreachable; _tmp2.append(g) catch unreachable; _tmp3.put(_tmp4, _tmp2.items.len - 1) catch unreachable; } } } var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { id: i32, customerId: i32, }) }).init(std.heap.page_allocator);for (_tmp2.items) |g| { _tmp5.append(g) catch unreachable; } var _tmp6 = std.ArrayList(struct { name: i32, count: i32, }).init(std.heap.page_allocator);for (_tmp5.items) |g| { _tmp6.append(struct { name: i32, count: i32, }{ .name = g.key, .count = (g.Items.len) }) catch unreachable; } const _tmp6Slice = _tmp6.toOwnedSlice() catch unreachable; break :blk2 _tmp6Slice; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 1,
+},
+    _tmp1{
+    .id = 102,
+    .customerId = 2,
+},
+}; break :blk1 _arr; });
+const stats = blk2: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    id: i32,
+    customerId: i32,
+}) }).init(std.heap.page_allocator); var _tmp3 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; const _tmp4 = c.name; if (_tmp3.get(_tmp4)) |idx| { _tmp2.items[idx].Items.append(o) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+    id: i32,
+    customerId: i32,
+}) }{ .key = _tmp4, .Items = std.ArrayList(struct {
+    id: i32,
+    customerId: i32,
+}).init(std.heap.page_allocator) }; g.Items.append(o) catch unreachable; _tmp2.append(g) catch unreachable; _tmp3.put(_tmp4, _tmp2.items.len - 1) catch unreachable; } } } var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    id: i32,
+    customerId: i32,
+}) }).init(std.heap.page_allocator);for (_tmp2.items) |g| { _tmp5.append(g) catch unreachable; } var _tmp6 = std.ArrayList(struct {
+    name: i32,
+    count: i32,
+}).init(std.heap.page_allocator);for (_tmp5.items) |g| { _tmp6.append(struct {
+    name: i32,
+    count: i32,
+}{
+    .name = g.key,
+    .count = (g.Items.len),
+}) catch unreachable; } const _tmp6Slice = _tmp6.toOwnedSlice() catch unreachable; break :blk2 _tmp6Slice; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Orders per customer ---"});

--- a/tests/machine/x/zig/group_by_left_join.zig
+++ b/tests/machine/x/zig/group_by_left_join.zig
@@ -8,9 +8,62 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }, _tmp0{ .id = 3, .name = "Charlie" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1 }, _tmp1{ .id = 101, .customerId = 1 }, _tmp1{ .id = 102, .customerId = 2 }}; break :blk1 _arr; });
-const stats = blk3: { var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { id: i32, name: []const u8, }) }).init(std.heap.page_allocator); var _tmp5 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (customers) |c| { for (orders) |o| { if (!((o.customerId == c.id))) continue; const _tmp6 = c.name; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(c) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct { id: i32, name: []const u8, }) }{ .key = _tmp6, .Items = std.ArrayList(struct { id: i32, name: []const u8, }).init(std.heap.page_allocator) }; g.Items.append(c) catch unreachable; _tmp4.append(g) catch unreachable; _tmp5.put(_tmp6, _tmp4.items.len - 1) catch unreachable; } } } var _tmp7 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { id: i32, name: []const u8, }) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch unreachable; } var _tmp8 = std.ArrayList(struct { name: i32, count: i32, }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(struct { name: i32, count: i32, }{ .name = g.key, .count = (blk2: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { if (!(r.o)) continue; _tmp2.append(r) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk2 _tmp3; }).len }) catch unreachable; } const _tmp8Slice = _tmp8.toOwnedSlice() catch unreachable; break :blk3 _tmp8Slice; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+    _tmp0{
+    .id = 3,
+    .name = "Charlie",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 1,
+},
+    _tmp1{
+    .id = 102,
+    .customerId = 2,
+},
+}; break :blk1 _arr; });
+const stats = blk3: { var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    id: i32,
+    name: []const u8,
+}) }).init(std.heap.page_allocator); var _tmp5 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (customers) |c| { for (orders) |o| { if (!((o.customerId == c.id))) continue; const _tmp6 = c.name; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(c) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+    id: i32,
+    name: []const u8,
+}) }{ .key = _tmp6, .Items = std.ArrayList(struct {
+    id: i32,
+    name: []const u8,
+}).init(std.heap.page_allocator) }; g.Items.append(c) catch unreachable; _tmp4.append(g) catch unreachable; _tmp5.put(_tmp6, _tmp4.items.len - 1) catch unreachable; } } } var _tmp7 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    id: i32,
+    name: []const u8,
+}) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch unreachable; } var _tmp8 = std.ArrayList(struct {
+    name: i32,
+    count: i32,
+}).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(struct {
+    name: i32,
+    count: i32,
+}{
+    .name = g.key,
+    .count = (blk2: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { if (!(r.o)) continue; _tmp2.append(r) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk2 _tmp3; }).len,
+}) catch unreachable; } const _tmp8Slice = _tmp8.toOwnedSlice() catch unreachable; break :blk3 _tmp8Slice; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Group Left Join ---"});

--- a/tests/machine/x/zig/group_by_multi_join.zig
+++ b/tests/machine/x/zig/group_by_multi_join.zig
@@ -22,11 +22,77 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const nations = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "A" }, _tmp0{ .id = 2, .name = "B" }}; break :blk0 _arr; });
-const suppliers = (blk1: { const _tmp1 = struct { id: i32, nation: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 1, .nation = 1 }, _tmp1{ .id = 2, .nation = 2 }}; break :blk1 _arr; });
-const partsupp = (blk2: { const _tmp2 = struct { part: i32, supplier: i32, cost: f64, qty: i32, }; const _arr = &[_]_tmp2{_tmp2{ .part = 100, .supplier = 1, .cost = 10, .qty = 2 }, _tmp2{ .part = 100, .supplier = 2, .cost = 20, .qty = 1 }, _tmp2{ .part = 200, .supplier = 1, .cost = 5, .qty = 3 }}; break :blk2 _arr; });
-const filtered = blk3: { var _tmp3 = std.ArrayList(struct { part: i32, value: f64, }).init(std.heap.page_allocator); for (partsupp) |ps| { for (suppliers) |s| { if (!((s.id == ps.supplier))) continue; for (nations) |n| { if (!((n.id == s.nation))) continue; if (!(std.mem.eql(u8, n.name, "A"))) continue; _tmp3.append(struct { part: i32, value: f64, }{ .part = ps.part, .value = (ps.cost * ps.qty) }) catch unreachable; } } } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk3 _tmp4; };
-const grouped = blk5: { var _tmp7 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator); var _tmp8 = std.AutoHashMap(i32, usize).init(std.heap.page_allocator); for (filtered) |x| { const _tmp9 = x.part; if (_tmp8.get(_tmp9)) |idx| { _tmp7.items[idx].Items.append(x) catch unreachable; } else { var g = struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }{ .key = _tmp9, .Items = std.ArrayList(std.StringHashMap(i32)).init(std.heap.page_allocator) }; g.Items.append(x) catch unreachable; _tmp7.append(g) catch unreachable; _tmp8.put(_tmp9, _tmp7.items.len - 1) catch unreachable; } } var _tmp10 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp10.append(g) catch unreachable; } var _tmp11 = std.ArrayList(struct { part: i32, total: f64, }).init(std.heap.page_allocator);for (_tmp10.items) |g| { _tmp11.append(struct { part: i32, total: f64, }{ .part = g.key, .total = _sum_int(blk4: { var _tmp5 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { _tmp5.append(r.value) catch unreachable; } const _tmp6 = _tmp5.toOwnedSlice() catch unreachable; break :blk4 _tmp6; }) }) catch unreachable; } const _tmp11Slice = _tmp11.toOwnedSlice() catch unreachable; break :blk5 _tmp11Slice; };
+const nations = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "A",
+},
+    _tmp0{
+    .id = 2,
+    .name = "B",
+},
+}; break :blk0 _arr; });
+const suppliers = (blk1: { const _tmp1 = struct {
+    id: i32,
+    nation: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 1,
+    .nation = 1,
+},
+    _tmp1{
+    .id = 2,
+    .nation = 2,
+},
+}; break :blk1 _arr; });
+const partsupp = (blk2: { const _tmp2 = struct {
+    part: i32,
+    supplier: i32,
+    cost: f64,
+    qty: i32,
+}; const _arr = &[_]_tmp2{
+    _tmp2{
+    .part = 100,
+    .supplier = 1,
+    .cost = 10,
+    .qty = 2,
+},
+    _tmp2{
+    .part = 100,
+    .supplier = 2,
+    .cost = 20,
+    .qty = 1,
+},
+    _tmp2{
+    .part = 200,
+    .supplier = 1,
+    .cost = 5,
+    .qty = 3,
+},
+}; break :blk2 _arr; });
+const filtered = blk3: { var _tmp3 = std.ArrayList(struct {
+    part: i32,
+    value: f64,
+}).init(std.heap.page_allocator); for (partsupp) |ps| { for (suppliers) |s| { if (!((s.id == ps.supplier))) continue; for (nations) |n| { if (!((n.id == s.nation))) continue; if (!(std.mem.eql(u8, n.name, "A"))) continue; _tmp3.append(struct {
+    part: i32,
+    value: f64,
+}{
+    .part = ps.part,
+    .value = (ps.cost * ps.qty),
+}) catch unreachable; } } } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk3 _tmp4; };
+const grouped = blk5: { var _tmp7 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator); var _tmp8 = std.AutoHashMap(i32, usize).init(std.heap.page_allocator); for (filtered) |x| { const _tmp9 = x.part; if (_tmp8.get(_tmp9)) |idx| { _tmp7.items[idx].Items.append(x) catch unreachable; } else { var g = struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }{ .key = _tmp9, .Items = std.ArrayList(std.StringHashMap(i32)).init(std.heap.page_allocator) }; g.Items.append(x) catch unreachable; _tmp7.append(g) catch unreachable; _tmp8.put(_tmp9, _tmp7.items.len - 1) catch unreachable; } } var _tmp10 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp10.append(g) catch unreachable; } var _tmp11 = std.ArrayList(struct {
+    part: i32,
+    total: f64,
+}).init(std.heap.page_allocator);for (_tmp10.items) |g| { _tmp11.append(struct {
+    part: i32,
+    total: f64,
+}{
+    .part = g.key,
+    .total = _sum_int(blk4: { var _tmp5 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { _tmp5.append(r.value) catch unreachable; } const _tmp6 = _tmp5.toOwnedSlice() catch unreachable; break :blk4 _tmp6; }),
+}) catch unreachable; } const _tmp11Slice = _tmp11.toOwnedSlice() catch unreachable; break :blk5 _tmp11Slice; };
 
 pub fn main() void {
     _print_list(std.StringHashMap(i32), grouped);

--- a/tests/machine/x/zig/group_by_multi_join_sort.zig
+++ b/tests/machine/x/zig/group_by_multi_join_sort.zig
@@ -14,13 +14,207 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const nation = (blk0: { const _tmp0 = struct { n_nationkey: i32, n_name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .n_nationkey = 1, .n_name = "BRAZIL" }}; break :blk0 _arr; });
-const customer = (blk1: { const _tmp1 = struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_nationkey: i32, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, }; const _arr = &[_]_tmp1{_tmp1{ .c_custkey = 1, .c_name = "Alice", .c_acctbal = 100, .c_nationkey = 1, .c_address = "123 St", .c_phone = "123-456", .c_comment = "Loyal" }}; break :blk1 _arr; });
-const orders = (blk2: { const _tmp2 = struct { o_orderkey: i32, o_custkey: i32, o_orderdate: []const u8, }; const _arr = &[_]_tmp2{_tmp2{ .o_orderkey = 1000, .o_custkey = 1, .o_orderdate = "1993-10-15" }, _tmp2{ .o_orderkey = 2000, .o_custkey = 1, .o_orderdate = "1994-01-02" }}; break :blk2 _arr; });
-const lineitem = (blk3: { const _tmp3 = struct { l_orderkey: i32, l_returnflag: []const u8, l_extendedprice: f64, l_discount: f64, }; const _arr = &[_]_tmp3{_tmp3{ .l_orderkey = 1000, .l_returnflag = "R", .l_extendedprice = 1000, .l_discount = 0.1 }, _tmp3{ .l_orderkey = 2000, .l_returnflag = "N", .l_extendedprice = 500, .l_discount = 0 }}; break :blk3 _arr; });
+const nation = (blk0: { const _tmp0 = struct {
+    n_nationkey: i32,
+    n_name: []const u8,
+}; const _arr = &[_]_tmp0{_tmp0{
+    .n_nationkey = 1,
+    .n_name = "BRAZIL",
+}}; break :blk0 _arr; });
+const customer = (blk1: { const _tmp1 = struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_nationkey: i32,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+}; const _arr = &[_]_tmp1{_tmp1{
+    .c_custkey = 1,
+    .c_name = "Alice",
+    .c_acctbal = 100,
+    .c_nationkey = 1,
+    .c_address = "123 St",
+    .c_phone = "123-456",
+    .c_comment = "Loyal",
+}}; break :blk1 _arr; });
+const orders = (blk2: { const _tmp2 = struct {
+    o_orderkey: i32,
+    o_custkey: i32,
+    o_orderdate: []const u8,
+}; const _arr = &[_]_tmp2{
+    _tmp2{
+    .o_orderkey = 1000,
+    .o_custkey = 1,
+    .o_orderdate = "1993-10-15",
+},
+    _tmp2{
+    .o_orderkey = 2000,
+    .o_custkey = 1,
+    .o_orderdate = "1994-01-02",
+},
+}; break :blk2 _arr; });
+const lineitem = (blk3: { const _tmp3 = struct {
+    l_orderkey: i32,
+    l_returnflag: []const u8,
+    l_extendedprice: f64,
+    l_discount: f64,
+}; const _arr = &[_]_tmp3{
+    _tmp3{
+    .l_orderkey = 1000,
+    .l_returnflag = "R",
+    .l_extendedprice = 1000,
+    .l_discount = 0.1,
+},
+    _tmp3{
+    .l_orderkey = 2000,
+    .l_returnflag = "N",
+    .l_extendedprice = 500,
+    .l_discount = 0,
+},
+}; break :blk3 _arr; });
 const start_date = "1993-10-01";
 const end_date = "1994-01-01";
-const result = blk6: { var _tmp8 = std.ArrayList(struct { key: struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, n_name: []const u8, }, Items: std.ArrayList(struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_nationkey: i32, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, }) }).init(std.heap.page_allocator); var _tmp9 = std.AutoHashMap(struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, n_name: []const u8, }, usize).init(std.heap.page_allocator); for (customer) |c| { for (orders) |o| { if (!((o.o_custkey == c.c_custkey))) continue; for (lineitem) |l| { if (!((l.l_orderkey == o.o_orderkey))) continue; for (nation) |n| { if (!((n.n_nationkey == c.c_nationkey))) continue; if (!((((o.o_orderdate >= start_date) and (o.o_orderdate < end_date)) and std.mem.eql(u8, l.l_returnflag, "R")))) continue; const _tmp10 = struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, n_name: []const u8, }{ .c_custkey = c.c_custkey, .c_name = c.c_name, .c_acctbal = c.c_acctbal, .c_address = c.c_address, .c_phone = c.c_phone, .c_comment = c.c_comment, .n_name = n.n_name }; if (_tmp9.get(_tmp10)) |idx| { _tmp8.items[idx].Items.append(c) catch unreachable; } else { var g = struct { key: struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, n_name: []const u8, }, Items: std.ArrayList(struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_nationkey: i32, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, }) }{ .key = _tmp10, .Items = std.ArrayList(struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_nationkey: i32, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, }).init(std.heap.page_allocator) }; g.Items.append(c) catch unreachable; _tmp8.append(g) catch unreachable; _tmp9.put(_tmp10, _tmp8.items.len - 1) catch unreachable; } } } } } var _tmp11 = std.ArrayList(struct { key: struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, n_name: []const u8, }, Items: std.ArrayList(struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_nationkey: i32, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, }) }).init(std.heap.page_allocator);for (_tmp8.items) |g| { _tmp11.append(g) catch unreachable; } var _tmp12 = std.ArrayList(struct { item: struct { key: struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, n_name: []const u8, }, Items: std.ArrayList(struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_nationkey: i32, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, }) }, key: i32 }).init(std.heap.page_allocator);for (_tmp11.items) |g| { _tmp12.append(.{ .item = g, .key = -_sum_int(blk5: { var _tmp6 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp6.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch unreachable; } const _tmp7 = _tmp6.toOwnedSlice() catch unreachable; break :blk5 _tmp7; }) }) catch unreachable; } for (0.._tmp12.items.len) |i| { for (i+1.._tmp12.items.len) |j| { if (_tmp12.items[j].key < _tmp12.items[i].key) { const t = _tmp12.items[i]; _tmp12.items[i] = _tmp12.items[j]; _tmp12.items[j] = t; } } } var _tmp13 = std.ArrayList(struct { key: struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, n_name: []const u8, }, Items: std.ArrayList(struct { c_custkey: i32, c_name: []const u8, c_acctbal: f64, c_nationkey: i32, c_address: []const u8, c_phone: []const u8, c_comment: []const u8, }) }).init(std.heap.page_allocator);for (_tmp12.items) |p| { _tmp13.append(p.item) catch unreachable; } var _tmp14 = std.ArrayList(struct { c_custkey: i32, c_name: i32, revenue: i32, c_acctbal: i32, n_name: i32, c_address: i32, c_phone: i32, c_comment: i32, }).init(std.heap.page_allocator);for (_tmp13.items) |g| { _tmp14.append(struct { c_custkey: i32, c_name: i32, revenue: i32, c_acctbal: i32, n_name: i32, c_address: i32, c_phone: i32, c_comment: i32, }{ .c_custkey = g.key.c_custkey, .c_name = g.key.c_name, .revenue = _sum_int(blk4: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp4.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch unreachable; } const _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk4 _tmp5; }), .c_acctbal = g.key.c_acctbal, .n_name = g.key.n_name, .c_address = g.key.c_address, .c_phone = g.key.c_phone, .c_comment = g.key.c_comment }) catch unreachable; } const _tmp14Slice = _tmp14.toOwnedSlice() catch unreachable; break :blk6 _tmp14Slice; };
+const result = blk6: { var _tmp8 = std.ArrayList(struct { key: struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+    n_name: []const u8,
+}, Items: std.ArrayList(struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_nationkey: i32,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+}) }).init(std.heap.page_allocator); var _tmp9 = std.AutoHashMap(struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+    n_name: []const u8,
+}, usize).init(std.heap.page_allocator); for (customer) |c| { for (orders) |o| { if (!((o.o_custkey == c.c_custkey))) continue; for (lineitem) |l| { if (!((l.l_orderkey == o.o_orderkey))) continue; for (nation) |n| { if (!((n.n_nationkey == c.c_nationkey))) continue; if (!((((o.o_orderdate >= start_date) and (o.o_orderdate < end_date)) and std.mem.eql(u8, l.l_returnflag, "R")))) continue; const _tmp10 = struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+    n_name: []const u8,
+}{
+    .c_custkey = c.c_custkey,
+    .c_name = c.c_name,
+    .c_acctbal = c.c_acctbal,
+    .c_address = c.c_address,
+    .c_phone = c.c_phone,
+    .c_comment = c.c_comment,
+    .n_name = n.n_name,
+}; if (_tmp9.get(_tmp10)) |idx| { _tmp8.items[idx].Items.append(c) catch unreachable; } else { var g = struct { key: struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+    n_name: []const u8,
+}, Items: std.ArrayList(struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_nationkey: i32,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+}) }{ .key = _tmp10, .Items = std.ArrayList(struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_nationkey: i32,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+}).init(std.heap.page_allocator) }; g.Items.append(c) catch unreachable; _tmp8.append(g) catch unreachable; _tmp9.put(_tmp10, _tmp8.items.len - 1) catch unreachable; } } } } } var _tmp11 = std.ArrayList(struct { key: struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+    n_name: []const u8,
+}, Items: std.ArrayList(struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_nationkey: i32,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+}) }).init(std.heap.page_allocator);for (_tmp8.items) |g| { _tmp11.append(g) catch unreachable; } var _tmp12 = std.ArrayList(struct { item: struct { key: struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+    n_name: []const u8,
+}, Items: std.ArrayList(struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_nationkey: i32,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+}) }, key: i32 }).init(std.heap.page_allocator);for (_tmp11.items) |g| { _tmp12.append(.{ .item = g, .key = -_sum_int(blk5: { var _tmp6 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp6.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch unreachable; } const _tmp7 = _tmp6.toOwnedSlice() catch unreachable; break :blk5 _tmp7; }) }) catch unreachable; } for (0.._tmp12.items.len) |i| { for (i+1.._tmp12.items.len) |j| { if (_tmp12.items[j].key < _tmp12.items[i].key) { const t = _tmp12.items[i]; _tmp12.items[i] = _tmp12.items[j]; _tmp12.items[j] = t; } } } var _tmp13 = std.ArrayList(struct { key: struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+    n_name: []const u8,
+}, Items: std.ArrayList(struct {
+    c_custkey: i32,
+    c_name: []const u8,
+    c_acctbal: f64,
+    c_nationkey: i32,
+    c_address: []const u8,
+    c_phone: []const u8,
+    c_comment: []const u8,
+}) }).init(std.heap.page_allocator);for (_tmp12.items) |p| { _tmp13.append(p.item) catch unreachable; } var _tmp14 = std.ArrayList(struct {
+    c_custkey: i32,
+    c_name: i32,
+    revenue: i32,
+    c_acctbal: i32,
+    n_name: i32,
+    c_address: i32,
+    c_phone: i32,
+    c_comment: i32,
+}).init(std.heap.page_allocator);for (_tmp13.items) |g| { _tmp14.append(struct {
+    c_custkey: i32,
+    c_name: i32,
+    revenue: i32,
+    c_acctbal: i32,
+    n_name: i32,
+    c_address: i32,
+    c_phone: i32,
+    c_comment: i32,
+}{
+    .c_custkey = g.key.c_custkey,
+    .c_name = g.key.c_name,
+    .revenue = _sum_int(blk4: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp4.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch unreachable; } const _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk4 _tmp5; }),
+    .c_acctbal = g.key.c_acctbal,
+    .n_name = g.key.n_name,
+    .c_address = g.key.c_address,
+    .c_phone = g.key.c_phone,
+    .c_comment = g.key.c_comment,
+}) catch unreachable; } const _tmp14Slice = _tmp14.toOwnedSlice() catch unreachable; break :blk6 _tmp14Slice; };
 
 pub fn main() void {
     std.debug.print("{any}\n", .{result});

--- a/tests/machine/x/zig/group_by_sort.zig
+++ b/tests/machine/x/zig/group_by_sort.zig
@@ -22,8 +22,55 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const items = (blk0: { const _tmp0 = struct { cat: []const u8, val: i32, }; const _arr = &[_]_tmp0{_tmp0{ .cat = "a", .val = 3 }, _tmp0{ .cat = "a", .val = 1 }, _tmp0{ .cat = "b", .val = 5 }, _tmp0{ .cat = "b", .val = 2 }}; break :blk0 _arr; });
-const grouped = blk3: { var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, }) }).init(std.heap.page_allocator); var _tmp6 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (items) |i| { const _tmp7 = i.cat; if (_tmp6.get(_tmp7)) |idx| { _tmp5.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, }) }{ .key = _tmp7, .Items = std.ArrayList(struct { cat: []const u8, val: i32, }).init(std.heap.page_allocator) }; g.Items.append(i) catch unreachable; _tmp5.append(g) catch unreachable; _tmp6.put(_tmp7, _tmp5.items.len - 1) catch unreachable; } } var _tmp8 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, }) }).init(std.heap.page_allocator);for (_tmp5.items) |g| { _tmp8.append(g) catch unreachable; } var _tmp9 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, }) }, key: i32 }).init(std.heap.page_allocator);for (_tmp8.items) |g| { _tmp9.append(.{ .item = g, .key = -_sum_int(blk2: { var _tmp3 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp3.append(x.val) catch unreachable; } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk2 _tmp4; }) }) catch unreachable; } for (0.._tmp9.items.len) |i| { for (i+1.._tmp9.items.len) |j| { if (_tmp9.items[j].key < _tmp9.items[i].key) { const t = _tmp9.items[i]; _tmp9.items[i] = _tmp9.items[j]; _tmp9.items[j] = t; } } } var _tmp10 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { cat: []const u8, val: i32, }) }).init(std.heap.page_allocator);for (_tmp9.items) |p| { _tmp10.append(p.item) catch unreachable; } var _tmp11 = std.ArrayList(struct { cat: i32, total: f64, }).init(std.heap.page_allocator);for (_tmp10.items) |g| { _tmp11.append(struct { cat: i32, total: f64, }{ .cat = g.key, .total = _sum_int(blk1: { var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp1.append(x.val) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; }) }) catch unreachable; } const _tmp11Slice = _tmp11.toOwnedSlice() catch unreachable; break :blk3 _tmp11Slice; };
+const items = (blk0: { const _tmp0 = struct {
+    cat: []const u8,
+    val: i32,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .cat = "a",
+    .val = 3,
+},
+    _tmp0{
+    .cat = "a",
+    .val = 1,
+},
+    _tmp0{
+    .cat = "b",
+    .val = 5,
+},
+    _tmp0{
+    .cat = "b",
+    .val = 2,
+},
+}; break :blk0 _arr; });
+const grouped = blk3: { var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+}) }).init(std.heap.page_allocator); var _tmp6 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (items) |i| { const _tmp7 = i.cat; if (_tmp6.get(_tmp7)) |idx| { _tmp5.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+}) }{ .key = _tmp7, .Items = std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+}).init(std.heap.page_allocator) }; g.Items.append(i) catch unreachable; _tmp5.append(g) catch unreachable; _tmp6.put(_tmp7, _tmp5.items.len - 1) catch unreachable; } } var _tmp8 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+}) }).init(std.heap.page_allocator);for (_tmp5.items) |g| { _tmp8.append(g) catch unreachable; } var _tmp9 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+}) }, key: i32 }).init(std.heap.page_allocator);for (_tmp8.items) |g| { _tmp9.append(.{ .item = g, .key = -_sum_int(blk2: { var _tmp3 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp3.append(x.val) catch unreachable; } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk2 _tmp4; }) }) catch unreachable; } for (0.._tmp9.items.len) |i| { for (i+1.._tmp9.items.len) |j| { if (_tmp9.items[j].key < _tmp9.items[i].key) { const t = _tmp9.items[i]; _tmp9.items[i] = _tmp9.items[j]; _tmp9.items[j] = t; } } } var _tmp10 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    cat: []const u8,
+    val: i32,
+}) }).init(std.heap.page_allocator);for (_tmp9.items) |p| { _tmp10.append(p.item) catch unreachable; } var _tmp11 = std.ArrayList(struct {
+    cat: i32,
+    total: f64,
+}).init(std.heap.page_allocator);for (_tmp10.items) |g| { _tmp11.append(struct {
+    cat: i32,
+    total: f64,
+}{
+    .cat = g.key,
+    .total = _sum_int(blk1: { var _tmp1 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp1.append(x.val) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; }),
+}) catch unreachable; } const _tmp11Slice = _tmp11.toOwnedSlice() catch unreachable; break :blk3 _tmp11Slice; };
 
 pub fn main() void {
     _print_list(std.StringHashMap(i32), grouped);

--- a/tests/machine/x/zig/group_items_iteration.zig
+++ b/tests/machine/x/zig/group_items_iteration.zig
@@ -24,8 +24,36 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
-const data = (blk0: { const _tmp0 = struct { tag: []const u8, val: i32, }; const _arr = &[_]_tmp0{_tmp0{ .tag = "a", .val = 1 }, _tmp0{ .tag = "a", .val = 2 }, _tmp0{ .tag = "b", .val = 3 }}; break :blk0 _arr; });
-const groups = blk1: { var _tmp1 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { tag: []const u8, val: i32, }) }).init(std.heap.page_allocator); var _tmp2 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (data) |d| { const _tmp3 = d.tag; if (_tmp2.get(_tmp3)) |idx| { _tmp1.items[idx].Items.append(d) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct { tag: []const u8, val: i32, }) }{ .key = _tmp3, .Items = std.ArrayList(struct { tag: []const u8, val: i32, }).init(std.heap.page_allocator) }; g.Items.append(d) catch unreachable; _tmp1.append(g) catch unreachable; _tmp2.put(_tmp3, _tmp1.items.len - 1) catch unreachable; } } var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct { tag: []const u8, val: i32, }) }).init(std.heap.page_allocator);for (_tmp1.items) |g| { _tmp4.append(g) catch unreachable; } var _tmp5 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp5.append(g) catch unreachable; } const _tmp5Slice = _tmp5.toOwnedSlice() catch unreachable; break :blk1 _tmp5Slice; };
+const data = (blk0: { const _tmp0 = struct {
+    tag: []const u8,
+    val: i32,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .tag = "a",
+    .val = 1,
+},
+    _tmp0{
+    .tag = "a",
+    .val = 2,
+},
+    _tmp0{
+    .tag = "b",
+    .val = 3,
+},
+}; break :blk0 _arr; });
+const groups = blk1: { var _tmp1 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    tag: []const u8,
+    val: i32,
+}) }).init(std.heap.page_allocator); var _tmp2 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (data) |d| { const _tmp3 = d.tag; if (_tmp2.get(_tmp3)) |idx| { _tmp1.items[idx].Items.append(d) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+    tag: []const u8,
+    val: i32,
+}) }{ .key = _tmp3, .Items = std.ArrayList(struct {
+    tag: []const u8,
+    val: i32,
+}).init(std.heap.page_allocator) }; g.Items.append(d) catch unreachable; _tmp1.append(g) catch unreachable; _tmp2.put(_tmp3, _tmp1.items.len - 1) catch unreachable; } } var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+    tag: []const u8,
+    val: i32,
+}) }).init(std.heap.page_allocator);for (_tmp1.items) |g| { _tmp4.append(g) catch unreachable; } var _tmp5 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp5.append(g) catch unreachable; } const _tmp5Slice = _tmp5.toOwnedSlice() catch unreachable; break :blk1 _tmp5Slice; };
 var tmp = &[]i32{};
 const result = blk2: { var _tmp6 = std.ArrayList(struct { item: i32, key: i32 }).init(std.heap.page_allocator); for (tmp) |r| { _tmp6.append(.{ .item = r, .key = r.tag }) catch unreachable; } for (0.._tmp6.items.len) |i| { for (i+1.._tmp6.items.len) |j| { if (_tmp6.items[j].key < _tmp6.items[i].key) { const t = _tmp6.items[i]; _tmp6.items[i] = _tmp6.items[j]; _tmp6.items[j] = t; } } } var _tmp7 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp6.items) |p| { _tmp7.append(p.item) catch unreachable; } const _tmp8 = _tmp7.toOwnedSlice() catch unreachable; break :blk2 _tmp8; };
 
@@ -35,7 +63,13 @@ pub fn main() void {
         for (g.items) |x| {
             total = (total + x.val);
         }
-        tmp = _append(i32, tmp, struct { tag: i32, total: i32, }{ .tag = g.key, .total = total });
+        tmp = _append(i32, tmp, struct {
+    tag: i32,
+    total: i32,
+}{
+    .tag = g.key,
+    .total = total,
+});
     }
     _print_list(i32, result);
 }

--- a/tests/machine/x/zig/in_operator.zig
+++ b/tests/machine/x/zig/in_operator.zig
@@ -5,7 +5,11 @@ fn _contains_list_int(v: []const i32, item: i32) bool {
     return false;
 }
 
-const xs = &[_]i32{1, 2, 3};
+const xs = &[_]i32{
+    1,
+    2,
+    3,
+};
 
 pub fn main() void {
     std.debug.print("{}\n", .{_contains_list_int(xs, 2)});

--- a/tests/machine/x/zig/in_operator_extended.zig
+++ b/tests/machine/x/zig/in_operator_extended.zig
@@ -5,7 +5,11 @@ fn _contains_list_int(v: []const i32, item: i32) bool {
     return false;
 }
 
-const xs = &[_]i32{1, 2, 3};
+const xs = &[_]i32{
+    1,
+    2,
+    3,
+};
 const ys = blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (xs) |x| { if (!((@mod(x, 2) == 1))) continue; _tmp0.append(x) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
 const m = struct { a: i32, }{ .a = 1 };
 const s = "hello";

--- a/tests/machine/x/zig/inner_join.zig
+++ b/tests/machine/x/zig/inner_join.zig
@@ -1,8 +1,61 @@
 const std = @import("std");
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }, _tmp0{ .id = 3, .name = "Charlie" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, total: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1, .total = 250 }, _tmp1{ .id = 101, .customerId = 2, .total = 125 }, _tmp1{ .id = 102, .customerId = 1, .total = 300 }, _tmp1{ .id = 103, .customerId = 4, .total = 80 }}; break :blk1 _arr; });
-const result = blk2: { var _tmp2 = std.ArrayList(struct { orderId: i32, customerName: []const u8, total: i32, }).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; _tmp2.append(struct { orderId: i32, customerName: []const u8, total: i32, }{ .orderId = o.id, .customerName = c.name, .total = o.total }) catch unreachable; } } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk2 _tmp3; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+    _tmp0{
+    .id = 3,
+    .name = "Charlie",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+    .total = 250,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 2,
+    .total = 125,
+},
+    _tmp1{
+    .id = 102,
+    .customerId = 1,
+    .total = 300,
+},
+    _tmp1{
+    .id = 103,
+    .customerId = 4,
+    .total = 80,
+},
+}; break :blk1 _arr; });
+const result = blk2: { var _tmp2 = std.ArrayList(struct {
+    orderId: i32,
+    customerName: []const u8,
+    total: i32,
+}).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; _tmp2.append(struct {
+    orderId: i32,
+    customerName: []const u8,
+    total: i32,
+}{
+    .orderId = o.id,
+    .customerName = c.name,
+    .total = o.total,
+}) catch unreachable; } } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk2 _tmp3; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Orders with customer info ---"});

--- a/tests/machine/x/zig/join_multi.zig
+++ b/tests/machine/x/zig/join_multi.zig
@@ -1,9 +1,54 @@
 const std = @import("std");
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1 }, _tmp1{ .id = 101, .customerId = 2 }}; break :blk1 _arr; });
-const items = (blk2: { const _tmp2 = struct { orderId: i32, sku: []const u8, }; const _arr = &[_]_tmp2{_tmp2{ .orderId = 100, .sku = "a" }, _tmp2{ .orderId = 101, .sku = "b" }}; break :blk2 _arr; });
-const result = blk3: { var _tmp3 = std.ArrayList(struct { name: []const u8, sku: []const u8, }).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; for (items) |i| { if (!((o.id == i.orderId))) continue; _tmp3.append(struct { name: []const u8, sku: []const u8, }{ .name = c.name, .sku = i.sku }) catch unreachable; } } } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk3 _tmp4; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 2,
+},
+}; break :blk1 _arr; });
+const items = (blk2: { const _tmp2 = struct {
+    orderId: i32,
+    sku: []const u8,
+}; const _arr = &[_]_tmp2{
+    _tmp2{
+    .orderId = 100,
+    .sku = "a",
+},
+    _tmp2{
+    .orderId = 101,
+    .sku = "b",
+},
+}; break :blk2 _arr; });
+const result = blk3: { var _tmp3 = std.ArrayList(struct {
+    name: []const u8,
+    sku: []const u8,
+}).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; for (items) |i| { if (!((o.id == i.orderId))) continue; _tmp3.append(struct {
+    name: []const u8,
+    sku: []const u8,
+}{
+    .name = c.name,
+    .sku = i.sku,
+}) catch unreachable; } } } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk3 _tmp4; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Multi Join ---"});

--- a/tests/machine/x/zig/json_builtin.zig
+++ b/tests/machine/x/zig/json_builtin.zig
@@ -7,7 +7,13 @@ fn _json(v: anytype) void {
     std.debug.print("{s}\n", .{buf.items});
 }
 
-const m = struct { a: i32, b: i32, }{ .a = 1, .b = 2 };
+const m = struct {
+    a: i32,
+    b: i32,
+}{
+    .a = 1,
+    .b = 2,
+};
 
 pub fn main() void {
     _json(m);

--- a/tests/machine/x/zig/left_join.zig
+++ b/tests/machine/x/zig/left_join.zig
@@ -1,8 +1,67 @@
 const std = @import("std");
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, total: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1, .total = 250 }, _tmp1{ .id = 101, .customerId = 3, .total = 80 }}; break :blk1 _arr; });
-const result = blk2: { var _tmp2 = std.ArrayList(struct { orderId: i32, customer: struct { id: i32, name: []const u8, }, total: i32, }).init(std.heap.page_allocator); for (orders) |o| { var matched = false; for (customers) |c| { if (!((o.customerId == c.id))) continue; matched = true; _tmp2.append(struct { orderId: i32, customer: struct { id: i32, name: []const u8, }, total: i32, }{ .orderId = o.id, .customer = c, .total = o.total }) catch unreachable; } if (!matched) { const c: ?struct { id: i32, name: []const u8, } = null; _tmp2.append(struct { orderId: i32, customer: struct { id: i32, name: []const u8, }, total: i32, }{ .orderId = o.id, .customer = c, .total = o.total }) catch unreachable; } } const res = _tmp2.toOwnedSlice() catch unreachable; break :blk2 res; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+    .total = 250,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 3,
+    .total = 80,
+},
+}; break :blk1 _arr; });
+const result = blk2: { var _tmp2 = std.ArrayList(struct {
+    orderId: i32,
+    customer: struct {
+    id: i32,
+    name: []const u8,
+},
+    total: i32,
+}).init(std.heap.page_allocator); for (orders) |o| { var matched = false; for (customers) |c| { if (!((o.customerId == c.id))) continue; matched = true; _tmp2.append(struct {
+    orderId: i32,
+    customer: struct {
+    id: i32,
+    name: []const u8,
+},
+    total: i32,
+}{
+    .orderId = o.id,
+    .customer = c,
+    .total = o.total,
+}) catch unreachable; } if (!matched) { const c: ?struct {
+    id: i32,
+    name: []const u8,
+} = null; _tmp2.append(struct {
+    orderId: i32,
+    customer: struct {
+    id: i32,
+    name: []const u8,
+},
+    total: i32,
+}{
+    .orderId = o.id,
+    .customer = c,
+    .total = o.total,
+}) catch unreachable; } } const res = _tmp2.toOwnedSlice() catch unreachable; break :blk2 res; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Left Join ---"});

--- a/tests/machine/x/zig/left_join_multi.zig
+++ b/tests/machine/x/zig/left_join_multi.zig
@@ -1,9 +1,57 @@
 const std = @import("std");
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1 }, _tmp1{ .id = 101, .customerId = 2 }}; break :blk1 _arr; });
-const items = (blk2: { const _tmp2 = struct { orderId: i32, sku: []const u8, }; const _arr = &[_]_tmp2{_tmp2{ .orderId = 100, .sku = "a" }}; break :blk2 _arr; });
-const result = blk3: { var _tmp3 = std.ArrayList(struct { orderId: i32, name: []const u8, item: struct { orderId: i32, sku: []const u8, }, }).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; for (items) |i| { if (!((o.id == i.orderId))) continue; _tmp3.append(struct { orderId: i32, name: []const u8, item: struct { orderId: i32, sku: []const u8, }, }{ .orderId = o.id, .name = c.name, .item = i }) catch unreachable; } } } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk3 _tmp4; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 2,
+},
+}; break :blk1 _arr; });
+const items = (blk2: { const _tmp2 = struct {
+    orderId: i32,
+    sku: []const u8,
+}; const _arr = &[_]_tmp2{_tmp2{
+    .orderId = 100,
+    .sku = "a",
+}}; break :blk2 _arr; });
+const result = blk3: { var _tmp3 = std.ArrayList(struct {
+    orderId: i32,
+    name: []const u8,
+    item: struct {
+    orderId: i32,
+    sku: []const u8,
+},
+}).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; for (items) |i| { if (!((o.id == i.orderId))) continue; _tmp3.append(struct {
+    orderId: i32,
+    name: []const u8,
+    item: struct {
+    orderId: i32,
+    sku: []const u8,
+},
+}{
+    .orderId = o.id,
+    .name = c.name,
+    .item = i,
+}) catch unreachable; } } } const _tmp4 = _tmp3.toOwnedSlice() catch unreachable; break :blk3 _tmp4; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Left Join Multi ---"});

--- a/tests/machine/x/zig/len_builtin.zig
+++ b/tests/machine/x/zig/len_builtin.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("{d}\n", .{(&[_]i32{1, 2, 3}).len});
+    std.debug.print("{d}\n", .{(&[_]i32{
+    1,
+    2,
+    3,
+}).len});
 }

--- a/tests/machine/x/zig/len_map.zig
+++ b/tests/machine/x/zig/len_map.zig
@@ -1,5 +1,11 @@
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("{d}\n", .{struct { a: i32, b: i32, }{ .a = 1, .b = 2 }.count()});
+    std.debug.print("{d}\n", .{struct {
+    a: i32,
+    b: i32,
+}{
+    .a = 1,
+    .b = 2,
+}.count()});
 }

--- a/tests/machine/x/zig/list_assign.zig
+++ b/tests/machine/x/zig/list_assign.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 
-var nums = &[_]i32{1, 2};
+var nums = &[_]i32{
+    1,
+    2,
+};
 
 pub fn main() void {
     nums.items[1] = 3;

--- a/tests/machine/x/zig/list_index.zig
+++ b/tests/machine/x/zig/list_index.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 
-const xs = &[_]i32{10, 20, 30};
+const xs = &[_]i32{
+    10,
+    20,
+    30,
+};
 
 pub fn main() void {
     std.debug.print("{d}\n", .{xs[1]});

--- a/tests/machine/x/zig/list_nested_assign.zig
+++ b/tests/machine/x/zig/list_nested_assign.zig
@@ -1,6 +1,15 @@
 const std = @import("std");
 
-var matrix = &[_][]const i32{&[_]i32{1, 2}, &[_]i32{3, 4}};
+var matrix = &[_][]const i32{
+    &[_]i32{
+    1,
+    2,
+},
+    &[_]i32{
+    3,
+    4,
+},
+};
 
 pub fn main() void {
     matrix.items[1][0] = 5;

--- a/tests/machine/x/zig/list_set_ops.zig
+++ b/tests/machine/x/zig/list_set_ops.zig
@@ -44,8 +44,31 @@ fn _print_list(comptime T: type, v: []const T) void {
 }
 
 pub fn main() void {
-    _print_list(i32, _union(i32, &[_]i32{1, 2}, &[_]i32{2, 3}));
-    _print_list(i32, _except(i32, &[_]i32{1, 2, 3}, &[_]i32{2}));
-    _print_list(i32, _intersect(i32, &[_]i32{1, 2, 3}, &[_]i32{2, 4}));
-    std.debug.print("{d}\n", .{(_union_all(i32, &[_]i32{1, 2}, &[_]i32{2, 3})).len});
+    _print_list(i32, _union(i32, &[_]i32{
+    1,
+    2,
+}, &[_]i32{
+    2,
+    3,
+}));
+    _print_list(i32, _except(i32, &[_]i32{
+    1,
+    2,
+    3,
+}, &[_]i32{2}));
+    _print_list(i32, _intersect(i32, &[_]i32{
+    1,
+    2,
+    3,
+}, &[_]i32{
+    2,
+    4,
+}));
+    std.debug.print("{d}\n", .{(_union_all(i32, &[_]i32{
+    1,
+    2,
+}, &[_]i32{
+    2,
+    3,
+})).len});
 }

--- a/tests/machine/x/zig/load_yaml.zig
+++ b/tests/machine/x/zig/load_yaml.zig
@@ -29,7 +29,16 @@ const Person = struct {
 };
 
 const people = _load_json([]Person, "../interpreter/valid/people.yaml");
-const adults = blk0: { var _tmp0 = std.ArrayList(struct { name: []const u8, email: []const u8, }).init(std.heap.page_allocator); for (people) |p| { if (!((p.age >= 18))) continue; _tmp0.append(struct { name: []const u8, email: []const u8, }{ .name = p.name, .email = p.email }) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
+const adults = blk0: { var _tmp0 = std.ArrayList(struct {
+    name: []const u8,
+    email: []const u8,
+}).init(std.heap.page_allocator); for (people) |p| { if (!((p.age >= 18))) continue; _tmp0.append(struct {
+    name: []const u8,
+    email: []const u8,
+}{
+    .name = p.name,
+    .email = p.email,
+}) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
 
 pub fn main() void {
     for (adults) |a| {

--- a/tests/machine/x/zig/map_index.zig
+++ b/tests/machine/x/zig/map_index.zig
@@ -1,6 +1,12 @@
 const std = @import("std");
 
-const m = struct { a: i32, b: i32, }{ .a = 1, .b = 2 };
+const m = struct {
+    a: i32,
+    b: i32,
+}{
+    .a = 1,
+    .b = 2,
+};
 
 pub fn main() void {
     std.debug.print("{any}\n", .{m["b"]});

--- a/tests/machine/x/zig/map_literal_dynamic.zig
+++ b/tests/machine/x/zig/map_literal_dynamic.zig
@@ -2,7 +2,10 @@ const std = @import("std");
 
 var x = 3;
 var y = 4;
-var m: struct { a: i32, b: i32, } = undefined;
+var m: struct {
+    a: i32,
+    b: i32,
+} = undefined;
 
 pub fn main() void {
     std.debug.print("{any} {any}\n", .{m["a"], m["b"]});

--- a/tests/machine/x/zig/map_membership.zig
+++ b/tests/machine/x/zig/map_membership.zig
@@ -5,7 +5,13 @@ fn _contains_list_int(v: []const i32, item: i32) bool {
     return false;
 }
 
-const m = struct { a: i32, b: i32, }{ .a = 1, .b = 2 };
+const m = struct {
+    a: i32,
+    b: i32,
+}{
+    .a = 1,
+    .b = 2,
+};
 
 pub fn main() void {
     std.debug.print("{any}\n", .{_contains_list_int(m, "a")});

--- a/tests/machine/x/zig/membership.zig
+++ b/tests/machine/x/zig/membership.zig
@@ -5,7 +5,11 @@ fn _contains_list_int(v: []const i32, item: i32) bool {
     return false;
 }
 
-const nums = &[_]i32{1, 2, 3};
+const nums = &[_]i32{
+    1,
+    2,
+    3,
+};
 
 pub fn main() void {
     std.debug.print("{}\n", .{_contains_list_int(nums, 2)});

--- a/tests/machine/x/zig/min_max_builtin.zig
+++ b/tests/machine/x/zig/min_max_builtin.zig
@@ -14,7 +14,11 @@ fn _max_int(v: []const i32) i32 {
     return m;
 }
 
-const nums = &[_]i32{3, 1, 4};
+const nums = &[_]i32{
+    3,
+    1,
+    4,
+};
 
 pub fn main() void {
     std.debug.print("{any}\n", .{_min_int(nums)});

--- a/tests/machine/x/zig/order_by_map.zig
+++ b/tests/machine/x/zig/order_by_map.zig
@@ -8,9 +8,43 @@ fn _print_list(comptime T: type, v: []const T) void {
     std.debug.print("\n", .{});
 }
 
-const data = (blk0: { const _tmp0 = struct { a: i32, b: i32, }; const _arr = &[_]_tmp0{_tmp0{ .a = 1, .b = 2 }, _tmp0{ .a = 1, .b = 1 }, _tmp0{ .a = 0, .b = 5 }}; break :blk0 _arr; });
-const sorted = blk1: { var _tmp1 = std.ArrayList(struct { item: struct { a: i32, b: i32, }, key: struct { a: i32, b: i32, } }).init(std.heap.page_allocator); for (data) |x| { _tmp1.append(.{ .item = x, .key = struct { a: i32, b: i32, }{ .a = x.a, .b = x.b } }) catch unreachable; } for (0.._tmp1.items.len) |i| { for (i+1.._tmp1.items.len) |j| { if (_tmp1.items[j].key < _tmp1.items[i].key) { const t = _tmp1.items[i]; _tmp1.items[i] = _tmp1.items[j]; _tmp1.items[j] = t; } } } var _tmp2 = std.ArrayList(struct { a: i32, b: i32, }).init(std.heap.page_allocator);for (_tmp1.items) |p| { _tmp2.append(p.item) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk1 _tmp3; };
+const data = (blk0: { const _tmp0 = struct {
+    a: i32,
+    b: i32,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .a = 1,
+    .b = 2,
+},
+    _tmp0{
+    .a = 1,
+    .b = 1,
+},
+    _tmp0{
+    .a = 0,
+    .b = 5,
+},
+}; break :blk0 _arr; });
+const sorted = blk1: { var _tmp1 = std.ArrayList(struct { item: struct {
+    a: i32,
+    b: i32,
+}, key: struct {
+    a: i32,
+    b: i32,
+} }).init(std.heap.page_allocator); for (data) |x| { _tmp1.append(.{ .item = x, .key = struct {
+    a: i32,
+    b: i32,
+}{
+    .a = x.a,
+    .b = x.b,
+} }) catch unreachable; } for (0.._tmp1.items.len) |i| { for (i+1.._tmp1.items.len) |j| { if (_tmp1.items[j].key < _tmp1.items[i].key) { const t = _tmp1.items[i]; _tmp1.items[i] = _tmp1.items[j]; _tmp1.items[j] = t; } } } var _tmp2 = std.ArrayList(struct {
+    a: i32,
+    b: i32,
+}).init(std.heap.page_allocator);for (_tmp1.items) |p| { _tmp2.append(p.item) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk1 _tmp3; };
 
 pub fn main() void {
-    _print_list(struct { a: i32, b: i32, }, sorted);
+    _print_list(struct {
+    a: i32,
+    b: i32,
+}, sorted);
 }

--- a/tests/machine/x/zig/outer_join.zig
+++ b/tests/machine/x/zig/outer_join.zig
@@ -1,8 +1,96 @@
 const std = @import("std");
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }, _tmp0{ .id = 3, .name = "Charlie" }, _tmp0{ .id = 4, .name = "Diana" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, total: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1, .total = 250 }, _tmp1{ .id = 101, .customerId = 2, .total = 125 }, _tmp1{ .id = 102, .customerId = 1, .total = 300 }, _tmp1{ .id = 103, .customerId = 5, .total = 80 }}; break :blk1 _arr; });
-const result = blk2: { var _tmp2 = std.ArrayList(struct { order: struct { id: i32, customerId: i32, total: i32, }, customer: struct { id: i32, name: []const u8, }, }).init(std.heap.page_allocator); var _tmp3 = std.AutoHashMap(usize, bool).init(std.heap.page_allocator); for (orders, 0..) |o, _i| { var c: ?struct { id: i32, name: []const u8, } = null; var mi: usize = 0; for (customers, 0..) |j, ji| { if (!((o.customerId == c.id))) continue; c = j; mi = ji; _tmp3.put(ji, true) catch {}; break; } _tmp2.append(struct { order: struct { id: i32, customerId: i32, total: i32, }, customer: struct { id: i32, name: []const u8, }, }{ .order = o, .customer = c }) catch unreachable; } for (customers, 0..) |j, ji| { if (!_tmp3.contains(ji)) { const o: ?struct { id: i32, customerId: i32, total: i32, } = null; c = j; _tmp2.append(struct { order: struct { id: i32, customerId: i32, total: i32, }, customer: struct { id: i32, name: []const u8, }, }{ .order = o, .customer = c }) catch unreachable; } } const res = _tmp2.toOwnedSlice() catch unreachable; break :blk2 res; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+    _tmp0{
+    .id = 3,
+    .name = "Charlie",
+},
+    _tmp0{
+    .id = 4,
+    .name = "Diana",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+    .total = 250,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 2,
+    .total = 125,
+},
+    _tmp1{
+    .id = 102,
+    .customerId = 1,
+    .total = 300,
+},
+    _tmp1{
+    .id = 103,
+    .customerId = 5,
+    .total = 80,
+},
+}; break :blk1 _arr; });
+const result = blk2: { var _tmp2 = std.ArrayList(struct {
+    order: struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+},
+    customer: struct {
+    id: i32,
+    name: []const u8,
+},
+}).init(std.heap.page_allocator); var _tmp3 = std.AutoHashMap(usize, bool).init(std.heap.page_allocator); for (orders, 0..) |o, _i| { var c: ?struct {
+    id: i32,
+    name: []const u8,
+} = null; var mi: usize = 0; for (customers, 0..) |j, ji| { if (!((o.customerId == c.id))) continue; c = j; mi = ji; _tmp3.put(ji, true) catch {}; break; } _tmp2.append(struct {
+    order: struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+},
+    customer: struct {
+    id: i32,
+    name: []const u8,
+},
+}{
+    .order = o,
+    .customer = c,
+}) catch unreachable; } for (customers, 0..) |j, ji| { if (!_tmp3.contains(ji)) { const o: ?struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+} = null; c = j; _tmp2.append(struct {
+    order: struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+},
+    customer: struct {
+    id: i32,
+    name: []const u8,
+},
+}{
+    .order = o,
+    .customer = c,
+}) catch unreachable; } } const res = _tmp2.toOwnedSlice() catch unreachable; break :blk2 res; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Outer Join using syntax ---"});

--- a/tests/machine/x/zig/query_sum_select.zig
+++ b/tests/machine/x/zig/query_sum_select.zig
@@ -6,7 +6,11 @@ fn _sum_int(v: []const i32) i32 {
     return sum;
 }
 
-const nums = &[_]i32{1, 2, 3};
+const nums = &[_]i32{
+    1,
+    2,
+    3,
+};
 const result = blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (nums) |n| { if (!((n > 1))) continue; _tmp0.append(_sum_int(n)) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
 
 pub fn main() void {

--- a/tests/machine/x/zig/right_join.zig
+++ b/tests/machine/x/zig/right_join.zig
@@ -1,8 +1,78 @@
 const std = @import("std");
 
-const customers = (blk0: { const _tmp0 = struct { id: i32, name: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .id = 1, .name = "Alice" }, _tmp0{ .id = 2, .name = "Bob" }, _tmp0{ .id = 3, .name = "Charlie" }, _tmp0{ .id = 4, .name = "Diana" }}; break :blk0 _arr; });
-const orders = (blk1: { const _tmp1 = struct { id: i32, customerId: i32, total: i32, }; const _arr = &[_]_tmp1{_tmp1{ .id = 100, .customerId = 1, .total = 250 }, _tmp1{ .id = 101, .customerId = 2, .total = 125 }, _tmp1{ .id = 102, .customerId = 1, .total = 300 }}; break :blk1 _arr; });
-const result = blk2: { var _tmp2 = std.ArrayList(struct { customerName: []const u8, order: struct { id: i32, customerId: i32, total: i32, }, }).init(std.heap.page_allocator); for (orders) |o| { var matched = false; for (customers) |c| { if (!((o.customerId == c.id))) continue; matched = true; _tmp2.append(struct { customerName: []const u8, order: struct { id: i32, customerId: i32, total: i32, }, }{ .customerName = c.name, .order = o }) catch unreachable; } if (!matched) { const c: ?struct { id: i32, name: []const u8, } = null; _tmp2.append(struct { customerName: []const u8, order: struct { id: i32, customerId: i32, total: i32, }, }{ .customerName = c.name, .order = o }) catch unreachable; } } const res = _tmp2.toOwnedSlice() catch unreachable; break :blk2 res; };
+const customers = (blk0: { const _tmp0 = struct {
+    id: i32,
+    name: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .id = 1,
+    .name = "Alice",
+},
+    _tmp0{
+    .id = 2,
+    .name = "Bob",
+},
+    _tmp0{
+    .id = 3,
+    .name = "Charlie",
+},
+    _tmp0{
+    .id = 4,
+    .name = "Diana",
+},
+}; break :blk0 _arr; });
+const orders = (blk1: { const _tmp1 = struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}; const _arr = &[_]_tmp1{
+    _tmp1{
+    .id = 100,
+    .customerId = 1,
+    .total = 250,
+},
+    _tmp1{
+    .id = 101,
+    .customerId = 2,
+    .total = 125,
+},
+    _tmp1{
+    .id = 102,
+    .customerId = 1,
+    .total = 300,
+},
+}; break :blk1 _arr; });
+const result = blk2: { var _tmp2 = std.ArrayList(struct {
+    customerName: []const u8,
+    order: struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+},
+}).init(std.heap.page_allocator); for (orders) |o| { var matched = false; for (customers) |c| { if (!((o.customerId == c.id))) continue; matched = true; _tmp2.append(struct {
+    customerName: []const u8,
+    order: struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+},
+}{
+    .customerName = c.name,
+    .order = o,
+}) catch unreachable; } if (!matched) { const c: ?struct {
+    id: i32,
+    name: []const u8,
+} = null; _tmp2.append(struct {
+    customerName: []const u8,
+    order: struct {
+    id: i32,
+    customerId: i32,
+    total: i32,
+},
+}{
+    .customerName = c.name,
+    .order = o,
+}) catch unreachable; } } const res = _tmp2.toOwnedSlice() catch unreachable; break :blk2 res; };
 
 pub fn main() void {
     std.debug.print("{s}\n", .{"--- Right Join using syntax ---"});

--- a/tests/machine/x/zig/save_jsonl_stdout.zig
+++ b/tests/machine/x/zig/save_jsonl_stdout.zig
@@ -28,7 +28,19 @@ fn _save_json(rows: anytype, path: ?[]const u8) void {
     _write_output(path, buf.items);
 }
 
-const people = (blk0: { const _tmp0 = struct { name: []const u8, age: i32, }; const _arr = &[_]_tmp0{_tmp0{ .name = "Alice", .age = 30 }, _tmp0{ .name = "Bob", .age = 25 }}; break :blk0 _arr; });
+const people = (blk0: { const _tmp0 = struct {
+    name: []const u8,
+    age: i32,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .name = "Alice",
+    .age = 30,
+},
+    _tmp0{
+    .name = "Bob",
+    .age = 25,
+},
+}; break :blk0 _arr; });
 
 pub fn main() void {
     _save_json(people, "-");

--- a/tests/machine/x/zig/slice.zig
+++ b/tests/machine/x/zig/slice.zig
@@ -51,7 +51,15 @@ fn _print_list(comptime T: type, v: []const T) void {
 }
 
 pub fn main() void {
-    _print_list(i32, _slice_list(i32, &[_]i32{1, 2, 3}, 1, 3, 1));
-    _print_list(i32, _slice_list(i32, &[_]i32{1, 2, 3}, 0, 2, 1));
+    _print_list(i32, _slice_list(i32, &[_]i32{
+    1,
+    2,
+    3,
+}, 1, 3, 1));
+    _print_list(i32, _slice_list(i32, &[_]i32{
+    1,
+    2,
+    3,
+}, 0, 2, 1));
     std.debug.print("{s}\n", .{_slice_string("hello", 1, 4, 1)});
 }

--- a/tests/machine/x/zig/sort_stable.zig
+++ b/tests/machine/x/zig/sort_stable.zig
@@ -8,7 +8,23 @@ fn _print_list(comptime T: type, v: []const T) void {
     std.debug.print("\n", .{});
 }
 
-const items = (blk0: { const _tmp0 = struct { n: i32, v: []const u8, }; const _arr = &[_]_tmp0{_tmp0{ .n = 1, .v = "a" }, _tmp0{ .n = 1, .v = "b" }, _tmp0{ .n = 2, .v = "c" }}; break :blk0 _arr; });
+const items = (blk0: { const _tmp0 = struct {
+    n: i32,
+    v: []const u8,
+}; const _arr = &[_]_tmp0{
+    _tmp0{
+    .n = 1,
+    .v = "a",
+},
+    _tmp0{
+    .n = 1,
+    .v = "b",
+},
+    _tmp0{
+    .n = 2,
+    .v = "c",
+},
+}; break :blk0 _arr; });
 const result = blk1: { var _tmp1 = std.ArrayList(struct { item: u8, key: i32 }).init(std.heap.page_allocator); for (items) |i| { _tmp1.append(.{ .item = i.v, .key = i.n }) catch unreachable; } for (0.._tmp1.items.len) |i| { for (i+1.._tmp1.items.len) |j| { if (_tmp1.items[j].key < _tmp1.items[i].key) { const t = _tmp1.items[i]; _tmp1.items[i] = _tmp1.items[j]; _tmp1.items[j] = t; } } } var _tmp2 = std.ArrayList(u8).init(std.heap.page_allocator);for (_tmp1.items) |p| { _tmp2.append(p.item) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk1 _tmp3; };
 
 pub fn main() void {

--- a/tests/machine/x/zig/sum_builtin.zig
+++ b/tests/machine/x/zig/sum_builtin.zig
@@ -7,5 +7,9 @@ fn _sum_int(v: []const i32) i32 {
 }
 
 pub fn main() void {
-    std.debug.print("{any}\n", .{_sum_int(&[_]i32{1, 2, 3})});
+    std.debug.print("{any}\n", .{_sum_int(&[_]i32{
+    1,
+    2,
+    3,
+})});
 }

--- a/tests/machine/x/zig/tree_sum.zig
+++ b/tests/machine/x/zig/tree_sum.zig
@@ -5,7 +5,15 @@ const Tree = union(enum) {
     Node: struct { left: *Tree, value: i32, right: *Tree },
 };
 
-const t = Tree{ .Node = .{ .left = &Tree{ .Leaf = {} }, .value = 1, .right = &Tree{ .Node = .{ .left = &Tree{ .Leaf = {} }, .value = 2, .right = &Tree{ .Leaf = {} } } } } };
+const t = Tree{ .Node = .{
+    .left = &Tree{ .Leaf = {} },
+    .value = 1,
+    .right = &Tree{ .Node = .{
+    .left = &Tree{ .Leaf = {} },
+    .value = 2,
+    .right = &Tree{ .Leaf = {} },
+} },
+} };
 
 fn sum_tree(t: *Tree) i32 {
     return switch (t.*) {.Leaf => 0, .Node => |_tmp0| ((sum_tree(&_tmp0.left) + _tmp0.value) + sum_tree(&_tmp0.right)), };

--- a/tests/machine/x/zig/two-sum.zig
+++ b/tests/machine/x/zig/two-sum.zig
@@ -1,17 +1,28 @@
 const std = @import("std");
 
-const result = twoSum(&[_]i32{2, 7, 11, 15}, 9);
+const result = twoSum(&[_]i32{
+    2,
+    7,
+    11,
+    15,
+}, 9);
 
 fn twoSum(nums: []const i32, target: i32) []const i32 {
     const n = (nums).len;
     for (0 .. n) |i| {
         for ((i + 1) .. n) |j| {
             if (((nums[i] + nums[j]) == target)) {
-                return [_]i32{i, j};
+                return [_]i32{
+    i,
+    j,
+};
             }
         }
     }
-    return [_]i32{-1, -1};
+    return [_]i32{
+    -1,
+    -1,
+};
 }
 
 pub fn main() void {

--- a/tests/machine/x/zig/update_stmt.zig
+++ b/tests/machine/x/zig/update_stmt.zig
@@ -10,10 +10,52 @@ const Person = struct {
     status: []const u8,
 };
 
-const people = &[_]Person{Person{ .name = "Alice", .age = 17, .status = "minor" }, Person{ .name = "Bob", .age = 25, .status = "unknown" }, Person{ .name = "Charlie", .age = 18, .status = "unknown" }, Person{ .name = "Diana", .age = 16, .status = "minor" }};
+const people = &[_]Person{
+    Person{
+    .name = "Alice",
+    .age = 17,
+    .status = "minor",
+},
+    Person{
+    .name = "Bob",
+    .age = 25,
+    .status = "unknown",
+},
+    Person{
+    .name = "Charlie",
+    .age = 18,
+    .status = "unknown",
+},
+    Person{
+    .name = "Diana",
+    .age = 16,
+    .status = "minor",
+},
+};
 
 fn test_update_adult_status() void {
-    expect((people == &[_]Person{Person{ .name = "Alice", .age = 17, .status = "minor" }, Person{ .name = "Bob", .age = 26, .status = "adult" }, Person{ .name = "Charlie", .age = 19, .status = "adult" }, Person{ .name = "Diana", .age = 16, .status = "minor" }}));
+    expect((people == &[_]Person{
+    Person{
+    .name = "Alice",
+    .age = 17,
+    .status = "minor",
+},
+    Person{
+    .name = "Bob",
+    .age = 26,
+    .status = "adult",
+},
+    Person{
+    .name = "Charlie",
+    .age = 19,
+    .status = "adult",
+},
+    Person{
+    .name = "Diana",
+    .age = 16,
+    .status = "minor",
+},
+}));
 }
 
 pub fn main() void {

--- a/tests/machine/x/zig/user_type_literal.zig
+++ b/tests/machine/x/zig/user_type_literal.zig
@@ -10,7 +10,13 @@ const Book = struct {
     author: Person,
 };
 
-const book = Book{ .title = "Go", .author = Person{ .name = "Bob", .age = 42 } };
+const book = Book{
+    .title = "Go",
+    .author = Person{
+    .name = "Bob",
+    .age = 42,
+},
+};
 
 pub fn main() void {
     std.debug.print("{s}\n", .{book.author.name});

--- a/tests/machine/x/zig/values_builtin.zig
+++ b/tests/machine/x/zig/values_builtin.zig
@@ -1,6 +1,14 @@
 const std = @import("std");
 
-const m = struct { a: i32, b: i32, c: i32, }{ .a = 1, .b = 2, .c = 3 };
+const m = struct {
+    a: i32,
+    b: i32,
+    c: i32,
+}{
+    .a = 1,
+    .b = 2,
+    .c = 3,
+};
 
 pub fn main() void {
     std.debug.print("{any}\n", .{values(m)});


### PR DESCRIPTION
## Summary
- improve struct and list literal formatting in the Zig backend
- support multi-line anonymous structs in helpers
- regenerate machine Zig outputs
- mark TODO as complete in zig README

## Testing
- `go test ./...`
- `go run -tags slow scripts/compile_zig.go`

------
https://chatgpt.com/codex/tasks/task_e_686f29424684832088300dac9f9445a8