### PR TITLE
Improve PHP query grouping

### DIFF
--- a/tests/machine/x/php/group_by_join.php
+++ b/tests/machine/x/php/group_by_join.php
@@ -7,7 +7,7 @@ $stats = (function() use ($customers, $orders) {
         foreach ($customers as $c) {
             if ($o['customerId'] == $c['id']) {
                 $_k = json_encode($c['name']);
-                $groups[$_k][] = $o;
+                $groups[$_k][] = ["o" => $o, "c" => $c];
             }
         }
     }

--- a/tests/machine/x/php/group_by_multi_join_sort.out
+++ b/tests/machine/x/php/group_by_multi_join_sort.out
@@ -1,11 +1,3 @@
-PHP Warning:  Undefined array key "l" in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 34
-PHP Warning:  Trying to access array offset on null in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 34
-PHP Warning:  Undefined array key "l" in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 34
-PHP Warning:  Trying to access array offset on null in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 34
-PHP Warning:  Undefined array key "l" in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 40
-PHP Warning:  Trying to access array offset on null in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 40
-PHP Warning:  Undefined array key "l" in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 40
-PHP Warning:  Trying to access array offset on null in /workspace/mochi/tests/machine/x/php/group_by_multi_join_sort.php on line 40
 array(1) {
   [0]=>
   array(8) {
@@ -14,7 +6,7 @@ array(1) {
     ["c_name"]=>
     string(5) "Alice"
     ["revenue"]=>
-    int(0)
+    float(900)
     ["c_acctbal"]=>
     int(100)
     ["n_name"]=>

--- a/tests/machine/x/php/group_by_multi_join_sort.php
+++ b/tests/machine/x/php/group_by_multi_join_sort.php
@@ -16,7 +16,7 @@ $result = (function() use ($customer, $end_date, $lineitem, $nation, $orders, $s
                             if ($n['n_nationkey'] == $c['c_nationkey']) {
                                 if ($o['o_orderdate'] >= $start_date && $o['o_orderdate'] < $end_date && $l['l_returnflag'] == "R") {
                                     $_k = json_encode(["c_custkey" => $c['c_custkey'], "c_name" => $c['c_name'], "c_acctbal" => $c['c_acctbal'], "c_address" => $c['c_address'], "c_phone" => $c['c_phone'], "c_comment" => $c['c_comment'], "n_name" => $n['n_name']]);
-                                    $groups[$_k][] = $c;
+                                    $groups[$_k][] = ["c" => $c, "o" => $o, "l" => $l, "n" => $n];
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- enhance PHP compiler's handling of query groups
- support grouping rows with multiple variables
- regenerate machine PHP output for affected programs

## Testing
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f83638b248320b5ba5eca1b17dac9