### PR TITLE
Improve Swift group query compiler

### DIFF
--- a/compiler/x/swift/compiler_test.go
+++ b/compiler/x/swift/compiler_test.go
@@ -143,3 +143,36 @@ func extractLine(msg string) int {
 	}
 	return 0
 }
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	updateReadme()
+	os.Exit(code)
+}
+
+func updateReadme() {
+	root := testutil.FindRepoRoot(&testing.T{})
+	srcDir := filepath.Join(root, "tests", "vm", "valid")
+	outDir := filepath.Join(root, "tests", "machine", "x", "swift")
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	total := len(files)
+	compiled := 0
+	var lines []string
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		mark := "[ ]"
+		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+			compiled++
+			mark = "[x]"
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s.mochi", mark, name))
+	}
+	var buf bytes.Buffer
+	buf.WriteString("# Machine-generated Swift Programs\n\n")
+	buf.WriteString("This directory contains Swift code compiled from Mochi programs in `tests/vm/valid` using the experimental compiler.\n\n")
+	fmt.Fprintf(&buf, "## Progress\n\nCompiled: %d/%d programs\n\n", compiled, total)
+	buf.WriteString("## Checklist\n\n")
+	buf.WriteString(strings.Join(lines, "\n"))
+	buf.WriteString("\n")
+	os.WriteFile(filepath.Join(outDir, "README.md"), buf.Bytes(), 0644)
+}

--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,109 +1,107 @@
-# Machine-generated Swift Outputs
+# Machine-generated Swift Programs
 
-This directory contains Swift source code generated from the Mochi programs in `tests/vm/valid`. Each program is compiled to Swift and executed. Successful runs have a `.out` file; failures have a `.error`.
+This directory contains Swift code compiled from Mochi programs in `tests/vm/valid` using the experimental compiler.
 
-Compiled programs: 87/97
+## Progress
 
-Checklist:
-- [x] append_builtin
-- [x] avg_builtin
-- [x] basic_compare
-- [x] binary_precedence
-- [x] bool_chain
-- [x] break_continue
-- [x] cast_string_to_int
-- [x] cast_struct
-- [x] closure
-- [x] count_builtin
-- [x] cross_join
-- [x] cross_join_filter
-- [x] cross_join_triple
-- [x] dataset_sort_take_limit
-- [x] exists_builtin
-- [x] for_list_collection
-- [x] for_loop
-- [x] for_map_collection
-- [x] fun_call
-- [x] fun_expr_in_let
-- [x] fun_three_args
-- [x] if_else
-- [x] if_then_else
-- [x] if_then_else_nested
-- [x] in_operator
-- [x] in_operator_extended
-- [x] inner_join
-- [x] join_multi
-- [x] json_builtin
-- [x] left_join
-- [x] left_join_multi
-- [x] len_builtin
-- [x] len_map
-- [x] len_string
-- [x] let_and_print
-- [x] list_assign
-- [x] list_index
-- [x] list_nested_assign
-- [x] list_set_ops
-- [x] load_yaml
-- [x] map_assign
-- [x] map_in_operator
-- [x] map_index
-- [x] map_int_key
-- [x] map_literal_dynamic
-- [x] map_membership
-- [x] map_nested_assign
-- [x] match_expr
-- [x] match_full
-- [x] math_ops
-- [x] membership
-- [x] min_max_builtin
-- [x] nested_function
-- [x] order_by_map
-- [x] partial_application
-- [x] print_hello
-- [x] pure_fold
-- [x] pure_global_fold
-- [x] query_sum_select
-- [x] record_assign
-- [x] save_jsonl_stdout
-- [x] short_circuit
-- [x] slice
-- [x] sort_stable
-- [x] str_builtin
-- [x] string_compare
-- [x] string_concat
-- [x] string_contains
-- [x] string_in_operator
-- [x] string_index
-- [x] string_prefix_slice
-- [x] substring_builtin
-- [x] sum_builtin
-- [x] tail_recursion
-- [x] test_block
-- [x] tree_sum
-- [x] two-sum
-- [x] typed_let
-- [x] typed_var
-- [x] unary_neg
-- [x] update_stmt
-- [x] user_type_literal
-- [x] values_builtin
-- [x] var_assignment
-- [x] while_loop
-- [x] dataset_where_filter
-- [ ] group_by
-- [ ] group_by_conditional_sum
-- [ ] group_by_having
-- [ ] group_by_join
-- [ ] group_by_left_join
-- [ ] group_by_multi_join
-- [ ] group_by_multi_join_sort
-- [ ] group_by_sort
-- [ ] group_items_iteration
-- [ ] outer_join
-- [ ] right_join
+Compiled: 87/97 programs
 
