### PR TITLE
Regenerate Fortran machine README

### DIFF
--- a/tests/machine/x/fortran/README.md
+++ b/tests/machine/x/fortran/README.md
@@ -103,3 +103,7 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining tasks
+*(none)*
+


### PR DESCRIPTION
## Summary
- regenerate Fortran machine README after rerunning the compiler tests
- append a *Remaining tasks* section to the README

## Testing
- `go test -tags slow ./compiler/x/fortran -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f3659c6c483209f779fd19c627a91