### PR TITLE
Add golden output for 4-rings-or-4-squares puzzle

### DIFF
--- a/tests/rosetta/x/Mochi/4-rings-or-4-squares-puzzle.out
+++ b/tests/rosetta/x/Mochi/4-rings-or-4-squares-puzzle.out
@@ -1,0 +1,5 @@
+8 unique solutions in 1 to 7
+[7 2 6 1 3 5 4] [7 3 2 5 1 4 6] [6 4 1 5 2 3 7] [6 4 5 1 2 7 3] [4 5 3 1 6 2 7] [5 6 2 3 1 7 4] [4 7 1 3 2 6 5] [3 7 2 1 5 4 6]
+4 unique solutions in 3 to 9
+[9 6 4 5 3 7 8] [9 6 5 4 3 8 7] [8 7 3 5 4 6 9] [7 8 3 4 5 6 9]
+2860 non-unique solutions in 0 to 9


### PR DESCRIPTION
## Summary
- add expected output file for "4 rings or 4 squares" Rosetta task

## Testing
- `go test ./tools/rosetta -tags=slow -run TestMochiTasks -v`

------
https://chatgpt.com/codex/tasks/task_e_686fcea85a0483209080322e24497161