### PR TITLE
Improve C++ compiler printing

### DIFF
--- a/tests/machine/x/cpp/bool_chain.cpp
+++ b/tests/machine/x/cpp/bool_chain.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 bool boom() {
-  std::cout << std::boolalpha << std::string("boom") << std::endl;
+  std::cout << std::string("boom") << std::endl;
   return true;
 }
 

--- a/tests/machine/x/cpp/break_continue.cpp
+++ b/tests/machine/x/cpp/break_continue.cpp
@@ -12,7 +12,7 @@ int main() {
       break;
     }
     {
-      std::cout << std::boolalpha << std::string("odd number:");
+      std::cout << std::string("odd number:");
       std::cout << ' ';
       std::cout << std::boolalpha << n;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/cross_join.cpp
+++ b/tests/machine/x/cpp/cross_join.cpp
@@ -53,24 +53,23 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha
-            << std::string("--- Cross Join: All order-customer pairs ---")
+  std::cout << std::string("--- Cross Join: All order-customer pairs ---")
             << std::endl;
   for (auto entry : result) {
     {
-      std::cout << std::boolalpha << std::string("Order");
+      std::cout << std::string("Order");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.orderId;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("(customerId:");
+      std::cout << std::string("(customerId:");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.orderCustomerId;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string(", total: $");
+      std::cout << std::string(", total: $");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.orderTotal;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string(") paired with");
+      std::cout << std::string(") paired with");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.pairedCustomerName;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/cross_join_filter.cpp
+++ b/tests/machine/x/cpp/cross_join_filter.cpp
@@ -27,7 +27,7 @@ auto pairs = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Even pairs ---") << std::endl;
+  std::cout << std::string("--- Even pairs ---") << std::endl;
   for (auto p : pairs) {
     {
       std::cout << std::boolalpha << p.n;

--- a/tests/machine/x/cpp/cross_join_triple.cpp
+++ b/tests/machine/x/cpp/cross_join_triple.cpp
@@ -29,8 +29,7 @@ auto combos = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha
-            << std::string("--- Cross Join of three lists ---") << std::endl;
+  std::cout << std::string("--- Cross Join of three lists ---") << std::endl;
   for (auto c : combos) {
     {
       std::cout << std::boolalpha << c.n;

--- a/tests/machine/x/cpp/dataset_sort_take_limit.cpp
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.cpp
@@ -41,14 +41,13 @@ auto expensive = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha
-            << std::string("--- Top products (excluding most expensive) ---")
+  std::cout << std::string("--- Top products (excluding most expensive) ---")
             << std::endl;
   for (auto item : expensive) {
     {
       std::cout << std::boolalpha << item.name;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("costs $");
+      std::cout << std::string("costs $");
       std::cout << ' ';
       std::cout << std::boolalpha << item.price;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/dataset_where_filter.cpp
+++ b/tests/machine/x/cpp/dataset_where_filter.cpp
@@ -38,12 +38,12 @@ auto adults = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Adults ---") << std::endl;
+  std::cout << std::string("--- Adults ---") << std::endl;
   for (auto person : adults) {
     {
       std::cout << std::boolalpha << person.name;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("is");
+      std::cout << std::string("is");
       std::cout << ' ';
       std::cout << std::boolalpha << person.age;
       std::cout << ' ';

--- a/tests/machine/x/cpp/group_by.cpp
+++ b/tests/machine/x/cpp/group_by.cpp
@@ -78,17 +78,16 @@ auto stats = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- People grouped by city ---")
-            << std::endl;
+  std::cout << std::string("--- People grouped by city ---") << std::endl;
   for (auto s : stats) {
     {
       std::cout << std::boolalpha << s.city;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string(": count =");
+      std::cout << std::string(": count =");
       std::cout << ' ';
       std::cout << std::boolalpha << s.count;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string(", avg_age =");
+      std::cout << std::string(", avg_age =");
       std::cout << ' ';
       std::cout << std::boolalpha << s.avg_age;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/group_by_join.cpp
+++ b/tests/machine/x/cpp/group_by_join.cpp
@@ -85,13 +85,12 @@ auto stats = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Orders per customer ---")
-            << std::endl;
+  std::cout << std::string("--- Orders per customer ---") << std::endl;
   for (auto s : stats) {
     {
       std::cout << std::boolalpha << s.name;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("orders:");
+      std::cout << std::string("orders:");
       std::cout << ' ';
       std::cout << std::boolalpha << s.count;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/group_by_left_join.cpp
+++ b/tests/machine/x/cpp/group_by_left_join.cpp
@@ -115,13 +115,12 @@ auto stats = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Group Left Join ---")
-            << std::endl;
+  std::cout << std::string("--- Group Left Join ---") << std::endl;
   for (auto s : stats) {
     {
       std::cout << std::boolalpha << s.name;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("orders:");
+      std::cout << std::string("orders:");
       std::cout << ' ';
       std::cout << std::boolalpha << s.count;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/if_else.cpp
+++ b/tests/machine/x/cpp/if_else.cpp
@@ -4,9 +4,9 @@ auto x = 5;
 
 int main() {
   if ((x > 3)) {
-    std::cout << std::boolalpha << std::string("big") << std::endl;
+    std::cout << std::string("big") << std::endl;
   } else {
-    std::cout << std::boolalpha << std::string("small") << std::endl;
+    std::cout << std::string("small") << std::endl;
   }
   return 0;
 }

--- a/tests/machine/x/cpp/inner_join.cpp
+++ b/tests/machine/x/cpp/inner_join.cpp
@@ -54,19 +54,18 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha
-            << std::string("--- Orders with customer info ---") << std::endl;
+  std::cout << std::string("--- Orders with customer info ---") << std::endl;
   for (auto entry : result) {
     {
-      std::cout << std::boolalpha << std::string("Order");
+      std::cout << std::string("Order");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.orderId;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("by");
+      std::cout << std::string("by");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.customerName;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("- $");
+      std::cout << std::string("- $");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.total;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/join_multi.cpp
+++ b/tests/machine/x/cpp/join_multi.cpp
@@ -66,12 +66,12 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Multi Join ---") << std::endl;
+  std::cout << std::string("--- Multi Join ---") << std::endl;
   for (auto r : result) {
     {
       std::cout << std::boolalpha << r.name;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("bought item");
+      std::cout << std::string("bought item");
       std::cout << ' ';
       std::cout << std::boolalpha << r.sku;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/left_join.cpp
+++ b/tests/machine/x/cpp/left_join.cpp
@@ -162,18 +162,18 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Left Join ---") << std::endl;
+  std::cout << std::string("--- Left Join ---") << std::endl;
   for (auto entry : result) {
     {
-      std::cout << std::boolalpha << std::string("Order");
+      std::cout << std::string("Order");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.orderId;
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("customer");
+      std::cout << std::string("customer");
       std::cout << ' ';
       __json(entry.customer);
       std::cout << ' ';
-      std::cout << std::boolalpha << std::string("total");
+      std::cout << std::string("total");
       std::cout << ' ';
       std::cout << std::boolalpha << entry.total;
       std::cout << std::endl;

--- a/tests/machine/x/cpp/left_join_multi.cpp
+++ b/tests/machine/x/cpp/left_join_multi.cpp
@@ -187,8 +187,7 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Left Join Multi ---")
-            << std::endl;
+  std::cout << std::string("--- Left Join Multi ---") << std::endl;
   for (auto r : result) {
     {
       std::cout << std::boolalpha << r.orderId;

--- a/tests/machine/x/cpp/len_string.cpp
+++ b/tests/machine/x/cpp/len_string.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
 int main() {
-  std::cout << std::boolalpha << std::string("mochi").size() << std::endl;
+  std::cout << std::string("mochi").size() << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/outer_join.cpp
+++ b/tests/machine/x/cpp/outer_join.cpp
@@ -61,36 +61,35 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Outer Join using syntax ---")
-            << std::endl;
+  std::cout << std::string("--- Outer Join using syntax ---") << std::endl;
   for (auto row : result) {
     if ((row.order != __struct2{})) {
       if ((row.customer != __struct1{})) {
         {
-          std::cout << std::boolalpha << std::string("Order");
+          std::cout << std::string("Order");
           std::cout << ' ';
           std::cout << std::boolalpha << row.order.id;
           std::cout << ' ';
-          std::cout << std::boolalpha << std::string("by");
+          std::cout << std::string("by");
           std::cout << ' ';
           std::cout << std::boolalpha << row.customer.name;
           std::cout << ' ';
-          std::cout << std::boolalpha << std::string("- $");
+          std::cout << std::string("- $");
           std::cout << ' ';
           std::cout << std::boolalpha << row.order.total;
           std::cout << std::endl;
         }
       } else {
         {
-          std::cout << std::boolalpha << std::string("Order");
+          std::cout << std::string("Order");
           std::cout << ' ';
           std::cout << std::boolalpha << row.order.id;
           std::cout << ' ';
-          std::cout << std::boolalpha << std::string("by");
+          std::cout << std::string("by");
           std::cout << ' ';
-          std::cout << std::boolalpha << std::string("Unknown");
+          std::cout << std::string("Unknown");
           std::cout << ' ';
-          std::cout << std::boolalpha << std::string("- $");
+          std::cout << std::string("- $");
           std::cout << ' ';
           std::cout << std::boolalpha << row.order.total;
           std::cout << std::endl;
@@ -98,11 +97,11 @@ int main() {
       }
     } else {
       {
-        std::cout << std::boolalpha << std::string("Customer");
+        std::cout << std::string("Customer");
         std::cout << ' ';
         std::cout << std::boolalpha << row.customer.name;
         std::cout << ' ';
-        std::cout << std::boolalpha << std::string("has no orders");
+        std::cout << std::string("has no orders");
         std::cout << std::endl;
       }
     }

--- a/tests/machine/x/cpp/print_hello.cpp
+++ b/tests/machine/x/cpp/print_hello.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
 int main() {
-  std::cout << std::boolalpha << std::string("hello") << std::endl;
+  std::cout << std::string("hello") << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/python_math.cpp
+++ b/tests/machine/x/cpp/python_math.cpp
@@ -16,29 +16,29 @@ int main() {
   auto sin45 = math::sin((math::pi / 4));
   auto log_e = math::log(math::e);
   {
-    std::cout << std::boolalpha << std::string("Circle area with r =");
+    std::cout << std::string("Circle area with r =");
     std::cout << ' ';
-    std::cout << std::boolalpha << r;
+    std::cout << r;
     std::cout << ' ';
-    std::cout << std::boolalpha << std::string("=>");
+    std::cout << std::string("=>");
     std::cout << ' ';
     std::cout << std::boolalpha << area;
     std::cout << std::endl;
   }
   {
-    std::cout << std::boolalpha << std::string("Square root of 49:");
+    std::cout << std::string("Square root of 49:");
     std::cout << ' ';
     std::cout << std::boolalpha << root;
     std::cout << std::endl;
   }
   {
-    std::cout << std::boolalpha << std::string("sin(π/4):");
+    std::cout << std::string("sin(π/4):");
     std::cout << ' ';
     std::cout << std::boolalpha << sin45;
     std::cout << std::endl;
   }
   {
-    std::cout << std::boolalpha << std::string("log(e):");
+    std::cout << std::string("log(e):");
     std::cout << ' ';
     std::cout << std::boolalpha << log_e;
     std::cout << std::endl;

--- a/tests/machine/x/cpp/query_sum_select.cpp
+++ b/tests/machine/x/cpp/query_sum_select.cpp
@@ -13,6 +13,6 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << result << std::endl;
+  std::cout << result << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/right_join.cpp
+++ b/tests/machine/x/cpp/right_join.cpp
@@ -60,31 +60,30 @@ auto result = ([]() {
 })();
 
 int main() {
-  std::cout << std::boolalpha << std::string("--- Right Join using syntax ---")
-            << std::endl;
+  std::cout << std::string("--- Right Join using syntax ---") << std::endl;
   for (auto entry : result) {
     if ((entry.order != __struct2{})) {
       {
-        std::cout << std::boolalpha << std::string("Customer");
+        std::cout << std::string("Customer");
         std::cout << ' ';
         std::cout << std::boolalpha << entry.customerName;
         std::cout << ' ';
-        std::cout << std::boolalpha << std::string("has order");
+        std::cout << std::string("has order");
         std::cout << ' ';
         std::cout << std::boolalpha << entry.order.id;
         std::cout << ' ';
-        std::cout << std::boolalpha << std::string("- $");
+        std::cout << std::string("- $");
         std::cout << ' ';
         std::cout << std::boolalpha << entry.order.total;
         std::cout << std::endl;
       }
     } else {
       {
-        std::cout << std::boolalpha << std::string("Customer");
+        std::cout << std::string("Customer");
         std::cout << ' ';
         std::cout << std::boolalpha << entry.customerName;
         std::cout << ' ';
-        std::cout << std::boolalpha << std::string("has no orders");
+        std::cout << std::string("has no orders");
         std::cout << std::endl;
       }
     }

--- a/tests/machine/x/cpp/short_circuit.cpp
+++ b/tests/machine/x/cpp/short_circuit.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 bool boom(int a, int b) {
-  std::cout << std::boolalpha << std::string("boom") << std::endl;
+  std::cout << std::string("boom") << std::endl;
   return true;
 }
 

--- a/tests/machine/x/cpp/slice.cpp
+++ b/tests/machine/x/cpp/slice.cpp
@@ -24,8 +24,7 @@ int main() {
     }
     std::cout << std::endl;
   }
-  std::cout << std::boolalpha
-            << std::string(std::string("hello")).substr(1, (4) - (1))
+  std::cout << std::string(std::string("hello")).substr(1, (4) - (1))
             << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/substring_builtin.cpp
+++ b/tests/machine/x/cpp/substring_builtin.cpp
@@ -1,8 +1,7 @@
 #include <iostream>
 
 int main() {
-  std::cout << std::boolalpha
-            << std::string(std::string("mochi")).substr(1, (4) - (1))
+  std::cout << std::string(std::string("mochi")).substr(1, (4) - (1))
             << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/test_block.cpp
+++ b/tests/machine/x/cpp/test_block.cpp
@@ -3,6 +3,6 @@
 int main() {
   // test addition works
   auto x = (1 + 2);
-  std::cout << std::boolalpha << std::string("ok") << std::endl;
+  std::cout << std::string("ok") << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/update_stmt.cpp
+++ b/tests/machine/x/cpp/update_stmt.cpp
@@ -25,6 +25,6 @@ int main() {
     }
   }
   // test update adult status
-  std::cout << std::boolalpha << std::string("ok") << std::endl;
+  std::cout << std::string("ok") << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/var_assignment.cpp
+++ b/tests/machine/x/cpp/var_assignment.cpp
@@ -4,6 +4,6 @@ auto x = 1;
 
 int main() {
   x = 2;
-  std::cout << std::boolalpha << x << std::endl;
+  std::cout << x << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/while_loop.cpp
+++ b/tests/machine/x/cpp/while_loop.cpp
@@ -4,7 +4,7 @@ auto i = 0;
 
 int main() {
   while ((i < 3)) {
-    std::cout << std::boolalpha << i << std::endl;
+    std::cout << i << std::endl;
     i = (i + 1);
   }
   return 0;


### PR DESCRIPTION
## Summary
- refine the C++ backend `compilePrint` implementation
- update generated C++ machine examples to match new output

## Testing
- `go test ./compiler/x/cpp -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687077122acc8320aa4164d1af91006e