### PR TITLE
Improve C++ compiler runtime handling

### DIFF
--- a/compiler/x/cpp/runtime.go
+++ b/compiler/x/cpp/runtime.go
@@ -1,0 +1,12 @@
+package cpp
+
+const helperJSON = `template<typename T> void __json(const T&);
+inline void __json(int v){ std::cout<<v; }
+inline void __json(double v){ std::cout<<v; }
+inline void __json(bool v){ std::cout<<(v?"true":"false"); }
+inline void __json(const std::string &v){ std::cout<<"\""<<v<<"\""; }
+inline void __json(const char* v){ std::cout<<"\""<<v<<"\""; }
+template<typename T> void __json(const std::vector<T>& v){ std::cout<<"["; bool first=true; for(const auto&x:v){ if(!first) std::cout<<","; first=false; __json(x);} std::cout<<"]"; }
+template<typename K,typename V> void __json(const std::map<K,V>& m){ std::cout<<"{"; bool first=true; for(const auto&kv:m){ if(!first) std::cout<<","; first=false; __json(kv.first); std::cout<<":"; __json(kv.second);} std::cout<<"}"; }
+template<typename K,typename V> void __json(const std::unordered_map<K,V>& m){ std::cout<<"{"; bool first=true; for(const auto&kv:m){ if(!first) std::cout<<","; first=false; __json(kv.first); std::cout<<":"; __json(kv.second);} std::cout<<"}"; }
+`


### PR DESCRIPTION
## Summary
- make C++ compiler emit JSON helpers only when needed
- automatically select standard library includes based on generated code

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f2f4e9c74832096d9d0143dbd512a