### PR TITLE
Add v0.10.22 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 # 📦 CHANGELOG.md
+## [0.10.22] – 2025-07-10T17:45:54+07:00
+
+### Added
+
+* Go FFI MD5 example with tests
+* Outer and right join support for Java and Kotlin
+* Nested map assignment and union pattern support in the C backend
+* COBOL map operations and struct literals
+* Prolog update statements and test blocks with load/save builtins
+* YAML parser builtin for Dart and YAML/JSONL runtime support for Rust
+
+### Changed
+
+* Improved type inference across Go, OCaml, Scala, Swift and others
+* Better printing and formatting across Rust, Zig and Smalltalk compilers
+* Automated README generation with refreshed machine outputs
+* Enhanced join handling and sanitized names in the C backend
+
+### Fixed
+
+* Zero-arg call evaluation in Smalltalk and variable tracking in Scala
+* Map field casts and join query issues across Swift and Java
+* Removed obsolete error files and refreshed translations
+
 ## [0.10.21] – 2025-07-10T09:38:20+07:00
 
 ### Added

--- a/releases/v0.10.22.md
+++ b/releases/v0.10.22.md
@@ -1,0 +1,27 @@
+# Jul 2025 (v0.10.22)
+
+Released on Thu Jul 10 17:45:54 2025 +0700.
+
+Mochi v0.10.22 introduces outer join features and improved type inference across compilers while refreshing machine outputs and examples.
+
+## Examples
+
+- Go FFI MD5 example with inline tests
+
+## Compilers
+
+- Outer and right join support for Java and Kotlin
+- COBOL adds struct literals, map support and field assignment
+- Prolog compiler handles update statements and test blocks
+- C backend supports nested map assignment and union patterns
+- Rust runtime adds YAML/JSONL support with updated joins
+- Improved type inference and printing for Go, OCaml, Scala, Swift and others
+
+## Runtime
+
+- Ruby runtime treats '-' as stdin
+- Enhanced join handling and struct operations in the C backend
+
+## Documentation
+
+- Automated README updates for Racket, Swift and other machine outputs


### PR DESCRIPTION
## Summary
- document v0.10.22 release
- list latest changes in CHANGELOG

## Testing
- `make fmt`
- `make test` *(fails: TestInfer in ffi/go)*

------
https://chatgpt.com/codex/tasks/task_e_686f9ac896208320bfee980973f14f27