### PR TITLE
Regenerate PHP machine outputs

### DIFF
--- a/tests/machine/x/php/README.md
+++ b/tests/machine/x/php/README.md
@@ -3,7 +3,7 @@
 This directory stores PHP code produced by the compiler tests. Each Mochi program from `tests/vm/valid` is compiled and executed. On success a `.out` file is written. Failures generate a `.error` file.
 
 ## Summary
-97/97 files compiled successfully
+94/97 files compiled successfully
 
 ## Checklist
 - [x] append_builtin.mochi
@@ -29,10 +29,10 @@ This directory stores PHP code produced by the compiler tests. Each Mochi progra
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
 - [x] group_by.mochi
-- [x] group_by_conditional_sum.mochi
+- [ ] group_by_conditional_sum.mochi
 - [x] group_by_having.mochi
 - [x] group_by_join.mochi
-- [x] group_by_left_join.mochi
+- [ ] group_by_left_join.mochi
 - [x] group_by_multi_join.mochi
 - [x] group_by_multi_join_sort.mochi
 - [x] group_by_sort.mochi
@@ -75,7 +75,7 @@ This directory stores PHP code produced by the compiler tests. Each Mochi progra
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
-- [x] query_sum_select.mochi
+- [ ] query_sum_select.mochi
 - [x] record_assign.mochi
 - [x] right_join.mochi
 - [x] save_jsonl_stdout.mochi
@@ -103,3 +103,9 @@ This directory stores PHP code produced by the compiler tests. Each Mochi progra
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## TODO
+- [ ] Fix runtime warnings for cross join queries
+- [ ] Implement group_by_conditional_sum
+- [ ] Implement group_by_left_join
+- [ ] Implement query_sum_select

--- a/tests/machine/x/php/cross_join.out
+++ b/tests/machine/x/php/cross_join.out
@@ -1,3 +1,145 @@
-PHP Warning:  Undefined variable $orders in /workspace/mochi/tests/machine/x/php/cross_join.php on line 6
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/cross_join.php on line 6
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 8
 string(44) "--- Cross Join: All order-customer pairs ---"
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderCustomerId" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "orderTotal" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+PHP Warning:  Attempt to read property "pairedCustomerName" on array in /workspace/mochi/tests/machine/x/php/cross_join.php on line 15
+string(5) "Order"
+NULL
+string(12) "(customerId:"
+NULL
+string(10) ", total: $"
+NULL
+string(13) ") paired with"
+NULL

--- a/tests/machine/x/php/cross_join.php
+++ b/tests/machine/x/php/cross_join.php
@@ -1,7 +1,7 @@
 <?php
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"], ["id" => 3, "name" => "Charlie"]];
 $orders = [["id" => 100, "customerId" => 1, "total" => 250], ["id" => 101, "customerId" => 2, "total" => 125], ["id" => 102, "customerId" => 1, "total" => 300]];
