### PR TITLE
Add ASCII-art diagram converter example

### DIFF
--- a/tests/rosetta/x/Go/ASCII-art-diagram-converter/ascii-art-diagram-converter.go
+++ b/tests/rosetta/x/Go/ASCII-art-diagram-converter/ascii-art-diagram-converter.go
@@ -1,0 +1,131 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+    "fmt"
+    "log"
+    "math/big"
+    "strings"
+)
+
+type result struct {
+    name  string
+    size  int
+    start int
+    end   int
+}
+
+func (r result) String() string {
+    return fmt.Sprintf("%-7s   %2d    %3d   %3d", r.name, r.size, r.start, r.end)
+}
+
+func validate(diagram string) []string {
+    var lines []string
+    for _, line := range strings.Split(diagram, "\n") {
+        line = strings.Trim(line, " \t")
+        if line != "" {
+            lines = append(lines, line)
+        }
+    }
+    if len(lines) == 0 {
+        log.Fatal("diagram has no non-empty lines!")
+    }
+    width := len(lines[0])
+    cols := (width - 1) / 3
+    if cols != 8 && cols != 16 && cols != 32 && cols != 64 {
+        log.Fatal("number of columns should be 8, 16, 32 or 64")
+    }
+    if len(lines)%2 == 0 {
+        log.Fatal("number of non-empty lines should be odd")
+    }
+    if lines[0] != strings.Repeat("+--", cols)+"+" {
+        log.Fatal("incorrect header line")
+    }
+    for i, line := range lines {
+        if i == 0 {
+            continue
+        } else if i%2 == 0 {
+            if line != lines[0] {
+                log.Fatal("incorrect separator line")
+            }
+        } else if len(line) != width {
+            log.Fatal("inconsistent line widths")
+        } else if line[0] != '|' || line[width-1] != '|' {
+            log.Fatal("non-separator lines must begin and end with '|'")
+        }
+    }
+    return lines
+}
+
+func decode(lines []string) []result {
+    fmt.Println("Name     Bits  Start  End")
+    fmt.Println("=======  ====  =====  ===")
+    start := 0
+    width := len(lines[0])
+    var results []result
+    for i, line := range lines {
+        if i%2 == 0 {
+            continue
+        }
+        line := line[1 : width-1]
+        for _, name := range strings.Split(line, "|") {
+            size := (len(name) + 1) / 3
+            name = strings.TrimSpace(name)
+            res := result{name, size, start, start + size - 1}
+            results = append(results, res)
+            fmt.Println(res)
+            start += size
+        }
+    }
+    return results
+}
+
+func unpack(results []result, hex string) {
+    fmt.Println("\nTest string in hex:")
+    fmt.Println(hex)
+    fmt.Println("\nTest string in binary:")
+    bin := hex2bin(hex)
+    fmt.Println(bin)
+    fmt.Println("\nUnpacked:\n")
+    fmt.Println("Name     Size  Bit pattern")
+    fmt.Println("=======  ====  ================")
+    for _, res := range results {
+        fmt.Printf("%-7s   %2d   %s\n", res.name, res.size, bin[res.start:res.end+1])
+    }
+}
+
+func hex2bin(hex string) string {
+    z := new(big.Int)
+    z.SetString(hex, 16)
+    return fmt.Sprintf("%0*b", 4*len(hex), z)
+}
+
+func main() {
+    const diagram = `
+        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+         |                      ID                       |
+        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+        |QR|   Opcode  |AA|TC|RD|RA|   Z    |   RCODE   |
+        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+        |                    QDCOUNT                    |
+        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+
+        |                    ANCOUNT                    |
+        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+        |                    NSCOUNT                    |
+        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+        |                    ARCOUNT                    |
+        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+    `
+    lines := validate(diagram)
+    fmt.Println("Diagram after trimming whitespace and removal of blank lines:\n")
+    for _, line := range lines {
+        fmt.Println(line)
+    }
+    fmt.Println("\nDecoded:\n")
+    results := decode(lines)
+    hex := "78477bbf5496e12e1bf169a4" // test string
+    unpack(results, hex)
+}

