### PR TITLE
Fix C compiler struct list types

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -493,6 +493,7 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 			st.Methods = orig.Methods
 		}
 		c.env.SetStruct(t.Name, st)
+		c.compileStructListType(st)
 	}
 	for _, m := range t.Members {
 		if m.Method != nil {
@@ -1694,6 +1695,7 @@ func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) string {
 		path = fmt.Sprintf("%q", *l.Path)
 	}
 	c.need(needLoadJSON)
+	c.need(needMapStringInt)
 	c.need(needStringHeader)
 	return fmt.Sprintf("_load_json(%s)", path)
 }


### PR DESCRIPTION
## Summary
- ensure `_load_json` helper includes map_string_int definitions
- generate list types for each struct in the C backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68709044afdc8320955b07c6dd80930f