### PR TITLE
Improve hs compiler imports

### DIFF
--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -194,10 +194,16 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	header.WriteString("{-# LANGUAGE DeriveGeneric #-}\n")
 	header.WriteString("module Main where\n\n")
 	header.WriteString("import Data.Maybe (fromMaybe)\n")
-	header.WriteString("import Data.Time.Clock.POSIX (getPOSIXTime)\n")
-	header.WriteString("import qualified Data.Map as Map\n")
-	header.WriteString("import Data.List (intercalate, isPrefixOf, isInfixOf)\n")
-	header.WriteString("import qualified Data.List as List\n")
+	if c.usesTime {
+		header.WriteString("import Data.Time.Clock.POSIX (getPOSIXTime)\n")
+	}
+	if c.usesMap || c.usesLoad || c.usesSave || c.usesFetch {
+		header.WriteString("import qualified Data.Map as Map\n")
+	}
+	if c.usesList || c.usesSlice || c.usesSliceStr || c.usesLoop || c.usesFetch {
+		header.WriteString("import Data.List (intercalate, isPrefixOf, isInfixOf)\n")
+		header.WriteString("import qualified Data.List as List\n")
+	}
 	if c.usesJSON || c.usesLoad || c.usesSave || c.usesFetch {
 		header.WriteString("import qualified Data.Aeson as Aeson\n")
 	}

--- a/tests/machine/x/hs/README.md
+++ b/tests/machine/x/hs/README.md
@@ -112,3 +112,4 @@ while failures have a `.error` log.
 - [ ] Improve query output formatting beyond `_showAny` helpers.
 - [ ] Generate `.out` files once Haskell dependencies are available.
 - [ ] Implement record assignment transformations.
+- [x] Trim unused imports in generated code.


### PR DESCRIPTION
## Summary
- reduce unused imports in Haskell compiler output
- document trimming imports in machine README

## Testing
- `go test -tags slow ./compiler/x/hs -run TestHSCompiler_ValidPrograms -count=1` *(fails: build constraints exclude all Go files)*
- `go test ./...` *(interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686f77455cc083209eddd751d532423f