### PR TITLE
Improve Kotlin compiler indexing

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -813,7 +813,15 @@ func (c *Compiler) postfix(p *parser.PostfixExpr) (string, error) {
 					return "", err
 				}
 				if i < len(p.Ops)-1 {
-					val = fmt.Sprintf("%s[%s]!!", val, idx)
+					prefix := &parser.PostfixExpr{Target: p.Target, Ops: p.Ops[:i]}
+					ct := c.inferPostfixType(prefix)
+					if types.IsMapType(ct) {
+						val = fmt.Sprintf("(%s[%s] as MutableMap<*, *>)", val, idx)
+					} else if types.IsListType(ct) {
+						val = fmt.Sprintf("(%s[%s] as MutableList<Any?>)", val, idx)
+					} else {
+						val = fmt.Sprintf("%s[%s]!!", val, idx)
+					}
 				} else {
 					val = fmt.Sprintf("%s[%s]", val, idx)
 				}

--- a/compiler/x/kotlin/infer.go
+++ b/compiler/x/kotlin/infer.go
@@ -1,0 +1,49 @@
+//go:build slow
+
+package kotlin
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// inferExprType delegates to types.ExprType.
+func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
+	return types.ExprType(e, c.env)
+}
+
+// inferExprTypeHint delegates to types.ExprTypeHint.
+func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
+	return types.ExprTypeHint(e, hint, c.env)
+}
+
+func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+	if u == nil {
+		return types.AnyType{}
+	}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.ExprType(expr, c.env)
+}
+
+func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.ExprType(expr, c.env)
+}
+
+func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.ExprType(expr, c.env)
+}
+
+func resultType(op string, left, right types.Type) types.Type {
+	return types.ResultType(op, left, right)
+}

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -8,7 +8,7 @@ Each generated file now includes only the runtime helper functions that are actu
 
 Compiled: 97/97 programs
 
-Successfully ran: 81/97 programs
+Successfully ran: 82/97 programs
 
 ## Checklist
 
@@ -63,7 +63,7 @@ Successfully ran: 81/97 programs
 - [x] list_set_ops.mochi
 - [x] load_yaml.mochi
 - [x] map_assign.mochi
-- [ ] map_in_operator.mochi
+- [x] map_in_operator.mochi
 - [x] map_index.mochi
 - [x] map_int_key.mochi
 - [x] map_literal_dynamic.mochi

--- a/tests/machine/x/kotlin/group_by_multi_join_sort.error
+++ b/tests/machine/x/kotlin/group_by_multi_join_sort.error
@@ -1,48 +1,81 @@
-line 76:
+line 54:
 OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:76:13: error: unresolved reference: o
