### PR TITLE
Add README regeneration and variable order fix for Smalltalk

### DIFF
--- a/compiler/x/st/compiler_test.go
+++ b/compiler/x/st/compiler_test.go
@@ -95,3 +95,41 @@ func compileOne(t *testing.T, src, outDir, name, gstPath string) {
 	errFile := filepath.Join(outDir, name+".error")
 	os.Remove(errFile)
 }
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	updateReadme()
+	os.Exit(code)
+}
+
+func updateReadme() {
+	root := testutil.FindRepoRoot(&testing.T{})
+	srcDir := filepath.Join(root, "tests", "vm", "valid")
+	outDir := filepath.Join(root, "tests", "machine", "x", "st")
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	total := len(files)
+	compiled := 0
+	var lines []string
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		mark := "[ ]"
+		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+			compiled++
+			mark = "[x]"
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s.mochi", mark, name))
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "# Mochi to Smalltalk Machine Outputs (%d/%d compiled and run)\n\n", compiled, total)
+	buf.WriteString("This directory contains Smalltalk source code generated from the Mochi programs in `tests/vm/valid`. A checkbox indicates the program compiled and executed successfully during tests.\n\n")
+	buf.WriteString("## Checklist\n")
+	buf.WriteString(strings.Join(lines, "\n"))
+	buf.WriteString("\n\n")
+	buf.WriteString("## TODO\n")
+	buf.WriteString("- [x] full outer join semantics\n")
+	buf.WriteString("- [x] right join semantics\n\n")
+	if compiled == total {
+		buf.WriteString("All programs executed successfully with GNU Smalltalk.\n")
+	}
+	_ = os.WriteFile(filepath.Join(outDir, "README.md"), buf.Bytes(), 0644)
+}

--- a/tests/machine/x/st/README.md
+++ b/tests/machine/x/st/README.md
@@ -1,12 +1,6 @@
 # Mochi to Smalltalk Machine Outputs (97/97 compiled and run)
 
-This directory contains Smalltalk source code generated from the Mochi programs
-in `tests/vm/valid`. A checkbox indicates the program compiled and executed
-successfully during tests. The CI environment now installs `gst`, so all
-programs run to completion.  The Smalltalk compiler supports `join` and
-`group by` queries, allowing the examples below to execute as in the reference
-implementations. Dictionary keys now emit Smalltalk symbols to more closely
-match the hand written examples in `tests/human/x/st`.
+This directory contains Smalltalk source code generated from the Mochi programs in `tests/vm/valid`. A checkbox indicates the program compiled and executed successfully during tests.
 
 ## Checklist
 - [x] append_builtin.mochi
@@ -31,58 +25,6 @@ match the hand written examples in `tests/human/x/st`.
 - [x] fun_call.mochi
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
-- [x] if_else.mochi
-- [x] if_then_else.mochi
-- [x] if_then_else_nested.mochi
-- [x] in_operator.mochi
-- [x] in_operator_extended.mochi
-- [x] len_builtin.mochi
-- [x] len_map.mochi
-- [x] len_string.mochi
-- [x] math_ops.mochi
-- [x] membership.mochi
-- [x] min_max_builtin.mochi
-- [x] print_hello.mochi
-- [x] str_builtin.mochi
-- [x] string_compare.mochi
-- [x] string_concat.mochi
-- [x] string_contains.mochi
-- [x] string_in_operator.mochi
-- [x] string_index.mochi
-- [x] string_prefix_slice.mochi
-- [x] substring_builtin.mochi
-- [x] sum_builtin.mochi
-- [x] typed_let.mochi
-- [x] typed_var.mochi
-- [x] unary_neg.mochi
-- [x] while_loop.mochi
-- [x] let_and_print.mochi
-- [x] list_assign.mochi
-- [x] list_index.mochi
-- [x] list_nested_assign.mochi
-- [x] list_set_ops.mochi
-- [x] map_assign.mochi
-- [x] map_in_operator.mochi
-- [x] map_index.mochi
-- [x] map_int_key.mochi
-- [x] map_literal_dynamic.mochi
-- [x] map_membership.mochi
-- [x] map_nested_assign.mochi
-- [x] match_expr.mochi
-- [x] match_full.mochi
-- [x] nested_function.mochi
-- [x] order_by_map.mochi
-- [x] partial_application.mochi
-- [x] pure_fold.mochi
-- [x] pure_global_fold.mochi
-- [x] record_assign.mochi
-- [x] short_circuit.mochi
-- [x] slice.mochi
-- [x] sort_stable.mochi
-- [x] tail_recursion.mochi
-- [x] user_type_literal.mochi
-- [x] values_builtin.mochi
-- [x] var_assignment.mochi
 - [x] group_by.mochi
 - [x] group_by_conditional_sum.mochi
 - [x] group_by_having.mochi
