### PR TITLE
Add Mochi solution for Rosetta task Address-of-a-variable

### DIFF
--- a/tests/rosetta/x/Mochi/address-of-a-variable.mochi
+++ b/tests/rosetta/x/Mochi/address-of-a-variable.mochi
@@ -1,0 +1,6 @@
+// Mochi example for Rosetta task "Address of a variable"
+// Mochi currently does not expose raw memory addresses of variables.
+
+var myVar = 3.14
+print("value as float:", myVar)
+print("address: <not available>")

--- a/tests/rosetta/x/Mochi/address-of-a-variable.out
+++ b/tests/rosetta/x/Mochi/address-of-a-variable.out
@@ -1,0 +1,2 @@
+value as float: 3.14
+address: <not available>


### PR DESCRIPTION
## Summary
- add a Mochi implementation for the Rosetta Code task "Address-of-a-variable"
- provide corresponding expected output

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks/address-of-a-variable -count=1`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686fe4b41b948320b9aedcc289cf1b65