### PR TITLE
Improve C++ machine outputs

### DIFF
--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -106,8 +106,3 @@ Compiled programs: 100/100
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-
-## Remaining Tasks
-
-None
-

--- a/tests/machine/x/cpp/in_operator_extended.cpp
+++ b/tests/machine/x/cpp/in_operator_extended.cpp
@@ -13,8 +13,6 @@ auto ys = ([]() {
   }
   return __items;
 })();
-auto m = std::unordered_map<std::string, decltype(1)>{{std::string("a"), 1}};
-auto s = std::string("hello");
 
 int main() {
   {
@@ -27,6 +25,7 @@ int main() {
               << (std::find(ys.begin(), ys.end(), 2) != ys.end());
     std::cout << std::endl;
   }
+  auto m = std::unordered_map<std::string, decltype(1)>{{std::string("a"), 1}};
   {
     std::cout << std::boolalpha << (m.count(std::string("a")) > 0);
     std::cout << std::endl;
@@ -35,6 +34,7 @@ int main() {
     std::cout << std::boolalpha << (m.count(std::string("b")) > 0);
     std::cout << std::endl;
   }
+  auto s = std::string("hello");
   {
     std::cout << std::boolalpha
               << (s.find(std::string("ell")) != std::string::npos);

--- a/tests/machine/x/cpp/match_full.cpp
+++ b/tests/machine/x/cpp/match_full.cpp
@@ -11,26 +11,6 @@ auto label = ([]() {
     return std::string("three");
   return std::string("unknown");
 })();
-auto day = std::string("sun");
-auto mood = ([]() {
-  auto __v = day;
-  if (__v == std::string("mon"))
-    return std::string("tired");
-  else if (__v == std::string("fri"))
-    return std::string("excited");
-  else if (__v == std::string("sun"))
-    return std::string("relaxed");
-  return std::string("normal");
-})();
-auto ok = true;
-auto status = ([]() {
-  auto __v = ok;
-  if (__v == true)
-    return std::string("confirmed");
-  else if (__v == false)
-    return std::string("denied");
-  return decltype(std::string("confirmed")){};
-})();
 
 std::string classify(int n) {
   return ([&]() {
@@ -48,10 +28,30 @@ int main() {
     std::cout << std::boolalpha << label;
     std::cout << std::endl;
   }
+  auto day = std::string("sun");
+  auto mood = ([&]() {
+    auto __v = day;
+    if (__v == std::string("mon"))
+      return std::string("tired");
+    else if (__v == std::string("fri"))
+      return std::string("excited");
+    else if (__v == std::string("sun"))
+      return std::string("relaxed");
+    return std::string("normal");
+  })();
   {
     std::cout << std::boolalpha << mood;
     std::cout << std::endl;
   }
+  auto ok = true;
+  auto status = ([&]() {
+    auto __v = ok;
+    if (__v == true)
+      return std::string("confirmed");
+    else if (__v == false)
+      return std::string("denied");
+    return decltype(std::string("confirmed")){};
+  })();
   {
     std::cout << std::boolalpha << status;
     std::cout << std::endl;

--- a/tests/machine/x/cpp/python_math.cpp
+++ b/tests/machine/x/cpp/python_math.cpp
@@ -9,13 +9,12 @@ inline double log(double x) { return std::log(x); }
 const double pi = 3.141592653589793;
 const double e = 2.718281828459045;
 } // namespace math
-auto r = 3;
-auto area = (math::pi * math::pow(r, 2));
-auto root = math::sqrt(49);
-auto sin45 = math::sin((math::pi / 4));
-auto log_e = math::log(math::e);
-
 int main() {
+  auto r = 3;
+  auto area = (math::pi * math::pow(r, 2));
+  auto root = math::sqrt(49);
+  auto sin45 = math::sin((math::pi / 4));
+  auto log_e = math::log(math::e);
   {
     std::cout << std::boolalpha << std::string("Circle area with r =");
     std::cout << ' ';

--- a/tests/machine/x/cpp/string_prefix_slice.cpp
+++ b/tests/machine/x/cpp/string_prefix_slice.cpp
@@ -2,7 +2,6 @@
 
 auto prefix = std::string("fore");
 auto s1 = std::string("forest");
-auto s2 = std::string("desert");
 
 int main() {
   {
@@ -10,6 +9,7 @@ int main() {
               << (std::string(s1).substr(0, (prefix.size()) - (0)) == prefix);
     std::cout << std::endl;
   }
+  auto s2 = std::string("desert");
   {
     std::cout << std::boolalpha
               << (std::string(s2).substr(0, (prefix.size()) - (0)) == prefix);


### PR DESCRIPTION
## Summary
- regenerate C++ machine outputs so that top-level variables appear inside `main`
- update checklist in `tests/machine/x/cpp/README.md`

## Testing
- `go test -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_686fd6f742288320b52e980a751b44ef