### PR TITLE
Improve Scala query struct inference

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -1533,7 +1533,8 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		}
 
 		groupEnv := types.NewEnv(c.env)
-		groupEnv.SetVar(q.Group.Name, types.GroupType{Elem: types.AnyType{}}, false)
+		keyT := types.ExprType(q.Group.Exprs[0], c.env)
+		groupEnv.SetVar(q.Group.Name, types.GroupType{Key: keyT, Elem: types.AnyType{}}, false)
 
 		if q.Group.Having != nil {
 			c.env = groupEnv

--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -1,6 +1,6 @@
 # Scala Machine Translations
 
-This directory contains Scala code generated from the Mochi programs in `tests/vm/valid` using the Scala compiler. Each program was compiled with `scalac`. Successful runs produced an `.out` file while failures produced an `.error` file. The compiler now infers element types for lists and maps and emits `case class` definitions when possible.
+This directory contains Scala code generated from the Mochi programs in `tests/vm/valid` using the Scala compiler. Each program was compiled with `scalac`. Successful runs produced an `.out` file while failures produced an `.error` file. The compiler now infers element types for lists and maps and emits `case class` definitions when possible. Group-by queries now preserve the key type when generating case classes.
 
 Compiled programs: 97/97
 Executed successfully: 77/97

--- a/types/infer.go
+++ b/types/infer.go
@@ -554,7 +554,14 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			child.SetVar(j.Var, je, true)
 		}
 		orig := env
-		env = child
+		if p.Query.Group != nil {
+			keyT := ExprType(p.Query.Group.Exprs[0], child)
+			genv := NewEnv(child)
+			genv.SetVar(p.Query.Group.Name, GroupType{Key: keyT, Elem: elemType}, true)
+			env = genv
+		} else {
+			env = child
+		}
 		elem := ExprType(p.Query.Select, env)
 		env = orig
 		return ListType{Elem: elem}


### PR DESCRIPTION
## Summary
- handle key type in `GroupType`
- retain key type during Scala query compilation
- mention group key handling in Scala README

## Testing
- `go run -tags slow ./scripts/compile_scala.go`


------
https://chatgpt.com/codex/tasks/task_e_686fb46f87f483208b6dc541a0901186