### PR TITLE
Update Swift compiler and machine README

### DIFF
--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -988,9 +988,10 @@ func (c *compiler) matchExpr(m *parser.MatchExpr) (string, error) {
 	}
 	var b strings.Builder
 	b.WriteString("{ () in\n")
-	b.WriteString("    switch ")
+	b.WriteString("    let __t = ")
 	b.WriteString(target)
-	b.WriteString(" {\n")
+	b.WriteString("\n")
+	b.WriteString("    switch __t {\n")
 	for _, cse := range m.Cases {
 		var patStr string
 		if cse.Pattern.Binary.Left.Value.Target.Struct != nil {

--- a/scripts/compile_swift.go
+++ b/scripts/compile_swift.go
@@ -1,0 +1,52 @@
+//go:build ignore
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	swift "mochi/compiler/x/swift"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func main() {
+	pattern := filepath.Join("tests", "vm", "valid", "*.mochi")
+	if p := os.Getenv("PATTERN"); p != "" {
+		pattern = p
+	}
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		panic(err)
+	}
+	outDir := filepath.Join("tests", "machine", "x", "swift")
+	_ = os.MkdirAll(outDir, 0755)
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		errPath := filepath.Join(outDir, name+".error")
+		swiftPath := filepath.Join(outDir, name+".swift")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0644)
+			os.Remove(swiftPath)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			os.WriteFile(errPath, []byte(errs[0].Error()), 0644)
+			os.Remove(swiftPath)
+			continue
+		}
+		code, err := swift.New(env).Compile(prog)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0644)
+			os.Remove(swiftPath)
+			continue
+		}
+		os.WriteFile(swiftPath, code, 0644)
+		os.Remove(errPath)
+	}
+}

--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,7 +1,6 @@
 # Machine-generated Swift Outputs
 
-Compiled programs: 84/97
-
+Compiled programs: 86/97
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -65,7 +64,7 @@ Compiled programs: 84/97
 - [x] membership.mochi
 - [x] min_max_builtin.mochi
 - [x] nested_function.mochi
-- [ ] order_by_map.mochi
+- [x] order_by_map.mochi
 - [ ] outer_join.mochi
 - [x] partial_application.mochi
 - [x] print_hello.mochi
@@ -77,7 +76,7 @@ Compiled programs: 84/97
 - [x] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
 - [x] slice.mochi
-- [ ] sort_stable.mochi
+- [x] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi
@@ -103,4 +102,3 @@ Compiled programs: 84/97
 ## TODO
 - [ ] implement group+join queries
 - [ ] support variant types
-- [ ] support update statements


### PR DESCRIPTION
## Summary
- add compile_swift.go helper for generating Swift outputs
- avoid evaluating match expressions more than once
- refresh Swift machine README with up-to-date compilation status

## Testing
- `go test ./... -tags slow` *(fails: build errors in archived packages)*

------
https://chatgpt.com/codex/tasks/task_e_686f6c43915c832086d7179f608fc3c5