-$result = (function() {
+$result = (function() use ($customers, $orders) {
     $result = [];
     foreach ($orders as $o) {
         foreach ($customers as $c) {

--- a/tests/machine/x/php/cross_join_filter.out
+++ b/tests/machine/x/php/cross_join_filter.out
@@ -1,3 +1,9 @@
-PHP Warning:  Undefined variable $nums in /workspace/mochi/tests/machine/x/php/cross_join_filter.php on line 6
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/cross_join_filter.php on line 6
 string(18) "--- Even pairs ---"
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_filter.php on line 17
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_filter.php on line 17
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_filter.php on line 17
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_filter.php on line 17
+NULL
+NULL

--- a/tests/machine/x/php/cross_join_filter.php
+++ b/tests/machine/x/php/cross_join_filter.php
@@ -1,7 +1,7 @@
 <?php
 $nums = [1, 2, 3];
 $letters = ["A", "B"];
-$pairs = (function() {
+$pairs = (function() use ($letters, $nums) {
     $result = [];
     foreach ($nums as $n) {
         foreach ($letters as $l) {

--- a/tests/machine/x/php/cross_join_triple.out
+++ b/tests/machine/x/php/cross_join_triple.out
@@ -1,3 +1,49 @@
-PHP Warning:  Undefined variable $nums in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 7
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 7
 string(33) "--- Cross Join of three lists ---"
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "l" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/cross_join_triple.php on line 18
+NULL
+NULL
+NULL

--- a/tests/machine/x/php/cross_join_triple.php
+++ b/tests/machine/x/php/cross_join_triple.php
@@ -2,7 +2,7 @@
 $nums = [1, 2];
 $letters = ["A", "B"];
 $bools = [true, false];
-$combos = (function() {
+$combos = (function() use ($bools, $letters, $nums) {
     $result = [];
     foreach ($nums as $n) {
         foreach ($letters as $l) {

--- a/tests/machine/x/php/dataset_sort_take_limit.out
+++ b/tests/machine/x/php/dataset_sort_take_limit.out
@@ -1,3 +1,23 @@
-PHP Warning:  Undefined variable $products in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 5
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 6
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 6
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 6
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 6
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 6
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 6
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 6
 string(47) "--- Top products (excluding most expensive) ---"
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 15
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 15
+NULL
+string(7) "costs $"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 15
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 15
+NULL
+string(7) "costs $"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 15
+PHP Warning:  Attempt to read property "price" on array in /workspace/mochi/tests/machine/x/php/dataset_sort_take_limit.php on line 15
+NULL
+string(7) "costs $"
+NULL

--- a/tests/machine/x/php/dataset_sort_take_limit.php
+++ b/tests/machine/x/php/dataset_sort_take_limit.php
@@ -1,6 +1,6 @@
 <?php
 $products = [["name" => "Laptop", "price" => 1500], ["name" => "Smartphone", "price" => 900], ["name" => "Tablet", "price" => 600], ["name" => "Monitor", "price" => 300], ["name" => "Keyboard", "price" => 100], ["name" => "Mouse", "price" => 50], ["name" => "Headphones", "price" => 200]];
-$expensive = (function() {
+$expensive = (function() use ($products) {
     $result = [];
     foreach ($products as $p) {
         $result[] = [-$p->price, $p];

--- a/tests/machine/x/php/dataset_where_filter.out
+++ b/tests/machine/x/php/dataset_where_filter.out
@@ -1,3 +1,5 @@
-PHP Warning:  Undefined variable $people in /workspace/mochi/tests/machine/x/php/dataset_where_filter.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/dataset_where_filter.php on line 5
+PHP Warning:  Attempt to read property "age" on array in /workspace/mochi/tests/machine/x/php/dataset_where_filter.php on line 6
+PHP Warning:  Attempt to read property "age" on array in /workspace/mochi/tests/machine/x/php/dataset_where_filter.php on line 6
+PHP Warning:  Attempt to read property "age" on array in /workspace/mochi/tests/machine/x/php/dataset_where_filter.php on line 6
+PHP Warning:  Attempt to read property "age" on array in /workspace/mochi/tests/machine/x/php/dataset_where_filter.php on line 6
 string(14) "--- Adults ---"

--- a/tests/machine/x/php/dataset_where_filter.php
+++ b/tests/machine/x/php/dataset_where_filter.php
@@ -1,6 +1,6 @@
 <?php
 $people = [["name" => "Alice", "age" => 30], ["name" => "Bob", "age" => 15], ["name" => "Charlie", "age" => 65], ["name" => "Diana", "age" => 45]];
-$adults = (function() {
+$adults = (function() use ($people) {
     $result = [];
     foreach ($people as $person) {
         if ($person->age >= 18) {

--- a/tests/machine/x/php/exists_builtin.out
+++ b/tests/machine/x/php/exists_builtin.out
@@ -1,3 +1,1 @@
-PHP Warning:  Undefined variable $data in /workspace/mochi/tests/machine/x/php/exists_builtin.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/exists_builtin.php on line 5
-bool(false)
+bool(true)

--- a/tests/machine/x/php/exists_builtin.php
+++ b/tests/machine/x/php/exists_builtin.php
@@ -1,6 +1,6 @@
 <?php
 $data = [1, 2];
-$flag = count((function() {
+$flag = count((function() use ($data) {
     $result = [];
     foreach ($data as $x) {
         if ($x == 1) {

--- a/tests/machine/x/php/group_by.out
+++ b/tests/machine/x/php/group_by.out
@@ -1,3 +1,18 @@
-PHP Warning:  Undefined variable $people in /workspace/mochi/tests/machine/x/php/group_by.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by.php on line 5
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 6
+PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 12
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by.php on line 14
 string(30) "--- People grouped by city ---"
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 36
+PHP Warning:  Attempt to read property "count" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 36
+PHP Warning:  Attempt to read property "avg_age" on array in /workspace/mochi/tests/machine/x/php/group_by.php on line 36
+NULL
+string(9) ": count ="
+NULL
+string(11) ", avg_age ="
+NULL

--- a/tests/machine/x/php/group_by.php
+++ b/tests/machine/x/php/group_by.php
@@ -1,6 +1,6 @@
 <?php
 $people = [["name" => "Alice", "age" => 30, "city" => "Paris"], ["name" => "Bob", "age" => 15, "city" => "Hanoi"], ["name" => "Charlie", "age" => 65, "city" => "Paris"], ["name" => "Diana", "age" => 45, "city" => "Hanoi"], ["name" => "Eve", "age" => 70, "city" => "Paris"], ["name" => "Frank", "age" => 22, "city" => "Hanoi"]];
-$stats = (function() {
+$stats = (function() use ($people) {
     $groups = [];
     foreach ($people as $person) {
         $_k = json_encode($person->city);

--- a/tests/machine/x/php/group_by_conditional_sum.error
+++ b/tests/machine/x/php/group_by_conditional_sum.error
@@ -1,0 +1,14 @@
+PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 6
+PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 6
+PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 6
+PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 12
+PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 12
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 14
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 20
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 20
+PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php:24
+Stack trace:
+#0 /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php(29): {closure}()
+#1 {main}
+  thrown in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 24

--- a/tests/machine/x/php/group_by_conditional_sum.out
+++ b/tests/machine/x/php/group_by_conditional_sum.out
@@ -1,4 +1,0 @@
-PHP Warning:  Undefined variable $items in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 5
-array(0) {
-}

--- a/tests/machine/x/php/group_by_conditional_sum.php
+++ b/tests/machine/x/php/group_by_conditional_sum.php
@@ -1,6 +1,6 @@
 <?php
 $items = [["cat" => "a", "val" => 10, "flag" => true], ["cat" => "a", "val" => 5, "flag" => false], ["cat" => "b", "val" => 20, "flag" => true]];
-$result = (function() {
+$result = (function() use ($items) {
     $groups = [];
     foreach ($items as $i) {
         $_k = json_encode($i->cat);

--- a/tests/machine/x/php/group_by_having.out
+++ b/tests/machine/x/php/group_by_having.out
@@ -1,2 +1,8 @@
-PHP Warning:  Undefined variable $people in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 5
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 6
+PHP Warning:  Attempt to read property "city" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 6
+PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by_having.php on line 13

--- a/tests/machine/x/php/group_by_having.php
+++ b/tests/machine/x/php/group_by_having.php
@@ -1,6 +1,6 @@
 <?php
 $people = [["name" => "Alice", "city" => "Paris"], ["name" => "Bob", "city" => "Hanoi"], ["name" => "Charlie", "city" => "Paris"], ["name" => "Diana", "city" => "Hanoi"], ["name" => "Eve", "city" => "Paris"], ["name" => "Frank", "city" => "Hanoi"], ["name" => "George", "city" => "Paris"]];
-$big = (function() {
+$big = (function() use ($people) {
     $groups = [];
     foreach ($people as $p) {
         $_k = json_encode($p->city);

--- a/tests/machine/x/php/group_by_join.out
+++ b/tests/machine/x/php/group_by_join.out
@@ -1,3 +1,25 @@
-PHP Warning:  Undefined variable $orders in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 6
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 6
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 8
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 9
+PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 17
 string(27) "--- Orders per customer ---"
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 23
+PHP Warning:  Attempt to read property "count" on array in /workspace/mochi/tests/machine/x/php/group_by_join.php on line 23
+NULL
+string(7) "orders:"
+NULL

--- a/tests/machine/x/php/group_by_join.php
+++ b/tests/machine/x/php/group_by_join.php
@@ -1,7 +1,7 @@
 <?php
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"]];
 $orders = [["id" => 100, "customerId" => 1], ["id" => 101, "customerId" => 1], ["id" => 102, "customerId" => 2]];
-$stats = (function() {
+$stats = (function() use ($customers, $orders) {
     $groups = [];
     foreach ($orders as $o) {
         foreach ($customers as $c) {

--- a/tests/machine/x/php/group_by_left_join.error
+++ b/tests/machine/x/php/group_by_left_join.error
@@ -1,0 +1,60 @@
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Attempt to read property "key" on null in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 7
+PHP Fatal error:  Uncaught Error: Unknown named parameter $name in /workspace/mochi/tests/machine/x/php/group_by_left_join.php:38
+Stack trace:
+#0 /workspace/mochi/tests/machine/x/php/group_by_left_join.php(14): _group_by()
+#1 /workspace/mochi/tests/machine/x/php/group_by_left_join.php(29): {closure}()
+#2 {main}
+  thrown in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 38

--- a/tests/machine/x/php/group_by_left_join.out
+++ b/tests/machine/x/php/group_by_left_join.out
@@ -1,4 +1,0 @@
-PHP Warning:  Undefined variable $customers in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
-PHP Warning:  Undefined variable $orders in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 49
-string(23) "--- Group Left Join ---"

--- a/tests/machine/x/php/group_by_left_join.php
+++ b/tests/machine/x/php/group_by_left_join.php
@@ -1,8 +1,8 @@
 <?php
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"], ["id" => 3, "name" => "Charlie"]];
 $orders = [["id" => 100, "customerId" => 1], ["id" => 101, "customerId" => 1], ["id" => 102, "customerId" => 2]];
-$stats = (function() {
-    $_rows = _query($customers, [['items'=>$orders, 'on'=>function($c, $o){return $o->customerId == $c->id;}, 'left'=>true]], [ 'select' => function($c, $o){return ["name" => $g->key, "count" => count((function() {
+$stats = (function() use ($customers, $orders) {
+    $_rows = _query($customers, [['items'=>$orders, 'on'=>function($c, $o) use ($customers, $orders){return $o->customerId == $c->id;}, 'left'=>true]], [ 'select' => function($c, $o) use ($customers, $orders){return ["name" => $g->key, "count" => count((function() {
     $result = [];
     foreach ($g as $r) {
         if ($r->o) {
@@ -11,11 +11,11 @@ $stats = (function() {
     }
     return $result;
 })())];} ]);
-    $_groups = _group_by($_rows, function($c, $o){return $c->name;});
+    $_groups = _group_by($_rows, function($c, $o) use ($customers, $orders){return $c->name;});
     $result = [];
     foreach ($_groups as $__g) {
         $g = $__g;
-        $result[] = ["name" => $g->key, "count" => count((function() {
+        $result[] = ["name" => $g->key, "count" => count((function() use ($g) {
     $result = [];
     foreach ($g as $r) {
         if ($r->o) {

--- a/tests/machine/x/php/group_by_multi_join.out
+++ b/tests/machine/x/php/group_by_multi_join.out
@@ -1,6 +1,50 @@
-PHP Warning:  Undefined variable $partsupp in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 7
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 7
-PHP Warning:  Undefined variable $filtered in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 24
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 24
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "supplier" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "supplier" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "supplier" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "supplier" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "supplier" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "supplier" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "nation" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join.php on line 12
 array(0) {
 }

--- a/tests/machine/x/php/group_by_multi_join.php
+++ b/tests/machine/x/php/group_by_multi_join.php
@@ -2,7 +2,7 @@
 $nations = [["id" => 1, "name" => "A"], ["id" => 2, "name" => "B"]];
 $suppliers = [["id" => 1, "nation" => 1], ["id" => 2, "nation" => 2]];
 $partsupp = [["part" => 100, "supplier" => 1, "cost" => 10, "qty" => 2], ["part" => 100, "supplier" => 2, "cost" => 20, "qty" => 1], ["part" => 200, "supplier" => 1, "cost" => 5, "qty" => 3]];
-$filtered = (function() {
+$filtered = (function() use ($nations, $partsupp, $suppliers) {
     $result = [];
     foreach ($partsupp as $ps) {
         foreach ($suppliers as $s) {
@@ -19,7 +19,7 @@ $filtered = (function() {
     }
     return $result;
 })();
-$grouped = (function() {
+$grouped = (function() use ($filtered) {
     $groups = [];
     foreach ($filtered as $x) {
         $_k = json_encode($x->part);

--- a/tests/machine/x/php/group_by_multi_join_sort.out
+++ b/tests/machine/x/php/group_by_multi_join_sort.out
@@ -1,4 +1,26 @@
-PHP Warning:  Undefined variable $customer in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 10
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 10
+PHP Warning:  Attempt to read property "o_custkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 12
+PHP Warning:  Attempt to read property "c_custkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 12
+PHP Warning:  Attempt to read property "l_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "o_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "n_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "c_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "o_orderdate" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 17
+PHP Warning:  Attempt to read property "l_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "o_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "n_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "c_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "o_orderdate" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 17
+PHP Warning:  Attempt to read property "o_custkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 12
+PHP Warning:  Attempt to read property "c_custkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 12
+PHP Warning:  Attempt to read property "l_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "o_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "n_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "c_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "o_orderdate" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 17
+PHP Warning:  Attempt to read property "l_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "o_orderkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 14
+PHP Warning:  Attempt to read property "n_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "c_nationkey" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 16
+PHP Warning:  Attempt to read property "o_orderdate" on array in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 17
 array(0) {
 }

--- a/tests/machine/x/php/group_by_multi_join_sort.php
+++ b/tests/machine/x/php/group_by_multi_join_sort.php
@@ -5,7 +5,7 @@ $orders = [["o_orderkey" => 1000, "o_custkey" => 1, "o_orderdate" => "1993-10-15
 $lineitem = [["l_orderkey" => 1000, "l_returnflag" => "R", "l_extendedprice" => 1000, "l_discount" => 0.1], ["l_orderkey" => 2000, "l_returnflag" => "N", "l_extendedprice" => 500, "l_discount" => 0]];
 $start_date = "1993-10-01";
 $end_date = "1994-01-01";
-$result = (function() {
+$result = (function() use ($customer, $end_date, $lineitem, $nation, $orders, $start_date) {
     $groups = [];
     foreach ($customer as $c) {
         foreach ($orders as $o) {

--- a/tests/machine/x/php/group_by_sort.out
+++ b/tests/machine/x/php/group_by_sort.out
@@ -1,4 +1,18 @@
-PHP Warning:  Undefined variable $items in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 5
-array(0) {
+PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 6
+PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 6
+PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 6
+PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 6
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 14
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 14
+PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 18
+PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 20
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_sort.php on line 20
+array(1) {
+  [0]=>
+  array(2) {
+    ["cat"]=>
+    NULL
+    ["total"]=>
+    int(0)
+  }
 }

--- a/tests/machine/x/php/group_by_sort.php
+++ b/tests/machine/x/php/group_by_sort.php
@@ -1,6 +1,6 @@
 <?php
 $items = [["cat" => "a", "val" => 3], ["cat" => "a", "val" => 1], ["cat" => "b", "val" => 5], ["cat" => "b", "val" => 2]];
-$grouped = (function() {
+$grouped = (function() use ($items) {
     $groups = [];
     foreach ($items as $i) {
         $_k = json_encode($i->cat);

--- a/tests/machine/x/php/group_items_iteration.out
+++ b/tests/machine/x/php/group_items_iteration.out
@@ -1,6 +1,16 @@
-PHP Warning:  Undefined variable $data in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 5
-PHP Warning:  Undefined variable $tmp in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 26
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 26
-array(0) {
+PHP Warning:  Attempt to read property "tag" on array in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 6
+PHP Warning:  Attempt to read property "tag" on array in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 6
+PHP Warning:  Attempt to read property "tag" on array in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 6
+PHP Warning:  Attempt to read property "items" on array in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 19
+PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 19
+PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 22
+PHP Warning:  Attempt to read property "tag" on array in /workspace/mochi/tests/machine/x/php/group_items_iteration.php on line 27
+array(1) {
+  [0]=>
+  array(2) {
+    ["tag"]=>
+    NULL
+    ["total"]=>
+    int(0)
+  }
 }

--- a/tests/machine/x/php/group_items_iteration.php
+++ b/tests/machine/x/php/group_items_iteration.php
@@ -1,6 +1,6 @@
 <?php
 $data = [["tag" => "a", "val" => 1], ["tag" => "a", "val" => 2], ["tag" => "b", "val" => 3]];
-$groups = (function() {
+$groups = (function() use ($data) {
     $groups = [];
     foreach ($data as $d) {
         $_k = json_encode($d->tag);
@@ -21,7 +21,7 @@ foreach ($groups as $g) {
     }
     $tmp = array_merge($tmp, [["tag" => $g->key, "total" => $total]]);
 }
-$result = (function() {
+$result = (function() use ($tmp) {
     $result = [];
     foreach ($tmp as $r) {
         $result[] = [$r->tag, $r];

--- a/tests/machine/x/php/in_operator_extended.out
+++ b/tests/machine/x/php/in_operator_extended.out
@@ -1,6 +1,4 @@
-PHP Warning:  Undefined variable $xs in /workspace/mochi/tests/machine/x/php/in_operator_extended.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/in_operator_extended.php on line 5
-bool(false)
+bool(true)
 bool(false)
 bool(true)
 bool(false)

--- a/tests/machine/x/php/in_operator_extended.php
+++ b/tests/machine/x/php/in_operator_extended.php
@@ -1,6 +1,6 @@
 <?php
 $xs = [1, 2, 3];
-$ys = (function() {
+$ys = (function() use ($xs) {
     $result = [];
     foreach ($xs as $x) {
         if ($x % 2 == 1) {

--- a/tests/machine/x/php/inner_join.out
+++ b/tests/machine/x/php/inner_join.out
@@ -1,3 +1,169 @@
-PHP Warning:  Undefined variable $orders in /workspace/mochi/tests/machine/x/php/inner_join.php on line 6
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/inner_join.php on line 6
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 8
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 9
 string(33) "--- Orders with customer info ---"
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "customerName" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+PHP Warning:  Attempt to read property "total" on array in /workspace/mochi/tests/machine/x/php/inner_join.php on line 17
+string(5) "Order"
+NULL
+string(2) "by"
+NULL
+string(3) "- $"
+NULL

--- a/tests/machine/x/php/inner_join.php
+++ b/tests/machine/x/php/inner_join.php
@@ -1,7 +1,7 @@
 <?php
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"], ["id" => 3, "name" => "Charlie"]];
 $orders = [["id" => 100, "customerId" => 1, "total" => 250], ["id" => 101, "customerId" => 2, "total" => 125], ["id" => 102, "customerId" => 1, "total" => 300], ["id" => 103, "customerId" => 4, "total" => 80]];
-$result = (function() {
+$result = (function() use ($customers, $orders) {
     $result = [];
     foreach ($orders as $o) {
         foreach ($customers as $c) {

--- a/tests/machine/x/php/join_multi.out
+++ b/tests/machine/x/php/join_multi.out
@@ -1,3 +1,81 @@
-PHP Warning:  Undefined variable $orders in /workspace/mochi/tests/machine/x/php/join_multi.php on line 7
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/join_multi.php on line 7
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "customerId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 9
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "id" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "orderId" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 11
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 12
 string(18) "--- Multi Join ---"
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL
+PHP Warning:  Attempt to read property "name" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+PHP Warning:  Attempt to read property "sku" on array in /workspace/mochi/tests/machine/x/php/join_multi.php on line 22
+NULL
+string(11) "bought item"
+NULL

--- a/tests/machine/x/php/join_multi.php
+++ b/tests/machine/x/php/join_multi.php
@@ -2,7 +2,7 @@
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"]];
 $orders = [["id" => 100, "customerId" => 1], ["id" => 101, "customerId" => 2]];
 $items = [["orderId" => 100, "sku" => "a"], ["orderId" => 101, "sku" => "b"]];
-$result = (function() {
+$result = (function() use ($customers, $items, $orders) {
     $result = [];
     foreach ($orders as $o) {
         foreach ($customers as $c) {

--- a/tests/machine/x/php/left_join.php
+++ b/tests/machine/x/php/left_join.php
@@ -1,7 +1,7 @@
 <?php
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"]];
 $orders = [["id" => 100, "customerId" => 1, "total" => 250], ["id" => 101, "customerId" => 3, "total" => 80]];
-$result = _query($orders, [['items'=>$customers, 'on'=>function($o, $c){return $o->customerId == $c->id;}, 'left'=>true]], [ 'select' => function($o, $c){return ["orderId" => $o->id, "customer" => $c, "total" => $o->total];} ]);
+$result = _query($orders, [['items'=>$customers, 'on'=>function($o, $c) use ($customers, $orders){return $o->customerId == $c->id;}, 'left'=>true]], [ 'select' => function($o, $c) use ($customers, $orders){return ["orderId" => $o->id, "customer" => $c, "total" => $o->total];} ]);
 var_dump("--- Left Join ---");
 foreach ($result as $entry) {
     var_dump("Order", $entry->orderId, "customer", $entry->customer, "total", $entry->total);

--- a/tests/machine/x/php/left_join_multi.php
+++ b/tests/machine/x/php/left_join_multi.php
@@ -2,7 +2,7 @@
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"]];
 $orders = [["id" => 100, "customerId" => 1], ["id" => 101, "customerId" => 2]];
 $items = [["orderId" => 100, "sku" => "a"]];
-$result = _query($orders, [['items'=>$customers, 'on'=>function($o, $c){return $o->customerId == $c->id;}], ['items'=>$items, 'on'=>function($o, $c, $i){return $o->id == $i->orderId;}, 'left'=>true]], [ 'select' => function($o, $c, $i){return ["orderId" => $o->id, "name" => $c->name, "item" => $i];} ]);
+$result = _query($orders, [['items'=>$customers, 'on'=>function($o, $c) use ($customers, $items, $orders){return $o->customerId == $c->id;}], ['items'=>$items, 'on'=>function($o, $c, $i) use ($customers, $items, $orders){return $o->id == $i->orderId;}, 'left'=>true]], [ 'select' => function($o, $c, $i) use ($customers, $items, $orders){return ["orderId" => $o->id, "name" => $c->name, "item" => $i];} ]);
 var_dump("--- Left Join Multi ---");
 foreach ($result as $r) {
     var_dump($r->orderId, $r->name, $r->item);

--- a/tests/machine/x/php/load_yaml.out
+++ b/tests/machine/x/php/load_yaml.out
@@ -1,4 +1,2 @@
 PHP Warning:  file(/workspace/mochi/tests/machine/x/php/../interpreter/valid/people.yaml): Failed to open stream: No such file or directory in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 33
 PHP Warning:  foreach() argument must be of type array|object, false given in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 36
-PHP Warning:  Undefined variable $people in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 15
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 15

--- a/tests/machine/x/php/load_yaml.php
+++ b/tests/machine/x/php/load_yaml.php
@@ -10,7 +10,7 @@ class Person {
     }
 }
 $people = array_map(fn($it) => new Person($it), _load("../interpreter/valid/people.yaml", ["format" => "yaml"]));
-$adults = (function() {
+$adults = (function() use ($people) {
     $result = [];
     foreach ($people as $p) {
         if ($p->age >= 18) {

--- a/tests/machine/x/php/order_by_map.out
+++ b/tests/machine/x/php/order_by_map.out
@@ -1,4 +1,29 @@
-PHP Warning:  Undefined variable $data in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 5
-array(0) {
+PHP Warning:  Attempt to read property "a" on array in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 6
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 6
+PHP Warning:  Attempt to read property "a" on array in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 6
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 6
+PHP Warning:  Attempt to read property "a" on array in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 6
+PHP Warning:  Attempt to read property "b" on array in /workspace/mochi/tests/machine/x/php/order_by_map.php on line 6
+array(3) {
+  [0]=>
+  array(2) {
+    ["a"]=>
+    int(1)
+    ["b"]=>
+    int(2)
+  }
+  [1]=>
+  array(2) {
+    ["a"]=>
+    int(1)
+    ["b"]=>
+    int(1)
+  }
+  [2]=>
+  array(2) {
+    ["a"]=>
+    int(0)
+    ["b"]=>
+    int(5)
+  }
 }

--- a/tests/machine/x/php/order_by_map.php
+++ b/tests/machine/x/php/order_by_map.php
@@ -1,6 +1,6 @@
 <?php
 $data = [["a" => 1, "b" => 2], ["a" => 1, "b" => 1], ["a" => 0, "b" => 5]];
-$sorted = (function() {
+$sorted = (function() use ($data) {
     $result = [];
     foreach ($data as $x) {
         $result[] = [["a" => $x->a, "b" => $x->b], $x];

--- a/tests/machine/x/php/outer_join.php
+++ b/tests/machine/x/php/outer_join.php
@@ -1,7 +1,7 @@
 <?php
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"], ["id" => 3, "name" => "Charlie"], ["id" => 4, "name" => "Diana"]];
 $orders = [["id" => 100, "customerId" => 1, "total" => 250], ["id" => 101, "customerId" => 2, "total" => 125], ["id" => 102, "customerId" => 1, "total" => 300], ["id" => 103, "customerId" => 5, "total" => 80]];
-$result = _query($orders, [['items'=>$customers, 'on'=>function($o, $c){return $o->customerId == $c->id;}, 'left'=>true, 'right'=>true]], [ 'select' => function($o, $c){return ["order" => $o, "customer" => $c];} ]);
+$result = _query($orders, [['items'=>$customers, 'on'=>function($o, $c) use ($customers, $orders){return $o->customerId == $c->id;}, 'left'=>true, 'right'=>true]], [ 'select' => function($o, $c) use ($customers, $orders){return ["order" => $o, "customer" => $c];} ]);
 var_dump("--- Outer Join using syntax ---");
 foreach ($result as $row) {
     if ($row->order) {

--- a/tests/machine/x/php/query_sum_select.error
+++ b/tests/machine/x/php/query_sum_select.error
@@ -1,0 +1,6 @@
+PHP Fatal error:  Uncaught TypeError: array_sum(): Argument #1 ($array) must be of type array, int given in /workspace/mochi/tests/machine/x/php/query_sum_select.php:7
+Stack trace:
+#0 /workspace/mochi/tests/machine/x/php/query_sum_select.php(7): array_sum()
+#1 /workspace/mochi/tests/machine/x/php/query_sum_select.php(11): {closure}()
+#2 {main}
+  thrown in /workspace/mochi/tests/machine/x/php/query_sum_select.php on line 7

--- a/tests/machine/x/php/query_sum_select.out
+++ b/tests/machine/x/php/query_sum_select.out
@@ -1,4 +1,0 @@
-PHP Warning:  Undefined variable $nums in /workspace/mochi/tests/machine/x/php/query_sum_select.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/query_sum_select.php on line 5
-array(0) {
-}

--- a/tests/machine/x/php/query_sum_select.php
+++ b/tests/machine/x/php/query_sum_select.php
@@ -1,6 +1,6 @@
 <?php
 $nums = [1, 2, 3];
-$result = (function() {
+$result = (function() use ($nums) {
     $result = [];
     foreach ($nums as $n) {
         if ($n > 1) {

--- a/tests/machine/x/php/right_join.php
+++ b/tests/machine/x/php/right_join.php
@@ -1,7 +1,7 @@
 <?php
 $customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"], ["id" => 3, "name" => "Charlie"], ["id" => 4, "name" => "Diana"]];
 $orders = [["id" => 100, "customerId" => 1, "total" => 250], ["id" => 101, "customerId" => 2, "total" => 125], ["id" => 102, "customerId" => 1, "total" => 300]];
-$result = _query($customers, [['items'=>$orders, 'on'=>function($c, $o){return $o->customerId == $c->id;}, 'right'=>true]], [ 'select' => function($c, $o){return ["customerName" => $c->name, "order" => $o];} ]);
+$result = _query($customers, [['items'=>$orders, 'on'=>function($c, $o) use ($customers, $orders){return $o->customerId == $c->id;}, 'right'=>true]], [ 'select' => function($c, $o) use ($customers, $orders){return ["customerName" => $c->name, "order" => $o];} ]);
 var_dump("--- Right Join using syntax ---");
 foreach ($result as $entry) {
     if ($entry->order) {

--- a/tests/machine/x/php/sort_stable.out
+++ b/tests/machine/x/php/sort_stable.out
@@ -1,4 +1,14 @@
-PHP Warning:  Undefined variable $items in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 5
-PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 5
-array(0) {
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 6
+PHP Warning:  Attempt to read property "v" on array in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 6
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 6
+PHP Warning:  Attempt to read property "v" on array in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 6
+PHP Warning:  Attempt to read property "n" on array in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 6
+PHP Warning:  Attempt to read property "v" on array in /workspace/mochi/tests/machine/x/php/sort_stable.php on line 6
+array(3) {
+  [0]=>
+  NULL
+  [1]=>
+  NULL
+  [2]=>
+  NULL
 }

--- a/tests/machine/x/php/sort_stable.php
+++ b/tests/machine/x/php/sort_stable.php
@@ -1,6 +1,6 @@
 <?php
 $items = [["n" => 1, "v" => "a"], ["n" => 1, "v" => "b"], ["n" => 2, "v" => "c"]];
-$result = (function() {
+$result = (function() use ($items) {
     $result = [];
     foreach ($items as $i) {
         $result[] = [$i->n, $i->v];


### PR DESCRIPTION
## Summary
- regenerate PHP machine outputs by running compiler tests
- add TODO section to generated README

## Testing
- `go test ./compiler/x/php -tags=slow -run TestPHPCompiler_ValidPrograms -v`

------
https://chatgpt.com/codex/tasks/task_e_686f2b092d0083209449e693a58372ea