### PR TITLE
Fix group key type inference in C backend

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -4028,12 +4028,12 @@ func isBoolArg(e *parser.Expr, env *types.Env) bool {
 // heuristics similar to inferStructFromMap.
 func (c *Compiler) guessType(e *parser.Expr) types.Type {
 	t := c.exprType(e)
-	if types.ContainsAny(t) {
-		if name, ok := groupKeySelector(e); ok {
-			if kt, ok2 := c.groupKeys[name]; ok2 {
-				return kt
-			}
+	if name, ok := groupKeySelector(e); ok {
+		if kt, ok2 := c.groupKeys[name]; ok2 {
+			return kt
 		}
+	}
+	if types.ContainsAny(t) {
 		switch {
 		case isStringExpr(e, c.env):
 			return types.StringType{}


### PR DESCRIPTION
## Summary
- ensure guessType returns correct type for group keys before falling back on other heuristics

## Testing
- `go test ./compiler/x/c -run TestCompilePrograms -tags=slow -count=1` *(no tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_686f83421738832080838a23635db6d4