### PR TITLE
Add Rosetta 24-game examples

### DIFF
--- a/tests/rosetta/x/Go/24-game/24-game.go
+++ b/tests/rosetta/x/Go/24-game/24-game.go
@@ -1,0 +1,71 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+)
+
+func main() {
+	rand.Seed(time.Now().Unix())
+	n := make([]rune, 4)
+	for i := range n {
+		n[i] = rune(rand.Intn(9) + '1')
+	}
+	fmt.Printf("Your numbers: %c\n", n)
+	fmt.Print("Enter RPN: ")
+	var expr string
+	fmt.Scan(&expr)
+	if len(expr) != 7 {
+		fmt.Println("invalid. expression length must be 7." +
+			" (4 numbers, 3 operators, no spaces)")
+		return
+	}
+	stack := make([]float64, 0, 4)
+	for _, r := range expr {
+		if r >= '0' && r <= '9' {
+			if len(n) == 0 {
+				fmt.Println("too many numbers.")
+				return
+			}
+			i := 0
+			for n[i] != r {
+				i++
+				if i == len(n) {
+					fmt.Println("wrong numbers.")
+					return
+				}
+			}
+			n = append(n[:i], n[i+1:]...)
+			stack = append(stack, float64(r-'0'))
+			continue
+		}
+		if len(stack) < 2 {
+			fmt.Println("invalid expression syntax.")
+			return
+		}
+		switch r {
+		case '+':
+			stack[len(stack)-2] += stack[len(stack)-1]
+		case '-':
+			stack[len(stack)-2] -= stack[len(stack)-1]
+		case '*':
+			stack[len(stack)-2] *= stack[len(stack)-1]
+		case '/':
+			stack[len(stack)-2] /= stack[len(stack)-1]
+		default:
+			fmt.Printf("%c invalid.\n", r)
+			return
+		}
+		stack = stack[:len(stack)-1]
+	}
+	if math.Abs(stack[0]-24) > 1e-6 {
+		fmt.Println("incorrect.", stack[0], "!= 24")
+	} else {
+		fmt.Println("correct.")
+	}
+}

--- a/tests/rosetta/x/Mochi/24-game/24-game.mochi
+++ b/tests/rosetta/x/Mochi/24-game/24-game.mochi
@@ -1,0 +1,99 @@
+// 24 Game implementation in Mochi based on Go example
+
+fun rand1to9(): int {
+  return (now() % 9) + 1
+}
+
+fun absf(x: float): float {
+  if x < 0.0 { return -x }
+  return x
+}
+
+fun dropLast(xs: list<float>): list<float> {
+  var out: list<float> = []
+  var i = 0
+  while i < len(xs)-1 {
+    out = append(out, xs[i])
+    i = i + 1
+  }
+  return out
+}
+
+fun toDigit(ch: string): int {
+  let m = {"0":0,"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9}
+  if ch in m { return m[ch] }
+  return -1
+}
+
+var digits: list<int> = []
+var i = 0
+while i < 4 {
+  digits = append(digits, rand1to9())
+  i = i + 1
+}
+var numsStr = str(digits[0]) + " " + str(digits[1]) + " " + str(digits[2]) + " " + str(digits[3])
+print("Your numbers: " + numsStr)
+print("Enter RPN: ")
+var expr = input()
+if len(expr) != 7 {
+  print("invalid. expression length must be 7. (4 numbers, 3 operators, no spaces)")
+}
+
+var used: list<bool> = [false, false, false, false]
+var stack: list<float> = []
+var idx = 0
+while idx < len(expr) {
+  let ch = substring(expr, idx, idx+1)
+  let d = toDigit(ch)
+  if d >= 0 {
+    var found = false
+    var j = 0
+    var free = false
+    while j < 4 {
+      if !used[j] { free = true }
+      if !used[j] && digits[j] == d {
+        used[j] = true
+        found = true
+        break
+      }
+      j = j + 1
+    }
+    if !found {
+      if free {
+        print("wrong numbers.")
+      } else {
+        print("too many numbers.")
+      }
+    } else {
+      stack = append(stack, d as float)
+    }
+  } else {
+    if len(stack) < 2 {
+      print("invalid expression syntax.")
+    } else {
+      let b = stack[len(stack)-1]
+      let a = stack[len(stack)-2]
+      var res = 0.0
+      if ch == "+" {
+        res = a + b
+      } else if ch == "-" {
+        res = a - b
+      } else if ch == "*" {
+        res = a * b
+      } else if ch == "/" {
+        res = a / b
+      } else {
+        print(ch + " invalid.")
+      }
+      stack[len(stack)-2] = res
+      stack = dropLast(stack)
+    }
+  }
+  idx = idx + 1
+}
+
+if len(stack) != 1 || absf(stack[0] - 24.0) > 0.000001 {
+  print("incorrect. " + str(stack[0]) + " != 24")
+} else {
+  print("correct.")
+}


### PR DESCRIPTION
## Summary
- add Go implementation for the Rosetta “24-game" task
- provide equivalent Mochi version
- move examples under `tests/rosetta/x`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fb08574048320a3d7ca6f79653ac5