### PR TITLE
Improve Zig print translation

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -2480,6 +2480,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 				c.needsPrintList = true
 				return fmt.Sprintf("_print_list(%s, %s)", elem, arg), nil
 			}
+			if c.isStringLiteralExpr(call.Args[0]) {
+				lit := call.Args[0].Binary.Left.Value.Target.Lit.Str
+				return fmt.Sprintf("std.debug.print(%q, .{})", *lit+"\n"), nil
+			}
 		}
 		args := make([]string, len(call.Args))
 		fmtParts := make([]string, len(call.Args))
@@ -3039,6 +3043,17 @@ func (c *Compiler) isStringPrimary(p *parser.Primary) bool {
 		}
 	}
 	return false
+}
+
+func (c *Compiler) isStringLiteralExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) > 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) > 0 || u.Value == nil || u.Value.Target == nil || len(u.Value.Ops) > 0 {
+		return false
+	}
+	return u.Value.Target.Lit != nil && u.Value.Target.Lit.Str != nil
 }
 
 func (c *Compiler) isMapExpr(e *parser.Expr) bool {

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -102,3 +102,4 @@ These files were generated using the Zig compiler backend. Each `.mochi` program
 
 ## TODO
 - [ ] Keep generated outputs in sync with compiler improvements.
+- [ ] Optimize print statements for constant strings.

--- a/tests/machine/x/zig/bool_chain.zig
+++ b/tests/machine/x/zig/bool_chain.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
 fn boom() bool {
-    std.debug.print("{s}\n", .{"boom"});
+    std.debug.print("boom\n", .{});
     return true;
 }
 

--- a/tests/machine/x/zig/cross_join.zig
+++ b/tests/machine/x/zig/cross_join.zig
@@ -56,7 +56,7 @@ const result = blk2: { var _tmp2 = std.ArrayList(struct {
 }) catch unreachable; } } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk2 _tmp3; };
 
 pub fn main() void {
-    std.debug.print("{s}\n", .{"--- Cross Join: All order-customer pairs ---"});
+    std.debug.print("--- Cross Join: All order-customer pairs ---\n", .{});
     for (result) |entry| {
         std.debug.print("{s} {any} {s} {any} {s} {any} {s} {any}\n", .{"Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName});
     }

--- a/tests/machine/x/zig/cross_join_filter.zig
+++ b/tests/machine/x/zig/cross_join_filter.zig
@@ -21,7 +21,7 @@ const pairs = blk0: { var _tmp0 = std.ArrayList(struct {
 }) catch unreachable; } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
 
 pub fn main() void {
-    std.debug.print("{s}\n", .{"--- Even pairs ---"});
+    std.debug.print("--- Even pairs ---\n", .{});
     for (pairs) |p| {
         std.debug.print("{any} {any}\n", .{p.n, p.l});
     }

--- a/tests/machine/x/zig/cross_join_triple.zig
+++ b/tests/machine/x/zig/cross_join_triple.zig
@@ -27,7 +27,7 @@ const combos = blk0: { var _tmp0 = std.ArrayList(struct {
 }) catch unreachable; } } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; };
 
 pub fn main() void {
-    std.debug.print("{s}\n", .{"--- Cross Join of three lists ---"});
+    std.debug.print("--- Cross Join of three lists ---\n", .{});
     for (combos) |c| {
         std.debug.print("{any} {any} {any}\n", .{c.n, c.l, c.b});
     }

--- a/tests/machine/x/zig/dataset_sort_take_limit.zig
+++ b/tests/machine/x/zig/dataset_sort_take_limit.zig
@@ -66,7 +66,7 @@ const expensive = blk1: { var _tmp1 = std.ArrayList(struct { item: struct {
 }, _tmp3, 1, (1 + 3), 1); break :blk1 _tmp3; };
 
 pub fn main() void {
-    std.debug.print("{s}\n", .{"--- Top products (excluding most expensive) ---"});
+    std.debug.print("--- Top products (excluding most expensive) ---\n", .{});
     for (expensive) |item| {
         std.debug.print("{s} {s} {d}\n", .{item.name, "costs $", item.price});
     }

--- a/tests/machine/x/zig/dataset_where_filter.zig
+++ b/tests/machine/x/zig/dataset_where_filter.zig
@@ -36,7 +36,7 @@ const adults = blk1: { var _tmp1 = std.ArrayList(struct {
 }) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk1 _tmp2; };
 
 pub fn main() void {
-    std.debug.print("{s}\n", .{"--- Adults ---"});
+    std.debug.print("--- Adults ---\n", .{});
     for (adults) |person| {
         std.debug.print("{any} {s} {any} {s}\n", .{person.name, "is", person.age, if (person.is_senior) (" (senior)") else ("")});
     }

--- a/tests/machine/x/zig/if_else.zig
+++ b/tests/machine/x/zig/if_else.zig
@@ -4,8 +4,8 @@ const x = 5;
 
 pub fn main() void {
     if ((x > 3)) {
-        std.debug.print("{s}\n", .{"big"});
+        std.debug.print("big\n", .{});
     } else {
-        std.debug.print("{s}\n", .{"small"});
+        std.debug.print("small\n", .{});
     }
 }

--- a/tests/machine/x/zig/print_hello.zig
+++ b/tests/machine/x/zig/print_hello.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("{s}\n", .{"hello"});
+    std.debug.print("hello\n", .{});
 }


### PR DESCRIPTION
## Summary
- handle constant string literals in print builtin
- update generated Zig outputs for print constant improvements
- document remaining Zig TODOs

## Testing
- `go test ./compiler/x/zig -run TestZigCompiler_ValidPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686f6b6d70c48320b6e3e9c9d09cda04