### PR TITLE
Add todo list and simplify fetch in ts compiler

### DIFF
--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -1969,10 +1969,11 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 		}
 		c.use("_toAnyMap")
 		withStr = fmt.Sprintf("_toAnyMap(%s)", w)
-	} else {
-		withStr = "undefined"
 	}
 	c.use("_fetch")
+	if withStr == "" {
+		return fmt.Sprintf("await _fetch(%s)", urlStr), nil
+	}
 	return fmt.Sprintf("await _fetch(%s, %s)", urlStr, withStr), nil
 }
 

--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -105,3 +105,9 @@ Compiled: 97/97 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## Remaining Tasks
+
+- Integrate with Node runtime for dataset queries and joins
+- Support asynchronous `fetch` statements
+- Improve formatting to match human examples


### PR DESCRIPTION
## Summary
- note remaining tasks for TypeScript output
- simplify `_fetch` call generation when no options are needed

## Testing
- `go test -tags slow ./compiler/x/ts -run TestRoundtripVM -count=1`
- `go test -tags slow ./compiler/x/typescript -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686f7ccf40b08320b99d08bf2addbea5