### PR TITLE
Improve C# compiler list handling

### DIFF
--- a/compiler/x/cs/helpers.go
+++ b/compiler/x/cs/helpers.go
@@ -49,7 +49,7 @@ func csTypeOf(t types.Type) string {
 	case types.BoolType:
 		return "bool"
 	case types.ListType:
-		return csTypeOf(tt.Elem) + "[]"
+		return fmt.Sprintf("List<%s>", csTypeOf(tt.Elem))
 	case types.MapType:
 		return fmt.Sprintf("Dictionary<%s, %s>", csTypeOf(tt.Key), csTypeOf(tt.Value))
 	case types.StructType:

--- a/tests/machine/x/cs/append_builtin.cs
+++ b/tests/machine/x/cs/append_builtin.cs
@@ -5,7 +5,7 @@ class Program
 {
     static void Main()
     {
-        long[] a = new long[] { 1, 2 };
+        List<long> a = new List<long> { 1, 2 };
         Console.WriteLine(JsonSerializer.Serialize(new List<long>(a) { 3 }));
     }
 }

--- a/tests/machine/x/cs/avg_builtin.cs
+++ b/tests/machine/x/cs/avg_builtin.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 class Program
 {
     static void Main()
     {
-        Console.WriteLine(Enumerable.Average(new long[] { 1, 2, 3 }.Select(_tmp0 => Convert.ToDouble(_tmp0))));
+        Console.WriteLine(Enumerable.Average(new List<long> { 1, 2, 3 }.Select(_tmp0 => Convert.ToDouble(_tmp0))));
     }
 }

--- a/tests/machine/x/cs/break_continue.cs
+++ b/tests/machine/x/cs/break_continue.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 
 class Program
 {
     static void Main()
     {
-        long[] numbers = new long[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        List<long> numbers = new List<long> { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         foreach (var n in numbers)
         {
             if ((n % 2) == 0)

--- a/tests/machine/x/cs/count_builtin.cs
+++ b/tests/machine/x/cs/count_builtin.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 class Program
 {
     static void Main()
     {
-        Console.WriteLine(Enumerable.Count(new long[] { 1, 2, 3 }));
+        Console.WriteLine(Enumerable.Count(new List<long> { 1, 2, 3 }));
     }
 }

--- a/tests/machine/x/cs/cross_join.cs
+++ b/tests/machine/x/cs/cross_join.cs
@@ -6,8 +6,8 @@ class Program
 {
     static void Main()
     {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } } };
+        var customers = new List<dynamic> { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
+        var orders = new List<dynamic> { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } } };
         var result = new Func<List<Dictionary<string, dynamic>>>(() =>
         {
             var _res = new List<Dictionary<string, dynamic>>();

--- a/tests/machine/x/cs/cross_join_filter.cs
+++ b/tests/machine/x/cs/cross_join_filter.cs
@@ -6,8 +6,8 @@ class Program
 {
     static void Main()
     {
-        long[] nums = new long[] { 1, 2, 3 };
-        string[] letters = new string[] { "A", "B" };
+        List<long> nums = new List<long> { 1, 2, 3 };
+        List<string> letters = new List<string> { "A", "B" };
         var pairs = new Func<List<Dictionary<string, dynamic>>>(() =>
         {
             var _res = new List<Dictionary<string, dynamic>>();

--- a/tests/machine/x/cs/cross_join_triple.cs
+++ b/tests/machine/x/cs/cross_join_triple.cs
@@ -6,9 +6,9 @@ class Program
 {
     static void Main()
     {
-        long[] nums = new long[] { 1, 2 };
-        string[] letters = new string[] { "A", "B" };
-        bool[] bools = new bool[] { true, false };
+        List<long> nums = new List<long> { 1, 2 };
+        List<string> letters = new List<string> { "A", "B" };
+        List<bool> bools = new List<bool> { true, false };
         var combos = new Func<List<Dictionary<string, dynamic>>>(() =>
         {
             var _res = new List<Dictionary<string, dynamic>>();

--- a/tests/machine/x/cs/dataset_sort_take_limit.cs
+++ b/tests/machine/x/cs/dataset_sort_take_limit.cs
@@ -6,7 +6,7 @@ class Program
 {
     static void Main()
     {
-        var products = new dynamic[] { new Dictionary<string, dynamic> { { "name", "Laptop" }, { "price", 1500 } }, new Dictionary<string, dynamic> { { "name", "Smartphone" }, { "price", 900 } }, new Dictionary<string, dynamic> { { "name", "Tablet" }, { "price", 600 } }, new Dictionary<string, dynamic> { { "name", "Monitor" }, { "price", 300 } }, new Dictionary<string, dynamic> { { "name", "Keyboard" }, { "price", 100 } }, new Dictionary<string, dynamic> { { "name", "Mouse" }, { "price", 50 } }, new Dictionary<string, dynamic> { { "name", "Headphones" }, { "price", 200 } } };
+        var products = new List<dynamic> { new Dictionary<string, dynamic> { { "name", "Laptop" }, { "price", 1500 } }, new Dictionary<string, dynamic> { { "name", "Smartphone" }, { "price", 900 } }, new Dictionary<string, dynamic> { { "name", "Tablet" }, { "price", 600 } }, new Dictionary<string, dynamic> { { "name", "Monitor" }, { "price", 300 } }, new Dictionary<string, dynamic> { { "name", "Keyboard" }, { "price", 100 } }, new Dictionary<string, dynamic> { { "name", "Mouse" }, { "price", 50 } }, new Dictionary<string, dynamic> { { "name", "Headphones" }, { "price", 200 } } };
         var expensive = products.OrderBy(p => (-p.price)).Skip(1).Take(3).Select(p => p).ToArray();
         Console.WriteLine("--- Top products (excluding most expensive) ---");
         foreach (var item in expensive)

--- a/tests/machine/x/cs/dataset_where_filter.cs
+++ b/tests/machine/x/cs/dataset_where_filter.cs
@@ -6,7 +6,7 @@ class Program
 {
     static void Main()
     {
-        var people = new dynamic[] { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 } } };
+        var people = new List<dynamic> { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 } } };
         var adults = people.Where(person => (person.age >= 18)).Select(person => new Dictionary<string, dynamic> { { "name", person.name }, { "age", person.age }, { "is_senior", (person.age >= 60) } }).ToArray();
         Console.WriteLine("--- Adults ---");
         foreach (var person in adults)

--- a/tests/machine/x/cs/exists_builtin.cs
+++ b/tests/machine/x/cs/exists_builtin.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 class Program
 {
     static void Main()
     {
-        long[] data = new long[] { 1, 2 };
+        List<long> data = new List<long> { 1, 2 };
         bool flag = Enumerable.Any(data.Where(x => (x == 1)).Select(x => x).ToArray());
         Console.WriteLine(flag);
     }

--- a/tests/machine/x/cs/for_list_collection.cs
+++ b/tests/machine/x/cs/for_list_collection.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 
 class Program
 {
     static void Main()
     {
-        foreach (var n in new long[] { 1, 2, 3 })
+        foreach (var n in new List<long> { 1, 2, 3 })
         {
             Console.WriteLine(n);
         }

--- a/tests/machine/x/cs/group_by.cs
+++ b/tests/machine/x/cs/group_by.cs
@@ -6,7 +6,7 @@ class Program
 {
     static void Main()
     {
-        var people = new dynamic[] { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Eve" }, { "age", 70 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Frank" }, { "age", 22 }, { "city", "Hanoi" } } };
+        var people = new List<dynamic> { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Eve" }, { "age", 70 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Frank" }, { "age", 22 }, { "city", "Hanoi" } } };
         var stats = _group_by(people, person => person.city).Select(g => new Dictionary<string, dynamic> { { "city", g.Key }, { "count", Enumerable.Count(g) }, { "avg_age", _avg(g.Items.Select(p => p.age).ToArray()) } }).ToList();
         Console.WriteLine("--- People grouped by city ---");
         foreach (var s in stats)

--- a/tests/machine/x/cs/group_by_conditional_sum.cs
+++ b/tests/machine/x/cs/group_by_conditional_sum.cs
@@ -6,10 +6,21 @@ class Program
 {
     static void Main()
     {
-        var items = new dynamic[] { new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 10 }, { "flag", true } }, new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 5 }, { "flag", false } }, new Dictionary<string, dynamic> { { "cat", "b" }, { "val", 20 }, { "flag", true } } };
+        var items = new List<dynamic> { new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 10 }, { "flag", true } }, new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 5 }, { "flag", false } }, new Dictionary<string, dynamic> { { "cat", "b" }, { "val", 20 }, { "flag", true } } };
         var result = _group_by(items, i => i.cat).OrderBy(g => g.Key).Select(g => new Dictionary<string, dynamic> { { "cat", g.Key }, { "share", (_sum(g.Items.Select(x => (x.flag ? x.val : 0)).ToArray()) / _sum(g.Items.Select(x => x.val).ToArray())) } }).ToList();
         Console.WriteLine(JsonSerializer.Serialize(result));
     }
+    static double _sum(dynamic v)
+    {
+        if (v == null) return 0.0;
+        double _sum = 0;
+        foreach (var it in v)
+        {
+            _sum += Convert.ToDouble(it);
+        }
+        return _sum;
+    }
+
     static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn)
     {
         var groups = new Dictionary<string, _Group>();
@@ -29,17 +40,6 @@ class Program
         var res = new List<_Group>();
         foreach (var k in order) res.Add(groups[k]);
         return res;
-    }
-
-    static double _sum(dynamic v)
-    {
-        if (v == null) return 0.0;
-        double _sum = 0;
-        foreach (var it in v)
-        {
-            _sum += Convert.ToDouble(it);
-        }
-        return _sum;
     }
 
 }


### PR DESCRIPTION
## Summary
- generate C# `List<T>` types instead of arrays
- regenerate affected machine C# examples

## Testing
- `go test -tags slow ./compiler/x/cs -run ^$`

------
https://chatgpt.com/codex/tasks/task_e_686f8bec2d988320a2afb4f2c9fe1ead