### PR TITLE
Update Zig compiler output formatting

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -1077,7 +1077,7 @@ func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) (string, error) {
 			return "", err
 		}
 		c.needsEqual = true
-		expr = fmt.Sprintf("if (_equal(%s, %s)) %s else (%s)", target, pat, res, expr)
+		expr = fmt.Sprintf("if (_equal(%s, %s)) %s else %s", target, pat, res, expr)
 	}
 	return expr, nil
 }
@@ -1105,7 +1105,7 @@ func (c *Compiler) compileIfExpr(ie *parser.IfExpr) (string, error) {
 		}
 		elseVal = v
 	}
-	return fmt.Sprintf("if (%s) (%s) else (%s)", cond, thenVal, elseVal), nil
+	return fmt.Sprintf("if (%s) %s else %s", cond, thenVal, elseVal), nil
 }
 
 func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -1,105 +1,108 @@
-# Mochi to Zig Machine Outputs (97/97 compiled)
+# Zig Machine Output
 
-These files were generated using the Zig compiler backend. Each `.mochi` program from `tests/vm/valid` was compiled to Zig and executed; the resulting Zig sources and program outputs are stored here.
+This directory should contain Zig source code generated from the Mochi compiler. Each test file in `tests/vm/valid` would normally be compiled and executed. In this environment the `zig` compiler is unavailable so the generation tests were skipped. The files present were produced by prior runs and may be outdated.
 
-- [x] append_builtin.mochi
-- [x] avg_builtin.mochi
-- [x] basic_compare.mochi
-- [x] binary_precedence.mochi
-- [x] bool_chain.mochi
-- [x] break_continue.mochi
-- [x] cast_string_to_int.mochi
-- [x] cast_struct.mochi
-- [x] closure.mochi
-- [x] count_builtin.mochi
-- [x] cross_join.mochi
-- [x] cross_join_filter.mochi
-- [x] cross_join_triple.mochi
-- [x] dataset_sort_take_limit.mochi
-- [x] dataset_where_filter.mochi
-- [x] exists_builtin.mochi
-- [x] for_list_collection.mochi
-- [x] for_loop.mochi
-- [x] for_map_collection.mochi
-- [x] fun_call.mochi
-- [x] fun_expr_in_let.mochi
-- [x] fun_three_args.mochi
-- [x] group_by.mochi
-- [x] group_by_conditional_sum.mochi
-- [x] group_by_having.mochi
-- [x] group_by_join.mochi
-- [x] group_by_left_join.mochi
-- [x] group_by_multi_join.mochi
-- [x] group_by_multi_join_sort.mochi
-- [x] group_by_sort.mochi
-- [x] group_items_iteration.mochi
-- [x] if_else.mochi
-- [x] if_then_else.mochi
-- [x] if_then_else_nested.mochi
-- [x] in_operator.mochi
-- [x] in_operator_extended.mochi
-- [x] inner_join.mochi
-- [x] join_multi.mochi
-- [x] json_builtin.mochi
-- [x] left_join.mochi
-- [x] left_join_multi.mochi
-- [x] len_builtin.mochi
-- [x] len_map.mochi
-- [x] len_string.mochi
-- [x] let_and_print.mochi
-- [x] list_assign.mochi
-- [x] list_index.mochi
-- [x] list_nested_assign.mochi
-- [x] list_set_ops.mochi
-- [x] load_yaml.mochi
-- [x] map_assign.mochi
-- [x] map_in_operator.mochi
-- [x] map_index.mochi
-- [x] map_int_key.mochi
-- [x] map_literal_dynamic.mochi
-- [x] map_membership.mochi
-- [x] map_nested_assign.mochi
-- [x] match_expr.mochi
-- [x] match_full.mochi
-- [x] math_ops.mochi
-- [x] membership.mochi
-- [x] min_max_builtin.mochi
-- [x] nested_function.mochi
-- [x] order_by_map.mochi
-- [x] outer_join.mochi
-- [x] partial_application.mochi
-- [x] print_hello.mochi
-- [x] pure_fold.mochi
-- [x] pure_global_fold.mochi
-- [x] query_sum_select.mochi
-- [x] record_assign.mochi
-- [x] right_join.mochi
-- [x] save_jsonl_stdout.mochi
-- [x] short_circuit.mochi
-- [x] slice.mochi
-- [x] sort_stable.mochi
-- [x] str_builtin.mochi
-- [x] string_compare.mochi
-- [x] string_concat.mochi
-- [x] string_contains.mochi
-- [x] string_in_operator.mochi
-- [x] string_index.mochi
-- [x] string_prefix_slice.mochi
-- [x] substring_builtin.mochi
-- [x] sum_builtin.mochi
-- [x] tail_recursion.mochi
-- [x] test_block.mochi
-- [x] tree_sum.mochi
-- [x] two-sum.mochi
-- [x] typed_let.mochi
-- [x] typed_var.mochi
-- [x] unary_neg.mochi
-- [x] update_stmt.mochi
-- [x] user_type_literal.mochi
-- [x] values_builtin.mochi
-- [x] var_assignment.mochi
-- [x] while_loop.mochi
+Compiled programs: 36/97
 
