### PR TITLE
Add Prolog builtins for str and values

### DIFF
--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -834,6 +834,30 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, bool, error) {
 		c.needsGroup = true
 		c.writeln(fmt.Sprintf("count(%s, %s),", arg, tmp))
 		return tmp, true, nil
+	case "str":
+		if len(call.Args) != 1 {
+			return "", false, fmt.Errorf("str expects 1 arg")
+		}
+		arg, _, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return "", false, err
+		}
+		tmp := c.newTmp()
+		c.writeln(fmt.Sprintf("term_string(%s, %s),", arg, tmp))
+		return tmp, false, nil
+	case "values":
+		if len(call.Args) != 1 {
+			return "", false, fmt.Errorf("values expects 1 arg")
+		}
+		arg, _, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return "", false, err
+		}
+		pairs := c.newTmp()
+		tmp := c.newTmp()
+		c.writeln(fmt.Sprintf("dict_pairs(%s, _, %s),", arg, pairs))
+		c.writeln(fmt.Sprintf("findall(V, member(_-V, %s), %s),", pairs, tmp))
+		return tmp, false, nil
 	default:
 		args := make([]string, len(call.Args))
 		for i, a := range call.Args {

--- a/tests/machine/x/pl/README.md
+++ b/tests/machine/x/pl/README.md
@@ -4,7 +4,7 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 
 ## Summary
 
- - 77/97 programs compiled and ran successfully.
+ - 79/97 programs compiled and ran successfully.
 
 ### Checklist
 - [x] append_builtin

--- a/tests/machine/x/pl/str_builtin.out
+++ b/tests/machine/x/pl/str_builtin.out
@@ -1,2 +1,1 @@
-ERROR: /workspace/mochi/tests/machine/x/pl/str_builtin.pl:4:6: Syntax error: Operator expected
-
+123

--- a/tests/machine/x/pl/str_builtin.pl
+++ b/tests/machine/x/pl/str_builtin.pl
@@ -1,7 +1,7 @@
 :- style_check(-singleton).
 :- initialization(main, main).
 main :-
-    Str(123, _V0),
+    term_string(123, _V0),
     write(_V0),
     nl,
     true.

--- a/tests/machine/x/pl/values_builtin.out
+++ b/tests/machine/x/pl/values_builtin.out
@@ -1,2 +1,1 @@
-ERROR: /workspace/mochi/tests/machine/x/pl/values_builtin.pl:6:9: Syntax error: Operator expected
-
+[1,2,3]

--- a/tests/machine/x/pl/values_builtin.pl
+++ b/tests/machine/x/pl/values_builtin.pl
@@ -3,7 +3,8 @@
 main :-
     dict_create(_V0, map, [a-1, b-2, c-3]),
     M = _V0,
-    Values(M, _V1),
-    write(_V1),
+    dict_pairs(M, _, _V1),
+    findall(V, member(_-V, _V1), _V2),
+    write(_V2),
     nl,
     true.


### PR DESCRIPTION
## Summary
- implement `str` and `values` builtins in Prolog compiler
- update generated Prolog for `str_builtin` and `values_builtin`
- update Prolog machine README

## Testing
- `go test ./compiler/x/pl -tags slow` *(fails: TestPrologCompiler/while_loop)*

------
https://chatgpt.com/codex/tasks/task_e_686f572cac80832082f938d5fcbc855d