### PR TITLE
Improve Swift compiler arithmetic

### DIFF
--- a/tests/machine/x/swift/group_by_multi_join.swift
+++ b/tests/machine/x/swift/group_by_multi_join.swift
@@ -9,7 +9,7 @@ var filtered = ({
 			for n in nations {
 				if !(n["id"] as! Int == s["nation"] as! Int) { continue }
 				if !(n["name"] as! String == "A") { continue }
-				_res.append(["part": ps["part"] as! Int, "value": ps["cost"] as! Double * ps["qty"] as! Int])
+				_res.append(["part": ps["part"] as! Int, "value": ps["cost"] as! Double * Double(ps["qty"] as! Int)])
 			}
 		}
 	}

--- a/tests/machine/x/swift/group_items_iteration.swift
+++ b/tests/machine/x/swift/group_items_iteration.swift
@@ -1,5 +1,5 @@
 var data = [["tag": "a", "val": 1], ["tag": "a", "val": 2], ["tag": "b", "val": 3]]
-var groups = { () -> [Any] in
+var groups = { () -> [(key: AnyHashable, items: [[String:Any]])] in
     var _groups: [AnyHashable:[[String:Any]]] = [:]
     for d in data {
         let _k = d["tag"] as! String
@@ -9,7 +9,7 @@ var groups = { () -> [Any] in
     for (k, v) in _groups {
         _tmp.append((key: k, items: v))
     }
-    return _tmp.map { g in g }
+    return _tmp
 }()
 var tmp = []
 for g in groups {


### PR DESCRIPTION
## Summary
- improve Swift binary expression handling of Float/Int operations
- update machine-generated Swift samples for group joins and group iteration

## Testing
- `go test -tags slow ./compiler/x/swift -run TestCompileValidPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686fb5a4d63c8320a8986c4a608ac443