### PR TITLE
Improve Kotlin struct inference

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -1889,6 +1889,16 @@ func (c *Compiler) discoverStructs(prog *parser.Program) {
 				c.env.SetStruct(structName, stype)
 				c.env.SetVar(name, types.ListType{Elem: stype}, mutable)
 				c.mapNodes[ml] = structName
+			} else if id, ok := identName(q.Select); ok && id == q.Var {
+				if lt, ok := c.inferExprType(q.Source).(types.ListType); ok {
+					c.env.SetVar(name, types.ListType{Elem: lt.Elem}, mutable)
+				}
+			} else {
+				if t := selectorType(q.Select, c.env); t != nil {
+					if st, ok := t.(types.StructType); ok {
+						c.env.SetVar(name, types.ListType{Elem: st}, mutable)
+					}
+				}
 			}
 		}
 	}

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -118,3 +118,4 @@ Successfully ran: 88/100 programs
 - [ ] Compare output with reference implementations
 - [x] Emit data classes for uniform map lists
 - [x] Infer data classes from single map literals
+- [x] Infer struct type when query selects a struct variable

--- a/tests/machine/x/kotlin/dataset_sort_take_limit.kt
+++ b/tests/machine/x/kotlin/dataset_sort_take_limit.kt
@@ -13,6 +13,6 @@ val expensive = run {
 fun main() {
     println("--- Top products (excluding most expensive) ---")
     for (item in expensive) {
-        println(listOf((item as MutableMap<*, *>)["name"], "costs $", (item as MutableMap<*, *>)["price"]).joinToString(" "))
+        println(listOf(item.name, "costs $", item.price).joinToString(" "))
     }
 }

--- a/tests/machine/x/kotlin/group_by_having.kt
+++ b/tests/machine/x/kotlin/group_by_having.kt
@@ -23,9 +23,9 @@ fun toJson(v: Any?): String = when (v) {
 }
 
 class Group(val key: Any?, val items: MutableList<Any?>) : MutableList<Any?> by items
-data class People(var name: String, var city: String)
-
 data class Big(var city: Any?, var num: Int)
+
+data class People(var name: String, var city: String)
 
 val people = mutableListOf(People(name = "Alice", city = "Paris"), People(name = "Bob", city = "Hanoi"), People(name = "Charlie", city = "Paris"), People(name = "Diana", city = "Hanoi"), People(name = "Eve", city = "Paris"), People(name = "Frank", city = "Hanoi"), People(name = "George", city = "Paris"))
 

--- a/tests/machine/x/kotlin/group_by_join.kt
+++ b/tests/machine/x/kotlin/group_by_join.kt
@@ -10,11 +10,11 @@ fun toBool(v: Any?): Boolean = when (v) {
 }
 
 class Group(val key: Any?, val items: MutableList<Any?>) : MutableList<Any?> by items
-data class Stat(var name: Any?, var count: Int)
-
 data class Customer(var id: Int, var name: String)
 
 data class Order(var id: Int, var customerId: Int)
+
+data class Stat(var name: Any?, var count: Int)
 
 val customers = mutableListOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
 

--- a/tests/machine/x/kotlin/group_by_multi_join.kt
+++ b/tests/machine/x/kotlin/group_by_multi_join.kt
@@ -14,6 +14,8 @@ fun toBool(v: Any?): Boolean = when (v) {
 }
 
 class Group(val key: Any?, val items: MutableList<Any?>) : MutableList<Any?> by items
+data class Grouped(var part: Any?, var total: Int)
+
 data class Nation(var id: Int, var name: String)
 
 data class Supplier(var id: Int, var nation: Int)
@@ -21,8 +23,6 @@ data class Supplier(var id: Int, var nation: Int)
 data class Partsupp(var part: Int, var supplier: Int, var cost: Double, var qty: Int)
 
 data class Filtered(var part: Any?, var value: Any?)
-
-data class Grouped(var part: Any?, var total: Int)
 
 val nations = mutableListOf(Nation(id = 1, name = "A"), Nation(id = 2, name = "B"))
 

--- a/tests/machine/x/kotlin/group_by_multi_join_sort.kt
+++ b/tests/machine/x/kotlin/group_by_multi_join_sort.kt
@@ -29,6 +29,8 @@ fun toBool(v: Any?): Boolean = when (v) {
 }
 
 class Group(val key: Any?, val items: MutableList<Any?>) : MutableList<Any?> by items
+data class Result(var c_custkey: Any?, var c_name: Any?, var revenue: Int, var c_acctbal: Any?, var n_name: Any?, var c_address: Any?, var c_phone: Any?, var c_comment: Any?)
+
 data class Nation(var n_nationkey: Int, var n_name: String)
 
 data class Customer(var c_custkey: Int, var c_name: String, var c_acctbal: Double, var c_nationkey: Int, var c_address: String, var c_phone: String, var c_comment: String)
@@ -36,8 +38,6 @@ data class Customer(var c_custkey: Int, var c_name: String, var c_acctbal: Doubl
 data class Order(var o_orderkey: Int, var o_custkey: Int, var o_orderdate: String)
 
 data class Lineitem(var l_orderkey: Int, var l_returnflag: String, var l_extendedprice: Double, var l_discount: Double)
-
-data class Result(var c_custkey: Any?, var c_name: Any?, var revenue: Int, var c_acctbal: Any?, var n_name: Any?, var c_address: Any?, var c_phone: Any?, var c_comment: Any?)
 
 val nation = mutableListOf(Nation(n_nationkey = 1, n_name = "BRAZIL"))
 

--- a/tests/machine/x/kotlin/inner_join.kt
+++ b/tests/machine/x/kotlin/inner_join.kt
@@ -6,11 +6,11 @@ fun toBool(v: Any?): Boolean = when (v) {
     null -> false
     else -> true
 }
+data class Result(var orderId: Any?, var customerName: Any?, var total: Any?)
+
 data class Customer(var id: Int, var name: String)
 
 data class Order(var id: Int, var customerId: Int, var total: Int)
-
-data class Result(var orderId: Any?, var customerName: Any?, var total: Any?)
 
 val customers = mutableListOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
 

--- a/tests/machine/x/kotlin/left_join.kt
+++ b/tests/machine/x/kotlin/left_join.kt
@@ -6,11 +6,11 @@ fun toBool(v: Any?): Boolean = when (v) {
     null -> false
     else -> true
 }
-data class Customer(var id: Int, var name: String)
-
 data class Order(var id: Int, var customerId: Int, var total: Int)
 
 data class Result(var orderId: Any?, var customer: Any?, var total: Any?)
+
+data class Customer(var id: Int, var name: String)
 
 val customers = mutableListOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
 


### PR DESCRIPTION
## Summary
- enhance Kotlin compiler to infer struct type when a query selects an existing struct variable
- regenerate machine Kotlin output
- note new inference capability in README

## Testing
- `go run -tags slow scripts/compile_kotlin.go`

------
https://chatgpt.com/codex/tasks/task_e_686fda8589348320ac1f3e51484c0f06