### PR TITLE
Update Lua compiler test harness

### DIFF
--- a/compiler/x/lua/compiler_test.go
+++ b/compiler/x/lua/compiler_test.go
@@ -144,3 +144,37 @@ func TestLuaCompiler_ValidPrograms(t *testing.T) {
 		})
 	}
 }
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	updateReadme()
+	os.Exit(code)
+}
+
+func updateReadme() {
+	root := findRepoRoot(&testing.T{})
+	srcDir := filepath.Join(root, "tests", "vm", "valid")
+	outDir := filepath.Join(root, "tests", "machine", "x", "lua")
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	total := len(files)
+	compiled := 0
+	var lines []string
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		mark := "[ ]"
+		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+			compiled++
+			mark = "[x]"
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s", mark, name))
+	}
+	var buf bytes.Buffer
+	buf.WriteString("# Lua Machine Translations\n\n")
+	buf.WriteString("This directory stores Lua code generated from the Mochi programs in `tests/vm/valid`.\n")
+	buf.WriteString("Each program was compiled and executed using the Lua compiler. Successful runs produce a `.out` file, while failures have a `.error` file.\n\n")
+	fmt.Fprintf(&buf, "Compiled programs: %d/%d\n\n", compiled, total)
+	buf.WriteString("Checklist:\n")
+	buf.WriteString(strings.Join(lines, "\n"))
+	buf.WriteString("\n")
+	_ = os.WriteFile(filepath.Join(outDir, "README.md"), buf.Bytes(), 0o644)
+}

--- a/compiler/x/lua/helpers.go
+++ b/compiler/x/lua/helpers.go
@@ -147,6 +147,14 @@ func isString(t types.Type) bool { _, ok := t.(types.StringType); return ok }
 func isList(t types.Type) bool   { _, ok := t.(types.ListType); return ok }
 func isMap(t types.Type) bool    { _, ok := t.(types.MapType); return ok }
 func isAny(t types.Type) bool    { _, ok := t.(types.AnyType); return ok }
+func isNumber(t types.Type) bool {
+	switch t.(type) {
+	case types.IntType, types.Int64Type, types.FloatType:
+		return true
+	default:
+		return false
+	}
+}
 
 func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
 	return types.ResolveTypeRef(t, c.env)
@@ -180,6 +188,21 @@ func (c *Compiler) isMapUnary(u *parser.Unary) bool {
 func (c *Compiler) isMapPostfix(p *parser.PostfixExpr) bool {
 	_, ok := c.inferPostfixType(p).(types.MapType)
 	return ok
+}
+
+func (c *Compiler) isNumberExpr(e *parser.Expr) bool {
+	t := c.inferExprType(e)
+	return isNumber(t)
+}
+
+func (c *Compiler) isNumberUnary(u *parser.Unary) bool {
+	t := c.inferUnaryType(u)
+	return isNumber(t)
+}
+
+func (c *Compiler) isNumberPostfix(p *parser.PostfixExpr) bool {
+	t := c.inferPostfixType(p)
+	return isNumber(t)
 }
 
 // listLiteral returns the ListLiteral contained in e if e is a simple list

--- a/tests/machine/x/lua/README.md
+++ b/tests/machine/x/lua/README.md
@@ -5,13 +5,6 @@ Each program was compiled and executed using the Lua compiler. Successful runs p
 
 Compiled programs: 97/97
 
-The custom `__print` helper has been removed. Generated code now uses Lua's
-native `print` function directly. Lists passed to `print` are detected and
-printed element by element to match Mochi's output.
-
-Set `MOCHI_LUAC` to the path of the Lua bytecode compiler if `luac` is not on
-the PATH. The compiler uses this tool for a basic syntax check.
-
 Checklist:
 - [x] append_builtin
 - [x] avg_builtin
@@ -36,9 +29,14 @@ Checklist:
 - [x] fun_expr_in_let
 - [x] fun_three_args
 - [x] group_by
+- [x] group_by_conditional_sum
 - [x] group_by_having
 - [x] group_by_join
 - [x] group_by_left_join
+- [x] group_by_multi_join
+- [x] group_by_multi_join_sort
+- [x] group_by_sort
+- [x] group_items_iteration
 - [x] if_else
 - [x] if_then_else
 - [x] if_then_else_nested
@@ -56,6 +54,8 @@ Checklist:
 - [x] list_assign
 - [x] list_index
 - [x] list_nested_assign
+- [x] list_set_ops
+- [x] load_yaml
 - [x] map_assign
 - [x] map_in_operator
 - [x] map_index
@@ -69,6 +69,7 @@ Checklist:
 - [x] membership
 - [x] min_max_builtin
 - [x] nested_function
+- [x] order_by_map
 - [x] outer_join
 - [x] partial_application
 - [x] print_hello
@@ -79,6 +80,8 @@ Checklist:
 - [x] right_join
 - [x] save_jsonl_stdout
 - [x] short_circuit
+- [x] slice
+- [x] sort_stable
 - [x] str_builtin
 - [x] string_compare
 - [x] string_concat
@@ -90,6 +93,7 @@ Checklist:
 - [x] sum_builtin
 - [x] tail_recursion
 - [x] test_block
+- [x] tree_sum
 - [x] two-sum
 - [x] typed_let
 - [x] typed_var
@@ -99,17 +103,3 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-- [x] group_by_conditional_sum
-- [x] group_by_multi_join
-- [x] group_by_multi_join_sort
-- [x] group_by_sort
-- [x] group_items_iteration
-- [x] list_set_ops
-- [x] load_yaml
-- [x] order_by_map
-- [x] slice
-- [x] sort_stable
-- [x] tree_sum
-
-Remaining tasks:
-- [ ] None


### PR DESCRIPTION
## Summary
- add numeric type helper functions for Lua compiler
- auto-generate Lua machine README after running tests
- regenerate Lua machine README

## Testing
- `go test -tags slow ./compiler/x/lua -run TestLuaCompiler_ValidPrograms -count=1` *(fails: output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686f2af0505483209b705e6b22bb10ba