### PR TITLE
Add Mochi solution for Abelian sandpile identity

### DIFF
--- a/tests/rosetta/x/Mochi/abelian-sandpile-model-identity.mochi
+++ b/tests/rosetta/x/Mochi/abelian-sandpile-model-identity.mochi
@@ -1,0 +1,96 @@
+// Mochi implementation of Rosetta "Abelian sandpile model/Identity" task
+// Translated from Go version in tests/rosetta/x/Go/abelian-sandpile-model-identity.go
+
+fun neighborsList(): list<list<int>> {
+  return [
+    [1, 3],
+    [0, 2, 4],
+    [1, 5],
+    [0, 4, 6],
+    [1, 3, 5, 7],
+    [2, 4, 8],
+    [3, 7],
+    [4, 6, 8],
+    [5, 7],
+  ]
+}
+
+fun plus(a: list<int>, b: list<int>): list<int> {
+  var res: list<int> = []
+  var i = 0
+  while i < len(a) {
+    res = append(res, a[i] + b[i])
+    i = i + 1
+  }
+  return res
+}
+
+fun isStable(p: list<int>): bool {
+  for v in p {
+    if v > 3 { return false }
+  }
+  return true
+}
+
+fun topple(p: list<int>): int {
+  let neighbors = neighborsList()
+  var i = 0
+  while i < len(p) {
+    if p[i] > 3 {
+      p[i] = p[i] - 4
+      let nbs = neighbors[i]
+      for j in nbs {
+        p[j] = p[j] + 1
+      }
+        return 0
+    }
+    i = i + 1
+  }
+  return 0
+}
+
+fun pileString(p: list<int>): string {
+  var s = ""
+  var r = 0
+  while r < 3 {
+    var c = 0
+    while c < 3 {
+      s = s + str(p[3*r + c]) + " "
+      c = c + 1
+    }
+    s = s + "\n"
+    r = r + 1
+  }
+  return s
+}
+
+print("Avalanche of topplings:\n")
+var s4 = [4,3,3,3,1,2,0,2,3]
+print(pileString(s4))
+while !isStable(s4) {
+  topple(s4)
+  print(pileString(s4))
+}
+
+print("Commutative additions:\n")
+var s1 = [1,2,0,2,1,1,0,1,3]
+var s2 = [2,1,3,1,0,1,0,1,0]
+var s3_a = plus(s1, s2)
+while !isStable(s3_a) { topple(s3_a) }
+var s3_b = plus(s2, s1)
+while !isStable(s3_b) { topple(s3_b) }
+print(pileString(s1) + "\nplus\n\n" + pileString(s2) + "\nequals\n\n" + pileString(s3_a))
+print("and\n\n" + pileString(s2) + "\nplus\n\n" + pileString(s1) + "\nalso equals\n\n" + pileString(s3_b))
+
+print("Addition of identity sandpile:\n")
+var s3 = [3,3,3,3,3,3,3,3,3]
+var s3_id = [2,1,2,1,0,1,2,1,2]
+var s4b = plus(s3, s3_id)
+while !isStable(s4b) { topple(s4b) }
+print(pileString(s3) + "\nplus\n\n" + pileString(s3_id) + "\nequals\n\n" + pileString(s4b))
+
+print("Addition of identities:\n")
+var s5 = plus(s3_id, s3_id)
+while !isStable(s5) { topple(s5) }
+print(pileString(s3_id) + "\nplus\n\n" + pileString(s3_id) + "\nequals\n\n" + pileString(s5))
+

--- a/tests/rosetta/x/Mochi/abelian-sandpile-model-identity.out
+++ b/tests/rosetta/x/Mochi/abelian-sandpile-model-identity.out
@@ -1,0 +1,93 @@
+Avalanche of topplings:
+
+4 3 3 
+3 1 2 
+0 2 3 
+
+0 4 3 
+4 1 2 
+0 2 3 
+
+1 0 4 
+4 2 2 
+0 2 3 
+
+1 1 0 
+4 2 3 
+0 2 3 
+
+2 1 0 
+0 3 3 
+1 2 3 
+
+Commutative additions:
+
+1 2 0 
+2 1 1 
+0 1 3 
+
+plus
+
+2 1 3 
+1 0 1 
+0 1 0 
+
+equals
+
+3 3 3 
+3 1 2 
+0 2 3 
+
+and
+
+2 1 3 
+1 0 1 
+0 1 0 
+
+plus
+
+1 2 0 
+2 1 1 
+0 1 3 
+
+also equals
+
+3 3 3 
+3 1 2 
+0 2 3 
+
+Addition of identity sandpile:
+
+3 3 3 
+3 3 3 
+3 3 3 
+
+plus
+
+2 1 2 
+1 0 1 
+2 1 2 
+
+equals
+
+3 3 3 
+3 3 3 
+3 3 3 
+
+Addition of identities:
+
+2 1 2 
+1 0 1 
+2 1 2 
+
+plus
+
+2 1 2 
+1 0 1 
+2 1 2 
+
+equals
+
+2 1 2 
+1 0 1 
+2 1 2 


### PR DESCRIPTION
## Summary
- implement `abelian-sandpile-model-identity.mochi`
- add matching golden output

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686fdf79a03483209ebf87504bcf7fa6