### PR TITLE
Improve Lua compiler output

### DIFF
--- a/compiler/x/lua/runtime.go
+++ b/compiler/x/lua/runtime.go
@@ -31,15 +31,6 @@ const (
 		"    end\n" +
 		"end\n"
 
-	helperPrint = "function __print(...)\n" +
-		"    local args = {...}\n" +
-		"    local parts = {}\n" +
-		"    for i,a in ipairs(args) do\n" +
-		"        if a ~= nil and a ~= '' then parts[#parts+1] = tostring(a) end\n" +
-		"    end\n" +
-		"    print(table.concat(parts, ' '))\n" +
-		"end\n"
-
 	helperIter = "function __iter(obj)\n" +
 		"    if type(obj) == 'table' then\n" +
 		"        if obj[1] ~= nil or #obj > 0 then\n" +
@@ -750,9 +741,8 @@ const (
 		"            end\n" +
 		"            for ri, right in ipairs(jitems) do\n" +
 		"                if not matched[ri] then\n" +
-		"                    local undef = {}\n" +
-		"                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end\n" +
-		"                    local row = {table.unpack(undef)}\n" +
+		"                    local row = {}\n" +
+		"                    for _=1,ji do row[#row+1] = nil end\n" +
 		"                    row[#row+1] = right\n" +
 		"                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then\n" +
 		"                    else\n" +
@@ -781,9 +771,8 @@ const (
 		"                    end\n" +
 		"                end\n" +
 		"                if not m then\n" +
-		"                    local undef = {}\n" +
-		"                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end\n" +
-		"                    local row = {table.unpack(undef)}\n" +
+		"                    local row = {}\n" +
+		"                    for _=1,ji do row[#row+1] = nil end\n" +
 		"                    row[#row+1] = right\n" +
 		"                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then\n" +
 		"                    else\n" +
@@ -857,7 +846,6 @@ const (
 
 var helperMap = map[string]string{
 	"run_tests":      helperRunTests,
-	"print":          helperPrint,
 	"iter":           helperIter,
 	"div":            helperDiv,
 	"add":            helperAdd,

--- a/compiler/x/lua/statements.go
+++ b/compiler/x/lua/statements.go
@@ -366,10 +366,17 @@ func (c *Compiler) compileFor(s *parser.ForStmt) error {
 			}
 			c.indent++
 		case isMap(t):
+			keys := fmt.Sprintf("_k%d", c.tmpCount)
+			tmp := fmt.Sprintf("_m%d", c.tmpCount)
+			c.tmpCount++
+			c.writeln(fmt.Sprintf("local %s = %s", tmp, src))
+			c.writeln(fmt.Sprintf("local %s = {}", keys))
+			c.writeln(fmt.Sprintf("for k in pairs(%s) do %s[#%s+1] = k end", tmp, keys, keys))
+			c.writeln(fmt.Sprintf("table.sort(%s, function(a,b) return tostring(a)<tostring(b) end)", keys))
 			if useVar {
-				c.writeln(fmt.Sprintf("for %s in pairs(%s) do", name, src))
+				c.writeln(fmt.Sprintf("for _, %s in ipairs(%s) do", name, keys))
 			} else {
-				c.writeln(fmt.Sprintf("for _ in pairs(%s) do", src))
+				c.writeln(fmt.Sprintf("for _ in ipairs(%s) do", keys))
 			}
 			c.indent++
 		case isString(t):


### PR DESCRIPTION
## Summary
- update Lua compiler to generate inline print helpers instead of using `__print`
- sort map keys in Lua for loops for deterministic output

## Testing
- `go test ./compiler/x/lua -run TestLuaCompiler_ValidPrograms/right_join -tags slow -count=1`
- `go test ./compiler/x/lua -run TestLuaCompiler_ValidPrograms/basic_compare -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686f76439cc88320a198afdb8c5076cf