### PR TITLE
Update Fortran README checklists

### DIFF
--- a/tests/dataset/tpc-h/compiler/fortran/README.md
+++ b/tests/dataset/tpc-h/compiler/fortran/README.md
@@ -1,1 +1,29 @@
-Fortran compiler outputs will be added once implemented.
+# TPC-H Fortran Outputs
+
+This directory holds Fortran translations of the Mochi implementations of the TPC-H benchmark queries.
+Only query 1 has been translated so far.
+
+## Checklist
+
+- [x] q1
+- [ ] q2
+- [ ] q3
+- [ ] q4
+- [ ] q5
+- [ ] q6
+- [ ] q7
+- [ ] q8
+- [ ] q9
+- [ ] q10
+- [ ] q11
+- [ ] q12
+- [ ] q13
+- [ ] q14
+- [ ] q15
+- [ ] q16
+- [ ] q17
+- [ ] q18
+- [ ] q19
+- [ ] q20
+- [ ] q21
+- [ ] q22

--- a/tests/machine/x/fortran/README.md
+++ b/tests/machine/x/fortran/README.md
@@ -103,3 +103,8 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining tasks
+
+- [ ] Generate outputs for TPC-H dataset queries
+- [ ] Remove obsolete `.error` files after successful compilation


### PR DESCRIPTION
## Summary
- update checklist for TPC‑H Fortran outputs
- add a remaining tasks section for the Fortran machine outputs

## Testing
- `go test ./compiler/x/fortran -tags slow -run TestCompilePrograms -count=1 -v` *(fails: gfortran missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f7dd1496c83208d37cee612682e1e