### PR TITLE
Improve Swift compiler for group queries

### DIFF
--- a/tests/machine/x/swift/group_by_multi_join_sort.error
+++ b/tests/machine/x/swift/group_by_multi_join_sort.error
@@ -1,2 +1,4 @@
-line: 0
-error: unsupported query
+line 16: exit status 1
+					if !(n["n_nationkey"] as! Int == c["c_nationkey"] as! Int) { continue }
+					if !(o["o_orderdate"] as! String >= start_date && o["o_orderdate"] as! String < end_date && l["l_returnflag"] as! String == "R") { continue }
+					let _k = ["c_custkey": c["c_custkey"] as! Int, "c_name": c["c_name"] as! String, "c_acctbal": c["c_acctbal"] as! Double, "c_address": c["c_address"] as! String, "c_phone": c["c_phone"] as! String, "c_comment": c["c_comment"] as! String, "n_name": n["n_name"] as! String]

--- a/tests/machine/x/swift/group_by_multi_join_sort.swift
+++ b/tests/machine/x/swift/group_by_multi_join_sort.swift
@@ -1,0 +1,27 @@
+var nation = [["n_nationkey": 1, "n_name": "BRAZIL"]]
+var customer = [["c_custkey": 1, "c_name": "Alice", "c_acctbal": 100, "c_nationkey": 1, "c_address": "123 St", "c_phone": "123-456", "c_comment": "Loyal"]]
+var orders = [["o_orderkey": 1000, "o_custkey": 1, "o_orderdate": "1993-10-15"], ["o_orderkey": 2000, "o_custkey": 1, "o_orderdate": "1994-01-02"]]
+var lineitem = [["l_orderkey": 1000, "l_returnflag": "R", "l_extendedprice": 1000, "l_discount": 0.1], ["l_orderkey": 2000, "l_returnflag": "N", "l_extendedprice": 500, "l_discount": 0]]
+let start_date = "1993-10-01"
+let end_date = "1994-01-01"
+var result = ({
+	var _groups: [AnyHashable:[Any]] = [:]
+	for c in customer {
+		for o in orders {
+			if !(o["o_custkey"] as! Int == c["c_custkey"] as! Int) { continue }
+			for l in lineitem {
+				if !(l["l_orderkey"] as! Int == o["o_orderkey"] as! Int) { continue }
+				for n in nation {
+					if !(n["n_nationkey"] as! Int == c["c_nationkey"] as! Int) { continue }
+					if !(o["o_orderdate"] as! String >= start_date && o["o_orderdate"] as! String < end_date && l["l_returnflag"] as! String == "R") { continue }
+					let _k = ["c_custkey": c["c_custkey"] as! Int, "c_name": c["c_name"] as! String, "c_acctbal": c["c_acctbal"] as! Double, "c_address": c["c_address"] as! String, "c_phone": c["c_phone"] as! String, "c_comment": c["c_comment"] as! String, "n_name": n["n_name"] as! String]
+					_groups[_k, default: []].append(["c": c, "o": o, "l": l, "n": n])
+				}
+			}
+		}
+	}
+	var _tmp = _groups.map { (k, v) in (key: k, items: v) }
+	_tmp.sort { $0.items.map { x in x["l"] as! [String:Any]["l_extendedprice"]! * (1 - x["l"] as! [String:Any]["l_discount"]!) }.reduce(0, +) > $1.items.map { x in x["l"] as! [String:Any]["l_extendedprice"]! * (1 - x["l"] as! [String:Any]["l_discount"]!) }.reduce(0, +) }
+	return _tmp.map { g in ["c_custkey": g.key.c_custkey, "c_name": g.key.c_name, "revenue": g.items.map { x in x["l"] as! [String:Any]["l_extendedprice"]! * (1 - x["l"] as! [String:Any]["l_discount"]!) }.reduce(0, +), "c_acctbal": g.key.c_acctbal, "n_name": g.key.n_name, "c_address": g.key.c_address, "c_phone": g.key.c_phone, "c_comment": g.key.c_comment] }
+}())
+print(result)

--- a/tests/machine/x/swift/group_items_iteration.error
+++ b/tests/machine/x/swift/group_items_iteration.error
@@ -1,4 +1,4 @@
-line 14: exit status 1
-}()
-var tmp = []
-for g in groups {
+line 17: exit status 1
+    var total = 0
+    for x in g["items"] as! [[String:Any]] as! [[String:Any]] {
+        total = total + x["val"] as! Int

--- a/tests/machine/x/swift/group_items_iteration.swift
+++ b/tests/machine/x/swift/group_items_iteration.swift
@@ -11,13 +11,13 @@ var groups = { () -> [(key: AnyHashable, items: [[String:Any]])] in
     }
     return _tmp
 }()
-var tmp = []
-for g in groups {
+var tmp = [Any]()
+for g in groups as! [[String:Any]] {
     var total = 0
-    for x in g.items {
-        total = total + x.val
+    for x in g["items"] as! [[String:Any]] as! [[String:Any]] {
+        total = total + x["val"] as! Int
     }
-    tmp = tmp + [["tag": g.key, "total": total]]
+    tmp = tmp + [["tag": g["key"] as! AnyHashable, "total": total]]
 }
 var result = tmp.map { r in (value: r, key: r.tag) }.sorted { $0.key < $1.key }.map { $0.value }
 print(result)


### PR DESCRIPTION
## Summary
- allow sorting with joins in the Swift compiler
- provide field info when queries return group variables
- track group metadata in for loops
- tweak empty list literal generation
- update generated Swift outputs for failing tests

## Testing
- `go test -tags slow -v ./compiler/x/swift -run TestCompileValidPrograms/group_items_iteration -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686fcca205d08320bdc1d88d4d3a01c2