### PR TITLE
Add outer join support to Rust compiler

### DIFF
--- a/tests/machine/x/rust/outer_join.error
+++ b/tests/machine/x/rust/outer_join.error
@@ -1,2 +1,0 @@
-line 0: query features not supported
-let customers = [

--- a/tests/machine/x/rust/outer_join.out
+++ b/tests/machine/x/rust/outer_join.out
@@ -1,0 +1,7 @@
+"--- Outer Join using syntax ---"
+"Order" 100 "by" "Alice" "- $" 250
+"Order" 101 "by" "Bob" "- $" 125
+"Order" 102 "by" "Alice" "- $" 300
+"Order" 103 "by" "Unknown" "- $" 80
+"Customer" "Charlie" "has no orders"
+"Customer" "Diana" "has no orders"

--- a/tests/machine/x/rust/outer_join.rs
+++ b/tests/machine/x/rust/outer_join.rs
@@ -1,0 +1,36 @@
+#[derive(Default, Debug, Clone, PartialEq)]
+struct Customer {
+    id: i32,
+    name: &'static str,
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+struct Order {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+struct Result {
+    order: Order,
+    customer: Customer,
+}
+
+fn main() {
+    let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }, Customer { id: 3, name: "Charlie" }, Customer { id: 4, name: "Diana" }];
+    let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 2, total: 125 }, Order { id: 102, customerId: 1, total: 300 }, Order { id: 103, customerId: 5, total: 80 }];
+    let result = { let mut tmp1 = Vec::new();for o in &orders { let mut _matched = false; for c in &customers { if !(o.customerId == c.id) { continue; } _matched = true; tmp1.push(Result { order: o.clone(), customer: c.clone() }); } if !_matched { let c: Customer = Default::default(); tmp1.push(Result { order: o.clone(), customer: c.clone() }); } } for c in &customers { let mut _matched = false; for o in &orders { if o.customerId == c.id { _matched = true; break; } } if !_matched { let o: Order = Default::default(); tmp1.push(Result { order: o.clone(), customer: c.clone() }); } } tmp1 };
+    println!("{:?}", "--- Outer Join using syntax ---");
+    for row in result {
+        if row.order != Default::default() {
+            if row.customer != Default::default() {
+                println!("{:?} {:?} {:?} {:?} {:?} {:?}", "Order", row.order.id, "by", row.customer.name, "- $", row.order.total);
+            } else {
+                println!("{:?} {:?} {:?} {:?} {:?} {:?}", "Order", row.order.id, "by", "Unknown", "- $", row.order.total);
+            }
+        } else {
+            println!("{:?} {:?} {:?}", "Customer", row.customer.name, "has no orders");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `compileOuterJoinSimple` in the Rust backend
- invoke outer join compilation when query uses `outer join`
- add generated Rust translation and output for `outer_join.mochi`

## Testing
- `go test -v -tags slow ./compiler/x/rust -run TestCompilePrograms/outer_join -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f597455088320953db43dd87eb3e5