### PR TITLE
Add Mochi implementation for Rosetta task 23

### DIFF
--- a/tests/rosetta/x/Mochi/abstract-type.mochi
+++ b/tests/rosetta/x/Mochi/abstract-type.mochi
@@ -1,0 +1,40 @@
+// Mochi translation of Rosetta Code "Abstract type" task
+// Demonstrates union types and pattern matching.
+
+type Beast =
+  Dog(kind: string, name: string)
+  | Cat(kind: string, name: string)
+
+fun beastKind(b: Beast): string {
+  return match b {
+    Dog(k, _) => k
+    Cat(k, _) => k
+  }
+}
+
+fun beastName(b: Beast): string {
+  return match b {
+    Dog(_, n) => n
+    Cat(_, n) => n
+  }
+}
+
+fun beastCry(b: Beast): string {
+  return match b {
+    Dog(_, _) => "Woof"
+    Cat(_, _) => "Meow"
+  }
+}
+
+fun bprint(b: Beast) {
+  print(beastName(b) + ", who's a " + beastKind(b) + ", cries: \"" + beastCry(b) + "\".")
+}
+
+fun main() {
+  let d: Beast = Dog { kind: "labrador", name: "Max" }
+  let c: Beast = Cat { kind: "siamese", name: "Sammy" }
+  bprint(d)
+  bprint(c)
+}
+
+main()

--- a/tests/rosetta/x/Mochi/abstract-type.out
+++ b/tests/rosetta/x/Mochi/abstract-type.out
@@ -1,0 +1,2 @@
+Max, who's a labrador, cries: "Woof".
+Sammy, who's a siamese, cries: "Meow".


### PR DESCRIPTION
## Summary
- implement Rosetta "Abstract type" task in Mochi
- add expected output for the new Mochi program

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686fd242abc0832085d709e18c9f30a3