### PR TITLE
Fix Swift query field casts

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,6 +1,6 @@
 # Machine-generated Swift Outputs
 
-Compiled programs: 78/97
+Compiled programs: 80/97
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -15,8 +15,8 @@ Compiled programs: 78/97
 - [x] cross_join.mochi
 - [x] cross_join_filter.mochi
 - [x] cross_join_triple.mochi
-- [ ] dataset_sort_take_limit.mochi
-- [ ] dataset_where_filter.mochi
+- [x] dataset_sort_take_limit.mochi
+- [x] dataset_where_filter.mochi
 - [x] exists_builtin.mochi
 - [x] for_list_collection.mochi
 - [x] for_loop.mochi

--- a/tests/machine/x/swift/dataset_sort_take_limit.error
+++ b/tests/machine/x/swift/dataset_sort_take_limit.error
@@ -1,4 +1,0 @@
-line 2: exit status 1
-var products = [["name": "Laptop", "price": 1500], ["name": "Smartphone", "price": 900], ["name": "Tablet", "price": 600], ["name": "Monitor", "price": 300], ["name": "Keyboard", "price": 100], ["name": "Mouse", "price": 50], ["name": "Headphones", "price": 200]]
-var expensive = products.map { p in (value: p, key: p["price"]) }.sorted { $0.key > $1.key }.dropFirst(1).prefix(3).map { $0.value }
-print("--- Top products (excluding most expensive) ---")

--- a/tests/machine/x/swift/dataset_sort_take_limit.out
+++ b/tests/machine/x/swift/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/machine/x/swift/dataset_sort_take_limit.swift
+++ b/tests/machine/x/swift/dataset_sort_take_limit.swift
@@ -1,6 +1,6 @@
 var products = [["name": "Laptop", "price": 1500], ["name": "Smartphone", "price": 900], ["name": "Tablet", "price": 600], ["name": "Monitor", "price": 300], ["name": "Keyboard", "price": 100], ["name": "Mouse", "price": 50], ["name": "Headphones", "price": 200]]
-var expensive = products.map { p in (value: p, key: p["price"]) }.sorted { $0.key > $1.key }.dropFirst(1).prefix(3).map { $0.value }
+var expensive = products.map { p in (value: p, key: p["price"] as! Int) }.sorted { $0.key > $1.key }.dropFirst(1).prefix(3).map { $0.value }
 print("--- Top products (excluding most expensive) ---")
 for item in expensive {
-    print(item.name, "costs $", item.price)
+    print(item["name"] as! String, "costs $", item["price"] as! Int)
 }

--- a/tests/machine/x/swift/dataset_where_filter.error
+++ b/tests/machine/x/swift/dataset_where_filter.error
@@ -1,4 +1,0 @@
-line 5: exit status 1
-for person in adults {
-    print(person["name"], "is", person["age"], person["is_senior"] ? " (senior)" : "")
-}

--- a/tests/machine/x/swift/dataset_where_filter.out
+++ b/tests/machine/x/swift/dataset_where_filter.out
@@ -1,4 +1,4 @@
 --- Adults ---
-Alice is 30 
+Alice is 30
 Charlie is 65  (senior)
-Diana is 45 
+Diana is 45

--- a/tests/machine/x/swift/dataset_where_filter.swift
+++ b/tests/machine/x/swift/dataset_where_filter.swift
@@ -2,5 +2,5 @@ var people = [["name": "Alice", "age": 30], ["name": "Bob", "age": 15], ["name":
 var adults = people.compactMap { person in person["age"] as! Int >= 18 ? (["name": person["name"] as! String, "age": person["age"] as! Int, "is_senior": person["age"] as! Int >= 60]) : nil }
 print("--- Adults ---")
 for person in adults {
-    print(person["name"], "is", person["age"], person["is_senior"] ? " (senior)" : "")
+    print(person["name"] as! String, "is", person["age"] as! Int, person["is_senior"] as! Bool ? " (senior)" : "")
 }


### PR DESCRIPTION
## Summary
- improve query sort branch to preserve map field info
- infer list element types when query selects its variable
- regenerate Swift outputs for dataset_sort_take_limit and dataset_where_filter
- update Swift machine README

## Testing
- `go test ./compiler/x/swift -run TestCompileValidPrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f51364ab48320ac57680abf94a1ed