### PR TITLE
Add Swift json builtin support

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,6 +1,6 @@
 # Machine-generated Swift Outputs
 
-Compiled programs: 80/97
+Compiled programs: 81/97
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -40,7 +40,7 @@ Compiled programs: 80/97
 - [x] in_operator_extended.mochi
 - [x] inner_join.mochi
 - [x] join_multi.mochi
-- [ ] json_builtin.mochi
+- [x] json_builtin.mochi
 - [x] left_join.mochi
 - [x] left_join_multi.mochi
 - [x] len_builtin.mochi

--- a/tests/machine/x/swift/in_operator_extended.error
+++ b/tests/machine/x/swift/in_operator_extended.error
@@ -1,2 +1,0 @@
-line: 0
-error: unsupported expression at line 2

--- a/tests/machine/x/swift/json_builtin.error
+++ b/tests/machine/x/swift/json_builtin.error
@@ -1,3 +1,0 @@
-line 1: exit status 1
-let m = [a: 1, b: 2]
-json(m)

--- a/tests/machine/x/swift/json_builtin.out
+++ b/tests/machine/x/swift/json_builtin.out
@@ -1,0 +1,8 @@
+/workspace/mochi/tests/machine/x/swift/json_builtin.swift:13:27: warning: conditional cast from 'Any' to 'Any' always succeeds
+11 |         return x
+12 |     }
+13 |     if let obj = _sort(v) as? Any,
+   |                           `- warning: conditional cast from 'Any' to 'Any' always succeeds
+14 |        let data = try? JSONSerialization.data(withJSONObject: obj),
+15 |        let s = String(data: data, encoding: .utf8) {
+{"b":2,"a":1}

--- a/tests/machine/x/swift/json_builtin.swift
+++ b/tests/machine/x/swift/json_builtin.swift
@@ -1,2 +1,20 @@
+import Foundation
+
+func _json(_ v: Any) {
+    func _sort(_ x: Any) -> Any {
+        if let a = x as? [Any] { return a.map { _sort($0) } }
+        if let m = x as? [String:Any] {
+            var out: [String:Any] = [:]
+            for k in m.keys.sorted() { out[k] = _sort(m[k]!) }
+            return out
+        }
+        return x
+    }
+    if let obj = _sort(v) as? Any,
+       let data = try? JSONSerialization.data(withJSONObject: obj),
+       let s = String(data: data, encoding: .utf8) {
+        print(s)
+    }
+}
 let m = ["a": 1, "b": 2]
-json(m)
+_json(m)

--- a/tests/machine/x/swift/tree_sum.error
+++ b/tests/machine/x/swift/tree_sum.error
@@ -1,2 +1,0 @@
-line: 0
-error: variant types not supported


### PR DESCRIPTION
## Summary
- implement `json` builtin in the Swift compiler
- include runtime helper for printing JSON
- regenerate `json_builtin.swift` output and update checklist
- remove stale `.error` files

## Testing
- `go test ./compiler/x/swift -tags slow -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f575765fc8320bd8c0b14f4aca196