### PR TITLE
Add int expression grouping to C compiler

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -2034,6 +2034,120 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 					}
 					delete(c.groupKeys, q.Group.Name)
 					return res
+				} else if _, ok := c.exprType(q.Group.Exprs[0]).(types.IntType); ok {
+					c.need(needGroupByInt)
+					c.need(needListInt)
+					var cond string
+					if q.Where != nil {
+						cond = c.compileExpr(q.Where)
+					}
+					rows := c.newTemp()
+					keys := c.newTemp()
+					idxVar := c.newTemp()
+					listC := cTypeFromType(srcT)
+					if st, ok := lt.Elem.(types.StructType); ok {
+						c.compileStructType(st)
+						c.compileStructListType(st)
+					}
+					c.writeln(fmt.Sprintf("%s %s = %s_create(%s.len);", listC, rows, listC, src))
+					c.writeln(fmt.Sprintf("list_int %s = list_int_create(%s.len);", keys, src))
+					c.writeln(fmt.Sprintf("int %s = 0;", idxVar))
+					c.writeln(fmt.Sprintf("for (int i=0; i<%s.len; i++) {", src))
+					c.indent++
+					c.writeln(fmt.Sprintf("%s %s = %s.data[i];", cTypeFromType(lt.Elem), sanitizeName(q.Var), src))
+					if cond != "" {
+						c.writeln(fmt.Sprintf("if (!(%s)) { continue; }", cond))
+					}
+					key := c.compileExpr(q.Group.Exprs[0])
+					c.writeln(fmt.Sprintf("%s.data[%s] = %s;", rows, idxVar, sanitizeName(q.Var)))
+					c.writeln(fmt.Sprintf("%s.data[%s] = %s;", keys, idxVar, key))
+					c.writeln(fmt.Sprintf("%s++;", idxVar))
+					c.indent--
+					c.writeln("}")
+					c.writeln(fmt.Sprintf("%s.len = %s;", rows, idxVar))
+					c.writeln(fmt.Sprintf("%s.len = %s;", keys, idxVar))
+					groups := c.newTemp()
+					c.writeln(fmt.Sprintf("list_group_int %s = _group_by_int(%s);", groups, keys))
+					oldEnv := c.env
+					if c.env != nil {
+						genv := types.NewEnv(c.env)
+						genv.SetVar(q.Group.Name, types.GroupType{Elem: lt.Elem}, true)
+						c.env = genv
+					}
+					c.groupKeys[q.Group.Name] = types.IntType{}
+					if ml := asMapLiteral(q.Select); ml != nil {
+						if _, ok := c.structLits[ml]; !ok {
+							if st, ok2 := c.inferStructFromMap(ml, q.Var); ok2 {
+								c.structLits[ml] = st
+								if c.env != nil {
+									c.env.SetStruct(st.Name, st)
+								}
+								c.compileStructType(st)
+								c.compileStructListType(st)
+							}
+						}
+					}
+					var retT types.Type
+					if ml := asMapLiteral(q.Select); ml != nil {
+						if st, ok := c.structLits[ml]; ok {
+							retT = st
+						} else if st, ok2 := c.inferStructFromMap(ml, q.Var); ok2 {
+							retT = st
+							c.structLits[ml] = st
+							if c.env != nil {
+								c.env.SetStruct(st.Name, st)
+							}
+							c.compileStructType(st)
+							c.compileStructListType(st)
+						}
+					}
+					if retT == nil {
+						retT = c.exprType(q.Select)
+						if ml := asMapLiteral(q.Select); ml != nil {
+							if st, ok := retT.(types.StructType); ok {
+								c.structLits[ml] = st
+							}
+						}
+					}
+					retList := types.ListType{Elem: retT}
+					listRes := cTypeFromType(retList)
+					if listRes == "list_string" {
+						c.need(needListString)
+					} else if listRes == "list_float" {
+						c.need(needListFloat)
+					} else if listRes == "list_list_int" {
+						c.need(needListListInt)
+					}
+					res := c.newTemp()
+					idxRes := c.newTemp()
+					c.writeln(fmt.Sprintf("%s %s = %s_create(%s.len);", listRes, res, listRes, groups))
+					c.writeln(fmt.Sprintf("int %s = 0;", idxRes))
+					c.writeln(fmt.Sprintf("for (int gi=0; gi<%s.len; gi++) {", groups))
+					c.indent++
+					c.writeln(fmt.Sprintf("_GroupInt _gp = %s.data[gi];", groups))
+					items := c.newTemp()
+					c.writeln(fmt.Sprintf("%s %s = %s_create(_gp.items.len);", listC, items, listC))
+					c.writeln(fmt.Sprintf("for (int j=0; j<_gp.items.len; j++) {"))
+					c.indent++
+					c.writeln(fmt.Sprintf("%s.data[j] = %s.data[_gp.items.data[j]];", items, rows))
+					c.indent--
+					c.writeln("}")
+					c.writeln(fmt.Sprintf("%s.len = _gp.items.len;", items))
+					c.writeln(fmt.Sprintf("struct {int key; %s items; } %s = { _gp.key, %s };", listC, sanitizeName(q.Group.Name), items))
+					val := c.compileExpr(q.Select)
+					c.writeln(fmt.Sprintf("%s.data[%s] = %s;", res, idxRes, val))
+					c.writeln(fmt.Sprintf("%s++;", idxRes))
+					c.indent--
+					c.writeln("}")
+					c.writeln(fmt.Sprintf("%s.len = %s;", res, idxRes))
+					if c.env != nil {
+						c.env = oldEnv
+					}
+					if c.env != nil {
+						c.env = prevEnv
+					}
+					delete(c.groupKeys, q.Group.Name)
+					return res
 				}
 			}
 		} else if len(q.Group.Exprs) == 2 {


### PR DESCRIPTION
## Summary
- enhance C compiler to handle `group by` where the key expression is an integer
- updated code in compiler/x/c/compiler.go

## Testing
- `go test ./compiler/x/c -run TestCCompiler_ValidPrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686fb5df42b4832095ab9aacecd1dfc3