-## TODO
-- [ ] implement group+join queries
-- [ ] support variant types
-- [ ] handle map fields in join results without unsafe casts
+## Checklist
+
+- [x] append_builtin.mochi
+- [x] avg_builtin.mochi
+- [x] basic_compare.mochi
+- [x] binary_precedence.mochi
+- [x] bool_chain.mochi
+- [x] break_continue.mochi
+- [x] cast_string_to_int.mochi
+- [x] cast_struct.mochi
+- [x] closure.mochi
+- [x] count_builtin.mochi
+- [x] cross_join.mochi
+- [x] cross_join_filter.mochi
+- [x] cross_join_triple.mochi
+- [x] dataset_sort_take_limit.mochi
+- [x] dataset_where_filter.mochi
+- [x] exists_builtin.mochi
+- [x] for_list_collection.mochi
+- [x] for_loop.mochi
+- [x] for_map_collection.mochi
+- [x] fun_call.mochi
+- [x] fun_expr_in_let.mochi
+- [x] fun_three_args.mochi
+- [ ] group_by.mochi
+- [ ] group_by_conditional_sum.mochi
+- [x] group_by_having.mochi
+- [ ] group_by_join.mochi
+- [ ] group_by_left_join.mochi
+- [ ] group_by_multi_join.mochi
+- [ ] group_by_multi_join_sort.mochi
+- [ ] group_by_sort.mochi
+- [ ] group_items_iteration.mochi
+- [x] if_else.mochi
+- [x] if_then_else.mochi
+- [x] if_then_else_nested.mochi
+- [x] in_operator.mochi
+- [x] in_operator_extended.mochi
+- [x] inner_join.mochi
+- [x] join_multi.mochi
+- [x] json_builtin.mochi
+- [x] left_join.mochi
+- [x] left_join_multi.mochi
+- [x] len_builtin.mochi
+- [x] len_map.mochi
+- [x] len_string.mochi
+- [x] let_and_print.mochi
+- [x] list_assign.mochi
+- [x] list_index.mochi
+- [x] list_nested_assign.mochi
+- [x] list_set_ops.mochi
+- [x] load_yaml.mochi
+- [x] map_assign.mochi
+- [x] map_in_operator.mochi
+- [x] map_index.mochi
+- [x] map_int_key.mochi
+- [x] map_literal_dynamic.mochi
+- [x] map_membership.mochi
+- [x] map_nested_assign.mochi
+- [x] match_expr.mochi
+- [x] match_full.mochi
+- [x] math_ops.mochi
+- [x] membership.mochi
+- [x] min_max_builtin.mochi
+- [x] nested_function.mochi
+- [x] order_by_map.mochi
+- [ ] outer_join.mochi
+- [x] partial_application.mochi
+- [x] print_hello.mochi
+- [x] pure_fold.mochi
+- [x] pure_global_fold.mochi
+- [x] query_sum_select.mochi
+- [x] record_assign.mochi
+- [ ] right_join.mochi
+- [x] save_jsonl_stdout.mochi
+- [x] short_circuit.mochi
+- [x] slice.mochi
+- [x] sort_stable.mochi
+- [x] str_builtin.mochi
+- [x] string_compare.mochi
+- [x] string_concat.mochi
+- [x] string_contains.mochi
+- [x] string_in_operator.mochi
+- [x] string_index.mochi
+- [x] string_prefix_slice.mochi
+- [x] substring_builtin.mochi
+- [x] sum_builtin.mochi
+- [x] tail_recursion.mochi
+- [x] test_block.mochi
+- [x] tree_sum.mochi
+- [x] two-sum.mochi
+- [x] typed_let.mochi
+- [x] typed_var.mochi
+- [x] unary_neg.mochi
+- [x] update_stmt.mochi
+- [x] user_type_literal.mochi
+- [x] values_builtin.mochi
+- [x] var_assignment.mochi
+- [x] while_loop.mochi

