### PR TITLE
Fix Smalltalk compiler test outputs

### DIFF
--- a/compiler/x/st/compiler.go
+++ b/compiler/x/st/compiler.go
@@ -507,8 +507,12 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				val = stmt + "; cr"
 			} else {
 				call := val
-				for _, a := range args {
-					call += " value: " + a
+				if len(args) == 0 {
+					call += " value"
+				} else {
+					for _, a := range args {
+						call += " value: " + a
+					}
 				}
 				val = call
 			}
@@ -706,8 +710,12 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			return fmt.Sprintf("(%s copyFrom: %s to: %s)", args[0], args[1], args[2]), nil
 		default:
 			call := p.Call.Func
-			for _, a := range args {
-				call += " value: " + a
+			if len(args) == 0 {
+				call += " value"
+			} else {
+				for _, a := range args {
+					call += " value: " + a
+				}
 			}
 			return call, nil
 		}

--- a/tests/machine/x/st/bool_chain.error
+++ b/tests/machine/x/st/bool_chain.error
@@ -1,2 +1,0 @@
-line: 0
-error: gst interpreter not available

--- a/tests/machine/x/st/bool_chain.st
+++ b/tests/machine/x/st/bool_chain.st
@@ -1,6 +1,6 @@
 | boom |
 boom := [ | Transcript show: 'boom'; cr.
-true ].
+^true. ].
 Transcript show: ((((1 < 2) and: [(2 < 3)]) and: [(3 < 4)])) printString; cr.
 Transcript show: ((((1 < 2) and: [(2 > 3)]) and: [boom value])) printString; cr.
 Transcript show: (((((1 < 2) and: [(2 < 3)]) and: [(3 > 4)]) and: [boom value])) printString; cr.


### PR DESCRIPTION
## Summary
- handle zero-argument calls when compiling to Smalltalk
- regenerate Smalltalk VM output files
- drop obsolete error file for `bool_chain`

## Testing
- `go test ./compiler/x/st -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686f925ad1788320862c52c013ab1f33