### PR TITLE
Add Abbreviations-easy Rosetta sample

### DIFF
--- a/tests/rosetta/x/Go/Abbreviations-easy/abbreviations-easy.go
+++ b/tests/rosetta/x/Go/Abbreviations-easy/abbreviations-easy.go
@@ -1,0 +1,70 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+    "fmt"
+    "strings"
+)
+
+var table =
+    "Add ALTer  BAckup Bottom  CAppend Change SCHANGE  CInsert CLAst COMPress COpy " +
+    "COUnt COVerlay CURsor DELete CDelete Down DUPlicate Xedit EXPand EXTract Find " +
+    "NFind NFINDUp NFUp CFind FINdup FUp FOrward GET Help HEXType Input POWerinput " +
+     "Join SPlit SPLTJOIN  LOAD  Locate CLocate  LOWercase UPPercase  LPrefix MACRO " +
+    "MErge MODify MOve MSG Next Overlay PARSE PREServe PURge PUT PUTD  Query  QUIT " +
+    "READ  RECover REFRESH RENum REPeat  Replace CReplace  RESet  RESTore  RGTLEFT " +
+    "RIght LEft  SAVE  SET SHift SI  SORT  SOS  STAck STATus  TOP TRAnsfer Type Up "
+
+func validate(commands, words []string, minLens []int) []string {
+    results := make([]string, 0)
+    if len(words) == 0 {
+        return results
+    }
+    for _, word := range words {
+        matchFound := false
+        wlen := len(word)
+        for i, command := range commands {
+            if minLens[i] == 0 || wlen < minLens[i] || wlen > len(command) {
+                continue
+            }
+            c := strings.ToUpper(command)
+            w := strings.ToUpper(word)
+            if strings.HasPrefix(c, w) {
+                results = append(results, c)
+                matchFound = true
+                break
+            }
+        }
+        if !matchFound {
+            results = append(results, "*error*")
+        }
+    }
+    return results
+}
+
+func main() {
+    table = strings.TrimSpace(table)
+    commands := strings.Fields(table)
+    clen := len(commands)
+    minLens := make([]int, clen)
+    for i := 0; i < clen; i++ {
+        count := 0
+        for _, c := range commands[i] {
+            if c >= 'A' && c <= 'Z' {
+                count++
+            }
+        }
+        minLens[i] = count
+    }
+    sentence :=  "riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin"
+    words := strings.Fields(sentence)
+    results := validate(commands, words, minLens)
+    fmt.Print("user words:  ")
+    for j := 0; j < len(words); j++ {
+        fmt.Printf("%-*s ", len(results[j]), words[j])
+    }
+    fmt.Print("\nfull words:  ")
+    fmt.Println(strings.Join(results, " "))
+}

--- a/tests/rosetta/x/Mochi/Abbreviations-easy/abbreviations-easy.mochi
+++ b/tests/rosetta/x/Mochi/Abbreviations-easy/abbreviations-easy.mochi
@@ -1,0 +1,116 @@
+fun fields(s: string): list<string> {
+  var words: list<string> = []
+  var cur = ""
+  var i = 0
+  while i < len(s) {
+    let ch = substring(s, i, i + 1)
+    if ch == " " || ch == "\n" || ch == "\t" {
+      if len(cur) > 0 {
+        words = append(words, cur)
+        cur = ""
+      }
+    } else {
+      cur = cur + ch
+    }
+    i = i + 1
+  }
+  if len(cur) > 0 {
+    words = append(words, cur)
+  }
+  return words
+}
+
+fun padRight(s: string, width: int): string {
+  var out = s
+  var i = len(s)
+  while i < width {
+    out = out + " "
+    i = i + 1
+  }
+  return out
+}
+
+fun join(xs: list<string>, sep: string): string {
+  var res = ""
+  var i = 0
+  while i < len(xs) {
+    if i > 0 {
+      res = res + sep
+    }
+    res = res + xs[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun validate(commands: list<string>, words: list<string>, mins: list<int>): list<string> {
+  var results: list<string> = []
+  if len(words) == 0 {
+    return results
+  }
+  var wi = 0
+  while wi < len(words) {
+    let w = words[wi]
+    var found = false
+    let wlen = len(w)
+    var ci = 0
+    while ci < len(commands) {
+      let cmd = commands[ci]
+      if mins[ci] != 0 && wlen >= mins[ci] && wlen <= len(cmd) {
+        let c = upper(cmd)
+        let ww = upper(w)
+        if substring(c, 0, wlen) == ww {
+          results = append(results, c)
+          found = true
+          break
+        }
+      }
+      ci = ci + 1
+    }
+    if !found {
+      results = append(results, "*error*")
+    }
+    wi = wi + 1
+  }
+  return results
+}
+
+fun main() {
+  let table = "Add ALTer  BAckup Bottom  CAppend Change SCHANGE  CInsert CLAst COMPress Copy " +
+              "COUnt COVerlay CURsor DELete CDelete Down DUPlicate Xedit EXPand EXTract Find " +
+              "NFind NFINDUp NFUp CFind FINdup FUp FOrward GET Help HEXType Input POWerinput " +
+              " Join SPlit SPLTJOIN  LOAD  Locate CLocate  LOWercase UPPercase  LPrefix MACRO " +
+              "MErge MODify MOve MSG Next Overlay PARSE PREServe PURge PUT PUTD  Query  QUIT " +
+              "READ  RECover REFRESH RENum REPeat  Replace CReplace  RESet  RESTore  RGTLEFT " +
+              "RIght LEft  SAVE  SET SHift SI  SORT  SOS  STAck STATus  TOP TRAnsfer TypeUp "
+  let commands = fields(table)
+  var mins: list<int> = []
+  var i = 0
+  while i < len(commands) {
+    var count = 0
+    var j = 0
+    let cmd = commands[i]
+    while j < len(cmd) {
+      let ch = substring(cmd, j, j + 1)
+      if ch >= "A" && ch <= "Z" {
+        count = count + 1
+      }
+      j = j + 1
+    }
+    mins = append(mins, count)
+    i = i + 1
+  }
+  let sentence = "riG   rePEAT copies  put mo   rest    types   fup.    6\npoweRin"
+  let words = fields(sentence)
+  let results = validate(commands, words, mins)
+  var out1 = "user words:  "
+  var k = 0
+  while k < len(words) {
+    out1 = out1 + padRight(words[k], len(results[k])) + " "
+    k = k + 1
+  }
+  print(out1)
+  print("full words:  " + join(results, " "))
+}
+
+main()

--- a/tests/rosetta/x/Mochi/Abbreviations-easy/abbreviations-easy.out
+++ b/tests/rosetta/x/Mochi/Abbreviations-easy/abbreviations-easy.out
@@ -1,0 +1,2 @@
+user words:  riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin    
+full words:  RIGHT REPEAT *error* PUT MOVE RESTORE *error* *error* *error* POWERINPUT


### PR DESCRIPTION
## Summary
- add Rosetta Go source for `Abbreviations-easy`
- implement corresponding Mochi version with output

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/Abbreviations-easy/abbreviations-easy.mochi`

------
https://chatgpt.com/codex/tasks/task_e_686fb376bc888320b6eaa87ede6d4a63