### PR TITLE
Add ceil/floor builtins to Python compiler

### DIFF
--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -925,6 +925,18 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		c.use("_values")
 		return fmt.Sprintf("_values(%s)", args[0]), nil
+	case "ceil":
+		if len(args) != 1 {
+			return "", fmt.Errorf("ceil expects 1 arg")
+		}
+		c.imports["math"] = "math"
+		return fmt.Sprintf("math.ceil(%s)", args[0]), nil
+	case "floor":
+		if len(args) != 1 {
+			return "", fmt.Errorf("floor expects 1 arg")
+		}
+		c.imports["math"] = "math"
+		return fmt.Sprintf("math.floor(%s)", args[0]), nil
 	case "eval":
 		return fmt.Sprintf("eval(%s)", argStr), nil
 	default:

--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -100,3 +100,12 @@ Compiled programs: 97/97 successful.
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## Remaining Tasks
+
+The Python backend still lacks support for a few Mochi features:
+
+* `import` statements targeting languages other than Python
+* Error handling using `try`/`catch`
+* Concurrency primitives such as `spawn` and channels
+* Conversion of complex Python constructs like list comprehensions back to Mochi


### PR DESCRIPTION
## Summary
- support `ceil` and `floor` builtins in the Python backend
- list outstanding features in the Python machine README

## Testing
- `go test ./compiler/x/python -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f8333e9088320873964ad0ef088a4