### PR TITLE
Improve F# compiler loop handling

### DIFF
--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -111,5 +111,5 @@ Compiled programs: 97/97
 
 ## Remaining Tasks
 
-- [ ] Improve formatting of generated F# code to more closely match hand written examples
+- [x] Improve formatting of generated F# loops when `break` and `continue` are not used
 - [ ] Expand support for additional standard library functions

--- a/tests/machine/x/fs/append_builtin.fs
+++ b/tests/machine/x/fs/append_builtin.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let a = [1; 2]
 printfn "%s" (String.concat " " (List.map string (a @ [3])))

--- a/tests/machine/x/fs/avg_builtin.fs
+++ b/tests/machine/x/fs/avg_builtin.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" ((List.sum [1; 2; 3] / List.length [1; 2; 3]))

--- a/tests/machine/x/fs/basic_compare.fs
+++ b/tests/machine/x/fs/basic_compare.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let a = 10 - 3
 let b = 2 + 2
 printfn "%A" (a)

--- a/tests/machine/x/fs/binary_precedence.fs
+++ b/tests/machine/x/fs/binary_precedence.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (1 + 2 * 3)
 printfn "%A" ((1 + 2) * 3)
 printfn "%A" (2 * 3 + 1)

--- a/tests/machine/x/fs/bool_chain.fs
+++ b/tests/machine/x/fs/bool_chain.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let boom () =
     printfn "%s" "boom"
     true

--- a/tests/machine/x/fs/break_continue.fs
+++ b/tests/machine/x/fs/break_continue.fs
@@ -13,4 +13,4 @@ try
                 raise Break
             printfn "%s" (String.concat " " [string "odd number:"; string n])
         with Continue -> ()
-with Break -> ()
+    with Break -> ()

--- a/tests/machine/x/fs/cast_string_to_int.fs
+++ b/tests/machine/x/fs/cast_string_to_int.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%s" "1995"

--- a/tests/machine/x/fs/cast_struct.fs
+++ b/tests/machine/x/fs/cast_struct.fs
@@ -1,10 +1,7 @@
 open System
 
-exception Break
-exception Continue
-
 type Todo = {
-    title: string
+    mutable title: string
 }
 let todo: Todo = { title = "hi" }
 printfn "%s" todo.title

--- a/tests/machine/x/fs/closure.fs
+++ b/tests/machine/x/fs/closure.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let makeAdder (n) =
     fun x -> x + n
 let add10 = makeAdder 10

--- a/tests/machine/x/fs/count_builtin.fs
+++ b/tests/machine/x/fs/count_builtin.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (List.length [1; 2; 3])

--- a/tests/machine/x/fs/cross_join.fs
+++ b/tests/machine/x/fs/cross_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -23,9 +20,5 @@ let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId 
 let result = [ for o in orders do 
   for c in customers do yield { orderId = o.id; orderCustomerId = o.customerId; pairedCustomerName = c.name; orderTotal = o.total } ]
 printfn "%s" "--- Cross Join: All order-customer pairs ---"
-try
-    for entry in result do
-        try
-            printfn "%s" (String.concat " " [string "Order"; string entry.orderId; string "(customerId:"; string entry.orderCustomerId; string ", total: $"; string entry.orderTotal; string ") paired with"; string entry.pairedCustomerName])
-        with Continue -> ()
-with Break -> ()
+for entry in result do
+    printfn "%s" (String.concat " " [string "Order"; string entry.orderId; string "(customerId:"; string entry.orderCustomerId; string ", total: $"; string entry.orderTotal; string ") paired with"; string entry.pairedCustomerName])

--- a/tests/machine/x/fs/cross_join_filter.fs
+++ b/tests/machine/x/fs/cross_join_filter.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     n: obj
     l: obj
@@ -12,9 +9,5 @@ let letters = ["A"; "B"]
 let pairs = [ for n in nums do 
   for l in letters do if n % 2 = 0 then yield { n = n; l = l } ]
 printfn "%s" "--- Even pairs ---"
-try
-    for p in pairs do
-        try
-            printfn "%s" (String.concat " " [string p.n; string p.l])
-        with Continue -> ()
-with Break -> ()
+for p in pairs do
+    printfn "%s" (String.concat " " [string p.n; string p.l])

