### PR TITLE
Add Rosetta task 25 Mochi version

### DIFF
--- a/tests/rosetta/x/Mochi/abundant-deficient-and-perfect-number-classifications.mochi
+++ b/tests/rosetta/x/Mochi/abundant-deficient-and-perfect-number-classifications.mochi
@@ -1,0 +1,39 @@
+// Mochi implementation of Rosetta "Abundant, deficient and perfect number classifications" task
+// Translated from Go version in tests/rosetta/x/Go/abundant-deficient-and-perfect-number-classifications.go
+
+fun pfacSum(i: int): int {
+  var sum = 0
+  var p = 1
+  while p <= i / 2 {
+    if i % p == 0 {
+      sum = sum + p
+    }
+    p = p + 1
+  }
+  return sum
+}
+
+fun main() {
+  var d = 0
+  var a = 0
+  var pnum = 0
+  var i = 1
+  while i <= 20000 {
+    let j = pfacSum(i)
+    if j < i {
+      d = d + 1
+    }
+    if j == i {
+      pnum = pnum + 1
+    }
+    if j > i {
+      a = a + 1
+    }
+    i = i + 1
+  }
+  print("There are " + str(d) + " deficient numbers between 1 and 20000")
+  print("There are " + str(a) + " abundant numbers  between 1 and 20000")
+  print("There are " + str(pnum) + " perfect numbers between 1 and 20000")
+}
+
+main()

--- a/tests/rosetta/x/Mochi/abundant-deficient-and-perfect-number-classifications.out
+++ b/tests/rosetta/x/Mochi/abundant-deficient-and-perfect-number-classifications.out
@@ -1,0 +1,3 @@
+There are 15043 deficient numbers between 1 and 20000
+There are 4953 abundant numbers  between 1 and 20000
+There are 4 perfect numbers between 1 and 20000


### PR DESCRIPTION
## Summary
- implement Rosetta Code task *Abundant-deficient-and-perfect-number-classifications* in Mochi
- add golden output for the new Mochi implementation

## Testing
- `go test ./tools/rosetta -run TestMochiTasks -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686fd2558a608320b7b65e68826ec745