### PR TITLE
Fix Smalltalk compiler zero-arg calls

### DIFF
--- a/compiler/x/smalltalk/compiler.go
+++ b/compiler/x/smalltalk/compiler.go
@@ -503,8 +503,12 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				val = stmt + "; cr"
 			} else {
 				call := val
-				for _, a := range args {
-					call += " value: " + a
+				if len(args) == 0 {
+					call += " value"
+				} else {
+					for _, a := range args {
+						call += " value: " + a
+					}
 				}
 				val = call
 			}
@@ -692,8 +696,12 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			return fmt.Sprintf("(%s copyFrom: %s to: %s)", args[0], args[1], args[2]), nil
 		default:
 			call := p.Call.Func
-			for _, a := range args {
-				call += " value: " + a
+			if len(args) == 0 {
+				call += " value"
+			} else {
+				for _, a := range args {
+					call += " value: " + a
+				}
 			}
 			return call, nil
 		}

--- a/tests/machine/x/st/bool_chain.error
+++ b/tests/machine/x/st/bool_chain.error
@@ -1,0 +1,2 @@
+line: 0
+error: gst interpreter not available

--- a/tests/machine/x/st/bool_chain.st
+++ b/tests/machine/x/st/bool_chain.st
@@ -1,6 +1,6 @@
 | boom |
 boom := [ | Transcript show: 'boom'; cr.
-^true. ].
+true ].
 Transcript show: ((((1 < 2) and: [(2 < 3)]) and: [(3 < 4)])) printString; cr.
-Transcript show: ((((1 < 2) and: [(2 > 3)]) and: [boom])) printString; cr.
-Transcript show: (((((1 < 2) and: [(2 < 3)]) and: [(3 > 4)]) and: [boom])) printString; cr.
+Transcript show: ((((1 < 2) and: [(2 > 3)]) and: [boom value])) printString; cr.
+Transcript show: (((((1 < 2) and: [(2 < 3)]) and: [(3 > 4)]) and: [boom value])) printString; cr.


### PR DESCRIPTION
## Summary
- handle zero argument function calls in the Smalltalk backend
- regenerate `bool_chain.st` with the updated compiler
- record missing GST interpreter in `bool_chain.error`

## Testing
- `go test ./compiler/x/smalltalk -run TestCompilePrograms/bool_chain -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f836ac4408320b931943ad959c6a7