### PR TITLE
Update Haskell compiler boolean handling

### DIFF
--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -392,7 +392,7 @@ func (c *Compiler) compileMainStmt(s *parser.Statement) error {
 				child.SetVar(asn.Name, t, true)
 				c.env = child
 			}
-			cond, err := c.compileExpr(s.While.Cond)
+			cond, err := c.compileBoolExpr(s.While.Cond)
 			if err != nil {
 				c.env = orig
 				return err
@@ -427,7 +427,7 @@ func (c *Compiler) compileMainStmt(s *parser.Statement) error {
 			if err != nil {
 				return err
 			}
-			cond, err := c.compileExpr(s.While.Cond)
+			cond, err := c.compileBoolExpr(s.While.Cond)
 			if err != nil {
 				return err
 			}
@@ -451,7 +451,7 @@ func (c *Compiler) compileMainStmt(s *parser.Statement) error {
 }
 
 func (c *Compiler) compileIfMain(stmt *parser.IfStmt) error {
-	cond, err := c.compileExpr(stmt.Cond)
+	cond, err := c.compileBoolExpr(stmt.Cond)
 	if err != nil {
 		return err
 	}
@@ -903,7 +903,7 @@ func (c *Compiler) compileStmtExpr(stmts []*parser.Statement, top bool) (string,
 			if err != nil {
 				return "", err
 			}
-			cond, err := c.compileExpr(s.While.Cond)
+			cond, err := c.compileBoolExpr(s.While.Cond)
 			if err != nil {
 				return "", err
 			}
@@ -945,7 +945,7 @@ func (c *Compiler) compileIfExpr(stmt *parser.IfStmt) (string, error) {
 			return "", err
 		}
 	}
-	cond, err := c.compileExpr(stmt.Cond)
+	cond, err := c.compileBoolExpr(stmt.Cond)
 	if err != nil {
 		return "", err
 	}
@@ -971,7 +971,7 @@ func (c *Compiler) compileIfExprExpr(e *parser.IfExpr) (string, error) {
 	} else {
 		elseExpr = "()"
 	}
-	cond, err := c.compileExpr(e.Cond)
+	cond, err := c.compileBoolExpr(e.Cond)
 	if err != nil {
 		return "", err
 	}
@@ -983,6 +983,21 @@ func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 		return "", nil
 	}
 	return c.compileBinary(e.Binary)
+}
+
+// compileBoolExpr compiles an expression expected to yield a Bool. If the
+// expression has type `any`, it is wrapped with `_asBool` to coerce the value
+// at runtime.
+func (c *Compiler) compileBoolExpr(e *parser.Expr) (string, error) {
+	expr, err := c.compileExpr(e)
+	if err != nil {
+		return "", err
+	}
+	if _, ok := c.inferExprType(e).(types.AnyType); ok {
+		c.usesAnyValue = true
+		return fmt.Sprintf("_asBool (%s)", expr), nil
+	}
+	return expr, nil
 }
 
 func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {


### PR DESCRIPTION
## Summary
- improve boolean context handling in Haskell compiler

## Testing
- `go vet ./...`
- `go test ./compiler/x/hs -tags=slow -run TestHSCompiler_ValidPrograms -count=1` *(fails: running test requires networked setup)*

------
https://chatgpt.com/codex/tasks/task_e_686f564cdb70832088b77ff463d70b69