### PR TITLE
Improve Prolog compiler identifier handling

### DIFF
--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"mochi/parser"
 )
@@ -657,6 +658,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, bool, error) {
 		}
 		if v, ok := c.vars[p.Selector.Root]; ok {
 			return v, false, nil
+		}
+		if len(p.Selector.Root) > 0 && unicode.IsUpper(rune(p.Selector.Root[0])) {
+			return sanitizeAtom(p.Selector.Root), false, nil
 		}
 		return sanitizeVar(p.Selector.Root), false, nil
 	case p.Selector != nil:


### PR DESCRIPTION
## Summary
- treat upper case identifiers as Prolog atoms in the pl compiler

## Testing
- `go test ./compiler/x/pl -tags slow -run TestPrologCompiler/tree_sum -count=1` *(fails: exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_686f6709aa988320ab37117a7b9afb4e