### PR TITLE
Update Pascal query type inference

### DIFF
--- a/compiler/x/pascal/helpers.go
+++ b/compiler/x/pascal/helpers.go
@@ -106,9 +106,17 @@ func inferQueryType(q *parser.QueryExpr, env *types.Env) types.Type {
 	if q.Group != nil {
 		genv := types.NewEnv(child)
 		genv.SetVar(q.Group.Name, types.AnyType{}, true)
-		return types.ListType{Elem: types.TypeOfExprBasic(q.Select, genv)}
+		elem = types.TypeOfExprBasic(q.Select, genv)
+		if asMapLiteral(q.Select) != nil {
+			elem = types.MapType{Key: types.StringType{}, Value: types.AnyType{}}
+		}
+		return types.ListType{Elem: elem}
 	}
-	return types.ListType{Elem: types.TypeOfExprBasic(q.Select, child)}
+	elem = types.TypeOfExprBasic(q.Select, child)
+	if asMapLiteral(q.Select) != nil {
+		elem = types.MapType{Key: types.StringType{}, Value: types.AnyType{}}
+	}
+	return types.ListType{Elem: elem}
 }
 
 func (c *Compiler) newTypedVar(typ string) string {


### PR DESCRIPTION
## Summary
- adjust Pascal helper to infer query results with map literals as `map<string, Variant>`

## Testing
- `go test -tags slow ./compiler/x/pascal -run CrossJoin -v` *(fails: no tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_686f8365f9608320b5ca1fc7a4c75c19