@@ -92,20 +34,72 @@ match the hand written examples in `tests/human/x/st`.
 - [x] group_by_multi_join_sort.mochi
 - [x] group_by_sort.mochi
 - [x] group_items_iteration.mochi
+- [x] if_else.mochi
+- [x] if_then_else.mochi
+- [x] if_then_else_nested.mochi
+- [x] in_operator.mochi
+- [x] in_operator_extended.mochi
 - [x] inner_join.mochi
 - [x] join_multi.mochi
 - [x] json_builtin.mochi
 - [x] left_join.mochi
 - [x] left_join_multi.mochi
- - [x] load_yaml.mochi
+- [x] len_builtin.mochi
+- [x] len_map.mochi
+- [x] len_string.mochi
+- [x] let_and_print.mochi
+- [x] list_assign.mochi
+- [x] list_index.mochi
+- [x] list_nested_assign.mochi
+- [x] list_set_ops.mochi
+- [x] load_yaml.mochi
+- [x] map_assign.mochi
+- [x] map_in_operator.mochi
+- [x] map_index.mochi
+- [x] map_int_key.mochi
+- [x] map_literal_dynamic.mochi
+- [x] map_membership.mochi
+- [x] map_nested_assign.mochi
+- [x] match_expr.mochi
+- [x] match_full.mochi
+- [x] math_ops.mochi
+- [x] membership.mochi
+- [x] min_max_builtin.mochi
+- [x] nested_function.mochi
+- [x] order_by_map.mochi
 - [x] outer_join.mochi
+- [x] partial_application.mochi
+- [x] print_hello.mochi
+- [x] pure_fold.mochi
+- [x] pure_global_fold.mochi
 - [x] query_sum_select.mochi
+- [x] record_assign.mochi
 - [x] right_join.mochi
- - [x] save_jsonl_stdout.mochi
+- [x] save_jsonl_stdout.mochi
+- [x] short_circuit.mochi
+- [x] slice.mochi
+- [x] sort_stable.mochi
+- [x] str_builtin.mochi
+- [x] string_compare.mochi
+- [x] string_concat.mochi
+- [x] string_contains.mochi
+- [x] string_in_operator.mochi
+- [x] string_index.mochi
+- [x] string_prefix_slice.mochi
+- [x] substring_builtin.mochi
+- [x] sum_builtin.mochi
+- [x] tail_recursion.mochi
 - [x] test_block.mochi
 - [x] tree_sum.mochi
 - [x] two-sum.mochi
+- [x] typed_let.mochi
+- [x] typed_var.mochi
+- [x] unary_neg.mochi
 - [x] update_stmt.mochi
+- [x] user_type_literal.mochi
+- [x] values_builtin.mochi
+- [x] var_assignment.mochi
+- [x] while_loop.mochi
 
 ## TODO
 - [x] full outer join semantics

