### PR TITLE
Improve Dart compiler truthiness handling

### DIFF
--- a/tests/machine/x/dart/README.md
+++ b/tests/machine/x/dart/README.md
@@ -103,3 +103,22 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining Tasks
+
+The following programs still fail to compile or run:
+
+- group_by
+- group_by_conditional_sum
+- group_by_left_join
+- group_by_multi_join_sort
+- group_by_sort
+- group_items_iteration
+- load_yaml
+- match_full
+- outer_join
+- query_sum_select
+- right_join
+- slice
+- tree_sum
+- two-sum


### PR DESCRIPTION
## Summary
- add `_truthy` helper for Dart compiler
- detect non-boolean conditions and wrap with `_truthy`
- handle unary `!` for non-bool expressions
- document remaining tasks in Dart README

## Testing
- `go test ./...`
- `go test -tags slow ./compiler/x/dart -run TestDartCompiler_ValidPrograms` *(fails: `exec: "dart": executable file not found in $PATH`)*

------
https://chatgpt.com/codex/tasks/task_e_686f36225b048320a2aac6ff1f43386d