### PR TITLE
Fix Ruby runtime path for STDIO

### DIFF
--- a/compiler/x/rb/runtime.go
+++ b/compiler/x/rb/runtime.go
@@ -64,7 +64,7 @@ end`
     delim = opts['delimiter'] || delim
     delim = delim[0] if delim.is_a?(String) && !delim.empty?
   end
-  io = (path.nil? || path == '') ? STDIN : File.open(path, 'r')
+  io = (path.nil? || path == '' || path == '-') ? STDIN : File.open(path, 'r')
   begin
     case fmt
     when 'csv','tsv'
@@ -121,7 +121,7 @@ end`
     delim = delim[0] if delim.is_a?(String) && !delim.empty?
   end
   rows = rows.map { |r| r.respond_to?(:to_h) ? r.to_h : r }
-  io = (path.nil? || path == '') ? STDOUT : File.open(path, 'w')
+  io = (path.nil? || path == '' || path == '-') ? STDOUT : File.open(path, 'w')
   begin
     case fmt
     when 'csv','tsv'

--- a/tests/machine/x/rb/load_yaml.rb
+++ b/tests/machine/x/rb/load_yaml.rb
@@ -13,7 +13,7 @@ def _load(path=nil, opts=nil)
     delim = opts['delimiter'] || delim
     delim = delim[0] if delim.is_a?(String) && !delim.empty?
   end
-  io = (path.nil? || path == '') ? STDIN : File.open(path, 'r')
+  io = (path.nil? || path == '' || path == '-') ? STDIN : File.open(path, 'r')
   begin
     case fmt
     when 'csv','tsv'

--- a/tests/machine/x/rb/save_jsonl_stdout.out
+++ b/tests/machine/x/rb/save_jsonl_stdout.out
@@ -1,0 +1,2 @@
+{"name":"Alice","age":30}
+{"name":"Bob","age":25}

--- a/tests/machine/x/rb/save_jsonl_stdout.rb
+++ b/tests/machine/x/rb/save_jsonl_stdout.rb
@@ -14,7 +14,7 @@ def _save(rows, path=nil, opts=nil)
     delim = delim[0] if delim.is_a?(String) && !delim.empty?
   end
   rows = rows.map { |r| r.respond_to?(:to_h) ? r.to_h : r }
-  io = (path.nil? || path == '') ? STDOUT : File.open(path, 'w')
+  io = (path.nil? || path == '' || path == '-') ? STDOUT : File.open(path, 'w')
   begin
     case fmt
     when 'csv','tsv'


### PR DESCRIPTION
## Summary
- allow `"-"` path to read from STDIN and write to STDOUT in the Ruby runtime
- update generated Ruby code and outputs for `load_yaml` and `save_jsonl_stdout`

## Testing
- `go test ./compiler/x/rb -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f8376d6608320936a149cca2232e9