### PR TITLE
Add Mochi solution for Rosetta 'Amb' task

### DIFF
--- a/tests/rosetta/x/Mochi/amb.mochi
+++ b/tests/rosetta/x/Mochi/amb.mochi
@@ -1,0 +1,53 @@
+// Mochi implementation of Rosetta "Amb" task
+// Translated from Go version in tests/rosetta/x/Go/amb-2.go
+
+fun amb(wordsets: list<list<string>>, res: list<string>, idx: int): bool {
+  if idx == len(wordsets) {
+    return true
+  }
+  var prev = ""
+  if idx > 0 {
+    prev = res[idx - 1]
+  }
+  var i = 0
+  while i < len(wordsets[idx]) {
+    let w = wordsets[idx][i]
+    if idx == 0 || substring(prev, len(prev) - 1, len(prev)) == substring(w, 0, 1) {
+      res[idx] = w
+      if amb(wordsets, res, idx + 1) {
+        return true
+      }
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fun main() {
+  let wordset = [
+    ["the", "that", "a"],
+    ["frog", "elephant", "thing"],
+    ["walked", "treaded", "grows"],
+    ["slowly", "quickly"],
+  ]
+  var res: list<string> = []
+  var i = 0
+  while i < len(wordset) {
+    res = append(res, "")
+    i = i + 1
+  }
+  if amb(wordset, res, 0) {
+    var out = "[" + res[0]
+    var j = 1
+    while j < len(res) {
+      out = out + " " + res[j]
+      j = j + 1
+    }
+    out = out + "]"
+    print(out)
+  } else {
+    print("No amb found")
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/amb.out
+++ b/tests/rosetta/x/Mochi/amb.out
@@ -1,0 +1,1 @@
+[that thing grows slowly]


### PR DESCRIPTION
## Summary
- add Mochi implementation for the "Amb" Rosetta Code task
- store expected output for the new task

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/amb.mochi`
- `go test -tags slow ./tools/rosetta -run TestMochiTasks -count=1` *(fails: compile error for existing task)*

------
https://chatgpt.com/codex/tasks/task_e_686fe5b445088320838250c53bba3368