-## TODO
-- [ ] Keep generated outputs in sync with compiler improvements.
-- [ ] Optimize print statements for constant strings.
+## Checklist
+- [x] append_builtin
+- [x] avg_builtin
+- [x] basic_compare
+- [x] binary_precedence
+- [x] bool_chain
+- [x] break_continue
+- [x] cast_string_to_int
+- [x] cast_struct
+- [ ] closure
+- [x] count_builtin
+- [ ] cross_join
+- [ ] cross_join_filter
+- [ ] cross_join_triple
+- [ ] dataset_sort_take_limit
+- [ ] dataset_where_filter
+- [ ] exists_builtin
+- [x] for_list_collection
+- [x] for_loop
+- [ ] for_map_collection
+- [x] fun_call
+- [ ] fun_expr_in_let
+- [x] fun_three_args
+- [ ] group_by
+- [ ] group_by_conditional_sum
+- [ ] group_by_having
+- [ ] group_by_join
+- [ ] group_by_left_join
+- [ ] group_by_multi_join
+- [ ] group_by_multi_join_sort
+- [ ] group_by_sort
+- [ ] group_items_iteration
+- [x] if_else
+- [x] if_then_else
+- [x] if_then_else_nested
+- [x] in_operator
+- [x] in_operator_extended
+- [ ] inner_join
+- [ ] join_multi
+- [ ] json_builtin
+- [ ] left_join
+- [ ] left_join_multi
+- [x] len_builtin
+- [ ] len_map
+- [x] len_string
+- [x] let_and_print
+- [ ] list_assign
+- [x] list_index
+- [ ] list_nested_assign
+- [x] list_set_ops
+- [ ] load_yaml
+- [ ] map_assign
+- [ ] map_in_operator
+- [ ] map_index
+- [ ] map_int_key
+- [ ] map_literal_dynamic
+- [ ] map_membership
+- [ ] map_nested_assign
+- [ ] match_expr
+- [ ] match_full
+- [ ] math_ops
+- [x] membership
+- [x] min_max_builtin
+- [ ] nested_function
+- [ ] order_by_map
+- [ ] outer_join
+- [ ] partial_application
+- [x] print_hello
+- [x] pure_fold
+- [x] pure_global_fold
+- [ ] query_sum_select
+- [ ] record_assign
+- [ ] right_join
+- [ ] save_jsonl_stdout
+- [ ] short_circuit
+- [x] slice
+- [ ] sort_stable
+- [x] str_builtin
+- [ ] string_compare
+- [x] string_concat
+- [ ] string_contains
+- [ ] string_in_operator
+- [ ] string_index
+- [x] string_prefix_slice
+- [ ] substring_builtin
+- [x] sum_builtin
+- [x] tail_recursion
+- [x] test_block
+- [ ] tree_sum
+- [ ] two-sum
+- [ ] typed_let
+- [ ] typed_var
+- [x] unary_neg
+- [ ] update_stmt
+- [x] user_type_literal
+- [ ] values_builtin
+- [ ] var_assignment
+- [ ] while_loop
+
+## Remaining Tasks
+
+The programs unchecked above either failed to compile or were not executed because the `zig` compiler was missing. Installing `zig` and re-running the tests will regenerate fresh outputs.


### PR DESCRIPTION
## Summary
- refine Zig conditional expression generation for readability
- note unavailable zig compiler and update checklist for Zig outputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f7231c1c083209d34753156367a98