### PR TITLE
Add Rosetta 100-doors example

### DIFF
--- a/tests/x/Go/100-doors/100-doors-1.go
+++ b/tests/x/Go/100-doors/100-doors-1.go
@@ -1,0 +1,33 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import "fmt"
+
+func main() {
+    doors := [100]bool{}
+
+    // the 100 passes called for in the task description
+    for pass := 1; pass <= 100; pass++ {
+        for door := pass-1; door < 100; door += pass {
+            doors[door] = !doors[door]
+        }
+    }
+
+    // one more pass to answer the question
+    for i, v := range doors {
+        if v {
+            fmt.Print("1")
+        } else {
+            fmt.Print("0")
+        }
+
+        if i%10 == 9 {
+            fmt.Print("\n")
+        } else {
+            fmt.Print(" ")
+        }
+
+    }
+}

--- a/tests/x/Go/100-doors/100-doors-2.go
+++ b/tests/x/Go/100-doors/100-doors-2.go
@@ -1,0 +1,23 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import "fmt"
+
+func main() {
+    var door int = 1
+    var incrementer = 0
+
+    for current := 1; current <= 100; current++ {
+        fmt.Printf("Door %d ", current)
+
+        if current == door {
+            fmt.Printf("Open\n")
+            incrementer++
+            door += 2*incrementer + 1
+        } else {
+            fmt.Printf("Closed\n")
+        }
+    }
+}

--- a/tests/x/Go/100-doors/100-doors-3.go
+++ b/tests/x/Go/100-doors/100-doors-3.go
@@ -1,0 +1,23 @@
+//go:build ignore
+// +build ignore
+
+// 100 (optimized) doors in Go
+
+package main
+
+import (
+    "fmt"
+    "math"
+)
+
+func main() {
+    for i := 1; i <= 100; i++ {
+        f := math.Sqrt(float64(i))
+        if math.Mod(f, 1) == 0 {
+            fmt.Print("O")
+        } else {
+            fmt.Print("-")
+        }
+    }
+    fmt.Println()
+}

--- a/tests/x/Mochi/100-doors/100-doors.mochi
+++ b/tests/x/Mochi/100-doors/100-doors.mochi
@@ -1,0 +1,34 @@
+// 100 doors problem implemented in Mochi
+// Follows the basic simulation approach from the Go example.
+
+// initialize 100 doors, all closed (false)
+var doors = []
+for i in 0..100 {
+  doors = append(doors, false)
+}
+
+// perform 100 passes toggling doors
+for pass in 1..101 {
+  var door = pass - 1
+  while door < 100 {
+    doors[door] = !doors[door]
+    door = door + pass
+  }
+}
+
+// print door states in 10x10 grid using 1 for open, 0 for closed
+for row in 0..10 {
+  var line = ""
+  for col in 0..10 {
+    let idx = row * 10 + col
+    if doors[idx] {
+      line = line + "1"
+    } else {
+      line = line + "0"
+    }
+    if col < 9 {
+      line = line + " "
+    }
+  }
+  print(line)
+}


### PR DESCRIPTION
## Summary
- add Go reference programs for the 100-doors task
- add a Mochi implementation for the 100-doors task

## Testing
- `go run ./cmd/mochi run tests/x/Mochi/100-doors/100-doors.mochi | head`
- `go test ./... --vet=off` *(fails: TestInfer in mochi/runtime/ffi/go)*


------
https://chatgpt.com/codex/tasks/task_e_686fa0e6de90832099fad8d96f929e2a