--- a/tests/machine/x/swift/for_map_collection.out
+++ b/tests/machine/x/swift/for_map_collection.out
@@ -1,2 +1,2 @@
-(key: "a", value: 1)
 (key: "b", value: 2)
+(key: "a", value: 1)

--- a/tests/machine/x/swift/group_by.error
+++ b/tests/machine/x/swift/group_by.error
@@ -1,4 +1,4 @@
 line 2: exit status 1
 var people = [["name": "Alice", "age": 30, "city": "Paris"], ["name": "Bob", "age": 15, "city": "Hanoi"], ["name": "Charlie", "age": 65, "city": "Paris"], ["name": "Diana", "age": 45, "city": "Hanoi"], ["name": "Eve", "age": 70, "city": "Paris"], ["name": "Frank", "age": 22, "city": "Hanoi"]]
 var stats = { () -> [Any] in
-    let _groups = Dictionary(grouping: people) { person in person["city"] as! String }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]

--- a/tests/machine/x/swift/group_by.swift
+++ b/tests/machine/x/swift/group_by.swift
@@ -1,7 +1,14 @@
 var people = [["name": "Alice", "age": 30, "city": "Paris"], ["name": "Bob", "age": 15, "city": "Hanoi"], ["name": "Charlie", "age": 65, "city": "Paris"], ["name": "Diana", "age": 45, "city": "Hanoi"], ["name": "Eve", "age": 70, "city": "Paris"], ["name": "Frank", "age": 22, "city": "Hanoi"]]
 var stats = { () -> [Any] in
-    let _groups = Dictionary(grouping: people) { person in person["city"] as! String }
-    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]
+    for person in people {
+        let _k = person["city"] as! String
+        _groups[_k, default: []].append(person)
+    }
+    var _tmp: [(key: AnyHashable, items: [[String:Any]])] = []
+    for (k, v) in _groups {
+        _tmp.append((key: k, items: v))
+    }
     return _tmp.map { g in (city: g.key, count: g.items.count, avg_age: (g.items.map { p in p["age"] }.reduce(0, +) / g.items.map { p in p["age"] }.count)) }
 }()
 print("--- People grouped by city ---")

--- a/tests/machine/x/swift/group_by_conditional_sum.error
+++ b/tests/machine/x/swift/group_by_conditional_sum.error
@@ -1,4 +1,4 @@
-line 2: exit status 1
-var items = [["cat": "a", "val": 10, "flag": true], ["cat": "a", "val": 5, "flag": false], ["cat": "b", "val": 20, "flag": true]]
-var result = { () -> [Any] in
-    let _groups = Dictionary(grouping: items) { i in i["cat"] as! String }
+line 12: exit status 1
+    }
+    _tmp.sort { $0.key < $1.key }
+    return _tmp.map { g in (cat: g.key, share: g.items.map { x in x["flag"] ? x["val"] : 0 }.reduce(0, +) / g.items.map { x in x["val"] }.reduce(0, +)) }

--- a/tests/machine/x/swift/group_by_conditional_sum.swift
+++ b/tests/machine/x/swift/group_by_conditional_sum.swift
@@ -1,7 +1,14 @@
 var items = [["cat": "a", "val": 10, "flag": true], ["cat": "a", "val": 5, "flag": false], ["cat": "b", "val": 20, "flag": true]]
 var result = { () -> [Any] in
-    let _groups = Dictionary(grouping: items) { i in i["cat"] as! String }
-    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]
+    for i in items {
+        let _k = i["cat"] as! String
+        _groups[_k, default: []].append(i)
+    }
+    var _tmp: [(key: AnyHashable, items: [[String:Any]])] = []
+    for (k, v) in _groups {
+        _tmp.append((key: k, items: v))
+    }
     _tmp.sort { $0.key < $1.key }
     return _tmp.map { g in (cat: g.key, share: g.items.map { x in x["flag"] ? x["val"] : 0 }.reduce(0, +) / g.items.map { x in x["val"] }.reduce(0, +)) }
 }()

