### PR TITLE
Improve Zig match compilation

### DIFF
--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -198,6 +198,24 @@ func simpleStringKey(e *parser.Expr) (string, bool) {
 	return "", false
 }
 
+// literalExpr reports whether e is a simple literal expression
+// like an integer, float, bool or string.
+func literalExpr(e *parser.Expr) bool {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target == nil || p.Target.Lit == nil {
+		return false
+	}
+	lit := p.Target.Lit
+	return lit.Int != nil || lit.Float != nil || lit.Bool != nil || lit.Str != nil
+}
+
 func identName(e *parser.Expr) (string, bool) {
 	if e == nil || len(e.Binary.Right) != 0 {
 		return "", false


### PR DESCRIPTION
## Summary
- enhance zig compiler to output switch expressions for simple match cases
- add helper to detect literal expressions

## Testing
- `go build -tags slow ./compiler/x/zig`

------
https://chatgpt.com/codex/tasks/task_e_686f7cafb55083208e817f860df628bb