### PR TITLE
Improve Scala compiler struct inference

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -28,7 +28,7 @@ Executed successfully: 77/97
 - [x] fun_call.mochi
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
-- [ ] group_by.mochi
+ - [x] group_by.mochi
 - [ ] group_by_conditional_sum.mochi
 - [ ] group_by_having.mochi
 - [ ] group_by_join.mochi

--- a/tests/machine/x/scala/group_by.scala
+++ b/tests/machine/x/scala/group_by.scala
@@ -1,10 +1,13 @@
 object group_by {
-  val people = List[Map[String, Any]](Map[String, Any]("name" -> ("Alice"), "age" -> (30), "city" -> ("Paris")), Map[String, Any]("name" -> ("Bob"), "age" -> (15), "city" -> ("Hanoi")), Map[String, Any]("name" -> ("Charlie"), "age" -> (65), "city" -> ("Paris")), Map[String, Any]("name" -> ("Diana"), "age" -> (45), "city" -> ("Hanoi")), Map[String, Any]("name" -> ("Eve"), "age" -> (70), "city" -> ("Paris")), Map[String, Any]("name" -> ("Frank"), "age" -> (22), "city" -> ("Hanoi")))
-  val stats = ((for { person <- people } yield (person("city"), (person))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Map[String, Any]("city" -> (g._1), "count" -> ((g._2).size), "avg_age" -> ((for { p <- g._2 } yield p.age).sum.toDouble / (for { p <- g._2 } yield p.age).size)) } }.toList
+  case class Auto1(name: String, age: Int, city: String)
+  case class Auto2(city: Any, count: Int, avg_age: Double)
+
+  val people = List[Auto1](Auto1(name = "Alice", age = 30, city = "Paris"), Auto1(name = "Bob", age = 15, city = "Hanoi"), Auto1(name = "Charlie", age = 65, city = "Paris"), Auto1(name = "Diana", age = 45, city = "Hanoi"), Auto1(name = "Eve", age = 70, city = "Paris"), Auto1(name = "Frank", age = 22, city = "Hanoi"))
+  val stats = ((for { person <- people } yield (person.city, (person))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Auto2(city = g._1, count = (g._2).size, avg_age = (for { p <- g._2 } yield p.age).sum.toDouble / (for { p <- g._2 } yield p.age).size) } }.toList
   def main(args: Array[String]): Unit = {
     println(("--- People grouped by city ---"))
     for(s <- stats) {
-      println((s("city")) + " " + (": count =") + " " + (s("count")) + " " + (", avg_age =") + " " + (s("avg_age")))
+      println((s.city) + " " + (": count =") + " " + (s.count) + " " + (", avg_age =") + " " + (s.avg_age))
     }
   }
 }


### PR DESCRIPTION
## Summary
- enhance Scala compiler with new `detectStructMap` helper
- infer struct types from list literals and query results
- compile `group_by.mochi` to case classes
- update Scala machine README

## Testing
- `go test ./...` *(fails: TestInfer in runtime/ffi/go)*

------
https://chatgpt.com/codex/tasks/task_e_686fa6b52ea0832094f99faf5e1ca7f9