### PR TITLE
Improve Scala compiler struct typing

### DIFF
--- a/tests/machine/x/scala/group_by.scala
+++ b/tests/machine/x/scala/group_by.scala
@@ -1,6 +1,6 @@
 object group_by {
   case class Auto1(name: String, age: Int, city: String)
-  case class Auto2(city: Any, count: Int, avg_age: Double)
+  case class Auto2(city: String, count: Int, avg_age: Double)
 
   val people = List[Auto1](Auto1(name = "Alice", age = 30, city = "Paris"), Auto1(name = "Bob", age = 15, city = "Hanoi"), Auto1(name = "Charlie", age = 65, city = "Paris"), Auto1(name = "Diana", age = 45, city = "Hanoi"), Auto1(name = "Eve", age = 70, city = "Paris"), Auto1(name = "Frank", age = 22, city = "Hanoi"))
   val stats = ((for { person <- people } yield (person.city, (person))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Auto2(city = g._1, count = (g._2).size, avg_age = (for { p <- g._2 } yield p.age).sum.toDouble / (for { p <- g._2 } yield p.age).size) } }.toList

--- a/types/infer.go
+++ b/types/infer.go
@@ -308,6 +308,14 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 						} else {
 							cur = tt.Elem
 						}
+					case GroupType:
+						if field == "key" {
+							cur = tt.Key
+						} else if field == "items" {
+							cur = ListType{Elem: tt.Elem}
+						} else {
+							cur = AnyType{}
+						}
 					case StringType:
 						if field == "contains" {
 							cur = FuncType{Params: []Type{StringType{}}, Return: BoolType{}}


### PR DESCRIPTION
## Summary
- handle selectors on `GroupType` in type inference
- regenerate Scala translation for `group_by` example with typed `city` field

## Testing
- `go build -tags slow -o /tmp/build /tmp/build.go`


------
https://chatgpt.com/codex/tasks/task_e_686fcf4ccd048320a8b5a5090ae0bef1