### PR TITLE
Improve C++ map literal handling

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -1079,7 +1079,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			}
 			vals = append(vals, v)
 		}
-		if simple {
+		if simple && len(p.Map.Items) > 1 {
 			sig := strings.Join(names, ",")
 			info, ok := c.structMap[sig]
 			if !ok {

--- a/tests/machine/x/cpp/in_operator_extended.cpp
+++ b/tests/machine/x/cpp/in_operator_extended.cpp
@@ -1,16 +1,8 @@
 #include <algorithm>
 #include <iostream>
+#include <unordered_map>
 #include <vector>
 
-struct __struct1 {
-  decltype(1) a;
-};
-inline bool operator==(const __struct1 &a, const __struct1 &b) {
-  return a.a == b.a;
-}
-inline bool operator!=(const __struct1 &a, const __struct1 &b) {
-  return !(a == b);
-}
 std::vector<int> xs = std::vector<decltype(1)>{1, 2, 3};
 auto ys = ([]() {
   std::vector<int> __items;
@@ -21,7 +13,7 @@ auto ys = ([]() {
   }
   return __items;
 })();
-auto m = __struct1{1};
+auto m = std::unordered_map<std::string, decltype(1)>{{std::string("a"), 1}};
 auto s = std::string("hello");
 
 int main() {
@@ -36,13 +28,11 @@ int main() {
     std::cout << std::endl;
   }
   {
-    std::cout << std::boolalpha
-              << (std::find(m.begin(), m.end(), std::string("a")) != m.end());
+    std::cout << std::boolalpha << (m.count(std::string("a")) > 0);
     std::cout << std::endl;
   }
   {
-    std::cout << std::boolalpha
-              << (std::find(m.begin(), m.end(), std::string("b")) != m.end());
+    std::cout << std::boolalpha << (m.count(std::string("b")) > 0);
     std::cout << std::endl;
   }
   {

--- a/tests/machine/x/cpp/in_operator_extended.out
+++ b/tests/machine/x/cpp/in_operator_extended.out
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false


### PR DESCRIPTION
## Summary
- treat single-field map literals as `unordered_map` instead of structs
- regenerate machine output for `in_operator_extended`

## Testing
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f834531148320956257db609fbf96