### PR TITLE
Add Mochi Rosetta MD5 test

### DIFF
--- a/runtime/ffi/go/infer_test.go
+++ b/runtime/ffi/go/infer_test.go
@@ -18,8 +18,8 @@ func TestInfer(t *testing.T) {
 		t.Fatalf("unexpected module path %s", info.Path)
 	}
 
-	if len(info.Functions) != 2 {
-		t.Fatalf("expected 2 functions, got %d", len(info.Functions))
+	if len(info.Functions) != 3 {
+		t.Fatalf("expected 3 functions, got %d", len(info.Functions))
 	}
 
 	var add ffiinfo.FuncInfo
@@ -51,6 +51,23 @@ func TestInfer(t *testing.T) {
 	}
 	if strings.TrimSpace(add.Examples[0].Output) != "5" {
 		t.Fatalf("Add example output incorrect: %q", add.Examples[0].Output)
+	}
+
+	foundMD5 := false
+	for _, f := range info.Functions {
+		if f.Name == "MD5Hex" {
+			foundMD5 = true
+			if len(f.Params) != 1 || f.Params[0].Type != "string" {
+				t.Fatalf("MD5Hex params incorrect: %+v", f.Params)
+			}
+			if len(f.Results) != 1 || f.Results[0].Type != "string" {
+				t.Fatalf("MD5Hex results incorrect: %+v", f.Results)
+			}
+			break
+		}
+	}
+	if !foundMD5 {
+		t.Fatalf("expected MD5Hex function in inference results")
 	}
 
 	foundFail := false

--- a/tests/rosetta/x/Mochi/MD5/md5.mochi
+++ b/tests/rosetta/x/Mochi/MD5/md5.mochi
@@ -1,0 +1,20 @@
+import go "mochi/runtime/ffi/go/testpkg" as testpkg auto
+
+for pair in [
+  ["d41d8cd98f00b204e9800998ecf8427e", ""],
+  ["0cc175b9c0f1b6a831c399e269772661", "a"],
+  ["900150983cd24fb0d6963f7d28e17f72", "abc"],
+  ["f96b697d7cb7938d525a2f31aaf161d0", "message digest"],
+  ["c3fcd3d76192e4007dfb496cca67e13b", "abcdefghijklmnopqrstuvwxyz"],
+  ["d174ab98d277d9f5a5611c2c9f419d9f", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"],
+  ["57edf4a22be3c955ac49da2e2107b67a", "12345678901234567890" + "123456789012345678901234567890123456789012345678901234567890"],
+  ["e38ca1d920c4b8b8d3946b2c72f01680", "The quick brown fox jumped over the lazy dog's back"],
+] {
+  let sum = testpkg.MD5Hex(pair[1])
+  if sum != pair[0] {
+    print("MD5 fail")
+    print("  for string,", pair[1])
+    print("  expected:  ", pair[0])
+    print("  got:       ", sum)
+  }
+}

--- a/tools/rosetta/mochi_golden_test.go
+++ b/tools/rosetta/mochi_golden_test.go
@@ -1,0 +1,41 @@
+//go:build slow
+
+package rosetta
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"mochi/golden"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func TestMochiMD5(t *testing.T) {
+	golden.Run(t, "tests/rosetta/x/Mochi/MD5", ".mochi", ".out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("type error: %v", errs[0])
+		}
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			return nil, fmt.Errorf("compile error: %w", err)
+		}
+		var out bytes.Buffer
+		m := vm.New(p, &out)
+		if err := m.Run(); err != nil {
+			return nil, fmt.Errorf("run error: %w", err)
+		}
+		b := bytes.TrimSpace(out.Bytes())
+		if b == nil {
+			b = []byte{}
+		}
+		return b, nil
+	})
+}

--- a/tools/rosetta/rosetta.go
+++ b/tools/rosetta/rosetta.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/rosetta_test.go
+++ b/tools/rosetta/rosetta_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (


### PR DESCRIPTION
## Summary
- add Mochi implementation of MD5 Rosetta example
- create golden output and add golden test harness
- mark rosetta tool sources with the `slow` build tag
- update Go FFI inference tests for new MD5Hex function

## Testing
- `go test -tags slow ./tools/rosetta -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fa0571f8c83209eeec40ff6bf9307