### PR TITLE
Add md5 hash example with tests

### DIFF
--- a/tests/interpreter/valid/md5_python.mochi
+++ b/tests/interpreter/valid/md5_python.mochi
@@ -1,0 +1,18 @@
+import python "builtins" as py auto
+
+fun md5hex(s: string): string {
+  let q = py.repr(s) as string
+  return py.eval("__import__('hashlib').md5(" + q + ".encode()).hexdigest()") as string
+}
+
+test "md5" {
+  expect md5hex("") == "d41d8cd98f00b204e9800998ecf8427e"
+  expect md5hex("a") == "0cc175b9c0f1b6a831c399e269772661"
+  expect md5hex("abc") == "900150983cd24fb0d6963f7d28e17f72"
+  expect md5hex("message digest") == "f96b697d7cb7938d525a2f31aaf161d0"
+  expect md5hex("abcdefghijklmnopqrstuvwxyz") == "c3fcd3d76192e4007dfb496cca67e13b"
+  expect md5hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") == "d174ab98d277d9f5a5611c2c9f419d9f"
+  expect md5hex("12345678901234567890" +
+                 "123456789012345678901234567890123456789012345678901234567890") == "57edf4a22be3c955ac49da2e2107b67a"
+  expect md5hex("The quick brown fox jumped over the lazy dog's back") == "e38ca1d920c4b8b8d3946b2c72f01680"
+}


### PR DESCRIPTION
## Summary
- add md5 hashing example using Python FFI
- include inline tests covering RFC 1321 values

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f93f146a88320bfe8f2fce05c6780