### PR TITLE
Improve C backend sorting

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -2558,10 +2558,8 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 		cond = c.compileExpr(q.Where)
 	}
 
-	var sortExpr string
 	var sortT types.Type
 	if q.Sort != nil {
-		sortExpr = c.compileExpr(q.Sort)
 		sortT = c.exprType(q.Sort)
 	}
 
@@ -2620,7 +2618,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 	iter := c.newTemp()
 	var keyArr string
 	keyType := ""
-	if sortExpr != "" {
+	if q.Sort != nil {
 		keyType = cTypeFromType(sortT)
 		if keyType == "" {
 			keyType = "int"
@@ -2657,6 +2655,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 	}
 	c.writeln(fmt.Sprintf("%s.data[%s] = %s;", res, idx, val))
 	if keyType != "" {
+		sortExpr := c.compileExpr(q.Sort)
 		c.writeln(fmt.Sprintf("%s[%s] = %s;", keyArr, idx, sortExpr))
 	}
 	c.writeln(fmt.Sprintf("%s++;", idx))


### PR DESCRIPTION
## Summary
- fix query compilation for sort-by expressions so the key can depend on loop variables
- regenerate C machine outputs

## Testing
- `go test ./compiler/x/c -run TestCCompiler_ValidPrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f8be903388320874ce17a789027a6