--- a/tests/machine/x/fs/cross_join_triple.fs
+++ b/tests/machine/x/fs/cross_join_triple.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     n: obj
     l: obj
@@ -15,9 +12,5 @@ let combos = [ for n in nums do
   for l in letters do 
   for b in bools do yield { n = n; l = l; b = b } ]
 printfn "%s" "--- Cross Join of three lists ---"
-try
-    for c in combos do
-        try
-            printfn "%s" (String.concat " " [string c.n; string c.l; string c.b])
-        with Continue -> ()
-with Break -> ()
+for c in combos do
+    printfn "%s" (String.concat " " [string c.n; string c.l; string c.b])

--- a/tests/machine/x/fs/dataset_sort_take_limit.fs
+++ b/tests/machine/x/fs/dataset_sort_take_limit.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     name: string
     price: int
@@ -10,9 +7,5 @@ type Anon1 = {
 let products = [{ name = "Laptop"; price = 1500 }; { name = "Smartphone"; price = 900 }; { name = "Tablet"; price = 600 }; { name = "Monitor"; price = 300 }; { name = "Keyboard"; price = 100 }; { name = "Mouse"; price = 50 }; { name = "Headphones"; price = 200 }]
 let expensive = [ for p in products do yield p ] |> List.sortByDescending (fun p -> p.price) |> List.skip 1 |> List.take 3
 printfn "%s" "--- Top products (excluding most expensive) ---"
-try
-    for item in expensive do
-        try
-            printfn "%s" (String.concat " " [string item.name; string "costs $"; string item.price])
-        with Continue -> ()
-with Break -> ()
+for item in expensive do
+    printfn "%s" (String.concat " " [string item.name; string "costs $"; string item.price])

--- a/tests/machine/x/fs/dataset_where_filter.fs
+++ b/tests/machine/x/fs/dataset_where_filter.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     name: string
     age: int
@@ -15,9 +12,5 @@ type Anon2 = {
 let people = [{ name = "Alice"; age = 30 }; { name = "Bob"; age = 15 }; { name = "Charlie"; age = 65 }; { name = "Diana"; age = 45 }]
 let adults = [ for person in people do if person.age >= 18 then yield { name = person.name; age = person.age; is_senior = person.age >= 60 } ]
 printfn "%s" "--- Adults ---"
-try
-    for person in adults do
-        try
-            printfn "%s" (String.concat " " [string person.name; string "is"; string person.age; string (if person.is_senior then " (senior)" else "")])
-        with Continue -> ()
-with Break -> ()
+for person in adults do
+    printfn "%s" (String.concat " " [string person.name; string "is"; string person.age; string (if person.is_senior then " (senior)" else "")])

--- a/tests/machine/x/fs/exists_builtin.fs
+++ b/tests/machine/x/fs/exists_builtin.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let data = [1; 2]
 let flag = not (List.isEmpty [ for x in data do if x = 1 then yield x ])
 printfn "%A" (flag)

--- a/tests/machine/x/fs/for_list_collection.fs
+++ b/tests/machine/x/fs/for_list_collection.fs
@@ -1,11 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
-try
-    for n in [1; 2; 3] do
-        try
-            printfn "%A" (n)
-        with Continue -> ()
-with Break -> ()
+for n in [1; 2; 3] do
+    printfn "%A" (n)

--- a/tests/machine/x/fs/for_loop.fs
+++ b/tests/machine/x/fs/for_loop.fs
@@ -1,11 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
-try
-    for i in 1 .. 4 do
-        try
-            printfn "%A" (i)
-        with Continue -> ()
-with Break -> ()
+for i in 1 .. 4 do
+    printfn "%A" (i)

--- a/tests/machine/x/fs/for_map_collection.fs
+++ b/tests/machine/x/fs/for_map_collection.fs
@@ -1,12 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable m = dict [("a", 1); ("b", 2)]
-try
-    for k in m do
-        try
-            printfn "%A" (k)
-        with Continue -> ()
-with Break -> ()
+for k in m do
+    printfn "%A" (k)

--- a/tests/machine/x/fs/fun_call.fs
+++ b/tests/machine/x/fs/fun_call.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let add (a) (b) =
     a + b
 printfn "%A" (add 2 3)

--- a/tests/machine/x/fs/fun_expr_in_let.fs
+++ b/tests/machine/x/fs/fun_expr_in_let.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let square = fun x -> x * x
 printfn "%A" (square 6)

--- a/tests/machine/x/fs/fun_three_args.fs
+++ b/tests/machine/x/fs/fun_three_args.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let sum3 (a) (b) (c) =
     a + b + c
 printfn "%A" (sum3 1 2 3)

--- a/tests/machine/x/fs/group_by.fs
+++ b/tests/machine/x/fs/group_by.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     name: string
     age: int
@@ -18,9 +15,5 @@ let stats = [ for gKey, gItems in [ for person in people do yield person ] |> Li
     let g = {| key = gKey; items = gItems |}
     yield { city = g.key; count = List.length g.items; avg_age = (List.sum [ for p in g do yield p.age ] / List.length [ for p in g do yield p.age ]) } ]
 printfn "%s" "--- People grouped by city ---"
-try
-    for s in stats do
-        try
-            printfn "%s" (String.concat " " [string s.city; string ": count ="; string s.count; string ", avg_age ="; string s.avg_age])
-        with Continue -> ()
-with Break -> ()
+for s in stats do
+    printfn "%s" (String.concat " " [string s.city; string ": count ="; string s.count; string ", avg_age ="; string s.avg_age])

--- a/tests/machine/x/fs/group_by_conditional_sum.fs
+++ b/tests/machine/x/fs/group_by_conditional_sum.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     cat: string
     ``val``: int

--- a/tests/machine/x/fs/group_by_having.fs
+++ b/tests/machine/x/fs/group_by_having.fs
@@ -1,9 +1,6 @@
 open System
 open System.Text.Json
 
-exception Break
-exception Continue
-
 type Anon1 = {
     name: string
     city: string

--- a/tests/machine/x/fs/group_by_join.fs
+++ b/tests/machine/x/fs/group_by_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -22,9 +19,5 @@ let stats = [ for gKey, gItems in [ for o in orders do
     let g = {| key = gKey; items = gItems |}
     yield { name = g.key; count = List.length g.items } ]
 printfn "%s" "--- Orders per customer ---"
-try
-    for s in stats do
-        try
-            printfn "%s" (String.concat " " [string s.name; string "orders:"; string s.count])
-        with Continue -> ()
-with Break -> ()
+for s in stats do
+    printfn "%s" (String.concat " " [string s.name; string "orders:"; string s.count])

--- a/tests/machine/x/fs/group_by_left_join.fs
+++ b/tests/machine/x/fs/group_by_left_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -22,9 +19,5 @@ let stats = [ for gKey, gItems in [ for c in customers do
     let g = {| key = gKey; items = gItems |}
     yield { name = g.key; count = List.length [ for r in g do if r.o then yield r ] } ]
 printfn "%s" "--- Group Left Join ---"
-try
-    for s in stats do
-        try
-            printfn "%s" (String.concat " " [string s.name; string "orders:"; string s.count])
-        with Continue -> ()
-with Break -> ()
+for s in stats do
+    printfn "%s" (String.concat " " [string s.name; string "orders:"; string s.count])

--- a/tests/machine/x/fs/group_by_multi_join.fs
+++ b/tests/machine/x/fs/group_by_multi_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string

--- a/tests/machine/x/fs/group_by_multi_join_sort.fs
+++ b/tests/machine/x/fs/group_by_multi_join_sort.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     n_nationkey: int
     n_name: string

--- a/tests/machine/x/fs/group_by_sort.fs
+++ b/tests/machine/x/fs/group_by_sort.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     cat: string
     ``val``: int

--- a/tests/machine/x/fs/group_items_iteration.fs
+++ b/tests/machine/x/fs/group_items_iteration.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     tag: string
     ``val``: int
@@ -16,18 +13,10 @@ let groups = [ for gKey, gItems in [ for d in data do yield d ] |> List.groupBy 
     let g = {| key = gKey; items = gItems |}
     yield g ]
 let mutable tmp = [||]
-try
-    for g in groups do
-        try
-            let mutable total = 0
-            try
-                for x in g.items do
-                    try
-                        total <- total + x.val
-                    with Continue -> ()
-            with Break -> ()
-            tmp <- tmp @ [{ tag = g.key; total = total }]
-        with Continue -> ()
-with Break -> ()
+for g in groups do
+    let mutable total = 0
+    for x in g.items do
+        total <- total + x.val
+    tmp <- tmp @ [{ tag = g.key; total = total }]
 let result = [ for r in tmp do yield r ] |> List.sortBy (fun r -> r.tag)
 printfn "%A" (result)

--- a/tests/machine/x/fs/if_else.fs
+++ b/tests/machine/x/fs/if_else.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let x = 5
 if x > 3 then
     printfn "%s" "big"

--- a/tests/machine/x/fs/if_then_else.fs
+++ b/tests/machine/x/fs/if_then_else.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let x = 12
 let msg: string = (if x > 10 then "yes" else "no")
 printfn "%s" msg

--- a/tests/machine/x/fs/if_then_else_nested.fs
+++ b/tests/machine/x/fs/if_then_else_nested.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let x = 8
 let msg = (if x > 10 then "big" else (if x > 5 then "medium" else "small"))
 printfn "%A" (msg)

--- a/tests/machine/x/fs/in_operator.fs
+++ b/tests/machine/x/fs/in_operator.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let xs = [1; 2; 3]
 printfn "%b" (List.contains 2 xs)
 printfn "%b" (not (List.contains 5 xs))

--- a/tests/machine/x/fs/in_operator_extended.fs
+++ b/tests/machine/x/fs/in_operator_extended.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     a: int
 }

--- a/tests/machine/x/fs/inner_join.fs
+++ b/tests/machine/x/fs/inner_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -22,9 +19,5 @@ let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId 
 let result = [ for o in orders do 
   for c in customers do if o.customerId = c.id then yield { orderId = o.id; customerName = c.name; total = o.total } ]
 printfn "%s" "--- Orders with customer info ---"
-try
-    for entry in result do
-        try
-            printfn "%s" (String.concat " " [string "Order"; string entry.orderId; string "by"; string entry.customerName; string "- $"; string entry.total])
-        with Continue -> ()
-with Break -> ()
+for entry in result do
+    printfn "%s" (String.concat " " [string "Order"; string entry.orderId; string "by"; string entry.customerName; string "- $"; string entry.total])

--- a/tests/machine/x/fs/join_multi.fs
+++ b/tests/machine/x/fs/join_multi.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -26,9 +23,5 @@ let result = [ for o in orders do
   for c in customers do 
   for i in items do if o.customerId = c.id && o.id = i.orderId then yield { name = c.name; sku = i.sku } ]
 printfn "%s" "--- Multi Join ---"
-try
-    for r in result do
-        try
-            printfn "%s" (String.concat " " [string r.name; string "bought item"; string r.sku])
-        with Continue -> ()
-with Break -> ()
+for r in result do
+    printfn "%s" (String.concat " " [string r.name; string "bought item"; string r.sku])

--- a/tests/machine/x/fs/json_builtin.fs
+++ b/tests/machine/x/fs/json_builtin.fs
@@ -1,9 +1,6 @@
 open System
 open System.Text.Json
 
-exception Break
-exception Continue
-
 type Anon1 = {
     a: int
     b: int

--- a/tests/machine/x/fs/left_join.fs
+++ b/tests/machine/x/fs/left_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -22,9 +19,5 @@ let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId 
 let result = [ for o in orders do 
   let c = List.tryFind (fun c -> o.customerId = c.id) customers yield { orderId = o.id; customer = c; total = o.total } ]
 printfn "%s" "--- Left Join ---"
-try
-    for entry in result do
-        try
-            printfn "%s" (String.concat " " [string "Order"; string entry.orderId; string "customer"; string entry.customer; string "total"; string entry.total])
-        with Continue -> ()
-with Break -> ()
+for entry in result do
+    printfn "%s" (String.concat " " [string "Order"; string entry.orderId; string "customer"; string entry.customer; string "total"; string entry.total])

--- a/tests/machine/x/fs/left_join_multi.fs
+++ b/tests/machine/x/fs/left_join_multi.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -27,9 +24,5 @@ let result = [ for o in orders do
   for c in customers do 
   let i = List.tryFind (fun i -> o.id = i.orderId) items if o.customerId = c.id then yield { orderId = o.id; name = c.name; item = i } ]
 printfn "%s" "--- Left Join Multi ---"
-try
-    for r in result do
-        try
-            printfn "%s" (String.concat " " [string r.orderId; string r.name; string r.item])
-        with Continue -> ()
-with Break -> ()
+for r in result do
+    printfn "%s" (String.concat " " [string r.orderId; string r.name; string r.item])

--- a/tests/machine/x/fs/len_builtin.fs
+++ b/tests/machine/x/fs/len_builtin.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (List.length [1; 2; 3])

--- a/tests/machine/x/fs/len_map.fs
+++ b/tests/machine/x/fs/len_map.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (List.length dict [("a", 1); ("b", 2)])

--- a/tests/machine/x/fs/len_string.fs
+++ b/tests/machine/x/fs/len_string.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" ("mochi".Length)

--- a/tests/machine/x/fs/let_and_print.fs
+++ b/tests/machine/x/fs/let_and_print.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let a = 10
 let b: int = 20
 printfn "%A" (a + b)

--- a/tests/machine/x/fs/list_assign.fs
+++ b/tests/machine/x/fs/list_assign.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable nums = [|1; 2|]
 nums.[1] <- 3
 printfn "%A" (nums.[1])

--- a/tests/machine/x/fs/list_index.fs
+++ b/tests/machine/x/fs/list_index.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let xs = [10; 20; 30]
 printfn "%A" (xs.[1])

--- a/tests/machine/x/fs/list_nested_assign.fs
+++ b/tests/machine/x/fs/list_nested_assign.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable matrix = [|[1; 2]; [3; 4]|]
 matrix.[1].[0] <- 5
 printfn "%A" (matrix.[1].[0])

--- a/tests/machine/x/fs/list_set_ops.fs
+++ b/tests/machine/x/fs/list_set_ops.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%s" (String.concat " " (List.map string [1; 2] union [2; 3]))
 printfn "%s" (String.concat " " (List.map string [1; 2; 3] except [2]))
 printfn "%s" (String.concat " " (List.map string [1; 2; 3] intersect [2; 4]))

--- a/tests/machine/x/fs/load_yaml.fs
+++ b/tests/machine/x/fs/load_yaml.fs
@@ -2,9 +2,6 @@ open System
 open System.IO
 open YamlDotNet.Serialization
 
-exception Break
-exception Continue
-
 type Anon1 = {
     name: obj
     email: obj
@@ -18,9 +15,5 @@ let people = (let deserializer = DeserializerBuilder().Build()
     let yamlText = File.ReadAllText("../interpreter/valid/people.yaml")
     deserializer.Deserialize<Person list>(yamlText))
 let adults = [ for p in people do if p.age >= 18 then yield { name = p.name; email = p.email } ]
-try
-    for a in adults do
-        try
-            printfn "%s" (String.concat " " [string a.name; string a.email])
-        with Continue -> ()
-with Break -> ()
+for a in adults do
+    printfn "%s" (String.concat " " [string a.name; string a.email])

--- a/tests/machine/x/fs/map_assign.fs
+++ b/tests/machine/x/fs/map_assign.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable scores = dict [("alice", 1)]
 scores.["bob"] <- 2
 printfn "%A" (scores.["bob"])

--- a/tests/machine/x/fs/map_in_operator.fs
+++ b/tests/machine/x/fs/map_in_operator.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let m = dict [(1, "a"); (2, "b")]
 printfn "%b" (m.ContainsKey 1)
 printfn "%b" (m.ContainsKey 3)

--- a/tests/machine/x/fs/map_index.fs
+++ b/tests/machine/x/fs/map_index.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let m = dict [("a", 1); ("b", 2)]
 printfn "%A" (m.["b"])

--- a/tests/machine/x/fs/map_int_key.fs
+++ b/tests/machine/x/fs/map_int_key.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let m = dict [(1, "a"); (2, "b")]
 printfn "%A" (m.[1])

--- a/tests/machine/x/fs/map_literal_dynamic.fs
+++ b/tests/machine/x/fs/map_literal_dynamic.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable x = 3
 let mutable y = 4
 let mutable m = dict [("a", x); ("b", y)]

--- a/tests/machine/x/fs/map_membership.fs
+++ b/tests/machine/x/fs/map_membership.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let m = dict [("a", 1); ("b", 2)]
 printfn "%s" m.ContainsKey "a"
 printfn "%s" m.ContainsKey "c"

--- a/tests/machine/x/fs/map_nested_assign.fs
+++ b/tests/machine/x/fs/map_nested_assign.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable data = dict [("outer", dict [("inner", 1)])]
 data.["outer"].["inner"] <- 2
 printfn "%A" (data.["outer"].["inner"])

--- a/tests/machine/x/fs/match_expr.fs
+++ b/tests/machine/x/fs/match_expr.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let x = 2
 let label = (match x with
     | 1 -> "one"

--- a/tests/machine/x/fs/match_full.fs
+++ b/tests/machine/x/fs/match_full.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let x = 2
 let label = (match x with
     | 1 -> "one"

--- a/tests/machine/x/fs/math_ops.fs
+++ b/tests/machine/x/fs/math_ops.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (6 * 7)
 printfn "%A" (7 / 2)
 printfn "%A" (7 % 2)

--- a/tests/machine/x/fs/membership.fs
+++ b/tests/machine/x/fs/membership.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let nums = [1; 2; 3]
 printfn "%b" (List.contains 2 nums)
 printfn "%b" (List.contains 4 nums)

--- a/tests/machine/x/fs/min_max_builtin.fs
+++ b/tests/machine/x/fs/min_max_builtin.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let nums = [3; 1; 4]
 printfn "%A" (List.min nums)
 printfn "%A" (List.max nums)

--- a/tests/machine/x/fs/nested_function.fs
+++ b/tests/machine/x/fs/nested_function.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let outer (x) =
     let inner (y) =
         x + y

--- a/tests/machine/x/fs/order_by_map.fs
+++ b/tests/machine/x/fs/order_by_map.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     a: int
     b: int

--- a/tests/machine/x/fs/outer_join.fs
+++ b/tests/machine/x/fs/outer_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -22,15 +19,11 @@ let result = (let orderPart = [ for o in orders do
         yield { order = None; customer = Some c } ]
  orderPart @ customerPart)
 printfn "%s" "--- Outer Join using syntax ---"
-try
-    for row in result do
-        try
-            if row.order then
-                if row.customer then
-                    printfn "%s" (String.concat " " [string "Order"; string row.order.id; string "by"; string row.customer.name; string "- $"; string row.order.total])
-                else
-                    printfn "%s" (String.concat " " [string "Order"; string row.order.id; string "by"; string "Unknown"; string "- $"; string row.order.total])
-            else
-                printfn "%s" (String.concat " " [string "Customer"; string row.customer.name; string "has no orders"])
-        with Continue -> ()
-with Break -> ()
+for row in result do
+    if row.order then
+        if row.customer then
+            printfn "%s" (String.concat " " [string "Order"; string row.order.id; string "by"; string row.customer.name; string "- $"; string row.order.total])
+        else
+            printfn "%s" (String.concat " " [string "Order"; string row.order.id; string "by"; string "Unknown"; string "- $"; string row.order.total])
+    else
+        printfn "%s" (String.concat " " [string "Customer"; string row.customer.name; string "has no orders"])

--- a/tests/machine/x/fs/partial_application.fs
+++ b/tests/machine/x/fs/partial_application.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let add (a) (b) =
     a + b
 let add5 = add 5

--- a/tests/machine/x/fs/print_hello.fs
+++ b/tests/machine/x/fs/print_hello.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%s" "hello"

--- a/tests/machine/x/fs/pure_fold.fs
+++ b/tests/machine/x/fs/pure_fold.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let triple (x) =
     x * 3
 printfn "%A" (triple 1 + 2)

--- a/tests/machine/x/fs/pure_global_fold.fs
+++ b/tests/machine/x/fs/pure_global_fold.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let k = 2
 let inc (x) =
     x + k

--- a/tests/machine/x/fs/query_sum_select.fs
+++ b/tests/machine/x/fs/query_sum_select.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let nums = [1; 2; 3]
 let result = [ for n in nums do if n > 1 then yield List.sum n ]
 printfn "%A" (result)

--- a/tests/machine/x/fs/record_assign.fs
+++ b/tests/machine/x/fs/record_assign.fs
@@ -1,10 +1,7 @@
 open System
 
-exception Break
-exception Continue
-
 type Counter = {
-    n: int
+    mutable n: int
 }
 let inc (c) =
     c.n <- c.n + 1

--- a/tests/machine/x/fs/right_join.fs
+++ b/tests/machine/x/fs/right_join.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     id: int
     name: string
@@ -21,12 +18,8 @@ let orders = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId 
 let result = [ for o in orders do 
   let c = List.tryFind (fun c -> o.customerId = c.id) customers yield { customerName = c.name; order = o } ]
 printfn "%s" "--- Right Join using syntax ---"
-try
-    for entry in result do
-        try
-            if entry.order then
-                printfn "%s" (String.concat " " [string "Customer"; string entry.customerName; string "has order"; string entry.order.id; string "- $"; string entry.order.total])
-            else
-                printfn "%s" (String.concat " " [string "Customer"; string entry.customerName; string "has no orders"])
-        with Continue -> ()
-with Break -> ()
+for entry in result do
+    if entry.order then
+        printfn "%s" (String.concat " " [string "Customer"; string entry.customerName; string "has order"; string entry.order.id; string "- $"; string entry.order.total])
+    else
+        printfn "%s" (String.concat " " [string "Customer"; string entry.customerName; string "has no orders"])

--- a/tests/machine/x/fs/save_jsonl_stdout.fs
+++ b/tests/machine/x/fs/save_jsonl_stdout.fs
@@ -1,9 +1,6 @@
 open System
 open System.Text.Json
 
-exception Break
-exception Continue
-
 type Anon1 = {
     name: string
     age: int

--- a/tests/machine/x/fs/short_circuit.fs
+++ b/tests/machine/x/fs/short_circuit.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let boom (a) (b) =
     printfn "%s" "boom"
     true

--- a/tests/machine/x/fs/slice.fs
+++ b/tests/machine/x/fs/slice.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%s" (String.concat " " (List.map string [1; 2; 3].[1..(3-1)]))
 printfn "%s" (String.concat " " (List.map string [1; 2; 3].[0..(2-1)]))
 printfn "%s" "hello".Substring(1, 4 - 1)

--- a/tests/machine/x/fs/sort_stable.fs
+++ b/tests/machine/x/fs/sort_stable.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Anon1 = {
     n: int
     v: string

--- a/tests/machine/x/fs/str_builtin.fs
+++ b/tests/machine/x/fs/str_builtin.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (string 123)

--- a/tests/machine/x/fs/string_compare.fs
+++ b/tests/machine/x/fs/string_compare.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%s" "a" < "b"
 printfn "%s" "a" <= "a"
 printfn "%s" "b" > "a"

--- a/tests/machine/x/fs/string_concat.fs
+++ b/tests/machine/x/fs/string_concat.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%s" "hello " + "world"

--- a/tests/machine/x/fs/string_contains.fs
+++ b/tests/machine/x/fs/string_contains.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let s: string = "catch"
 printfn "%s" s.contains("cat")
 printfn "%s" s.contains("dog")

--- a/tests/machine/x/fs/string_in_operator.fs
+++ b/tests/machine/x/fs/string_in_operator.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let s: string = "catch"
 printfn "%s" List.contains "cat" s
 printfn "%s" List.contains "dog" s

--- a/tests/machine/x/fs/string_index.fs
+++ b/tests/machine/x/fs/string_index.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let s: string = "mochi"
 printfn "%s" s.[1]

--- a/tests/machine/x/fs/string_prefix_slice.fs
+++ b/tests/machine/x/fs/string_prefix_slice.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let prefix: string = "fore"
 let s1: string = "forest"
 printfn "%s" s1.Substring(0, List.length prefix - 0) = prefix

--- a/tests/machine/x/fs/substring_builtin.fs
+++ b/tests/machine/x/fs/substring_builtin.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" ("mochi".Substring(1, 4 - 1))

--- a/tests/machine/x/fs/sum_builtin.fs
+++ b/tests/machine/x/fs/sum_builtin.fs
@@ -1,6 +1,3 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (List.sum [1; 2; 3])

--- a/tests/machine/x/fs/tail_recursion.fs
+++ b/tests/machine/x/fs/tail_recursion.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let sum_rec (n) (acc) =
     if n = 0 then
         acc

--- a/tests/machine/x/fs/test_block.fs
+++ b/tests/machine/x/fs/test_block.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let x = 1 + 2
 assert (x = 3)
 printfn "%s" "ok"

--- a/tests/machine/x/fs/tree_sum.fs
+++ b/tests/machine/x/fs/tree_sum.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Tree =
     | Leaf
     | Node of Tree * int * Tree

--- a/tests/machine/x/fs/two-sum.fs
+++ b/tests/machine/x/fs/two-sum.fs
@@ -1,22 +1,11 @@
 open System
 
-exception Break
-exception Continue
-
 let twoSum (nums) (target) =
     let n = List.length nums
-    try
-        for i in 0 .. n do
-            try
-                try
-                    for j in i + 1 .. n do
-                        try
-                            if nums.[i] + nums.[j] = target then
-                                [i; j]
-                        with Continue -> ()
-                with Break -> ()
-            with Continue -> ()
-    with Break -> ()
+    for i in 0 .. n do
+        for j in i + 1 .. n do
+            if nums.[i] + nums.[j] = target then
+                [i; j]
     [-1; -1]
 let result = twoSum [2; 7; 11; 15] 9
 printfn "%A" (result.[0])

--- a/tests/machine/x/fs/typed_let.fs
+++ b/tests/machine/x/fs/typed_let.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let y: int = 0
 printfn "%A" (y)

--- a/tests/machine/x/fs/typed_var.fs
+++ b/tests/machine/x/fs/typed_var.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable x: int = 0
 printfn "%A" (x)

--- a/tests/machine/x/fs/unary_neg.fs
+++ b/tests/machine/x/fs/unary_neg.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 printfn "%A" (-3)
 printfn "%A" (5 + (-2))

--- a/tests/machine/x/fs/update_stmt.fs
+++ b/tests/machine/x/fs/update_stmt.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 type Person = {
     mutable name: string
     mutable age: int

--- a/tests/machine/x/fs/user_type_literal.fs
+++ b/tests/machine/x/fs/user_type_literal.fs
@@ -1,15 +1,12 @@
 open System
 
-exception Break
-exception Continue
-
 type Person = {
-    name: string
-    age: int
+    mutable name: string
+    mutable age: int
 }
 type Book = {
-    title: string
-    author: Person
+    mutable title: string
+    mutable author: Person
 }
 let book = { title = "Go"; author = { name = "Bob"; age = 42 } }
 printfn "%A" (book.author.name)

--- a/tests/machine/x/fs/values_builtin.fs
+++ b/tests/machine/x/fs/values_builtin.fs
@@ -1,7 +1,4 @@
 open System
 
-exception Break
-exception Continue
-
 let m = dict [("a", 1); ("b", 2); ("c", 3)]
 printfn "%s" (String.concat " " (List.map string (Seq.toList (m.Values))))

--- a/tests/machine/x/fs/var_assignment.fs
+++ b/tests/machine/x/fs/var_assignment.fs
@@ -1,8 +1,5 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable x = 1
 x <- 2
 printfn "%A" (x)

--- a/tests/machine/x/fs/while_loop.fs
+++ b/tests/machine/x/fs/while_loop.fs
@@ -1,13 +1,6 @@
 open System
 
-exception Break
-exception Continue
-
 let mutable i = 0
-try
-    while i < 3 do
-        try
-            printfn "%A" (i)
-            i <- i + 1
-        with Continue -> ()
-with Break -> ()
+while i < 3 do
+    printfn "%A" (i)
+    i <- i + 1


### PR DESCRIPTION
## Summary
- enhance fs compiler so Break/Continue exceptions are only emitted when used
- skip `try..with` wrapping around loops without `break` or `continue`
- update generated F# machine code to use simpler loops
- mark improved loop formatting in machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f32dceed083208e81817be96856af