### PR TITLE
Improve PHP compiler map handling

### DIFF
--- a/tests/machine/x/php/group_by_conditional_sum.error
+++ b/tests/machine/x/php/group_by_conditional_sum.error
@@ -1,8 +1,3 @@
-PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 6
-PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 6
-PHP Warning:  Attempt to read property "cat" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 6
-PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 12
-PHP Warning:  Attempt to read property "key" on array in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 12
 PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 14
 PHP Warning:  foreach() argument must be of type array|object, null given in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 14
 PHP Warning:  Undefined variable $g in /workspace/mochi/tests/machine/x/php/group_by_conditional_sum.php on line 20

--- a/tests/machine/x/php/group_by_conditional_sum.php
+++ b/tests/machine/x/php/group_by_conditional_sum.php
@@ -3,22 +3,22 @@ $items = [["cat" => "a", "val" => 10, "flag" => true], ["cat" => "a", "val" => 5
 $result = (function() use ($items) {
     $groups = [];
     foreach ($items as $i) {
-        $_k = json_encode($i->cat);
+        $_k = json_encode($i['cat']);
         $groups[$_k][] = $i;
     }
     $result = [];
     foreach ($groups as $_k => $__g) {
         $g = ['key'=>json_decode($_k, true),'items'=> $__g];
-        $result[] = [$g->key, ["cat" => $g->key, "share" => array_sum((function() {
+        $result[] = [$g['key'], ["cat" => $g['key'], "share" => array_sum((function() {
     $result = [];
     foreach ($g as $x) {
-        $result[] = ($x->flag ? $x->val : 0);
+        $result[] = ($x['flag'] ? $x['val'] : 0);
     }
     return $result;
 })()) / array_sum((function() {
     $result = [];
     foreach ($g as $x) {
-        $result[] = $x->val;
+        $result[] = $x['val'];
     }
     return $result;
 })())]];


### PR DESCRIPTION
## Summary
- fix PHP compiler to treat anonymous struct fields as map access
- add detection of group element types
- update generated PHP for `group_by_conditional_sum`

## Testing
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f33dd7c748320877200b47891a036