### PR TITLE
Fix CPP compiler global lambda capture

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -2331,7 +2331,12 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 // compileLambda builds a C++ lambda from the given parameters and body.
 func (c *Compiler) compileLambda(params []*parser.Param, exprBody *parser.Expr, stmts []*parser.Statement) (string, error) {
 	var buf strings.Builder
-	buf.WriteString("[=](")
+	cap := "[=]"
+	if c.scope == 0 {
+		cap = "[]"
+	}
+	buf.WriteString(cap)
+	buf.WriteString("(")
 	for i, p := range params {
 		if i > 0 {
 			buf.WriteString(", ")

--- a/scripts/compile_cpp.go
+++ b/scripts/compile_cpp.go
@@ -1,0 +1,45 @@
+//go:build ignore
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	cpp "mochi/compiler/x/cpp"
+	"mochi/parser"
+)
+
+func main() {
+	pattern := filepath.Join("tests", "vm", "valid", "*.mochi")
+	if p := os.Getenv("PATTERN"); p != "" {
+		pattern = p
+	}
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		panic(err)
+	}
+	outDir := filepath.Join("tests", "machine", "x", "cpp")
+	_ = os.MkdirAll(outDir, 0755)
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		errPath := filepath.Join(outDir, name+".error")
+		cppPath := filepath.Join(outDir, name+".cpp")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0644)
+			os.Remove(cppPath)
+			continue
+		}
+		code, err := cpp.New().Compile(prog)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0644)
+			os.Remove(cppPath)
+			continue
+		}
+		os.WriteFile(cppPath, code, 0644)
+		os.Remove(errPath)
+	}
+}

--- a/tests/machine/x/cpp/fun_expr_in_let.cpp
+++ b/tests/machine/x/cpp/fun_expr_in_let.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-auto square = [=](int x) { return (x * x); };
+auto square = [](int x) { return (x * x); };
 
 int main() {
   {

--- a/tests/machine/x/cpp/fun_expr_in_let.error
+++ b/tests/machine/x/cpp/fun_expr_in_let.error
@@ -1,7 +1,0 @@
-line 3: ../../../tests/machine/x/cpp/fun_expr_in_let.cpp:3:16: error: non-local lambda expression cannot have a capture-default
-    3 | auto square = [=](int x) { return (x * x); };
-      |                ^
-
-  2 | 
-  3 | auto square = [=](int x) { return (x * x); };
-  4 | 


### PR DESCRIPTION
## Summary
- adjust lambda capture in the C++ compiler when generating code at global scope
- add helper script `compile_cpp.go` for regenerating machine outputs
- regenerate `fun_expr_in_let.cpp` without the invalid capture
- remove outdated error file

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f66a06998832093e46509a2110ba9