### PR TITLE
Improve C backend struct inference

### DIFF
--- a/tests/machine/x/c/cast_struct.c
+++ b/tests/machine/x/c/cast_struct.c
@@ -3,26 +3,12 @@
 
 typedef struct Todo Todo;
 
-typedef struct {
-  char *title;
-} todoItem;
-typedef struct {
-  int len;
-  todoItem *data;
-} list_todoItem;
-static list_todoItem list_todoItem_create(int len) {
-  list_todoItem l;
-  l.len = len;
-  l.data = (todoItem *)malloc(sizeof(todoItem) * len);
-  return l;
-}
-
 typedef struct Todo {
   char *title;
 } Todo;
 
 int main() {
-  todoItem todo = (Todo){.title = "hi"};
+  Todo todo = (Todo){.title = "hi"};
   printf("%s\n", todo.title);
   return 0;
 }

--- a/tests/machine/x/c/cast_struct.error
+++ b/tests/machine/x/c/cast_struct.error
@@ -1,8 +1,0 @@
-line: 0
-error: cc error: exit status 1
-/workspace/mochi/tests/machine/x/c/cast_struct.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/cast_struct.c:25:19: error: invalid initializer
-   25 |   todoItem todo = (Todo){.title = "hi"};
-      |                   ^
-
-   1: #include <stdio.h>


### PR DESCRIPTION
## Summary
- improve struct inference when casting map literals
- regenerate cast_struct C output

## Testing
- `go vet ./...`
- `go test ./compiler/x/c -run TestCCompiler_ValidPrograms/cast_struct -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_686fe96acf488320bcc062a6c2a15ff8