### PR TITLE
Add Mochi example for Active Directory Connect

### DIFF
--- a/tests/rosetta/x/Mochi/active-directory-connect.mochi
+++ b/tests/rosetta/x/Mochi/active-directory-connect.mochi
@@ -1,0 +1,26 @@
+// Mochi implementation of Rosetta "Active Directory Connect" task
+
+fun connect(client: map<string, any>): bool {
+  return client["Host"] != ""
+}
+
+fun main() {
+  let client = {
+    "Base": "dc=example,dc=com",
+    "Host": "ldap.example.com",
+    "Port": 389,
+    "UseSSL": false,
+    "BindDN": "uid=readonlyuser,ou=People,dc=example,dc=com",
+    "BindPassword": "readonlypassword",
+    "UserFilter": "(uid=%s)",
+    "GroupFilter": "(memberUid=%s)",
+    "Attributes": ["givenName", "sn", "mail", "uid"],
+  }
+  if connect(client) {
+    print("Connected to " + client["Host"])
+  } else {
+    print("Failed to connect")
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/active-directory-connect.out
+++ b/tests/rosetta/x/Mochi/active-directory-connect.out
@@ -1,0 +1,1 @@
+Connected to ldap.example.com


### PR DESCRIPTION
## Summary
- add Mochi translation for the Active Directory Connect Rosetta task

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686fd3c1fa5c8320aef1285fb29c39e6