### PR TITLE
Improve OCaml loop translation

### DIFF
--- a/compiler/x/ocaml/compiler.go
+++ b/compiler/x/ocaml/compiler.go
@@ -420,15 +420,12 @@ func (c *Compiler) compileFor(fr *parser.ForStmt) error {
 		if err != nil {
 			return err
 		}
-		loopName := fmt.Sprintf("__loop%d", c.loop)
-		c.loop++
-		c.writeln(fmt.Sprintf("let rec %s i =", loopName))
+		c.writeln("try")
 		c.indent++
-		c.writeln(fmt.Sprintf("if i > %s then () else (", end))
+		c.writeln(fmt.Sprintf("for %s = %s to %s do", fr.Name, start, end))
 		c.indent++
 		c.writeln("try")
 		c.indent++
-		c.writeln(fmt.Sprintf("let %s = i in", fr.Name))
 		for _, st := range fr.Body {
 			if err := c.compileStmt(st); err != nil {
 				return err
@@ -436,11 +433,10 @@ func (c *Compiler) compileFor(fr *parser.ForStmt) error {
 		}
 		c.indent--
 		c.writeln("with Continue -> ()")
-		c.writeln(fmt.Sprintf("; %s (i + 1))", loopName))
 		c.indent--
+		c.writeln("done")
 		c.indent--
-		c.writeln("in")
-		c.writeln(fmt.Sprintf("try %s %s with Break -> ()", loopName, start))
+		c.writeln("with Break -> ()")
 		return nil
 	}
 	src, err := c.compileExpr(fr.Source)

--- a/tests/machine/x/ocaml/README.md
+++ b/tests/machine/x/ocaml/README.md
@@ -106,3 +106,4 @@ Compiled programs: 97/97 successful.
 - [ ] Improve support for complex query groups and joins
 - [ ] Integrate an OCaml runtime to execute compiled programs in CI
 - [ ] Expand anonymous record typing for clearer generated code
+- [x] Emit native `for` loops when iterating over numeric ranges


### PR DESCRIPTION
## Summary
- enhance OCaml compiler so `for` statements over numeric ranges emit native OCaml `for` loops
- record the improvement in the OCaml machine README

## Testing
- `go test ./compiler/x/ocaml -tags slow -run TestPrograms -count=1` *(skipped: `ocamlc` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f83621f148320938ba8b599e0f099