### PR TITLE
Improve TypeScript compiler formatting

### DIFF
--- a/compiler/x/typescript/compiler.go
+++ b/compiler/x/typescript/compiler.go
@@ -1160,7 +1160,7 @@ func (c *Compiler) primary(p *parser.Primary) (string, error) {
 			}
 			elems[i] = s
 		}
-		return "[" + strings.Join(elems, ", ") + "]", nil
+		return c.formatList(elems), nil
 	case p.Map != nil:
 		items := make([]string, len(p.Map.Items))
 		for i, m := range p.Map.Items {
@@ -1174,7 +1174,7 @@ func (c *Compiler) primary(p *parser.Primary) (string, error) {
 			}
 			items[i] = fmt.Sprintf("%s: %s", strings.Trim(k, "\""), v)
 		}
-		return "{" + strings.Join(items, ", ") + "}", nil
+		return c.formatMap(items), nil
 	case p.Struct != nil:
 		fields := []string{}
 		if names, ok := c.variants[p.Struct.Name]; ok {
@@ -1437,6 +1437,44 @@ func getFormat(e *parser.Expr) string {
 		}
 	}
 	return ""
+}
+
+func (c *Compiler) formatList(elems []string) string {
+	flat := "[" + strings.Join(elems, ", ") + "]"
+	if len(elems) <= 2 && len(flat) <= 40 {
+		return flat
+	}
+	var b strings.Builder
+	indent := strings.Repeat("  ", c.indent)
+	b.WriteString("[\n")
+	for i, s := range elems {
+		b.WriteString(indent + "  " + s)
+		if i < len(elems)-1 {
+			b.WriteString(",")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(indent + "]")
+	return b.String()
+}
+
+func (c *Compiler) formatMap(items []string) string {
+	flat := "{" + strings.Join(items, ", ") + "}"
+	if len(items) <= 2 && len(flat) <= 40 {
+		return flat
+	}
+	var b strings.Builder
+	indent := strings.Repeat("  ", c.indent)
+	b.WriteString("{\n")
+	for i, s := range items {
+		b.WriteString(indent + "  " + s)
+		if i < len(items)-1 {
+			b.WriteString(",")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(indent + "}")
+	return b.String()
 }
 
 func isSimpleIterable(e *parser.Expr) bool {

--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -110,4 +110,4 @@ Compiled: 97/97 programs
 
 - Integrate with Node runtime for dataset queries and joins
 - Support asynchronous `fetch` statements
-- Improve formatting to match human examples
+- Finish improving formatting to match human examples


### PR DESCRIPTION
## Summary
- enhance `compiler/x/typescript` so list and map literals format across
  multiple lines when large
- regenerate machine generated TypeScript README with current checklist

## Testing
- `go test ./compiler/x/typescript -tags slow -run TestCompilePrograms -v` *(fails: deno not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f8be617348320b2551b6f9a7546cc