--- a/tests/machine/x/swift/group_by_having.out
+++ b/tests/machine/x/swift/group_by_having.out
@@ -1,10 +1,10 @@
-/workspace/mochi/tests/machine/x/swift/group_by_having.swift:21:65: warning: forced cast from 'String?' to 'String' only unwraps optionals; did you mean to use '!'?
-19 | var people = [["name": "Alice", "city": "Paris"], ["name": "Bob", "city": "Hanoi"], ["name": "Charlie", "city": "Paris"], ["name": "Diana", "city": "Hanoi"], ["name": "Eve", "city": "Paris"], ["name": "Frank", "city": "Hanoi"], ["name": "George", "city": "Paris"]]
-20 | var big = { () -> [Any] in
-21 |     let _groups = Dictionary(grouping: people) { p in p["city"] as! String }
-   |                                                                 `- warning: forced cast from 'String?' to 'String' only unwraps optionals; did you mean to use '!'?
-22 |     var _tmp = _groups.map { (k, v) in (key: k, items: v) }
-23 |     _tmp = _tmp.filter { g in g.items.count >= 4 }
+/workspace/mochi/tests/machine/x/swift/group_by_having.swift:23:28: warning: forced cast from 'String?' to 'String' only unwraps optionals; did you mean to use '!'?
+21 |     var _groups: [AnyHashable:[[String:Any]]] = [:]
+22 |     for p in people {
+23 |         let _k = p["city"] as! String
+   |                            `- warning: forced cast from 'String?' to 'String' only unwraps optionals; did you mean to use '!'?
+24 |         _groups[_k, default: []].append(p)
+25 |     }
 
 /workspace/mochi/tests/machine/x/swift/group_by_having.swift:13:27: warning: conditional cast from 'Any' to 'Any' always succeeds
 11 |         return x

--- a/tests/machine/x/swift/group_by_having.swift
+++ b/tests/machine/x/swift/group_by_having.swift
@@ -18,8 +18,15 @@ func _json(_ v: Any) {
 }
 var people = [["name": "Alice", "city": "Paris"], ["name": "Bob", "city": "Hanoi"], ["name": "Charlie", "city": "Paris"], ["name": "Diana", "city": "Hanoi"], ["name": "Eve", "city": "Paris"], ["name": "Frank", "city": "Hanoi"], ["name": "George", "city": "Paris"]]
 var big = { () -> [Any] in
-    let _groups = Dictionary(grouping: people) { p in p["city"] as! String }
-    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]
+    for p in people {
+        let _k = p["city"] as! String
+        _groups[_k, default: []].append(p)
+    }
+    var _tmp: [(key: AnyHashable, items: [[String:Any]])] = []
+    for (k, v) in _groups {
+        _tmp.append((key: k, items: v))
+    }
     _tmp = _tmp.filter { g in g.items.count >= 4 }
     return _tmp.map { g in (city: g.key, num: g.items.count) }
 }()

--- a/tests/machine/x/swift/group_by_multi_join.swift
+++ b/tests/machine/x/swift/group_by_multi_join.swift
@@ -16,8 +16,15 @@ var filtered = ({
 	return _res
 }())
 var grouped = { () -> [Any] in
-    let _groups = Dictionary(grouping: filtered) { x in x["part"] }
-    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]
+    for x in filtered {
+        let _k = x["part"]
+        _groups[_k, default: []].append(x)
+    }
+    var _tmp: [(key: AnyHashable, items: [[String:Any]])] = []
+    for (k, v) in _groups {
+        _tmp.append((key: k, items: v))
+    }
     return _tmp.map { g in (part: g.key, total: g.items.map { r in r["value"] }.reduce(0, +)) }
 }()
 print(grouped)

--- a/tests/machine/x/swift/group_by_sort.error
+++ b/tests/machine/x/swift/group_by_sort.error
@@ -1,4 +1,4 @@
 line 2: exit status 1
 var items = [["cat": "a", "val": 3], ["cat": "a", "val": 1], ["cat": "b", "val": 5], ["cat": "b", "val": 2]]
 var grouped = { () -> [Any] in
-    let _groups = Dictionary(grouping: items) { i in i["cat"] as! String }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]

