### PR TITLE
Fix Fortran TPCH q1 output

### DIFF
--- a/tests/dataset/tpc-h/compiler/fortran/q1.f90.out
+++ b/tests/dataset/tpc-h/compiler/fortran/q1.f90.out
@@ -1,6 +1,6 @@
 program q1
   implicit none
-  print '(A)', '[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,'//
-               '"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,'//
+  print '(A)', '[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,'// &
+               '"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,'// &
                '"sum_disc_price":2750,"sum_qty":53}]'
 end program q1


### PR DESCRIPTION
## Summary
- fix string continuations in TPCH q1 Fortran code

## Testing
- `go test ./compiler/x/fortran -run TPCH -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f331cfe3c83208c4aae08b8657b83