--- a/tests/rosetta/x/Mochi/ASCII-art-diagram-converter/ascii-art-diagram-converter.mochi
+++ b/tests/rosetta/x/Mochi/ASCII-art-diagram-converter/ascii-art-diagram-converter.mochi
@@ -1,0 +1,116 @@
+import go "strings" as strings auto
+
+// Result represents a single field parsed from the diagram
+ type Result {
+  name: string,
+  size: int,
+  start: int,
+  end: int,
+ }
+
+fun validate(diagram: string): list<string> {
+  var lines: list<string> = []
+  for line in strings.Split(diagram, "\n") {
+    let trimmed = strings.TrimSpace(line)
+    if trimmed != "" {
+      lines = lines + [trimmed]
+    }
+  }
+  return lines
+}
+
+fun decode(lines: list<string>): list<Result> {
+  print("Name     Bits  Start  End")
+  print("=======  ====  =====  ===")
+  var results: list<Result> = []
+  var start = 0
+  let width = len(lines[0])
+  var i = 0
+  while i < len(lines) {
+    if i % 2 == 1 {
+      let inner = lines[i][1:width-1]
+      for part in strings.Split(inner, "|") {
+        let size = (len(part) + 1) / 3
+        let name = strings.TrimSpace(part)
+        let r = Result { name: name, size: size, start: start, end: start + size - 1 }
+        results = results + [r]
+        print(name, size, start, start + size - 1)
+        start = start + size
+      }
+    }
+    i = i + 1
+  }
+  return results
+}
+
+fun hexDigitBits(ch: string): string {
+  let c = strings.ToLower(ch)
+  if c == "0" { return "0000" }
+  if c == "1" { return "0001" }
+  if c == "2" { return "0010" }
+  if c == "3" { return "0011" }
+  if c == "4" { return "0100" }
+  if c == "5" { return "0101" }
+  if c == "6" { return "0110" }
+  if c == "7" { return "0111" }
+  if c == "8" { return "1000" }
+  if c == "9" { return "1001" }
+  if c == "a" { return "1010" }
+  if c == "b" { return "1011" }
+  if c == "c" { return "1100" }
+  if c == "d" { return "1101" }
+  if c == "e" { return "1110" }
+  if c == "f" { return "1111" }
+  return ""
+}
+
+fun hex2bin(hex: string): string {
+  var res = ""
+  var i = 0
+  while i < len(hex) {
+    res = res + hexDigitBits(hex[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun unpack(results: list<Result>, hex: string) {
+  print("\nTest string in hex:")
+  print(hex)
+  print("\nTest string in binary:")
+  let bin = hex2bin(hex)
+  print(bin)
+  print("\nUnpacked:\n")
+  print("Name     Size  Bit pattern")
+  print("=======  ====  ================")
+  for r in results {
+    print(r.name, r.size, bin[r.start:r.end+1])
+  }
+}
+
+fun main() {
+  let diagram =
+        "        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+\n" +
+        "         |                      ID                       |\n" +
+        "        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+\n" +
+        "        |QR|   Opcode  |AA|TC|RD|RA|   Z    |   RCODE   |\n" +
+        "        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+\n" +
+        "        |                    QDCOUNT                    |\n" +
+        "        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+\n" +
+        "\n" +
+        "        |                    ANCOUNT                    |\n" +
+        "        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+\n" +
+        "        |                    NSCOUNT                    |\n" +
+        "        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+\n" +
+        "        |                    ARCOUNT                    |\n" +
+        "        +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+\n"
+  let lines = validate(diagram)
+  print("Diagram after trimming whitespace and removal of blank lines:\n")
+  for line in lines { print(line) }
+  print("\nDecoded:\n")
+  let results = decode(lines)
+  let hex = "78477bbf5496e12e1bf169a4"
+  unpack(results, hex)
+}
+
+main()


### PR DESCRIPTION
## Summary
- add Go example for Rosetta Code task `ASCII-art-diagram-converter`
- port logic to Mochi in `ascii-art-diagram-converter.mochi`

## Testing
- `go run ./cmd/mochi --help` *(prints help)*


------
https://chatgpt.com/codex/tasks/task_e_686fb35e6c0c8320afe88bf8a4690b01