### PR TITLE
Add Mochi solution for Rosetta Amicable Pairs

### DIFF
--- a/tests/rosetta/x/Mochi/achilles-numbers.mochi
+++ b/tests/rosetta/x/Mochi/achilles-numbers.mochi
@@ -33,9 +33,8 @@ fun totient(n: int): int {
   return tot
 }
 
-var pps: map<int, bool> = {}
-
-fun getPerfectPowers(maxExp: int) {
+fun getPerfectPowers(maxExp: int): map<int, bool> {
+  let powers: map<int, bool> = {}
   let upper = pow10(maxExp)
   var i = 2
   while i * i < upper {
@@ -43,13 +42,14 @@ fun getPerfectPowers(maxExp: int) {
     while true {
       p = p * i
       if p >= upper { break }
-      pps[p] = true
+      powers[p] = true
     }
     i = i + 1
   }
+  return powers
 }
 
-fun getAchilles(minExp: int, maxExp: int): map<int, bool> {
+fun getAchilles(minExp: int, maxExp: int, pps: map<int, bool>): map<int, bool> {
   let lower = pow10(minExp)
   let upper = pow10(maxExp)
   var achilles: map<int, bool> = {}
@@ -108,8 +108,8 @@ fun pad(n: int, width: int): string {
 
 fun main() {
   let maxDigits = 15
-  getPerfectPowers(maxDigits)
-  let achSet = getAchilles(1, 5)
+  let pps = getPerfectPowers(maxDigits)
+  let achSet = getAchilles(1, 5, pps)
   var ach: list<int> = []
   for k in achSet.keys() { ach = ach + [k] }
   ach = sortInts(ach)

--- a/tests/rosetta/x/Mochi/amicable-pairs.mochi
+++ b/tests/rosetta/x/Mochi/amicable-pairs.mochi
@@ -1,0 +1,45 @@
+// Mochi implementation of Rosetta "Amicable pairs" task
+// Translated from Go version in tests/rosetta/x/Go/amicable-pairs.go
+
+fun pfacSum(i: int): int {
+  var sum = 0
+  var p = 1
+  while p <= i / 2 {
+    if i % p == 0 {
+      sum = sum + p
+    }
+    p = p + 1
+  }
+  return sum
+}
+
+fun pad5(n: int): string {
+  var s = str(n)
+  while len(s) < 5 {
+    s = " " + s
+  }
+  return s
+}
+
+fun main() {
+  var a: list<int> = []
+  for _ in 0..20000 {
+    a = append(a, 0)
+  }
+  var i = 1
+  while i < 20000 {
+    a[i] = pfacSum(i)
+    i = i + 1
+  }
+  print("The amicable pairs below 20,000 are:")
+  var n = 2
+  while n < 19999 {
+    let m = a[n]
+    if m > n && m < 20000 && n == a[m] {
+      print("  " + pad5(n) + " and " + pad5(m))
+    }
+    n = n + 1
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/amicable-pairs.out
+++ b/tests/rosetta/x/Mochi/amicable-pairs.out
@@ -1,0 +1,9 @@
+The amicable pairs below 20,000 are:
+    220 and   284
+   1184 and  1210
+   2620 and  2924
+   5020 and  5564
+   6232 and  6368
+  10744 and 10856
+  12285 and 14595
+  17296 and 18416


### PR DESCRIPTION
## Summary
- add Mochi implementation for the "Amicable pairs" Rosetta task
- update Achilles numbers program to pass its map through functions
- add golden output for the new example

## Testing
- `go run /tmp/compile_mochi.go`

------
https://chatgpt.com/codex/tasks/task_e_686fe98d7d0083209d363e68f114ce60