### PR TITLE
Update Zig compiler float formatting

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -2461,7 +2461,11 @@ func (c *Compiler) compileLiteral(l *parser.Literal, hint types.Type) (string, e
 	case l.Int != nil:
 		return strconv.Itoa(*l.Int), nil
 	case l.Float != nil:
-		return strconv.FormatFloat(*l.Float, 'f', -1, 64), nil
+		s := strconv.FormatFloat(*l.Float, 'f', -1, 64)
+		if !strings.ContainsAny(s, ".eE") && !strings.Contains(s, ".") {
+			s += ".0"
+		}
+		return s, nil
 	case l.Str != nil:
 		return strconv.Quote(*l.Str), nil
 	case l.Bool != nil:

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -103,4 +103,4 @@
 - [x] Support right and outer join queries
 - [x] Support join queries with grouping, having clauses, and sorting
 - [x] Format struct and list literals on multiple lines for readability
-- [ ] Improve float formatting for numeric outputs
+- [x] Improve float formatting for numeric outputs

--- a/tests/machine/x/zig/group_by_multi_join.zig
+++ b/tests/machine/x/zig/group_by_multi_join.zig
@@ -57,19 +57,19 @@ const partsupp = (blk2: { const _tmp2 = struct {
     _tmp2{
     .part = 100,
     .supplier = 1,
-    .cost = 10,
+    .cost = 10.0,
     .qty = 2,
 },
     _tmp2{
     .part = 100,
     .supplier = 2,
-    .cost = 20,
+    .cost = 20.0,
     .qty = 1,
 },
     _tmp2{
     .part = 200,
     .supplier = 1,
-    .cost = 5,
+    .cost = 5.0,
     .qty = 3,
 },
 }; break :blk2 _arr; });

--- a/tests/machine/x/zig/group_by_multi_join_sort.zig
+++ b/tests/machine/x/zig/group_by_multi_join_sort.zig
@@ -32,7 +32,7 @@ const customer = (blk1: { const _tmp1 = struct {
 }; const _arr = &[_]_tmp1{_tmp1{
     .c_custkey = 1,
     .c_name = "Alice",
-    .c_acctbal = 100,
+    .c_acctbal = 100.0,
     .c_nationkey = 1,
     .c_address = "123 St",
     .c_phone = "123-456",
@@ -63,14 +63,14 @@ const lineitem = (blk3: { const _tmp3 = struct {
     _tmp3{
     .l_orderkey = 1000,
     .l_returnflag = "R",
-    .l_extendedprice = 1000,
+    .l_extendedprice = 1000.0,
     .l_discount = 0.1,
 },
     _tmp3{
     .l_orderkey = 2000,
     .l_returnflag = "N",
-    .l_extendedprice = 500,
-    .l_discount = 0,
+    .l_extendedprice = 500.0,
+    .l_discount = 0.0,
 },
 }; break :blk3 _arr; });
 const start_date = "1993-10-01";


### PR DESCRIPTION
## Summary
- improve float literal formatting in the Zig compiler
- regenerate Zig machine outputs to use trailing `.0` for integers
- mark float formatting task completed in Zig README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f495dca388320b9e027802be285c0