### PR TITLE
Improve OCaml compiler struct inference

### DIFF
--- a/tests/machine/x/ocaml/README.md
+++ b/tests/machine/x/ocaml/README.md
@@ -105,3 +105,4 @@ Compiled programs: 97/97 successful.
 ## Remaining Tasks
 - [ ] Improve support for complex query groups and joins
 - [ ] Integrate an OCaml runtime to execute compiled programs in CI
+- [ ] Expand anonymous record typing for clearer generated code


### PR DESCRIPTION
## Summary
- enhance OCaml compiler with anonymous struct generation
- infer types for `let` and `var` when not explicitly typed
- expose generated struct definitions in output
- document upcoming task in OCaml machine README

## Testing
- `go test ./compiler/x/ocaml -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686f7d6a5aa08320be3d6c8710352639