--- a/tests/machine/x/st/basic_compare.st
+++ b/tests/machine/x/st/basic_compare.st
@@ -1,4 +1,4 @@
-| b a |
+| a b |
 a := (10 - 3).
 b := (2 + 2).
 Transcript show: (a) printString; cr.

--- a/tests/machine/x/st/break_continue.st
+++ b/tests/machine/x/st/break_continue.st
@@ -1,4 +1,4 @@
-| n numbers |
+| numbers n |
 Object subclass: #BreakSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!.
 Object subclass: #ContinueSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!.
 numbers := {1. 2. 3. 4. 5. 6. 7. 8. 9}.

--- a/tests/machine/x/st/cross_join_triple.st
+++ b/tests/machine/x/st/cross_join_triple.st
@@ -1,4 +1,4 @@
-| combos c nums letters bools |
+| nums letters bools combos c |
 nums := {1. 2}.
 letters := {'A'. 'B'}.
 bools := {true. false}.

--- a/tests/machine/x/st/dataset_where_filter.st
+++ b/tests/machine/x/st/dataset_where_filter.st
@@ -1,4 +1,4 @@
-| person people adults |
+| people adults person |
 people := {Dictionary newFrom:{#name->'Alice'. #age->30}. Dictionary newFrom:{#name->'Bob'. #age->15}. Dictionary newFrom:{#name->'Charlie'. #age->65}. Dictionary newFrom:{#name->'Diana'. #age->45}}.
 adults := [ | tmp |
   tmp := OrderedCollection new.

--- a/tests/machine/x/st/group_by.st
+++ b/tests/machine/x/st/group_by.st
@@ -1,4 +1,4 @@
-| stats s people |
+| people stats s |
 people := {Dictionary newFrom:{#name->'Alice'. #age->30. #city->'Paris'}. Dictionary newFrom:{#name->'Bob'. #age->15. #city->'Hanoi'}. Dictionary newFrom:{#name->'Charlie'. #age->65. #city->'Paris'}. Dictionary newFrom:{#name->'Diana'. #age->45. #city->'Hanoi'}. Dictionary newFrom:{#name->'Eve'. #age->70. #city->'Paris'}. Dictionary newFrom:{#name->'Frank'. #age->22. #city->'Hanoi'}}.
 stats := [ | groups tmp |
   groups := Dictionary new.

--- a/tests/machine/x/st/group_by_multi_join.st
+++ b/tests/machine/x/st/group_by_multi_join.st
@@ -1,4 +1,4 @@
-| partsupp filtered grouped nations suppliers |
+| nations suppliers partsupp filtered grouped |
 nations := {Dictionary newFrom:{#id->1. #name->'A'}. Dictionary newFrom:{#id->2. #name->'B'}}.
 suppliers := {Dictionary newFrom:{#id->1. #nation->1}. Dictionary newFrom:{#id->2. #nation->2}}.
 partsupp := {Dictionary newFrom:{#part->100. #supplier->1. #cost->10. #qty->2}. Dictionary newFrom:{#part->100. #supplier->2. #cost->20. #qty->1}. Dictionary newFrom:{#part->200. #supplier->1. #cost->5. #qty->3}}.

--- a/tests/machine/x/st/group_by_multi_join_sort.st
+++ b/tests/machine/x/st/group_by_multi_join_sort.st
@@ -1,4 +1,4 @@
-| start_date end_date result nation customer orders lineitem |
+| nation customer orders lineitem start_date end_date result |
 nation := {Dictionary newFrom:{#n_nationkey->1. #n_name->'BRAZIL'}}.
 customer := {Dictionary newFrom:{#c_custkey->1. #c_name->'Alice'. #c_acctbal->100. #c_nationkey->1. #c_address->'123 St'. #c_phone->'123-456'. #c_comment->'Loyal'}}.
 orders := {Dictionary newFrom:{#o_orderkey->1000. #o_custkey->1. #o_orderdate->'1993-10-15'}. Dictionary newFrom:{#o_orderkey->2000. #o_custkey->1. #o_orderdate->'1994-01-02'}}.

--- a/tests/machine/x/st/inner_join.st
+++ b/tests/machine/x/st/inner_join.st
@@ -1,4 +1,4 @@
-| result entry customers orders |
+| customers orders result entry |
 customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}. Dictionary newFrom:{#id->3. #name->'Charlie'}}.
 orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->2. #total->125}. Dictionary newFrom:{#id->102. #customerId->1. #total->300}. Dictionary newFrom:{#id->103. #customerId->4. #total->80}}.
 result := [ | tmp |

--- a/tests/machine/x/st/join_multi.st
+++ b/tests/machine/x/st/join_multi.st
@@ -1,4 +1,4 @@
-| r customers orders items result |
+| customers orders items result r |
 customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}}.
 orders := {Dictionary newFrom:{#id->100. #customerId->1}. Dictionary newFrom:{#id->101. #customerId->2}}.
 items := {Dictionary newFrom:{#orderId->100. #sku->'a'}. Dictionary newFrom:{#orderId->101. #sku->'b'}}.

--- a/tests/machine/x/st/left_join.st
+++ b/tests/machine/x/st/left_join.st
@@ -1,4 +1,4 @@
-| result entry customers orders |
+| customers orders result entry |
 customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}}.
 orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->3. #total->80}}.
 result := [ | tmp |

--- a/tests/machine/x/st/match_expr.st
+++ b/tests/machine/x/st/match_expr.st
@@ -1,4 +1,4 @@
-| label x |
+| x label |
 x := 2.
 label := (x = 1) ifTrue: ['one'] ifFalse: [(x = 2) ifTrue: ['two'] ifFalse: [(x = 3) ifTrue: ['three'] ifFalse: ['unknown']]].
 Transcript show: (label) printString; cr.

--- a/tests/machine/x/st/pure_global_fold.st
+++ b/tests/machine/x/st/pure_global_fold.st
@@ -1,4 +1,4 @@
-| inc k |
+| k inc |
 k := 2.
 inc := [:x | ^(x + k). ].
 Transcript show: (inc value: 3) printString; cr.

--- a/tests/machine/x/st/right_join.st
+++ b/tests/machine/x/st/right_join.st
@@ -1,4 +1,4 @@
-| result entry customers orders |
+| customers orders result entry |
 customers := {Dictionary newFrom:{#id->1. #name->'Alice'}. Dictionary newFrom:{#id->2. #name->'Bob'}. Dictionary newFrom:{#id->3. #name->'Charlie'}. Dictionary newFrom:{#id->4. #name->'Diana'}}.
 orders := {Dictionary newFrom:{#id->100. #customerId->1. #total->250}. Dictionary newFrom:{#id->101. #customerId->2. #total->125}. Dictionary newFrom:{#id->102. #customerId->1. #total->300}}.
 result := [ | tmp |

--- a/tests/machine/x/st/string_prefix_slice.st
+++ b/tests/machine/x/st/string_prefix_slice.st
@@ -1,4 +1,4 @@
-| s1 s2 prefix |
+| prefix s1 s2 |
 prefix := 'fore'.
 s1 := 'forest'.
 Transcript show: ((s1 at: 0 = prefix)) printString; cr.

--- a/tests/machine/x/st/two-sum.st
+++ b/tests/machine/x/st/two-sum.st
@@ -1,4 +1,4 @@
-| n i j result twoSum |
+| twoSum n i j result |
 twoSum := [:nums :target | n := (nums size).
 0 to: n do: [:i |.
 (i + 1) to: n do: [:j |.


### PR DESCRIPTION
## Summary
- ensure Smalltalk compiler emits variables in deterministic order
- auto-generate README after running Smalltalk compiler tests
- regenerate Smalltalk machine outputs and README with new compiler

## Testing
- `go test ./compiler/x/st -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f7229c448832096b3efd76fa88390