### PR TITLE
Improve Swift auto struct naming

### DIFF
--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -108,3 +108,7 @@ Compiled: 97/100 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+## Remaining Tasks
+
+- [ ] Support `import` statements for FFI modules (`go_auto.mochi`, `python_auto.mochi`, `python_math.mochi`).
+- [ ] Further improve automatic struct naming heuristics.


### PR DESCRIPTION
## Summary
- enhance Swift compiler to derive struct names from variable names
- add TODOs about FFI import support and struct naming

## Testing
- `go test ./compiler/x/swift -tags slow -run TestCompileValidPrograms -c`

------
https://chatgpt.com/codex/tasks/task_e_686fe7f67d18832090836535d370614e