### PR TITLE
Enhance Dart compiler with YAML support

### DIFF
--- a/tests/machine/x/dart/README.md
+++ b/tests/machine/x/dart/README.md
@@ -103,3 +103,9 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## TODO
+- [ ] Support YAML without external packages (done)
+- [ ] Implement group_by, right_join, outer_join, etc.
+- [ ] Ensure tree_sum and two-sum compile and run.
+

--- a/tests/machine/x/dart/load_yaml.dart
+++ b/tests/machine/x/dart/load_yaml.dart
@@ -1,23 +1,45 @@
 import 'dart:io';
 import 'dart:convert';
-import 'package:yaml/yaml.dart';
 
 dynamic _load(String path, dynamic opts) {
   var fmt = 'csv';
-  if (opts is Map && opts.containsKey('format'))
-    fmt = opts['format'].toString();
+  if (opts is Map && opts.containsKey('format')) fmt = opts['format'].toString();
   if (fmt == 'yaml') {
     var text = File(path).readAsStringSync();
-    var data = loadYaml(text);
-    if (data is List) return [for (var d in data) Map<String, dynamic>.from(d)];
-    if (data is Map) return [Map<String, dynamic>.from(data)];
-    return [];
+    var data = _parseYaml(text);
+    return data;
   }
   var text = File(path).readAsStringSync();
   var data = jsonDecode(text);
   if (data is List) return data;
   if (data is Map) return [data];
   return [];
+}
+
+List<Map<String,dynamic>> _parseYaml(String text) {
+  var rows = <Map<String,dynamic>>[];
+  Map<String,dynamic>? cur;
+  for (var line in LineSplitter.split(text)) {
+    var t = line.trim();
+    if (t.isEmpty) continue;
+    if (t.startsWith('-')) {
+      if (cur != null) rows.add(cur);
+      cur = <String,dynamic>{};
+      t = t.substring(1).trim();
+      if (t.isEmpty) continue;
+    }
+    var idx = t.indexOf(':');
+    if (idx <= 0) continue;
+    var key = t.substring(0, idx).trim();
+    var val = t.substring(idx+1).trim();
+    if ((val.startsWith("\"") && val.endsWith("\"")) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.substring(1, val.length-1);
+    }
+    var numVal = num.tryParse(val);
+    cur?[key] = numVal ?? val;
+  }
+  if (cur != null) rows.add(cur);
+  return rows;
 }
 
 class Person {
@@ -27,16 +49,7 @@ class Person {
   Person(this.name, this.age, this.email);
 }
 
-var people = [
-  for (var _it in (_load('tests/interpreter/valid/people.yaml', {
-    'format': 'yaml',
-  })))
-    Person(
-      (_it['name'] as String),
-      (_it['age'] as int),
-      (_it['email'] as String),
-    ),
-];
+var people = [for (var _it in (_load('tests/interpreter/valid/people.yaml', {'format': 'yaml'}))) Person((_it['name'] as String), (_it['age'] as int), (_it['email'] as String))];
 
 var adults = (() {
   var _q0 = <dynamic>[];
@@ -53,3 +66,4 @@ void main() {
     print([a['name'], a['email']].join(' '));
   }
 }
+


### PR DESCRIPTION
## Summary
- support YAML loading in Dart compiler without external packages
- regenerate `load_yaml.dart` using new compiler
- document remaining tasks for Dart compilation

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f350f020c8320bfce34faf77e9409