### PR TITLE
Regenerate Fortran machine results

### DIFF
--- a/tests/machine/x/fortran/cast_struct.error
+++ b/tests/machine/x/fortran/cast_struct.error
@@ -1,0 +1,20 @@
+error: gfortran: exit status 1
+/workspace/mochi/tests/machine/x/fortran/cast_struct.f90:6:20:
+
+    3 |   type :: Todo
+      |              2      
+......
+    6 |   type(Todo) :: todo
+      |                    1
+Error: Symbol ‘todo’ at (1) also declared as a type at (2)
+/workspace/mochi/tests/machine/x/fortran/cast_struct.f90:7:7:
+
+    7 |   todo%title = 'hi'
+      |       1
+Error: Derived type ‘todo’ cannot be used as a variable at (1)
+/workspace/mochi/tests/machine/x/fortran/cast_struct.f90:8:21:
+
+    8 |   print *, trim(todo%title)
+      |                     1
+Error: Function ‘todo’ requires an argument list at (1)
+

--- a/tests/machine/x/fortran/group_by_multi_join.error
+++ b/tests/machine/x/fortran/group_by_multi_join.error
@@ -1,0 +1,45 @@
+error: gfortran: exit status 1
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:19:31:
+
+   11 |   type :: PartSupp
+      |                  2             
+......
+   19 |   type(PartSupp) :: partsupp(3)
+      |                               1
+Error: Symbol ‘partsupp’ at (1) also declared as a type at (2)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:37:22:
+
+   37 |       if (partsupp(i)%supplier == suppliers(j)%id) then
+      |                      1
+Error: The leftmost part-ref in a data-ref cannot be a function reference at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:40:28:
+
+   40 |             if (partsupp(i)%part == 100) total100 = total100 + partsupp(i)%cost*partsupp(i)%qty
+      |                            1
+Error: The leftmost part-ref in a data-ref cannot be a function reference at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:41:28:
+
+   41 |             if (partsupp(i)%part == 200) total200 = total200 + partsupp(i)%cost*partsupp(i)%qty
+      |                            1
+Error: The leftmost part-ref in a data-ref cannot be a function reference at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:44:9:
+
+   44 |       end if
+      |         1
+Error: Expecting END DO statement at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:29:3:
+
+   29 |   partsupp(1) = PartSupp(100,1,10.0,2)
+      |   1
+Error: No initializer for component ‘supplier’ given in the structure constructor at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:30:3:
+
+   30 |   partsupp(2) = PartSupp(100,2,20.0,1)
+      |   1
+Error: No initializer for component ‘supplier’ given in the structure constructor at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join.f90:31:3:
+
+   31 |   partsupp(3) = PartSupp(200,1,5.0,3)
+      |   1
+Error: No initializer for component ‘supplier’ given in the structure constructor at (1)
+

--- a/tests/machine/x/fortran/group_by_multi_join_sort.error
+++ b/tests/machine/x/fortran/group_by_multi_join_sort.error
@@ -1,0 +1,72 @@
+error: gfortran: exit status 1
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:28:27:
+
+    3 |   type :: Nation
+      |                2           
+......
+   28 |   type(Nation) :: nation(1)
+      |                           1
+Error: Symbol ‘nation’ at (1) also declared as a type at (2)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:29:31:
+
+    7 |   type :: Customer
+      |                  2             
+......
+   29 |   type(Customer) :: customer(1)
+      |                               1
+Error: Symbol ‘customer’ at (1) also declared as a type at (2)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:31:31:
+
+   21 |   type :: LineItem
+      |                  2             
+......
+   31 |   type(LineItem) :: lineitem(2)
+      |                               1
+Error: Symbol ‘lineitem’ at (1) also declared as a type at (2)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:42:18:
+
+   42 |   if (lineitem(1)%l_returnflag == 'R' .and. orders(1)%o_custkey == customer(1)%c_custkey) then
+      |                  1
+Error: The leftmost part-ref in a data-ref cannot be a function reference at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:43:26:
+
+   43 |     revenue = lineitem(1)%l_extendedprice * (1.0 - lineitem(1)%l_discount)
+      |                          1
+Error: The leftmost part-ref in a data-ref cannot be a function reference at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:44:5:
+
+   44 |   end if
+      |     1
+Error: Expecting END PROGRAM statement at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:46:132:
+
+   46 |   write(*,'("map[c_acctbal:100 c_address:123 St c_comment:Loyal c_custkey:1 c_name:Alice c_phone:123-456 n_name:BRAZIL revenue:",F0.0,"]")') revenue
+      |                                                                                                                                    1
+Error: Line truncated at (1) [-Werror=line-truncation]
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:46:11:
+
+   46 |   write(*,'("map[c_acctbal:100 c_address:123 St c_comment:Loyal c_custkey:1 c_name:Alice c_phone:123-456 n_name:BRAZIL revenue:",F0.0,"]")') revenue
+      |           1
+Error: Syntax error in WRITE statement at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:34:3:
+
+   34 |   nation(1) = Nation(1,'BRAZIL')
+      |   1
+Error: No initializer for component ‘n_name’ given in the structure constructor at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:35:3:
+
+   35 |   customer(1) = Customer(1,'Alice',100.0,'123 St','123-456','Loyal',1)
+      |   1
+Error: No initializer for component ‘c_name’ given in the structure constructor at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:38:3:
+
+   38 |   lineitem(1) = LineItem(1000,'R',1000.0,0.1)
+      |   1
+Error: No initializer for component ‘l_returnflag’ given in the structure constructor at (1)
+/workspace/mochi/tests/machine/x/fortran/group_by_multi_join_sort.f90:39:3:
+
+   39 |   lineitem(2) = LineItem(2000,'N',500.0,0.0)
+      |   1
+Error: No initializer for component ‘l_returnflag’ given in the structure constructor at (1)
+f951: some warnings being treated as errors
+

