### PR TITLE
Add F# compiler updates

### DIFF
--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -1,8 +1,8 @@
 # F# Machine Output
 
 This directory contains generated F# code from the Mochi examples found in `tests/vm/valid`.
-Each Mochi file is compiled using `compiler/x/fs` and executed with `mono`. The resulting
-source is saved with a `.fs` extension and any program output goes in a matching `.out` file.
+Each Mochi file is compiled using `compiler/x/fs` and executed with `mono`.
+The resulting source is saved with a `.fs` extension and any program output goes in a matching `.out` file.
 Compilation failures are recorded with an `.error` file.
 
 ## Compilation Status
@@ -111,5 +111,5 @@ Compiled programs: 97/97
 
 ## Remaining Tasks
 
-- [x] Improve formatting of generated F# loops when `break` and `continue` are not used
- - [x] Expand support for additional standard library functions
+- [ ] Improve type inference for collections
+- [ ] Adjust printing of boolean fields in anonymous records


### PR DESCRIPTION
## Summary
- improve type inference for list literals
- propagate element types through for loops
- better string printing handling in F# compiler
- regenerate F# machine README

## Testing
- `go test ./compiler/x/fs -tags slow -run TestFSCompiler -count=1` *(fails: golden mismatch for cross_join_triple.out)*

------
https://chatgpt.com/codex/tasks/task_e_686f720be8bc8320bd73c8aa58e445eb