### PR TITLE
Improve Zig compiler map handling

### DIFF
--- a/tests/machine/x/zig/closure.error
+++ b/tests/machine/x/zig/closure.error
@@ -1,0 +1,8 @@
+Error on line 8: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/closure.zig:8:16: error: no field named 'call' in struct 'closure.makeAdder__struct_3386'
+/workspace/mochi/tests/machine/x/zig/closure.zig:6:13: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/closure.zig:3:24: note: called from here
+
+7:         return (x + self.n);
+8: } }{ .n = n }).call;
+9: }

--- a/tests/machine/x/zig/cross_join.error
+++ b/tests/machine/x/zig/cross_join.error
@@ -1,0 +1,9 @@
+Error on line 51: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/cross_join.zig:51:2: error: expected type 'cross_join.result__struct_3434', found 'cross_join.result__struct_3623'
+/workspace/mochi/tests/machine/x/zig/cross_join.zig:46:89: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/cross_join.zig:41:50: note: struct declared here
+/tmp/zig-0.12.0/lib/std/array_list.zig:261:42: note: parameter type declared here
+
+50:     orderTotal: i32,
+51: }{
+52:     .orderId = o.id,

--- a/tests/machine/x/zig/cross_join_filter.error
+++ b/tests/machine/x/zig/cross_join_filter.error
@@ -1,0 +1,9 @@
+Error on line 18: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/cross_join_filter.zig:18:2: error: expected type 'cross_join_filter.pairs__struct_3434', found 'cross_join_filter.pairs__struct_3619'
+/workspace/mochi/tests/machine/x/zig/cross_join_filter.zig:15:121: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/cross_join_filter.zig:12:49: note: struct declared here
+/tmp/zig-0.12.0/lib/std/array_list.zig:261:42: note: parameter type declared here
+
+17:     l: []const u8,
+18: }{
+19:     .n = n,

--- a/tests/machine/x/zig/cross_join_triple.error
+++ b/tests/machine/x/zig/cross_join_triple.error
@@ -1,0 +1,9 @@
+Error on line 23: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/cross_join_triple.zig:23:2: error: expected type 'cross_join_triple.combos__struct_3435', found 'cross_join_triple.combos__struct_3620'
+/workspace/mochi/tests/machine/x/zig/cross_join_triple.zig:19:103: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/cross_join_triple.zig:15:50: note: struct declared here
+/tmp/zig-0.12.0/lib/std/array_list.zig:261:42: note: parameter type declared here
+
+22:     b: bool,
+23: }{
+24:     .n = n,

--- a/tests/machine/x/zig/dataset_sort_take_limit.error
+++ b/tests/machine/x/zig/dataset_sort_take_limit.error
@@ -1,0 +1,8 @@
+Error on line 60: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/dataset_sort_take_limit.zig:60:85: error: expected type 'dataset_sort_take_limit.expensive__struct_3434.expensive__struct_3434__struct_3523', found 'dataset_sort_take_limit.products__struct_3620'
+/workspace/mochi/tests/machine/x/zig/dataset_sort_take_limit.zig:24:41: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/dataset_sort_take_limit.zig:57:68: note: struct declared here
+
+59:     price: i32,
+60: }, key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp1.append(.{ .item = p, .key = -p.price }) catch unreachable; } for (0.._tmp1.items.len) |i| { for (i+1.._tmp1.items.len) |j| { if (_tmp1.items[j].key < _tmp1.items[i].key) { const t = _tmp1.items[i]; _tmp1.items[i] = _tmp1.items[j]; _tmp1.items[j] = t; } } } var _tmp2 = std.ArrayList(struct {
+61:     name: []const u8,

--- a/tests/machine/x/zig/dataset_where_filter.error
+++ b/tests/machine/x/zig/dataset_where_filter.error
@@ -1,0 +1,9 @@
+Error on line 32: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/dataset_where_filter.zig:32:2: error: expected type 'dataset_where_filter.adults__struct_3433', found 'dataset_where_filter.adults__struct_3620'
+/workspace/mochi/tests/machine/x/zig/dataset_where_filter.zig:28:109: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/dataset_where_filter.zig:24:50: note: struct declared here
+/tmp/zig-0.12.0/lib/std/array_list.zig:261:42: note: parameter type declared here
+
+31:     is_senior: bool,
+32: }{
+33:     .name = person.name,

--- a/tests/machine/x/zig/exists_builtin.error
+++ b/tests/machine/x/zig/exists_builtin.error
@@ -1,0 +1,14 @@
+Error on line 34: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/heap/PageAllocator.zig:34:18: error: unable to evaluate comptime expression
+/tmp/zig-0.12.0/lib/std/heap/PageAllocator.zig:34:69: note: operation is runtime due to this operand
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:86:29: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:225:35: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:211:40: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:205:75: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:193:41: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:457:67: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:434:51: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:483:41: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:262:49: note: called from here
+/workspace/mochi/tests/machine/x/zig/exists_builtin.zig:7:141: note: called from here
+

--- a/tests/machine/x/zig/for_map_collection.zig
+++ b/tests/machine/x/zig/for_map_collection.zig
@@ -1,12 +1,11 @@
 const std = @import("std");
 
-var m: struct {
-    a: i32,
-    b: i32,
-} = undefined;
+var m: std.StringHashMap(i32) = undefined;
 
 pub fn main() void {
-    for (m) |k| {
-        std.debug.print("{any}\n", .{k});
+    var _tmp1 = m.keyIterator();
+    while (_tmp1.next()) |k_ptr| {
+        const k = k_ptr.*;
+        std.debug.print("{s}\n", .{k});
     }
 }

--- a/tests/machine/x/zig/fun_expr_in_let.error
+++ b/tests/machine/x/zig/fun_expr_in_let.error
@@ -1,0 +1,6 @@
+Error on line 4: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/fun_expr_in_let.zig:4:23: error: expected ',' after initializer
+
+3: const square = fn (x: i32) i32 {
+4:         return (x * x);
+5: };

--- a/tests/machine/x/zig/group_by.error
+++ b/tests/machine/x/zig/group_by.error
@@ -1,0 +1,7 @@
+Error on line 14: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/hash_map.zig:14:13: error: std.auto_hash.autoHash does not allow slices here ([]const u8) because the intent is unclear. Consider using std.StringHashMap for hashing the contents of []const u8. Alternatively, consider using std.auto_hash.hash or providing your own hash function instead.
+/tmp/zig-0.12.0/lib/std/hash_map.zig:55:39: note: called from here
+
+13:         .Struct, .Union, .Array, .Vector, .Pointer, .Slice => std.meta.eql(a, b),
+14:         else => a == b,
+15:     };

--- a/tests/machine/x/zig/group_by_conditional_sum.error
+++ b/tests/machine/x/zig/group_by_conditional_sum.error
@@ -1,0 +1,7 @@
+Error on line 58: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/group_by_conditional_sum.zig:58:3: error: expected type 'array_list.ArrayListAligned(group_by_conditional_sum.result__struct_3973.result__struct_3973__struct_3974,null)', found 'array_list.ArrayListAligned(group_by_conditional_sum.result__struct_4029,null)'
+/tmp/zig-0.12.0/lib/std/array_list.zig:31:12: note: struct declared here (2 times)
+
+57:     flag: bool,
+58: }).init(std.heap.page_allocator) }; g.Items.append(i) catch unreachable; _tmp5.append(g) catch unreachable; _tmp6.put(_tmp7, _tmp5.items.len - 1) catch unreachable; } } var _tmp8 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(struct {
+59:     cat: []const u8,

--- a/tests/machine/x/zig/group_by_conditional_sum.zig
+++ b/tests/machine/x/zig/group_by_conditional_sum.zig
@@ -47,7 +47,7 @@ const result = blk3: { var _tmp5 = std.ArrayList(struct { key: []const u8, Items
     cat: []const u8,
     val: i32,
     flag: bool,
-}) }).init(std.heap.page_allocator); var _tmp6 = std.AutoHashMap([]const u8, usize).init(std.heap.page_allocator); for (items) |i| { const _tmp7 = i.cat; if (_tmp6.get(_tmp7)) |idx| { _tmp5.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
+}) }).init(std.heap.page_allocator); var _tmp6 = std.StringHashMap(usize).init(std.heap.page_allocator); for (items) |i| { const _tmp7 = i.cat; if (_tmp6.get(_tmp7)) |idx| { _tmp5.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(struct {
     cat: []const u8,
     val: i32,
     flag: bool,

--- a/tests/machine/x/zig/group_by_having.error
+++ b/tests/machine/x/zig/group_by_having.error
@@ -1,0 +1,7 @@
+Error on line 14: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/hash_map.zig:14:13: error: std.auto_hash.autoHash does not allow slices here ([]const u8) because the intent is unclear. Consider using std.StringHashMap for hashing the contents of []const u8. Alternatively, consider using std.auto_hash.hash or providing your own hash function instead.
+/tmp/zig-0.12.0/lib/std/hash_map.zig:55:39: note: called from here
+
+13:         .Struct, .Union, .Array, .Vector, .Pointer, .Slice => std.meta.eql(a, b),
+14:         else => a == b,
+15:     };

--- a/tests/machine/x/zig/group_by_join.error
+++ b/tests/machine/x/zig/group_by_join.error
@@ -1,0 +1,7 @@
+Error on line 14: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/hash_map.zig:14:13: error: std.auto_hash.autoHash does not allow slices here ([]const u8) because the intent is unclear. Consider using std.StringHashMap for hashing the contents of []const u8. Alternatively, consider using std.auto_hash.hash or providing your own hash function instead.
+/tmp/zig-0.12.0/lib/std/hash_map.zig:55:39: note: called from here
+
+13:     name: []const u8,
+14: }; const _arr = &[_]_tmp0{
+15:     _tmp0{

--- a/tests/machine/x/zig/group_by_left_join.error
+++ b/tests/machine/x/zig/group_by_left_join.error
@@ -1,0 +1,7 @@
+Error on line 14: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/hash_map.zig:14:13: error: std.auto_hash.autoHash does not allow slices here ([]const u8) because the intent is unclear. Consider using std.StringHashMap for hashing the contents of []const u8. Alternatively, consider using std.auto_hash.hash or providing your own hash function instead.
+/tmp/zig-0.12.0/lib/std/hash_map.zig:55:39: note: called from here
+
+13:     name: []const u8,
+14: }; const _arr = &[_]_tmp0{
+15:     _tmp0{

--- a/tests/machine/x/zig/group_by_multi_join.error
+++ b/tests/machine/x/zig/group_by_multi_join.error
@@ -1,0 +1,9 @@
+Error on line 82: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/group_by_multi_join.zig:82:2: error: expected type 'group_by_multi_join.filtered__struct_4076', found 'group_by_multi_join.filtered__struct_4138'
+/workspace/mochi/tests/machine/x/zig/group_by_multi_join.zig:79:236: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/group_by_multi_join.zig:76:52: note: struct declared here
+/tmp/zig-0.12.0/lib/std/array_list.zig:261:42: note: parameter type declared here
+
+81:     value: f64,
+82: }{
+83:     .part = ps.part,

--- a/tests/machine/x/zig/group_by_multi_join_sort.error
+++ b/tests/machine/x/zig/group_by_multi_join_sort.error
@@ -1,0 +1,6 @@
+Error on line 102: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/group_by_multi_join_sort.zig:102:292: error: operator >= not allowed for type '[]const u8'
+
+101:     n_name: []const u8,
+102: }, usize).init(std.heap.page_allocator); for (customer) |c| { for (orders) |o| { if (!((o.o_custkey == c.c_custkey))) continue; for (lineitem) |l| { if (!((l.l_orderkey == o.o_orderkey))) continue; for (nation) |n| { if (!((n.n_nationkey == c.c_nationkey))) continue; if (!((((o.o_orderdate >= start_date) and (o.o_orderdate < end_date)) and std.mem.eql(u8, l.l_returnflag, "R")))) continue; const _tmp10 = struct {
+103:     c_custkey: i32,

--- a/tests/machine/x/zig/group_by_sort.error
+++ b/tests/machine/x/zig/group_by_sort.error
@@ -1,0 +1,7 @@
+Error on line 14: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/hash_map.zig:14:13: error: std.auto_hash.autoHash does not allow slices here ([]const u8) because the intent is unclear. Consider using std.StringHashMap for hashing the contents of []const u8. Alternatively, consider using std.auto_hash.hash or providing your own hash function instead.
+/tmp/zig-0.12.0/lib/std/hash_map.zig:55:39: note: called from here
+
+13:     }
+14:     std.debug.print("\n", .{});
+15: }

--- a/tests/machine/x/zig/group_items_iteration.error
+++ b/tests/machine/x/zig/group_items_iteration.error
@@ -1,0 +1,7 @@
+Error on line 14: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/hash_map.zig:14:13: error: std.auto_hash.autoHash does not allow slices here ([]const u8) because the intent is unclear. Consider using std.StringHashMap for hashing the contents of []const u8. Alternatively, consider using std.auto_hash.hash or providing your own hash function instead.
+/tmp/zig-0.12.0/lib/std/hash_map.zig:55:39: note: called from here
+
+13:         if (i > 0) std.debug.print(" ", .{});
+14:         std.debug.print("{any}", .{it});
+15:     }

--- a/tests/machine/x/zig/in_operator_extended.error
+++ b/tests/machine/x/zig/in_operator_extended.error
@@ -1,0 +1,14 @@
+Error on line 34: zig build error: exit status 1
+/tmp/zig-0.12.0/lib/std/heap/PageAllocator.zig:34:18: error: unable to evaluate comptime expression
+/tmp/zig-0.12.0/lib/std/heap/PageAllocator.zig:34:69: note: operation is runtime due to this operand
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:86:29: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:225:35: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:211:40: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:205:75: note: called from here
+/tmp/zig-0.12.0/lib/std/mem/Allocator.zig:193:41: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:457:67: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:434:51: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:483:41: note: called from here
+/tmp/zig-0.12.0/lib/std/array_list.zig:262:49: note: called from here
+/workspace/mochi/tests/machine/x/zig/in_operator_extended.zig:13:145: note: called from here
+

--- a/tests/machine/x/zig/inner_join.error
+++ b/tests/machine/x/zig/inner_join.error
@@ -1,0 +1,9 @@
+Error on line 54: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/inner_join.zig:54:2: error: expected type 'inner_join.result__struct_3434', found 'inner_join.result__struct_3623'
+/workspace/mochi/tests/machine/x/zig/inner_join.zig:50:130: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/inner_join.zig:46:50: note: struct declared here
+/tmp/zig-0.12.0/lib/std/array_list.zig:261:42: note: parameter type declared here
+
+53:     total: i32,
+54: }{
+55:     .orderId = o.id,

--- a/tests/machine/x/zig/join_multi.error
+++ b/tests/machine/x/zig/join_multi.error
@@ -1,0 +1,9 @@
+Error on line 48: zig build error: exit status 1
+/workspace/mochi/tests/machine/x/zig/join_multi.zig:48:2: error: expected type 'join_multi.result__struct_3435', found 'join_multi.result__struct_3626'
+/workspace/mochi/tests/machine/x/zig/join_multi.zig:45:186: note: struct declared here
+/workspace/mochi/tests/machine/x/zig/join_multi.zig:42:50: note: struct declared here
+/tmp/zig-0.12.0/lib/std/array_list.zig:261:42: note: parameter type declared here
+
+47:     sku: []const u8,
+48: }{
+49:     .name = c.name,


### PR DESCRIPTION
## Summary
- handle map literals in Zig compiler to generate `StringHashMap`
- account for map types when inferring variables
- update machine-generated Zig for `for_map_collection`
- regenerate failing `.error` outputs for other Zig programs

## Testing
- `go test ./compiler/x/zig -run 'TestZigCompiler_ValidPrograms/(for_map_collection|group_by_conditional_sum)$' -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_686f668b73308320aae59379c8034797