--- a/tests/machine/x/swift/group_by_sort.swift
+++ b/tests/machine/x/swift/group_by_sort.swift
@@ -1,7 +1,14 @@
 var items = [["cat": "a", "val": 3], ["cat": "a", "val": 1], ["cat": "b", "val": 5], ["cat": "b", "val": 2]]
 var grouped = { () -> [Any] in
-    let _groups = Dictionary(grouping: items) { i in i["cat"] as! String }
-    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]
+    for i in items {
+        let _k = i["cat"] as! String
+        _groups[_k, default: []].append(i)
+    }
+    var _tmp: [(key: AnyHashable, items: [[String:Any]])] = []
+    for (k, v) in _groups {
+        _tmp.append((key: k, items: v))
+    }
     _tmp.sort { $0.items.map { x in x["val"] }.reduce(0, +) > $1.items.map { x in x["val"] }.reduce(0, +) }
     return _tmp.map { g in (cat: g.key, total: g.items.map { x in x["val"] }.reduce(0, +)) }
 }()

--- a/tests/machine/x/swift/group_items_iteration.error
+++ b/tests/machine/x/swift/group_items_iteration.error
@@ -1,4 +1,4 @@
-line 4: exit status 1
-    let _groups = Dictionary(grouping: data) { d in d["tag"] as! String }
-    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
-    return _tmp.map { g in g }
+line 14: exit status 1
+}()
+var tmp = []
+for g in groups {

--- a/tests/machine/x/swift/group_items_iteration.swift
+++ b/tests/machine/x/swift/group_items_iteration.swift
@@ -1,7 +1,14 @@
 var data = [["tag": "a", "val": 1], ["tag": "a", "val": 2], ["tag": "b", "val": 3]]
 var groups = { () -> [Any] in
-    let _groups = Dictionary(grouping: data) { d in d["tag"] as! String }
-    var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+    var _groups: [AnyHashable:[[String:Any]]] = [:]
+    for d in data {
+        let _k = d["tag"] as! String
+        _groups[_k, default: []].append(d)
+    }
+    var _tmp: [(key: AnyHashable, items: [[String:Any]])] = []
+    for (k, v) in _groups {
+        _tmp.append((key: k, items: v))
+    }
     return _tmp.map { g in g }
 }()
 var tmp = []

--- a/tests/machine/x/swift/json_builtin.out
+++ b/tests/machine/x/swift/json_builtin.out
@@ -5,4 +5,4 @@
    |                           `- warning: conditional cast from 'Any' to 'Any' always succeeds
 14 |        let data = try? JSONSerialization.data(withJSONObject: obj),
 15 |        let s = String(data: data, encoding: .utf8) {
-{"a":1,"b":2}
+{"b":2,"a":1}

--- a/tests/machine/x/swift/left_join.out
+++ b/tests/machine/x/swift/left_join.out
@@ -82,5 +82,5 @@
 24 | }
 25 | 
 --- Left Join ---
-Order Optional(100) customer Optional(["name": "Alice", "id": 1]) total Optional(250)
+Order Optional(100) customer Optional(["id": 1, "name": "Alice"]) total Optional(250)
 Order Optional(101) customer Optional(nil) total Optional(80)

--- a/tests/machine/x/swift/left_join_multi.out
+++ b/tests/machine/x/swift/left_join_multi.out
@@ -55,4 +55,4 @@
 20 | }
 21 | 
 --- Left Join Multi ---
-Optional(100) Optional("Alice") Optional(["sku": "a", "orderId": 100])
+Optional(100) Optional("Alice") Optional(["orderId": 100, "sku": "a"])

--- a/tests/machine/x/swift/order_by_map.out
+++ b/tests/machine/x/swift/order_by_map.out
@@ -11,4 +11,4 @@
   |                                                                            `- warning: forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?
 3 | print(sorted)
 4 | 
-[["b": 5, "a": 0], ["b": 1, "a": 1], ["a": 1, "b": 2]]
+[["b": 5, "a": 0], ["a": 1, "b": 1], ["b": 2, "a": 1]]


### PR DESCRIPTION
## Summary
- add README generation to Swift compiler tests
- implement typed loop-based grouping in Swift compiler
- regenerate Swift machine outputs and README

## Testing
- `go test ./...`
- `go test -tags=slow ./compiler/x/swift -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686f925bff088320832a502efc6baf14