### PR TITLE
Improve C++ machine compiler

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -1092,12 +1092,13 @@ func (c *Compiler) compilePrint(args []*parser.Expr) error {
 		switch typ {
 		case "vector":
 			tmp := c.newTmp()
-			c.buf.WriteString("auto " + tmp + " = " + s + "; ")
+			c.buf.WriteString("auto " + tmp + " = " + s + "; bool first=true; for(const auto &_x : " + tmp + "){ if(!first) std::cout<<' '; first=false; ")
 			if et := c.elemType[s]; et != "" && strings.HasPrefix(et, "__struct") {
-				c.buf.WriteString("for(size_t i=0;i<" + tmp + ".size();++i){ if(i) std::cout<<' '; std::cout << \"<struct>\"; } ")
+				c.buf.WriteString("std::cout<<\"<struct>\";")
 			} else {
-				c.buf.WriteString("for(size_t i=0;i<" + tmp + ".size();++i){ if(i) std::cout<<' '; std::cout << std::boolalpha << " + tmp + "[i]; } ")
+				c.buf.WriteString("std::cout<<std::boolalpha<<_x;")
 			}
+			c.buf.WriteString(" } ")
 		case "bool":
 			c.buf.WriteString("std::cout << std::boolalpha << (" + s + "); ")
 		case "int", "double", "string":

--- a/tests/machine/x/cpp/append_builtin.cpp
+++ b/tests/machine/x/cpp/append_builtin.cpp
@@ -9,10 +9,12 @@ int main() {
       v.push_back(3);
       return v;
     })(a);
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp1[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }

--- a/tests/machine/x/cpp/group_by_conditional_sum.cpp
+++ b/tests/machine/x/cpp/group_by_conditional_sum.cpp
@@ -96,9 +96,11 @@ auto result = ([]() {
 int main() {
   {
     auto __tmp1 = result;
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
+      first = false;
       std::cout << "<struct>";
     }
     std::cout << std::endl;

--- a/tests/machine/x/cpp/group_by_multi_join.cpp
+++ b/tests/machine/x/cpp/group_by_multi_join.cpp
@@ -128,9 +128,11 @@ auto grouped = ([]() {
 int main() {
   {
     auto __tmp1 = grouped;
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
+      first = false;
       std::cout << "<struct>";
     }
     std::cout << std::endl;

--- a/tests/machine/x/cpp/group_by_multi_join_sort.cpp
+++ b/tests/machine/x/cpp/group_by_multi_join_sort.cpp
@@ -211,9 +211,11 @@ auto result = ([]() {
 int main() {
   {
     auto __tmp1 = result;
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
+      first = false;
       std::cout << "<struct>";
     }
     std::cout << std::endl;

--- a/tests/machine/x/cpp/group_by_sort.cpp
+++ b/tests/machine/x/cpp/group_by_sort.cpp
@@ -88,9 +88,11 @@ auto grouped = ([]() {
 int main() {
   {
     auto __tmp1 = grouped;
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
+      first = false;
       std::cout << "<struct>";
     }
     std::cout << std::endl;

--- a/tests/machine/x/cpp/group_items_iteration.cpp
+++ b/tests/machine/x/cpp/group_items_iteration.cpp
@@ -88,9 +88,11 @@ int main() {
   })();
   {
     auto __tmp1 = result;
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
+      first = false;
       std::cout << "<struct>";
     }
     std::cout << std::endl;

--- a/tests/machine/x/cpp/list_set_ops.cpp
+++ b/tests/machine/x/cpp/list_set_ops.cpp
@@ -10,10 +10,12 @@ int main() {
       a.erase(std::unique(a.begin(), a.end()), a.end());
       return a;
     })(std::vector<decltype(1)>{1, 2}, std::vector<decltype(2)>{2, 3});
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp1[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }
@@ -23,10 +25,12 @@ int main() {
         a.erase(std::remove(a.begin(), a.end(), x), a.end());
       return a;
     })(std::vector<decltype(1)>{1, 2, 3}, std::vector<decltype(2)>{2});
-    for (size_t i = 0; i < __tmp2.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp2) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp2[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }
@@ -38,10 +42,12 @@ int main() {
           r_.push_back(x);
       return r_;
     })(std::vector<decltype(1)>{1, 2, 3}, std::vector<decltype(2)>{2, 4});
-    for (size_t i = 0; i < __tmp3.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp3) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp3[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }

--- a/tests/machine/x/cpp/order_by_map.cpp
+++ b/tests/machine/x/cpp/order_by_map.cpp
@@ -32,9 +32,11 @@ auto sorted = ([]() {
 int main() {
   {
     auto __tmp1 = sorted;
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
+      first = false;
       std::cout << "<struct>";
     }
     std::cout << std::endl;

--- a/tests/machine/x/cpp/slice.cpp
+++ b/tests/machine/x/cpp/slice.cpp
@@ -6,10 +6,12 @@ int main() {
     auto __tmp1 = ([&](auto v) {
       return std::vector<int>(v.begin() + 1, v.begin() + 3);
     })(std::vector<decltype(1)>{1, 2, 3});
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp1[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }
@@ -17,10 +19,12 @@ int main() {
     auto __tmp2 = ([&](auto v) {
       return std::vector<int>(v.begin() + 0, v.begin() + 2);
     })(std::vector<decltype(1)>{1, 2, 3});
-    for (size_t i = 0; i < __tmp2.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp2) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp2[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }

--- a/tests/machine/x/cpp/sort_stable.cpp
+++ b/tests/machine/x/cpp/sort_stable.cpp
@@ -35,10 +35,12 @@ auto result = ([]() {
 int main() {
   {
     auto __tmp1 = result;
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp1[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }

--- a/tests/machine/x/cpp/values_builtin.cpp
+++ b/tests/machine/x/cpp/values_builtin.cpp
@@ -13,10 +13,12 @@ int main() {
         v.push_back(p.second);
       return v;
     })();
-    for (size_t i = 0; i < __tmp1.size(); ++i) {
-      if (i)
+    bool first = true;
+    for (const auto &_x : __tmp1) {
+      if (!first)
         std::cout << ' ';
-      std::cout << std::boolalpha << __tmp1[i];
+      first = false;
+      std::cout << std::boolalpha << _x;
     }
     std::cout << std::endl;
   }


### PR DESCRIPTION
## Summary
- tweak `compilePrint` to use range-based loops when printing vectors
- regenerate C++ machine outputs for tests

## Testing
- `go test ./compiler/x/cpp -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68708d40c38c83209fef70c55e7e5497