### PR TITLE
Refresh C# machine README

### DIFF
--- a/compiler/x/cs/compiler_test.go
+++ b/compiler/x/cs/compiler_test.go
@@ -148,6 +148,39 @@ func findRepoRoot(t *testing.T) string {
 		}
 		dir = parent
 	}
-	t.Fatal("go.mod not found")
-	return ""
+        t.Fatal("go.mod not found")
+        return ""
+}
+
+func TestMain(m *testing.M) {
+        code := m.Run()
+        updateReadme()
+        os.Exit(code)
+}
+
+func updateReadme() {
+        root := findRepoRoot(&testing.T{})
+        srcDir := filepath.Join(root, "tests", "vm", "valid")
+        outDir := filepath.Join(root, "tests", "machine", "x", "cs")
+        files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+        total := len(files)
+        compiled := 0
+        var lines []string
+        for _, f := range files {
+                name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+                mark := "[ ]"
+                if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+                        compiled++
+                        mark = "[x]"
+                }
+                lines = append(lines, fmt.Sprintf("- %s %s", mark, name))
+        }
+        var buf bytes.Buffer
+        buf.WriteString("# C# Machine Output\n\n")
+        buf.WriteString("This directory holds C# source generated from the Mochi programs in `tests/vm/valid`. Each compiled program has a `.cs` file and the expected output in a matching `.out`. If the compiler failed a `.error` file will be present instead.\n\n")
+        fmt.Fprintf(&buf, "Compiled programs: %d/%d\n\n", compiled, total)
+        buf.WriteString("Checklist:\n\n")
+        buf.WriteString(strings.Join(lines, "\n"))
+        buf.WriteString("\n")
+        _ = os.WriteFile(filepath.Join(outDir, "README.md"), buf.Bytes(), 0o644)
 }

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -1,10 +1,11 @@
 # C# Machine Output
 
-This directory holds C# source generated from the Mochi programs in `tests/vm/valid`.  Each compiled program has a `.cs` file and the expected output in a matching `.out`.  If the compiler failed a `.error` file will be present instead.
+This directory holds C# source generated from the Mochi programs in `tests/vm/valid`. Each compiled program has a `.cs` file and the expected output in a matching `.out`. If the compiler failed a `.error` file will be present instead.
 
-Compiled programs: 97/97
+Compiled programs: 93/97
 
-## Checklist
+Checklist:
+
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
@@ -29,13 +30,13 @@ Compiled programs: 97/97
 - [x] fun_three_args
 - [x] group_by
 - [x] group_by_conditional_sum
-- [x] group_by_having
+- [ ] group_by_having
 - [x] group_by_join
 - [x] group_by_left_join
 - [x] group_by_multi_join
 - [x] group_by_multi_join_sort
-- [x] group_by_sort
-- [x] group_items_iteration
+- [ ] group_by_sort
+- [ ] group_items_iteration
 - [x] if_else
 - [x] if_then_else
 - [x] if_then_else_nested
@@ -54,7 +55,7 @@ Compiled programs: 97/97
 - [x] list_index
 - [x] list_nested_assign
 - [x] list_set_ops
- - [x] load_yaml
+- [x] load_yaml
 - [x] map_assign
 - [x] map_in_operator
 - [x] map_index
@@ -75,12 +76,12 @@ Compiled programs: 97/97
 - [x] pure_fold
 - [x] pure_global_fold
 - [x] query_sum_select
- - [x] record_assign
+- [x] record_assign
 - [x] right_join
 - [x] save_jsonl_stdout
 - [x] short_circuit
 - [x] slice
- - [x] sort_stable
+- [x] sort_stable
 - [x] str_builtin
 - [x] string_compare
 - [x] string_concat
@@ -93,7 +94,7 @@ Compiled programs: 97/97
 - [x] tail_recursion
 - [x] test_block
 - [x] tree_sum
-- [x] two-sum
+- [ ] two-sum
 - [x] typed_let
 - [x] typed_var
 - [x] unary_neg
@@ -102,6 +103,3 @@ Compiled programs: 97/97
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-
-### Tasks remaining
-- [ ] Implement the remaining Mochi features and generate code for the unchecked programs above.


### PR DESCRIPTION
## Summary
- auto-generate the C# machine README on test runs
- regenerate the C# machine README

## Testing
- `MOCHI_SKIP_FORMATCS=1 go test -tags slow ./compiler/x/cs -run TestNothing -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f35dfb724832097541a2c600f3ada