### PR TITLE
Fix global var ordering for CPP compiler

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -159,13 +159,19 @@ func (c *Compiler) Compile(p *parser.Program) ([]byte, error) {
 
 	globals := []*parser.Statement{}
 	encounteredFun := false
+	encounteredStmt := false
 	for _, st := range p.Statements {
 		if st.Fun != nil {
 			encounteredFun = true
+			encounteredStmt = true
 			continue
 		}
-		if !encounteredFun && (st.Let != nil || st.Var != nil || st.Type != nil) {
+		if !encounteredFun && !encounteredStmt && (st.Let != nil || st.Var != nil || st.Type != nil) {
 			globals = append(globals, st)
+			continue
+		}
+		if st.Let == nil && st.Var == nil && st.Type == nil {
+			encounteredStmt = true
 		}
 	}
 

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -106,3 +106,8 @@ Compiled programs: 99/100
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining Tasks
+
+- [ ] Improve handling of empty list initializations
+

--- a/tests/machine/x/cpp/group_items_iteration.cpp
+++ b/tests/machine/x/cpp/group_items_iteration.cpp
@@ -61,18 +61,6 @@ auto groups = ([]() {
   return __items;
 })();
 auto tmp = std::vector<int>{};
-auto result = ([]() {
-  std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
-  for (auto r : tmp) {
-    __items.push_back({r.tag, r});
-  }
-  std::sort(__items.begin(), __items.end(),
-            [](auto &a, auto &b) { return a.first < b.first; });
-  std::vector<decltype(r)> __res;
-  for (auto &p : __items)
-    __res.push_back(p.second);
-  return __res;
-})();
 
 int main() {
   for (auto g : groups) {
@@ -85,12 +73,25 @@ int main() {
       return v;
     })(tmp);
   }
+  auto result = ([&]() {
+    std::vector<std::pair<decltype(std::declval<__struct3>().tag), __struct3>>
+        __items;
+    for (auto r : tmp) {
+      __items.push_back({r.tag, r});
+    }
+    std::sort(__items.begin(), __items.end(),
+              [](auto &a, auto &b) { return a.first < b.first; });
+    std::vector<__struct3> __res;
+    for (auto &p : __items)
+      __res.push_back(p.second);
+    return __res;
+  })();
   {
     auto __tmp1 = result;
     for (size_t i = 0; i < __tmp1.size(); ++i) {
       if (i)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp1[i];
+      std::cout << "<struct>";
     }
     std::cout << std::endl;
   }

--- a/tests/machine/x/cpp/group_items_iteration.error
+++ b/tests/machine/x/cpp/group_items_iteration.error
@@ -1,59 +1,7 @@
-line 65: ../../../tests/machine/x/cpp/group_items_iteration.cpp: In lambda function:
-../../../tests/machine/x/cpp/group_items_iteration.cpp:65:34: error: ‘r’ was not declared in this scope
-   65 |   std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
-      |                                  ^
-../../../tests/machine/x/cpp/group_items_iteration.cpp:65:42: error: template argument 1 is invalid
-   65 |   std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
-      |                                          ^~~~~~~~~~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:65:42: error: template argument 2 is invalid
-../../../tests/machine/x/cpp/group_items_iteration.cpp:65:53: error: template argument 1 is invalid
-   65 |   std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
-      |                                                     ^~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:65:53: error: template argument 2 is invalid
-../../../tests/machine/x/cpp/group_items_iteration.cpp:67:13: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
-   67 |     __items.push_back({r.tag, r});
-      |             ^~~~~~~~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:67:26: error: request for member ‘tag’ in ‘r’, which is of non-class type ‘int’
-   67 |     __items.push_back({r.tag, r});
-      |                          ^~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:69:21: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
-   69 |   std::sort(__items.begin(), __items.end(),
-      |                     ^~~~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:69:38: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
-   69 |   std::sort(__items.begin(), __items.end(),
-      |                                      ^~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:71:26: error: template argument 1 is invalid
-   71 |   std::vector<decltype(r)> __res;
-      |                          ^
-../../../tests/machine/x/cpp/group_items_iteration.cpp:71:26: error: template argument 2 is invalid
-../../../tests/machine/x/cpp/group_items_iteration.cpp:72:18: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
-   72 |   for (auto &p : __items)
-      |                  ^~~~~~~
-      |                  std::begin
-In file included from /usr/include/c++/13/string:53,
-                 from /usr/include/c++/13/bits/locale_classes.h:40,
-                 from /usr/include/c++/13/bits/ios_base.h:41,
-                 from /usr/include/c++/13/ios:44,
-                 from /usr/include/c++/13/ostream:40,
-                 from /usr/include/c++/13/iostream:41,
-                 from ../../../tests/machine/x/cpp/group_items_iteration.cpp:2:
-/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
-  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
-      |                                     ^~~~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:72:18: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
-   72 |   for (auto &p : __items)
-      |                  ^~~~~~~
-      |                  std::end
-/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
-  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
-      |                                     ^~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:73:11: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
-   73 |     __res.push_back(p.second);
-      |           ^~~~~~~~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = std::vector<int>]’:
-../../../tests/machine/x/cpp/group_items_iteration.cpp:86:7:   required from here
-../../../tests/machine/x/cpp/group_items_iteration.cpp:84:18: error: no matching function for call to ‘std::vector<int>::push_back(__struct3)’
-   84 |       v.push_back(__struct3{g.key, total});
+line 74: ../../../tests/machine/x/cpp/group_items_iteration.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = std::vector<int>]’:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:74:7:   required from here
+../../../tests/machine/x/cpp/group_items_iteration.cpp:72:18: error: no matching function for call to ‘std::vector<int>::push_back(__struct3)’
+   72 |       v.push_back(__struct3{g.key, total});
       |       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
 In file included from /usr/include/c++/13/vector:66,
                  from ../../../tests/machine/x/cpp/group_items_iteration.cpp:4:
@@ -69,14 +17,26 @@ In file included from /usr/include/c++/13/vector:66,
 /usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘__struct3’ to ‘std::vector<int>::value_type&&’ {aka ‘int&&’}
  1298 |       push_back(value_type&& __x)
       |                 ~~~~~~~~~~~~~^~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp: In function ‘int main()’:
-../../../tests/machine/x/cpp/group_items_iteration.cpp:90:35: error: request for member ‘size’ in ‘__tmp1’, which is of non-class type ‘int’
-   90 |     for (size_t i = 0; i < __tmp1.size(); ++i) {
-      |                                   ^~~~
-../../../tests/machine/x/cpp/group_items_iteration.cpp:93:44: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
-   93 |       std::cout << std::boolalpha << __tmp1[i];
-      |                                            ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In lambda function:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:80:28: error: request for member ‘tag’ in ‘r’, which is of non-class type ‘int’
+   80 |       __items.push_back({r.tag, r});
+      |                            ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:80:24: error: no matching function for call to ‘std::vector<std::pair<std::__cxx11::basic_string<char>, __struct3> >::push_back(<brace-enclosed initializer list>)’
+   80 |       __items.push_back({r.tag, r});
+      |       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<std::__cxx11::basic_string<char>, __struct3>; _Alloc = std::allocator<std::pair<std::__cxx11::basic_string<char>, __struct3> >; value_type = std::pair<std::__cxx11::basic_string<char>, __struct3>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<std::__cxx11::basic_string<char>, __struct3> >::value_type&’ {aka ‘const std::pair<std::__cxx11::basic_string<char>, __struct3>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<std::__cxx11::basic_string<char>, __struct3>; _Alloc = std::allocator<std::pair<std::__cxx11::basic_string<char>, __struct3> >; value_type = std::pair<std::__cxx11::basic_string<char>, __struct3>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<std::__cxx11::basic_string<char>, __struct3> >::value_type&&’ {aka ‘std::pair<std::__cxx11::basic_string<char>, __struct3>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
 
- 64 | auto result = ([]() {
- 65 |   std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
- 66 |   for (auto r : tmp) {
+ 73 |       return v;
+ 74 |     })(tmp);
+ 75 |   }


### PR DESCRIPTION
## Summary
- ensure C++ compiler only treats early declarations as globals
- update machine C++ README with remaining tasks
- regenerate group_items_iteration example and error log

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686fcc0570c8832090dfd7faec9288a4