### PR TITLE
Add Rust machine output for in_operator_extended

### DIFF
--- a/tests/machine/x/rust/in_operator_extended.error
+++ b/tests/machine/x/rust/in_operator_extended.error
@@ -1,2 +1,28 @@
-line 0: in unsupported
-let xs = [1, 2, 3]
+line 0: compile: exit status 1
+error[E0599]: no method named `contains` found for struct `BTreeMap` in the current scope
+ --> /workspace/mochi/tests/machine/x/rust/in_operator_extended.rs:7:32
+  |
+7 |     println!("{:?}", m.clone().contains(&"a"));
+  |                                ^^^^^^^^
+  |
+help: there is a method `contains_key` with a similar name
+  |
+7 |     println!("{:?}", m.clone().contains_key(&"a"));
+  |                                        ++++
+
+error[E0599]: no method named `contains` found for struct `BTreeMap` in the current scope
+ --> /workspace/mochi/tests/machine/x/rust/in_operator_extended.rs:8:32
+  |
+8 |     println!("{:?}", m.clone().contains(&"b"));
+  |                                ^^^^^^^^
+  |
+help: there is a method `contains_key` with a similar name
+  |
+8 |     println!("{:?}", m.clone().contains_key(&"b"));
+  |                                        ++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.
+
+fn main() {

--- a/tests/machine/x/rust/in_operator_extended.rs
+++ b/tests/machine/x/rust/in_operator_extended.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let xs = vec![1, 2, 3];
+    let ys = { let mut tmp1 = Vec::new();for &x in &xs { if !(x % 2 == 1) { continue; } tmp1.push(x); } tmp1 };
+    println!("{}", ys.contains(&1));
+    println!("{}", ys.contains(&2));
+    let m = { let mut m = std::collections::BTreeMap::new(); m.insert("a", 1); m };
+    println!("{:?}", m.clone().contains(&"a"));
+    println!("{:?}", m.clone().contains(&"b"));
+    let s = "hello";
+    println!("{}", s.contains("ell"));
+    println!("{}", s.contains("foo"));
+}


### PR DESCRIPTION
## Summary
- add generated machine output `.rs` for `in_operator_extended`
- update corresponding `.error` file for compilation failure

## Testing
- `go test ./compiler/x/rust -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_686fe39fefb48320b449add12e5822ed