### PR TITLE
Improve C# compiler builtins

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -2517,22 +2517,22 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(args) != 2 {
 			return "", fmt.Errorf("append expects 2 args")
 		}
-		tmp := c.newVar()
 		elem := "dynamic"
 		if lt, ok := c.inferExprType(call.Args[0]).(types.ListType); ok {
 			elem = csTypeOf(lt.Elem)
 		}
-		expr := fmt.Sprintf("new List<%s>(%s)", elem, args[0])
-		return fmt.Sprintf("(new Func<List<%s>>(() => {var %s=%s;%s.Add(%s);return %s;}))()", elem, tmp, expr, tmp, args[1], tmp), nil
+		return fmt.Sprintf("new List<%s>(%s){%s}", elem, args[0], args[1]), nil
 	case "values":
 		if len(args) != 1 {
 			return "", fmt.Errorf("values expects 1 arg")
 		}
-		tmp := c.newVar()
 		val := "dynamic"
 		if mt, ok := c.inferExprType(call.Args[0]).(types.MapType); ok {
 			val = csTypeOf(mt.Value)
+			c.useLinq = true
+			return fmt.Sprintf("%s.Values.ToList()", args[0]), nil
 		}
+		tmp := c.newVar()
 		c.useLinq = true
 		return fmt.Sprintf("(new Func<List<%s>>(() => {var %s=new List<%s>();foreach(System.Collections.DictionaryEntry kv in %s){%s.Add(kv.Value);}return %s;}))()", val, tmp, val, args[0], tmp, tmp), nil
 	case "exists":

--- a/scripts/compile_cs.go
+++ b/scripts/compile_cs.go
@@ -1,0 +1,52 @@
+//go:build ignore
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	cscode "mochi/compiler/x/cs"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func main() {
+	pattern := filepath.Join("tests", "vm", "valid", "*.mochi")
+	if p := os.Getenv("PATTERN"); p != "" {
+		pattern = p
+	}
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		panic(err)
+	}
+	outDir := filepath.Join("tests", "machine", "x", "cs")
+	_ = os.MkdirAll(outDir, 0755)
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		errPath := filepath.Join(outDir, name+".error")
+		csPath := filepath.Join(outDir, name+".cs")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0644)
+			os.Remove(csPath)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			os.WriteFile(errPath, []byte(errs[0].Error()), 0644)
+			os.Remove(csPath)
+			continue
+		}
+		code, err := cscode.New(env).Compile(prog)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0644)
+			os.Remove(csPath)
+			continue
+		}
+		os.WriteFile(csPath, code, 0644)
+		os.Remove(errPath)
+	}
+}


### PR DESCRIPTION
## Summary
- add a helper script to regenerate C# machine output
- tweak the C# backend so `append` uses collection initializers
- emit `Values.ToList()` for typed map `values()` calls

## Testing
- `go test ./compiler/x/cs -tags slow -run TestCompileValidPrograms -count=1 -v | head -n 20` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686f58353b288320b47e01fd62bc1433