### PR TITLE
Improve Scala compiler

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -107,4 +107,4 @@ Executed successfully: 77/97
 ## Remaining Tasks
 - Finish full query join support
 - Improve `load`/`save` expression handling
-- Enhance type inference for collection literals
+- Refine case class generation for complex queries


### PR DESCRIPTION
## Summary
- infer structs for map literals and emit case classes
- list and map compilation now uses named struct types
- update Scala machine README

## Testing
- `go test ./...` *(fails: TestInfer in runtime/ffi/go)*
- `go test -tags slow ./compiler/x/scala -run TestScalaCompilerMachine -count=1` *(skipped: scalac not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fa16f4880832081baf741746d2aab