-        if (o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag == "R") {
-            ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:76:44: error: unresolved reference: o
-        if (o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag == "R") {
-                                           ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:76:72: error: unresolved reference: l
-        if (o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag == "R") {
-                                                                       ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:51: error: unresolved reference: g
-            __res.add(mutableMapOf("c_custkey" to g.key.c_custkey, "c_name" to g.key.c_name, "revenue" to sum(run {
-                                                  ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:80: error: unresolved reference: g
-            __res.add(mutableMapOf("c_custkey" to g.key.c_custkey, "c_name" to g.key.c_name, "revenue" to sum(run {
-                                                                               ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:111: error: type inference failed. Expected type mismatch: inferred type is MutableList<Any> but List<Int> was expected
-            __res.add(mutableMapOf("c_custkey" to g.key.c_custkey, "c_name" to g.key.c_name, "revenue" to sum(run {
-                                                                                                              ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:79:15: error: unresolved reference: g
-    for (x in g) {
-              ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:83:20: error: unresolved reference: g
-}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment))
-                   ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:83:49: error: unresolved reference: g
-}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment))
-                                                ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:83:78: error: unresolved reference: g
-}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment))
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:54:83: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+public fun String.compareTo(other: String, ignoreCase: Boolean = ...): Int defined in kotlin.text
+                                if (toBool((o as MutableMap<*, *>)["o_orderdate"] >= start_date && (o as MutableMap<*, *>)["o_orderdate"] < end_date && (l as MutableMap<*, *>)["l_returnflag"] == "R")) {
+                                                                                  ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:54:139: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+public fun String.compareTo(other: String, ignoreCase: Boolean = ...): Int defined in kotlin.text
+                                if (toBool((o as MutableMap<*, *>)["o_orderdate"] >= start_date && (o as MutableMap<*, *>)["o_orderdate"] < end_date && (l as MutableMap<*, *>)["l_returnflag"] == "R")) {
+                                                                                                                                          ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:74:54: error: unresolved reference: c_custkey
+        __res.add((mutableMapOf("c_custkey" to g.key.c_custkey, "c_name" to g.key.c_name, "revenue" to sum(run {
+                                                     ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:74:83: error: unresolved reference: c_name
+        __res.add((mutableMapOf("c_custkey" to g.key.c_custkey, "c_name" to g.key.c_name, "revenue" to sum(run {
+                                                                                  ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:29: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<*, *>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                            ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:57: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<*, *>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                        ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:78: error: none of the following functions can be called with the arguments supplied: 
+public final operator fun times(other: Byte): Double defined in kotlin.Double
+public final operator fun times(other: Double): Double defined in kotlin.Double
+public final operator fun times(other: Float): Double defined in kotlin.Double
+public final operator fun times(other: Int): Double defined in kotlin.Double
+public final operator fun times(other: Long): Double defined in kotlin.Double
+public final operator fun times(other: Short): Double defined in kotlin.Double
+        __res.add((toDouble((x as MutableMap<*, *>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
                                                                              ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:83:108: error: unresolved reference: g
-}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment))
-                                                                                                           ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:83:138: error: unresolved reference: g
-}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment))
-                                                                                                                                         ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:87:28: error: type inference failed. Expected type mismatch: inferred type is MutableList<Any> but List<Int> was expected
-}.sortedByDescending { sum(run {
-                           ^
-/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:89:15: error: unresolved reference: g
-    for (x in g) {
-              ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:100: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<*, *>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                   ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:77:128: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<*, *>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                                               ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:80:26: error: unresolved reference: c_acctbal
+}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment) as MutableMap<Any?, Any?>))
+                         ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:80:55: error: unresolved reference: n_name
+}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment) as MutableMap<Any?, Any?>))
+                                                      ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:80:84: error: unresolved reference: c_address
+}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment) as MutableMap<Any?, Any?>))
+                                                                                   ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:80:114: error: unresolved reference: c_phone
+}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment) as MutableMap<Any?, Any?>))
+                                                                                                                 ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:80:144: error: unresolved reference: c_comment
+}), "c_acctbal" to g.key.c_acctbal, "n_name" to g.key.n_name, "c_address" to g.key.c_address, "c_phone" to g.key.c_phone, "c_comment" to g.key.c_comment) as MutableMap<Any?, Any?>))
+                                                                                                                                               ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:86:29: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<*, *>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                            ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:86:58: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<*, *>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                         ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:86:79: error: none of the following functions can be called with the arguments supplied: 
+public final operator fun times(other: Byte): Double defined in kotlin.Double
+public final operator fun times(other: Double): Double defined in kotlin.Double
+public final operator fun times(other: Float): Double defined in kotlin.Double
+public final operator fun times(other: Int): Double defined in kotlin.Double
+public final operator fun times(other: Long): Double defined in kotlin.Double
+public final operator fun times(other: Short): Double defined in kotlin.Double
+        __res.add((toDouble((x as MutableMap<*, *>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                              ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:86:101: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<*, *>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                    ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:86:130: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<*, *>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<*, *>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                                                 ^
 
- 75:     for (c in customer) {
- 76:         if (o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag == "R") {
- 77:             __res.add(mutableMapOf("c_custkey" to g.key.c_custkey, "c_name" to g.key.c_name, "revenue" to sum(run {
+ 53:                             if (toBool((n as MutableMap<*, *>)["n_nationkey"] == (c as MutableMap<*, *>)["c_nationkey"])) {
+ 54:                                 if (toBool((o as MutableMap<*, *>)["o_orderdate"] >= start_date && (o as MutableMap<*, *>)["o_orderdate"] < end_date && (l as MutableMap<*, *>)["l_returnflag"] == "R")) {
+ 55:                                     val __k = mutableMapOf("c_custkey" to (c as MutableMap<*, *>)["c_custkey"], "c_name" to (c as MutableMap<*, *>)["c_name"], "c_acctbal" to (c as MutableMap<*, *>)["c_acctbal"], "c_address" to (c as MutableMap<*, *>)["c_address"], "c_phone" to (c as MutableMap<*, *>)["c_phone"], "c_comment" to (c as MutableMap<*, *>)["c_comment"], "n_name" to (n as MutableMap<*, *>)["n_name"])

--- a/tests/machine/x/kotlin/group_by_sort.error
+++ b/tests/machine/x/kotlin/group_by_sort.error
@@ -1,1 +1,9 @@
-line 0:
+line 3:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/group_by_sort.kt:3:26: error: unresolved reference: toInt
+    for (n in list) s += toInt(n)
+                         ^
+
+  2:     var s = 0
+  3:     for (n in list) s += toInt(n)
+  4:     return s

--- a/tests/machine/x/kotlin/group_items_iteration.error
+++ b/tests/machine/x/kotlin/group_items_iteration.error
@@ -1,26 +1,14 @@
-line 85:
+line 38:
 OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:85:34: error: expecting property name or receiver type
-            total = total + x.val
-                                 ^
-/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:66:19: error: unresolved reference: g
-        __res.add(g)
-                  ^
-/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:71:11: error: type inference failed: Not enough information to infer parameter T in inline fun <T> mutableListOf(): MutableList<T>
+/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:38:11: error: type inference failed: Not enough information to infer parameter T in inline fun <T> mutableListOf(): MutableList<T>
 Please specify it explicitly.
 
 var tmp = mutableListOf()
           ^
-/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:79:14: error: unresolved reference: r
-}.sortedBy { r.tag }
-             ^
-/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:84:21: error: unresolved reference: items
-        for (x in g.items) {
+/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:52:21: error: type mismatch: inferred type is Double but Int was expected
+            total = toDouble(total) + toDouble((x as MutableMap<*, *>)["val"])
                     ^
-/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:87:51: error: unresolved reference: key
-        tmp = append(tmp, mutableMapOf("tag" to g.key, "total" to total))
-                                                  ^
 
- 84:         for (x in g.items) {
- 85:             total = total + x.val
- 86:         }
+ 37: 
+ 38: var tmp = mutableListOf()
+ 39: 

--- a/tests/machine/x/kotlin/list_nested_assign.kt
+++ b/tests/machine/x/kotlin/list_nested_assign.kt
@@ -2,5 +2,5 @@ var matrix = mutableListOf(mutableListOf(1, 2), mutableListOf(3, 4))
 
 fun main() {
     matrix[1]!![0] = 5
-    println(matrix[1]!![0])
+    println((matrix[1] as MutableList<Any?>)[0])
 }

--- a/tests/machine/x/kotlin/map_in_operator.out
+++ b/tests/machine/x/kotlin/map_in_operator.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/machine/x/kotlin/map_nested_assign.kt
+++ b/tests/machine/x/kotlin/map_nested_assign.kt
@@ -2,5 +2,5 @@ var data = mutableMapOf("outer" to mutableMapOf("inner" to 1))
 
 fun main() {
     data["outer"]!!["inner"] = 2
-    println(data["outer"]!!["inner"])
+    println((data["outer"] as MutableMap<*, *>)["inner"])
 }


### PR DESCRIPTION
## Summary
- enhance Kotlin compiler to infer types and cast on nested indexing
- add helper functions for type inference
- regenerate Kotlin examples and outputs
- update progress in Kotlin README

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f7ce8cdec83209a8ca125689d0b8c