### PR TITLE
Fix Scheme YAML parser

### DIFF
--- a/compiler/x/scheme/compiler.go
+++ b/compiler/x/scheme/compiler.go
@@ -26,7 +26,7 @@ const datasetHelpers = `(import (srfi 95) (chibi json) (chibi io) (chibi) (chibi
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/dataset_sort_take_limit.scm
+++ b/tests/machine/x/scheme/dataset_sort_take_limit.scm
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/group_by_conditional_sum.scm
+++ b/tests/machine/x/scheme/group_by_conditional_sum.scm
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/group_by_multi_join_sort.scm
+++ b/tests/machine/x/scheme/group_by_multi_join_sort.scm
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/group_by_sort.scm
+++ b/tests/machine/x/scheme/group_by_sort.scm
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/group_items_iteration.scm
+++ b/tests/machine/x/scheme/group_items_iteration.scm
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/load_yaml.scm
+++ b/tests/machine/x/scheme/load_yaml.scm
@@ -8,7 +8,7 @@
             (begin (set-cdr! p v) m)
             (cons (cons k v) m)))
 )
-(import (srfi 95) (chibi json) (chibi io) (chibi) (chibi string))
+(import (srfi 1) (srfi 95) (chibi json) (chibi io) (chibi process) (chibi) (chibi string))
 
 (define (_to_string v)
   (call-with-output-string (lambda (p) (write v p))))
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/order_by_map.scm
+++ b/tests/machine/x/scheme/order_by_map.scm
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/save_jsonl_stdout.scm
+++ b/tests/machine/x/scheme/save_jsonl_stdout.scm
@@ -10,7 +10,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())

--- a/tests/machine/x/scheme/sort_stable.scm
+++ b/tests/machine/x/scheme/sort_stable.scm
@@ -20,7 +20,7 @@
 (define (_parse_yaml text)
   (let ((rows '()) (cur '()))
     (for-each (lambda (ln)
-                (when (string-prefix? ln "- ")
+                (when (string-prefix? "- " ln)
                   (when (not (null? cur))
                     (set! rows (append rows (list cur))))
                   (set! cur '())


### PR DESCRIPTION
## Summary
- fix `_parse_yaml` in Scheme backend
- regenerate Scheme outputs with corrected YAML helper

## Testing
- `gofmt -w compiler/x/scheme/compiler.go`

------
https://chatgpt.com/codex/tasks/task_e_686fcc3c47dc832085f785e2676b94c3