### PR TITLE
Add COBOL struct literal support

### DIFF
--- a/tests/machine/x/cobol/README.md
+++ b/tests/machine/x/cobol/README.md
@@ -1,4 +1,4 @@
-# Mochi to COBOL Machine Translations (54/97 compiled)
+# Mochi to COBOL Machine Translations (55/97 compiled)
 
 Generated using `go run -tags slow scripts/compile_cobol.go`.
 
@@ -73,7 +73,7 @@ Generated using `go run -tags slow scripts/compile_cobol.go`.
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
 - [ ] query_sum_select.mochi
-- [ ] record_assign.mochi
+- [x] record_assign.mochi
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi

--- a/tests/machine/x/cobol/record_assign.cob
+++ b/tests/machine/x/cobol/record_assign.cob
@@ -1,0 +1,17 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. RECORD-ASSIGN.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 FN-INC-RES PIC 9 VALUE 0.
+       01 C.
+           05 N PIC 9 VALUE 0.
+       PROCEDURE DIVISION.
+       PERFORM FN_INC USING C
+       FN_INC_RES
+       DISPLAY N
+       STOP RUN.
+       
+       FN_INC.
+           PROCEDURE DIVISION USING C.
+               COMPUTE N = N + 1
+               EXIT.

--- a/tests/machine/x/cobol/record_assign.error
+++ b/tests/machine/x/cobol/record_assign.error
@@ -1,1 +1,0 @@
-unsupported expression at line 7

--- a/tests/machine/x/cobol/tree_sum.error
+++ b/tests/machine/x/cobol/tree_sum.error
@@ -1,1 +1,1 @@
-unsupported expression at line 16
+unsupported expression at line 19

--- a/tests/machine/x/cobol/user_type_literal.error
+++ b/tests/machine/x/cobol/user_type_literal.error
@@ -1,1 +1,1 @@
-unsupported expression at line 11
+unsupported expression at line 13


### PR DESCRIPTION
## Summary
- enhance COBOL compiler with struct literal and field assignment support
- regenerate COBOL machine outputs
- update README for COBOL machine translations
- compile `record_assign.mochi` successfully

## Testing
- `go run -tags slow scripts/compile_cobol.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f8bf084c88320a59872d34216b848