### PR TITLE
Add 100 prisoners rosetta update

### DIFF
--- a/tests/rosetta/x/Mochi/100-prisoners.mochi
+++ b/tests/rosetta/x/Mochi/100-prisoners.mochi
@@ -18,7 +18,7 @@ fun doTrials(trials: int, np: int, strategy: string) {
     var drawers: list<int> = []
     var i = 0
     while i < 100 {
-      drawers = drawers + [i]
+      drawers = append(drawers, i)
       i = i + 1
     }
     drawers = shuffle(drawers)
@@ -42,7 +42,7 @@ fun doTrials(trials: int, np: int, strategy: string) {
         var opened: list<bool> = []
         var k = 0
         while k < 100 {
-          opened = opened + [false]
+          opened = append(opened, false)
           k = k + 1
         }
         var d = 0


### PR DESCRIPTION
## Summary
- fix 100-prisoners.mochi to correctly append to lists
- keep runtime small by running 1000 trials
- verify rosetta golden tests pass

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/100-prisoners.mochi | head`
- `go test ./tools/rosetta -run TestMochiTasks -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_686fcac30a008320976e62ebc7cf3299