### PR TITLE
Improve Zig compiler print handling

### DIFF
--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -102,4 +102,4 @@ These files were generated using the Zig compiler backend. Each `.mochi` program
 
 ## TODO
 - [ ] Keep generated outputs in sync with compiler improvements.
-- [ ] Optimize print statements for constant strings.
+- [x] Optimize print statements for constant strings.


### PR DESCRIPTION
## Summary
- enhance Zig compiler to combine string literals with formatted values
- mark optimization task as complete in Zig machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f715d1ea0832096282d8bff57c7eb