### PR TITLE
Regenerate Rust machine README

### DIFF
--- a/tests/machine/x/rust/README.md
+++ b/tests/machine/x/rust/README.md
@@ -107,6 +107,7 @@ Compiled programs: 95/100
 - [x] while_loop
 
 ## Remaining Tasks
+- [ ] Add support for the `in` operator with query results and substrings
 
 - [ ] Implement support for dataset joins that currently fail to compile
 - [ ] Handle loading and saving external data


### PR DESCRIPTION
## Summary
- regenerate README for Rust machine outputs and note `in` operator TODO

## Testing
- `go test ./compiler/x/rust -run TestCompilePrograms -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68706d9d0fcc8320b737e147f1ba115f