### PR TITLE
Add Rosetta 24 game example

### DIFF
--- a/tests/rosetta/x/Go/24-game/24-game.go
+++ b/tests/rosetta/x/Go/24-game/24-game.go
@@ -1,0 +1,71 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+    "fmt"
+    "math"
+    "math/rand"
+    "time"
+)
+
+func main() {
+    rand.Seed(time.Now().Unix())
+    n := make([]rune, 4)
+    for i := range n {
+        n[i] = rune(rand.Intn(9) + '1')
+    }
+    fmt.Printf("Your numbers: %c\n", n)
+    fmt.Print("Enter RPN: ")
+    var expr string
+    fmt.Scan(&expr)
+    if len(expr) != 7 {
+        fmt.Println("invalid. expression length must be 7." +
+            " (4 numbers, 3 operators, no spaces)")
+        return
+    }
+    stack := make([]float64, 0, 4)
+    for _, r := range expr {
+        if r >= '0' && r <= '9' {
+            if len(n) == 0 {
+                fmt.Println("too many numbers.")
+                return
+            }
+            i := 0
+            for n[i] != r {
+                i++
+                if i == len(n) {
+                    fmt.Println("wrong numbers.")
+                    return
+                }
+            }
+            n = append(n[:i], n[i+1:]...)
+            stack = append(stack, float64(r-'0'))
+            continue
+        }
+        if len(stack) < 2 {
+            fmt.Println("invalid expression syntax.")
+            return
+        }
+        switch r {
+        case '+':
+            stack[len(stack)-2] += stack[len(stack)-1]
+        case '-':
+            stack[len(stack)-2] -= stack[len(stack)-1]
+        case '*':
+            stack[len(stack)-2] *= stack[len(stack)-1]
+        case '/':
+            stack[len(stack)-2] /= stack[len(stack)-1]
+        default:
+            fmt.Printf("%c invalid.\n", r)
+            return
+        }
+        stack = stack[:len(stack)-1]
+    }
+    if math.Abs(stack[0]-24) > 1e-6 {
+        fmt.Println("incorrect.", stack[0], "!= 24")
+    } else {
+        fmt.Println("correct.")
+    }
+}

--- a/tests/rosetta/x/Mochi/24-game/24-game.mochi
+++ b/tests/rosetta/x/Mochi/24-game/24-game.mochi
@@ -1,0 +1,85 @@
+// Mochi implementation of Rosetta "24 game" task
+// Generates four random digits 1-9 and asks for an RPN expression
+// using those digits to make the value 24.
+
+fun randDigit(): int { return (now() % 9) + 1 }
+
+fun main() {
+  var nums = []
+  var used = []
+  for i in 0..4 {
+    let d = randDigit()
+    nums = nums + [d]
+    used = used + [false]
+  }
+
+  print("Your numbers: ")
+  for i in 0..4 {
+    print(str(nums[i]))
+    if i < 3 { print(" ") }
+  }
+  print("\nEnter RPN: ")
+  var expr = input()
+  if len(expr) != 7 {
+    print("invalid. expression length must be 7. (4 numbers, 3 operators, no spaces)")
+    return
+  }
+
+  var stack = []
+  var i = 0
+  var valid = true
+  while i < len(expr) {
+    let ch = substring(expr, i, i+1)
+    if ch >= "0" && ch <= "9" {
+      var found = false
+      var j = 0
+      while j < 4 {
+        if !used[j] && nums[j] == int(ch) - int("0") {
+          used[j] = true
+          found = true
+          break
+        }
+        j = j + 1
+      }
+      if !found {
+        print("wrong numbers.")
+        valid = false
+        break
+      }
+      stack = stack + [float(int(ch) - int("0"))]
+    } else {
+      if len(stack) < 2 {
+        print("invalid expression syntax.")
+        valid = false
+        break
+      }
+      var b = stack[len(stack)-1]
+      var a = stack[len(stack)-2]
+      if ch == "+" {
+        stack[len(stack)-2] = a + b
+      } else if ch == "-" {
+        stack[len(stack)-2] = a - b
+      } else if ch == "*" {
+        stack[len(stack)-2] = a * b
+      } else if ch == "/" {
+        stack[len(stack)-2] = a / b
+      } else {
+        print(ch + " invalid.")
+        valid = false
+        break
+      }
+      stack = stack[:len(stack)-1]
+    }
+    i = i + 1
+  }
+
+  if valid {
+    if abs(stack[0] - 24.0) > 0.000001 {
+      print("incorrect. " + str(stack[0]) + " != 24")
+    } else {
+      print("correct.")
+    }
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- add Go version for Rosetta "24-game" task
- implement matching Mochi example
- move 24-game samples to `tests/rosetta/x`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fb07c395c832093fe5ad11e9a3c2b