--- a/tests/machine/x/fortran/list_set_ops.error
+++ b/tests/machine/x/fortran/list_set_ops.error
@@ -1,0 +1,12 @@
+error: gfortran: exit status 1
+/workspace/mochi/tests/machine/x/fortran/list_set_ops.f90:32:11:
+
+   32 |     n = (/1,2,3/)(i)
+      |           1
+Error: Invalid character in name at (1)
+/workspace/mochi/tests/machine/x/fortran/list_set_ops.f90:44:11:
+
+   44 |     n = (/1,2,3/)(i)
+      |           1
+Error: Invalid character in name at (1)
+

--- a/tests/machine/x/fortran/match_full.error
+++ b/tests/machine/x/fortran/match_full.error
@@ -1,0 +1,47 @@
+error: gfortran: exit status 1
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:17:33:
+
+   17 |   character(len=3) :: day = 'sun'
+      |                                 1
+Error: Unexpected data declaration statement at (1)
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:18:27:
+
+   18 |   character(len=10) :: mood
+      |                           1
+Error: Unexpected data declaration statement at (1)
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:31:24:
+
+   31 |   logical :: ok = .true.
+      |                        1
+Error: Unexpected data declaration statement at (1)
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:32:29:
+
+   32 |   character(len=10) :: status
+      |                             1
+Error: Unexpected data declaration statement at (1)
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:19:18:
+
+   19 |   select case (day)
+      |                  1
+Error: Symbol ‘day’ at (1) has no IMPLICIT type
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:21:8:
+
+   21 |     mood = 'tired'
+      |        1
+Error: Symbol ‘mood’ at (1) has no IMPLICIT type
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:33:8:
+
+   33 |   if (ok) then
+      |        1
+Error: Symbol ‘ok’ at (1) has no IMPLICIT type
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:34:10:
+
+   34 |     status = 'confirmed'
+      |          1
+Error: Symbol ‘status’ at (1) has no IMPLICIT type
+/workspace/mochi/tests/machine/x/fortran/match_full.f90:19:15:
+
+   19 |   select case (day)
+      |               1
+Error: Argument of SELECT statement at (1) cannot be UNKNOWN
+

--- a/tests/machine/x/fortran/nested_function.error
+++ b/tests/machine/x/fortran/nested_function.error
@@ -1,0 +1,37 @@
+error: gfortran: exit status 1
+/workspace/mochi/tests/machine/x/fortran/nested_function.f90:9:10:
+
+    9 |   contains
+      |          1
+Error: CONTAINS statement at (1) is already in a contained program unit
+/workspace/mochi/tests/machine/x/fortran/nested_function.f90:11:30:
+
+   11 |       integer, intent(in) :: y
+      |                              1
+Error: Unexpected data declaration statement at (1)
+/workspace/mochi/tests/machine/x/fortran/nested_function.f90:12:26:
+
+   12 |       integer :: res_inner
+      |                          1
+Error: Unexpected data declaration statement at (1)
+/workspace/mochi/tests/machine/x/fortran/nested_function.f90:14:22:
+
+   14 |     end function inner
+      |                      1
+Error: Expected label ‘outer’ for END FUNCTION statement at (1)
+/workspace/mochi/tests/machine/x/fortran/nested_function.f90:13:15:
+
+   13 |       res_inner = x + y
+      |               1
+Error: Symbol ‘res_inner’ at (1) has no IMPLICIT type
+/workspace/mochi/tests/machine/x/fortran/nested_function.f90:13:23:
+
+   13 |       res_inner = x + y
+      |                       1
+Error: Symbol ‘y’ at (1) has no IMPLICIT type
+/workspace/mochi/tests/machine/x/fortran/nested_function.f90:8:10:
+
+    8 |     res = inner(5)
+      |          1
+Error: Function ‘inner’ at (1) has no IMPLICIT type
+

--- a/tests/machine/x/fortran/user_type_literal.error
+++ b/tests/machine/x/fortran/user_type_literal.error
@@ -1,0 +1,25 @@
+error: gfortran: exit status 1
+/workspace/mochi/tests/machine/x/fortran/user_type_literal.f90:11:20:
+
+    7 |   type :: Book
+      |              2      
+......
+   11 |   type(Book) :: book
+      |                    1
+Error: Symbol ‘book’ at (1) also declared as a type at (2)
+/workspace/mochi/tests/machine/x/fortran/user_type_literal.f90:13:7:
+
+   13 |   book%title = 'Go'
+      |       1
+Error: Derived type ‘book’ cannot be used as a variable at (1)
+/workspace/mochi/tests/machine/x/fortran/user_type_literal.f90:14:7:
+
+   14 |   book%author = Person('Bob', 42)
+      |       1
+Error: Derived type ‘book’ cannot be used as a variable at (1)
+/workspace/mochi/tests/machine/x/fortran/user_type_literal.f90:16:21:
+
+   16 |   print *, trim(book%author%name)
+      |                     1
+Error: Function ‘book’ requires an argument list at (1)
+


### PR DESCRIPTION
## Summary
- rerun the Fortran compiler tests
- capture compilation errors for a few programs

## Testing
- `go test ./compiler/x/fortran -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686f2ae05b4083208b78e7b3c9f066e2