### PR TITLE
Improve TypeScript compiler loops

### DIFF
--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -105,8 +105,3 @@ Compiled: 97/97 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
-
-## Remaining Tasks
-
-- None
-

--- a/tests/machine/x/typescript/cross_join.ts
+++ b/tests/machine/x/typescript/cross_join.ts
@@ -1,18 +1,18 @@
 const customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}];
 const orders = [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp2 = [];
   for (const o of orders) {
     for (const c of customers) {
-      _tmp1.push({orderId: o.id, orderCustomerId: o.customerId, pairedCustomerName: c.name, orderTotal: o.total});
+      _tmp2.push({orderId: o.id, orderCustomerId: o.customerId, pairedCustomerName: c.name, orderTotal: o.total});
     }
   }
-  let res = _tmp1;
+  let res = _tmp2;
   return res;
 })()
 ;
 console.log("--- Cross Join: All order-customer pairs ---");
-const _tmp2 = result;
-for (const entry of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp3 = result;
+for (const entry of (Array.isArray(_tmp3) ? _tmp3 : Object.keys(_tmp3))) {
   console.log("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName);
 }

--- a/tests/machine/x/typescript/cross_join_filter.ts
+++ b/tests/machine/x/typescript/cross_join_filter.ts
@@ -1,19 +1,19 @@
 const nums = [1, 2, 3];
 const letters = ["A", "B"];
 const pairs = (() => {
-  const _tmp1 = [];
+  const _tmp4 = [];
   for (const n of nums) {
     for (const l of letters) {
       if (!(((n % 2) == 0))) continue;
-      _tmp1.push({n: n, l: l});
+      _tmp4.push({n: n, l: l});
     }
   }
-  let res = _tmp1;
+  let res = _tmp4;
   return res;
 })()
 ;
 console.log("--- Even pairs ---");
-const _tmp2 = pairs;
-for (const p of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp5 = pairs;
+for (const p of (Array.isArray(_tmp5) ? _tmp5 : Object.keys(_tmp5))) {
   console.log(p.n, p.l);
 }

--- a/tests/machine/x/typescript/cross_join_triple.ts
+++ b/tests/machine/x/typescript/cross_join_triple.ts
@@ -2,20 +2,20 @@ const nums = [1, 2];
 const letters = ["A", "B"];
 const bools = [true, false];
 const combos = (() => {
-  const _tmp1 = [];
+  const _tmp6 = [];
   for (const n of nums) {
     for (const l of letters) {
       for (const b of bools) {
-        _tmp1.push({n: n, l: l, b: b});
+        _tmp6.push({n: n, l: l, b: b});
       }
     }
   }
-  let res = _tmp1;
+  let res = _tmp6;
   return res;
 })()
 ;
 console.log("--- Cross Join of three lists ---");
-const _tmp2 = combos;
-for (const c of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp7 = combos;
+for (const c of (Array.isArray(_tmp7) ? _tmp7 : Object.keys(_tmp7))) {
   console.log(c.n, c.l, c.b);
 }

--- a/tests/machine/x/typescript/dataset_sort_take_limit.ts
+++ b/tests/machine/x/typescript/dataset_sort_take_limit.ts
@@ -1,17 +1,17 @@
 const products = [{name: "Laptop", price: 1500}, {name: "Smartphone", price: 900}, {name: "Tablet", price: 600}, {name: "Monitor", price: 300}, {name: "Keyboard", price: 100}, {name: "Mouse", price: 50}, {name: "Headphones", price: 200}];
 const expensive = (() => {
-  const _tmp1 = [];
+  const _tmp8 = [];
   for (const p of products) {
-    _tmp1.push({item: p, key: (-p.price)});
+    _tmp8.push({item: p, key: (-p.price)});
   }
-  let res = _tmp1;
+  let res = _tmp8;
   res = res.sort((a,b)=> a.key < b.key ? -1 : a.key > b.key ? 1 : 0).map(x=>x.item);
   res = res.slice(1, (1 + 3));
   return res;
 })()
 ;
 console.log("--- Top products (excluding most expensive) ---");
-const _tmp2 = expensive;
-for (const item of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp9 = expensive;
+for (const item of (Array.isArray(_tmp9) ? _tmp9 : Object.keys(_tmp9))) {
   console.log(item.name, "costs $", item.price);
 }

--- a/tests/machine/x/typescript/dataset_where_filter.ts
+++ b/tests/machine/x/typescript/dataset_where_filter.ts
@@ -1,16 +1,16 @@
 const people = [{name: "Alice", age: 30}, {name: "Bob", age: 15}, {name: "Charlie", age: 65}, {name: "Diana", age: 45}];
 const adults = (() => {
-  const _tmp1 = [];
+  const _tmp10 = [];
   for (const person of people) {
     if (!((person.age >= 18))) continue;
-    _tmp1.push({name: person.name, age: person.age, is_senior: (person.age >= 60)});
+    _tmp10.push({name: person.name, age: person.age, is_senior: (person.age >= 60)});
   }
-  let res = _tmp1;
+  let res = _tmp10;
   return res;
 })()
 ;
 console.log("--- Adults ---");
-const _tmp2 = adults;
-for (const person of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp11 = adults;
+for (const person of (Array.isArray(_tmp11) ? _tmp11 : Object.keys(_tmp11))) {
   console.log(person.name, "is", person.age, (person.is_senior ? " (senior)" : ""));
 }

--- a/tests/machine/x/typescript/for_list_collection.ts
+++ b/tests/machine/x/typescript/for_list_collection.ts
@@ -1,4 +1,3 @@
-const _tmp1 = [1, 2, 3];
-for (const n of (Array.isArray(_tmp1) ? _tmp1 : Object.keys(_tmp1))) {
+for (const n of [1, 2, 3]) {
   console.log(n);
 }

--- a/tests/machine/x/typescript/for_map_collection.ts
+++ b/tests/machine/x/typescript/for_map_collection.ts
@@ -1,5 +1,5 @@
 let m = {a: 1, b: 2};
-const _tmp1 = m;
-for (const k of (Array.isArray(_tmp1) ? _tmp1 : Object.keys(_tmp1))) {
+const _tmp13 = m;
+for (const k of (Array.isArray(_tmp13) ? _tmp13 : Object.keys(_tmp13))) {
   console.log(k);
 }

--- a/tests/machine/x/typescript/group_by.ts
+++ b/tests/machine/x/typescript/group_by.ts
@@ -11,19 +11,19 @@ const stats = (() => {
   for (const _k in groups) {
     const g = groups[_k];
     res.push({city: g.key, count: g.length, avg_age: ((() => {
-  const _tmp1 = [];
+  const _tmp14 = [];
   for (const p of g) {
-    _tmp1.push(p.age);
+    _tmp14.push(p.age);
   }
-  let res = _tmp1;
+  let res = _tmp14;
   return res;
 })()
 .reduce((a,b)=>a+b,0)/(() => {
-  const _tmp1 = [];
+  const _tmp14 = [];
   for (const p of g) {
-    _tmp1.push(p.age);
+    _tmp14.push(p.age);
   }
-  let res = _tmp1;
+  let res = _tmp14;
   return res;
 })()
 .length)});
@@ -32,7 +32,7 @@ const stats = (() => {
 })()
 ;
 console.log("--- People grouped by city ---");
-const _tmp3 = stats;
-for (const s of (Array.isArray(_tmp3) ? _tmp3 : Object.keys(_tmp3))) {
+const _tmp16 = stats;
+for (const s of (Array.isArray(_tmp16) ? _tmp16 : Object.keys(_tmp16))) {
   console.log(s.city, ": count =", s.count, ", avg_age =", s.avg_age);
 }

--- a/tests/machine/x/typescript/group_by_conditional_sum.ts
+++ b/tests/machine/x/typescript/group_by_conditional_sum.ts
@@ -11,19 +11,19 @@ const result = (() => {
   for (const _k in groups) {
     const g = groups[_k];
     res.push({item: {cat: g.key, share: (((() => {
-  const _tmp1 = [];
+  const _tmp17 = [];
   for (const x of g) {
-    _tmp1.push((x.flag ? x.val : 0));
+    _tmp17.push((x.flag ? x.val : 0));
   }
-  let res = _tmp1;
+  let res = _tmp17;
   return res;
 })()
 .reduce((a,b)=>a+b,0)) / ((() => {
-  const _tmp2 = [];
+  const _tmp18 = [];
   for (const x of g) {
-    _tmp2.push(x.val);
+    _tmp18.push(x.val);
   }
-  let res = _tmp2;
+  let res = _tmp18;
   return res;
 })()
 .reduce((a,b)=>a+b,0)))}, key: g.key});

--- a/tests/machine/x/typescript/group_by_join.ts
+++ b/tests/machine/x/typescript/group_by_join.ts
@@ -20,7 +20,7 @@ const stats = (() => {
 })()
 ;
 console.log("--- Orders per customer ---");
-const _tmp2 = stats;
-for (const s of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp22 = stats;
+for (const s of (Array.isArray(_tmp22) ? _tmp22 : Object.keys(_tmp22))) {
   console.log(s.name, "orders:", s.count);
 }

--- a/tests/machine/x/typescript/group_by_left_join.ts
+++ b/tests/machine/x/typescript/group_by_left_join.ts
@@ -15,12 +15,12 @@ const stats = (() => {
   for (const _k in groups) {
     const g = groups[_k];
     res.push({name: g.key, count: (() => {
-  const _tmp1 = [];
+  const _tmp23 = [];
   for (const r of g) {
     if (!(r.o)) continue;
-    _tmp1.push(r);
+    _tmp23.push(r);
   }
-  let res = _tmp1;
+  let res = _tmp23;
   return res;
 })()
 .length});
@@ -29,7 +29,7 @@ const stats = (() => {
 })()
 ;
 console.log("--- Group Left Join ---");
-const _tmp3 = stats;
-for (const s of (Array.isArray(_tmp3) ? _tmp3 : Object.keys(_tmp3))) {
+const _tmp25 = stats;
+for (const s of (Array.isArray(_tmp25) ? _tmp25 : Object.keys(_tmp25))) {
   console.log(s.name, "orders:", s.count);
 }

--- a/tests/machine/x/typescript/group_by_multi_join.ts
+++ b/tests/machine/x/typescript/group_by_multi_join.ts
@@ -2,18 +2,18 @@ const nations = [{id: 1, name: "A"}, {id: 2, name: "B"}];
 const suppliers = [{id: 1, nation: 1}, {id: 2, nation: 2}];
 const partsupp = [{part: 100, supplier: 1, cost: 10, qty: 2}, {part: 100, supplier: 2, cost: 20, qty: 1}, {part: 200, supplier: 1, cost: 5, qty: 3}];
 const filtered = (() => {
-  const _tmp1 = [];
+  const _tmp26 = [];
   for (const ps of partsupp) {
     for (const s of suppliers) {
       if (!((s.id == ps.supplier))) continue;
       for (const n of nations) {
         if (!((n.id == s.nation))) continue;
         if (!((n.name == "A"))) continue;
-        _tmp1.push({part: ps.part, value: (ps.cost * ps.qty)});
+        _tmp26.push({part: ps.part, value: (ps.cost * ps.qty)});
       }
     }
   }
-  let res = _tmp1;
+  let res = _tmp26;
   return res;
 })()
 ;
@@ -29,11 +29,11 @@ const grouped = (() => {
   for (const _k in groups) {
     const g = groups[_k];
     res.push({part: g.key, total: ((() => {
-  const _tmp2 = [];
+  const _tmp27 = [];
   for (const r of g) {
-    _tmp2.push(r.value);
+    _tmp27.push(r.value);
   }
-  let res = _tmp2;
+  let res = _tmp27;
   return res;
 })()
 .reduce((a,b)=>a+b,0))});

--- a/tests/machine/x/typescript/group_by_multi_join_sort.ts
+++ b/tests/machine/x/typescript/group_by_multi_join_sort.ts
@@ -26,19 +26,19 @@ const result = (() => {
   for (const _k in groups) {
     const g = groups[_k];
     res.push({item: {c_custkey: g.key.c_custkey, c_name: g.key.c_name, revenue: ((() => {
-  const _tmp1 = [];
+  const _tmp29 = [];
   for (const x of g) {
-    _tmp1.push((x.l.l_extendedprice * ((1 - x.l.l_discount))));
+    _tmp29.push((x.l.l_extendedprice * ((1 - x.l.l_discount))));
   }
-  let res = _tmp1;
+  let res = _tmp29;
   return res;
 })()
 .reduce((a,b)=>a+b,0)), c_acctbal: g.key.c_acctbal, n_name: g.key.n_name, c_address: g.key.c_address, c_phone: g.key.c_phone, c_comment: g.key.c_comment}, key: (-((() => {
-  const _tmp2 = [];
+  const _tmp30 = [];
   for (const x of g) {
-    _tmp2.push((x.l.l_extendedprice * ((1 - x.l.l_discount))));
+    _tmp30.push((x.l.l_extendedprice * ((1 - x.l.l_discount))));
   }
-  let res = _tmp2;
+  let res = _tmp30;
   return res;
 })()
 .reduce((a,b)=>a+b,0)))});

--- a/tests/machine/x/typescript/group_by_sort.ts
+++ b/tests/machine/x/typescript/group_by_sort.ts
@@ -11,19 +11,19 @@ const grouped = (() => {
   for (const _k in groups) {
     const g = groups[_k];
     res.push({item: {cat: g.key, total: ((() => {
-  const _tmp1 = [];
+  const _tmp32 = [];
   for (const x of g) {
-    _tmp1.push(x.val);
+    _tmp32.push(x.val);
   }
-  let res = _tmp1;
+  let res = _tmp32;
   return res;
 })()
 .reduce((a,b)=>a+b,0))}, key: (-((() => {
-  const _tmp2 = [];
+  const _tmp33 = [];
   for (const x of g) {
-    _tmp2.push(x.val);
+    _tmp33.push(x.val);
   }
-  let res = _tmp2;
+  let res = _tmp33;
   return res;
 })()
 .reduce((a,b)=>a+b,0)))});

--- a/tests/machine/x/typescript/group_items_iteration.ts
+++ b/tests/machine/x/typescript/group_items_iteration.ts
@@ -16,21 +16,21 @@ const groups = (() => {
 })()
 ;
 let tmp = [];
-const _tmp2 = groups;
-for (const g of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp36 = groups;
+for (const g of (Array.isArray(_tmp36) ? _tmp36 : Object.keys(_tmp36))) {
   let total = 0;
-  const _tmp3 = g.items;
-  for (const x of (Array.isArray(_tmp3) ? _tmp3 : Object.keys(_tmp3))) {
+  const _tmp37 = g.items;
+  for (const x of (Array.isArray(_tmp37) ? _tmp37 : Object.keys(_tmp37))) {
     total = (total + x.val);
   }
   tmp = [...tmp, {tag: g.key, total: total}];
 }
 const result = (() => {
-  const _tmp4 = [];
+  const _tmp38 = [];
   for (const r of tmp) {
-    _tmp4.push({item: r, key: r.tag});
+    _tmp38.push({item: r, key: r.tag});
   }
-  let res = _tmp4;
+  let res = _tmp38;
   res = res.sort((a,b)=> a.key < b.key ? -1 : a.key > b.key ? 1 : 0).map(x=>x.item);
   return res;
 })()

--- a/tests/machine/x/typescript/in_operator_extended.ts
+++ b/tests/machine/x/typescript/in_operator_extended.ts
@@ -4,12 +4,12 @@ function contains(a: any, b: any) {
 }
 const xs = [1, 2, 3];
 const ys = (() => {
-  const _tmp1 = [];
+  const _tmp39 = [];
   for (const x of xs) {
     if (!(((x % 2) == 1))) continue;
-    _tmp1.push(x);
+    _tmp39.push(x);
   }
-  let res = _tmp1;
+  let res = _tmp39;
   return res;
 })()
 ;

--- a/tests/machine/x/typescript/inner_join.ts
+++ b/tests/machine/x/typescript/inner_join.ts
@@ -1,19 +1,19 @@
 const customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}];
 const orders = [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}, {id: 103, customerId: 4, total: 80}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp40 = [];
   for (const o of orders) {
     for (const c of customers) {
       if (!((o.customerId == c.id))) continue;
-      _tmp1.push({orderId: o.id, customerName: c.name, total: o.total});
+      _tmp40.push({orderId: o.id, customerName: c.name, total: o.total});
     }
   }
-  let res = _tmp1;
+  let res = _tmp40;
   return res;
 })()
 ;
 console.log("--- Orders with customer info ---");
-const _tmp2 = result;
-for (const entry of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp41 = result;
+for (const entry of (Array.isArray(_tmp41) ? _tmp41 : Object.keys(_tmp41))) {
   console.log("Order", entry.orderId, "by", entry.customerName, "- $", entry.total);
 }

--- a/tests/machine/x/typescript/join_multi.ts
+++ b/tests/machine/x/typescript/join_multi.ts
@@ -2,22 +2,22 @@ const customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}];
 const orders = [{id: 100, customerId: 1}, {id: 101, customerId: 2}];
 const items = [{orderId: 100, sku: "a"}, {orderId: 101, sku: "b"}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp42 = [];
   for (const o of orders) {
     for (const c of customers) {
       if (!((o.customerId == c.id))) continue;
       for (const i of items) {
         if (!((o.id == i.orderId))) continue;
-        _tmp1.push({name: c.name, sku: i.sku});
+        _tmp42.push({name: c.name, sku: i.sku});
       }
     }
   }
-  let res = _tmp1;
+  let res = _tmp42;
   return res;
 })()
 ;
 console.log("--- Multi Join ---");
-const _tmp2 = result;
-for (const r of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp43 = result;
+for (const r of (Array.isArray(_tmp43) ? _tmp43 : Object.keys(_tmp43))) {
   console.log(r.name, "bought item", r.sku);
 }

--- a/tests/machine/x/typescript/left_join.ts
+++ b/tests/machine/x/typescript/left_join.ts
@@ -1,19 +1,19 @@
 const customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}];
 const orders = [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 3, total: 80}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp44 = [];
   for (const o of orders) {
     for (const c of customers) {
       if (!((o.customerId == c.id))) continue;
-      _tmp1.push({orderId: o.id, customer: c, total: o.total});
+      _tmp44.push({orderId: o.id, customer: c, total: o.total});
     }
   }
-  let res = _tmp1;
+  let res = _tmp44;
   return res;
 })()
 ;
 console.log("--- Left Join ---");
-const _tmp2 = result;
-for (const entry of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp45 = result;
+for (const entry of (Array.isArray(_tmp45) ? _tmp45 : Object.keys(_tmp45))) {
   console.log("Order", entry.orderId, "customer", entry.customer, "total", entry.total);
 }

--- a/tests/machine/x/typescript/left_join_multi.ts
+++ b/tests/machine/x/typescript/left_join_multi.ts
@@ -2,22 +2,22 @@ const customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}];
 const orders = [{id: 100, customerId: 1}, {id: 101, customerId: 2}];
 const items = [{orderId: 100, sku: "a"}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp46 = [];
   for (const o of orders) {
     for (const c of customers) {
       if (!((o.customerId == c.id))) continue;
       for (const i of items) {
         if (!((o.id == i.orderId))) continue;
-        _tmp1.push({orderId: o.id, name: c.name, item: i});
+        _tmp46.push({orderId: o.id, name: c.name, item: i});
       }
     }
   }
-  let res = _tmp1;
+  let res = _tmp46;
   return res;
 })()
 ;
 console.log("--- Left Join Multi ---");
-const _tmp2 = result;
-for (const r of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp47 = result;
+for (const r of (Array.isArray(_tmp47) ? _tmp47 : Object.keys(_tmp47))) {
   console.log(r.orderId, r.name, r.item);
 }

--- a/tests/machine/x/typescript/load_yaml.ts
+++ b/tests/machine/x/typescript/load_yaml.ts
@@ -1,16 +1,16 @@
 type Person = { name: any; age: any; email: any; };
 const people = JSON.parse("[{\"age\":30,\"email\":\"alice@example.com\",\"name\":\"Alice\"},{\"age\":15,\"email\":\"bob@example.com\",\"name\":\"Bob\"},{\"age\":20,\"email\":\"charlie@example.com\",\"name\":\"Charlie\"}]");
 const adults = (() => {
-  const _tmp1 = [];
+  const _tmp48 = [];
   for (const p of people) {
     if (!((p.age >= 18))) continue;
-    _tmp1.push({name: p.name, email: p.email});
+    _tmp48.push({name: p.name, email: p.email});
   }
-  let res = _tmp1;
+  let res = _tmp48;
   return res;
 })()
 ;
-const _tmp2 = adults;
-for (const a of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp49 = adults;
+for (const a of (Array.isArray(_tmp49) ? _tmp49 : Object.keys(_tmp49))) {
   console.log(a.name, a.email);
 }

--- a/tests/machine/x/typescript/match_expr.ts
+++ b/tests/machine/x/typescript/match_expr.ts
@@ -1,8 +1,8 @@
 const x = 2;
 const label = (() => {
-  const _tmp1 = x;
+  const _tmp50 = x;
   let _res;
-  switch (_tmp1) {
+  switch (_tmp50) {
     case 1:
       _res = "one";
       break;

--- a/tests/machine/x/typescript/match_full.ts
+++ b/tests/machine/x/typescript/match_full.ts
@@ -1,8 +1,8 @@
 const x = 2;
 const label = (() => {
-  const _tmp1 = x;
+  const _tmp51 = x;
   let _res;
-  switch (_tmp1) {
+  switch (_tmp51) {
     case 1:
       _res = "one";
       break;
@@ -22,9 +22,9 @@ const label = (() => {
 console.log(label);
 const day = "sun";
 const mood = (() => {
-  const _tmp2 = day;
+  const _tmp52 = day;
   let _res;
-  switch (_tmp2) {
+  switch (_tmp52) {
     case "mon":
       _res = "tired";
       break;
@@ -44,9 +44,9 @@ const mood = (() => {
 console.log(mood);
 const ok = true;
 const status = (() => {
-  const _tmp3 = ok;
+  const _tmp53 = ok;
   let _res;
-  switch (_tmp3) {
+  switch (_tmp53) {
     case true:
       _res = "confirmed";
       break;
@@ -63,9 +63,9 @@ const status = (() => {
 console.log(status);
 function classify(n) {
   return (() => {
-  const _tmp4 = n;
+  const _tmp54 = n;
   let _res;
-  switch (_tmp4) {
+  switch (_tmp54) {
     case 0:
       _res = "zero";
       break;

--- a/tests/machine/x/typescript/order_by_map.ts
+++ b/tests/machine/x/typescript/order_by_map.ts
@@ -1,10 +1,10 @@
 const data = [{a: 1, b: 2}, {a: 1, b: 1}, {a: 0, b: 5}];
 const sorted = (() => {
-  const _tmp1 = [];
+  const _tmp55 = [];
   for (const x of data) {
-    _tmp1.push({item: x, key: {a: x.a, b: x.b}});
+    _tmp55.push({item: x, key: {a: x.a, b: x.b}});
   }
-  let res = _tmp1;
+  let res = _tmp55;
   res = res.sort((a,b)=> a.key < b.key ? -1 : a.key > b.key ? 1 : 0).map(x=>x.item);
   return res;
 })()

--- a/tests/machine/x/typescript/outer_join.ts
+++ b/tests/machine/x/typescript/outer_join.ts
@@ -1,20 +1,20 @@
 const customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}, {id: 4, name: "Diana"}];
 const orders = [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}, {id: 103, customerId: 5, total: 80}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp56 = [];
   for (const o of orders) {
     for (const c of customers) {
       if (!((o.customerId == c.id))) continue;
-      _tmp1.push({order: o, customer: c});
+      _tmp56.push({order: o, customer: c});
     }
   }
-  let res = _tmp1;
+  let res = _tmp56;
   return res;
 })()
 ;
 console.log("--- Outer Join using syntax ---");
-const _tmp2 = result;
-for (const row of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp57 = result;
+for (const row of (Array.isArray(_tmp57) ? _tmp57 : Object.keys(_tmp57))) {
   if (row.order) {
     if (row.customer) {
       console.log("Order", row.order.id, "by", row.customer.name, "- $", row.order.total);

--- a/tests/machine/x/typescript/query_sum_select.ts
+++ b/tests/machine/x/typescript/query_sum_select.ts
@@ -1,11 +1,11 @@
 const nums = [1, 2, 3];
 const result = (() => {
-  let _tmp1 = 0;
+  let _tmp58 = 0;
   for (const n of nums) {
     if (!((n > 1))) continue;
-    _tmp1 += n;
+    _tmp58 += n;
   }
-  let res = _tmp1;
+  let res = _tmp58;
   return res;
 })()
 ;

--- a/tests/machine/x/typescript/right_join.ts
+++ b/tests/machine/x/typescript/right_join.ts
@@ -1,20 +1,20 @@
 const customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}, {id: 4, name: "Diana"}];
 const orders = [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp59 = [];
   for (const c of customers) {
     for (const o of orders) {
       if (!((o.customerId == c.id))) continue;
-      _tmp1.push({customerName: c.name, order: o});
+      _tmp59.push({customerName: c.name, order: o});
     }
   }
-  let res = _tmp1;
+  let res = _tmp59;
   return res;
 })()
 ;
 console.log("--- Right Join using syntax ---");
-const _tmp2 = result;
-for (const entry of (Array.isArray(_tmp2) ? _tmp2 : Object.keys(_tmp2))) {
+const _tmp60 = result;
+for (const entry of (Array.isArray(_tmp60) ? _tmp60 : Object.keys(_tmp60))) {
   if (entry.order) {
     console.log("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total);
   } else {

--- a/tests/machine/x/typescript/save_jsonl_stdout.ts
+++ b/tests/machine/x/typescript/save_jsonl_stdout.ts
@@ -1,6 +1,6 @@
 const people = [{name: "Alice", age: 30}, {name: "Bob", age: 25}];
 (() => {
-  for (const _tmp1 of people) {
-    console.log(JSON.stringify(_tmp1));
+  for (const _tmp61 of people) {
+    console.log(JSON.stringify(_tmp61));
   }
 })();

--- a/tests/machine/x/typescript/sort_stable.ts
+++ b/tests/machine/x/typescript/sort_stable.ts
@@ -1,10 +1,10 @@
 const items = [{n: 1, v: "a"}, {n: 1, v: "b"}, {n: 2, v: "c"}];
 const result = (() => {
-  const _tmp1 = [];
+  const _tmp62 = [];
   for (const i of items) {
-    _tmp1.push({item: i.v, key: i.n});
+    _tmp62.push({item: i.v, key: i.n});
   }
-  let res = _tmp1;
+  let res = _tmp62;
   res = res.sort((a,b)=> a.key < b.key ? -1 : a.key > b.key ? 1 : 0).map(x=>x.item);
   return res;
 })()

--- a/tests/machine/x/typescript/tree_sum.ts
+++ b/tests/machine/x/typescript/tree_sum.ts
@@ -1,15 +1,15 @@
 type Tree = { kind: "leaf" } | { kind: "node"; left: any; value: any; right: any };
 function sum_tree(t) {
   return (() => {
-  const _tmp1 = t;
+  const _tmp63 = t;
   let _res;
-  if (_tmp1.kind === "leaf") {
+  if (_tmp63.kind === "leaf") {
     _res = 0;
   }
-  else if (_tmp1.kind === "node") {
-    const left = _tmp1.left;
-    const value = _tmp1.value;
-    const right = _tmp1.right;
+  else if (_tmp63.kind === "node") {
+    const left = _tmp63.left;
+    const value = _tmp63.value;
+    const right = _tmp63.right;
     _res = ((sum_tree(left) + value) + sum_tree(right));
   }
   return _res;

--- a/tests/machine/x/typescript/update_stmt.ts
+++ b/tests/machine/x/typescript/update_stmt.ts
@@ -1,14 +1,14 @@
 type Person = { name: any; age: any; status: any; };
 const people = [{name: "Alice", age: 17, status: "minor"}, {name: "Bob", age: 25, status: "unknown"}, {name: "Charlie", age: 18, status: "unknown"}, {name: "Diana", age: 16, status: "minor"}];
 for (let i = 0; i < people.length; i++) {
-  let _tmp1 = people[i];
-  let status = _tmp1.status;
-  let age = _tmp1.age;
+  let _tmp64 = people[i];
+  let status = _tmp64.status;
+  let age = _tmp64.age;
   if ((age >= 18)) {
-    _tmp1.status = "adult";
-    _tmp1.age = (age + 1);
+    _tmp64.status = "adult";
+    _tmp64.age = (age + 1);
   }
-  people[i] = _tmp1;
+  people[i] = _tmp64;
 }
 if (!(JSON.stringify(people) === JSON.stringify([{name: "Alice", age: 17, status: "minor"}, {name: "Bob", age: 26, status: "adult"}, {name: "Charlie", age: 19, status: "adult"}, {name: "Diana", age: 16, status: "minor"}]))) { throw new Error("update adult status failed"); }
 console.log("ok");


### PR DESCRIPTION
## Summary
- enhance TypeScript compiler with `isSimpleIterable` helper
- emit `for..of` loops directly when iterating simple arrays or strings
- regenerate machine TypeScript outputs
- update machine README for TypeScript

## Testing
- `go test ./compiler/x/typescript -tags slow -run TestMain -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f79454e8c8320843e2a3af6f19aeb