### PR TITLE
Improve C++ backend determinism

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -3,13 +3,14 @@
 package cpp
 
 import (
-	"bytes"
-	"fmt"
-	"regexp"
-	"strconv"
-	"strings"
+        "bytes"
+        "fmt"
+        "regexp"
+        "sort"
+        "strconv"
+        "strings"
 
-	"mochi/parser"
+        "mochi/parser"
 )
 
 type structInfo struct {
@@ -226,11 +227,16 @@ func (c *Compiler) Compile(p *parser.Program) ([]byte, error) {
 	c.scope--
 	c.writeln("}")
 
-	if c.usesJSON {
-		for _, info := range c.structMap {
-			c.generateJSONPrinter(info)
-		}
-	}
+        if c.usesJSON {
+                names := make([]string, 0, len(c.structMap))
+                for name := range c.structMap {
+                        names = append(names, name)
+                }
+                sort.Strings(names)
+                for _, n := range names {
+                        c.generateJSONPrinter(c.structMap[n])
+                }
+        }
 
 	var body bytes.Buffer
 	body.Write(c.header.Bytes())

--- a/tests/machine/x/cpp/group_by_having.cpp
+++ b/tests/machine/x/cpp/group_by_having.cpp
@@ -78,21 +78,6 @@ inline bool operator==(const __struct3 &a, const __struct3 &b) {
 inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
-inline void __json(const __struct1 &v) {
-  bool first = true;
-  std::cout << "{";
-  if (!first)
-    std::cout << ",";
-  first = false;
-  std::cout << "\"name\":";
-  __json(v.name);
-  if (!first)
-    std::cout << ",";
-  first = false;
-  std::cout << "\"city\":";
-  __json(v.city);
-  std::cout << "}";
-}
 inline void __json(const __struct3 &v) {
   bool first = true;
   std::cout << "{";
@@ -106,6 +91,21 @@ inline void __json(const __struct3 &v) {
   first = false;
   std::cout << "\"num\":";
   __json(v.num);
+  std::cout << "}";
+}
+inline void __json(const __struct1 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"name\":";
+  __json(v.name);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"city\":";
+  __json(v.city);
   std::cout << "}";
 }
 std::vector<__struct1> people = std::vector<decltype(__struct1{

--- a/tests/machine/x/cpp/left_join.cpp
+++ b/tests/machine/x/cpp/left_join.cpp
@@ -81,21 +81,6 @@ inline bool operator==(const __struct3 &a, const __struct3 &b) {
 inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
-inline void __json(const __struct1 &v) {
-  bool first = true;
-  std::cout << "{";
-  if (!first)
-    std::cout << ",";
-  first = false;
-  std::cout << "\"id\":";
-  __json(v.id);
-  if (!first)
-    std::cout << ",";
-  first = false;
-  std::cout << "\"name\":";
-  __json(v.name);
-  std::cout << "}";
-}
 inline void __json(const __struct2 &v) {
   bool first = true;
   std::cout << "{";
@@ -114,6 +99,21 @@ inline void __json(const __struct2 &v) {
   first = false;
   std::cout << "\"total\":";
   __json(v.total);
+  std::cout << "}";
+}
+inline void __json(const __struct1 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"id\":";
+  __json(v.id);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"name\":";
+  __json(v.name);
   std::cout << "}";
 }
 inline void __json(const __struct3 &v) {

--- a/tests/machine/x/cpp/left_join_multi.cpp
+++ b/tests/machine/x/cpp/left_join_multi.cpp
@@ -89,21 +89,6 @@ inline bool operator==(const __struct4 &a, const __struct4 &b) {
 inline bool operator!=(const __struct4 &a, const __struct4 &b) {
   return !(a == b);
 }
-inline void __json(const __struct1 &v) {
-  bool first = true;
-  std::cout << "{";
-  if (!first)
-    std::cout << ",";
-  first = false;
-  std::cout << "\"id\":";
-  __json(v.id);
-  if (!first)
-    std::cout << ",";
-  first = false;
-  std::cout << "\"name\":";
-  __json(v.name);
-  std::cout << "}";
-}
 inline void __json(const __struct2 &v) {
   bool first = true;
   std::cout << "{";
@@ -119,19 +104,19 @@ inline void __json(const __struct2 &v) {
   __json(v.customerId);
   std::cout << "}";
 }
-inline void __json(const __struct3 &v) {
+inline void __json(const __struct1 &v) {
   bool first = true;
   std::cout << "{";
   if (!first)
     std::cout << ",";
   first = false;
-  std::cout << "\"orderId\":";
-  __json(v.orderId);
+  std::cout << "\"id\":";
+  __json(v.id);
   if (!first)
     std::cout << ",";
   first = false;
-  std::cout << "\"sku\":";
-  __json(v.sku);
+  std::cout << "\"name\":";
+  __json(v.name);
   std::cout << "}";
 }
 inline void __json(const __struct4 &v) {
@@ -152,6 +137,21 @@ inline void __json(const __struct4 &v) {
   first = false;
   std::cout << "\"item\":";
   __json(v.item);
+  std::cout << "}";
+}
+inline void __json(const __struct3 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"orderId\":";
+  __json(v.orderId);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"sku\":";
+  __json(v.sku);
   std::cout << "}";
 }
 std::vector<__struct1> customers =


### PR DESCRIPTION
## Summary
- add `sort` dependency in the C++ backend compiler
- generate JSON printer functions in a deterministic order
- update affected machine outputs

## Testing
- `go test ./compiler/x/cpp -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68706fe0ee908320a309fc721b152907