### PR TITLE
Fix Racket formatter

### DIFF
--- a/compiler/x/racket/tools.go
+++ b/compiler/x/racket/tools.go
@@ -22,6 +22,8 @@ func Format(src []byte) []byte {
 		cmd := exec.Command("raco", "fmt", "--stdin")
 		cmd.Stdin = bytes.NewReader(src)
 		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
 		if err := cmd.Run(); err == nil {
 			outBytes := out.Bytes()
 			if len(outBytes) > 0 && outBytes[len(outBytes)-1] != '\n' {


### PR DESCRIPTION
## Summary
- ensure formatted output is captured in the Racket backend

## Testing
- `go test -tags slow ./compiler/x/racket`

------
https://chatgpt.com/codex/tasks/task_e_686f8375b01883209f71074cedc329d9