### PR TITLE
Improve C# compiler int mapping

### DIFF
--- a/compiler/x/cs/helpers.go
+++ b/compiler/x/cs/helpers.go
@@ -40,7 +40,9 @@ func repoRoot() string {
 
 func csTypeOf(t types.Type) string {
 	switch tt := t.(type) {
-	case types.IntType, types.Int64Type:
+	case types.IntType:
+		return "int"
+	case types.Int64Type:
 		return "long"
 	case types.FloatType:
 		return "double"

--- a/tests/machine/x/cs/append_builtin.cs
+++ b/tests/machine/x/cs/append_builtin.cs
@@ -5,7 +5,7 @@ class Program
 {
     static void Main()
     {
-        List<long> a = new List<long> { 1, 2 };
-        Console.WriteLine(JsonSerializer.Serialize(new List<long>(a) { 3 }));
+        List<int> a = new List<int> { 1, 2 };
+        Console.WriteLine(JsonSerializer.Serialize(new List<int>(a) { 3 }));
     }
 }

--- a/tests/machine/x/cs/avg_builtin.cs
+++ b/tests/machine/x/cs/avg_builtin.cs
@@ -6,6 +6,6 @@ class Program
 {
     static void Main()
     {
-        Console.WriteLine(Enumerable.Average(new List<long> { 1, 2, 3 }.Select(_tmp0 => Convert.ToDouble(_tmp0))));
+        Console.WriteLine(Enumerable.Average(new List<int> { 1, 2, 3 }.Select(_tmp0 => Convert.ToDouble(_tmp0))));
     }
 }

--- a/tests/machine/x/cs/basic_compare.cs
+++ b/tests/machine/x/cs/basic_compare.cs
@@ -4,8 +4,8 @@ class Program
 {
     static void Main()
     {
-        long a = (10 - 3);
-        long b = (2 + 2);
+        int a = (10 - 3);
+        int b = (2 + 2);
         Console.WriteLine(a);
         Console.WriteLine((a == 7));
         Console.WriteLine((b < 5));

--- a/tests/machine/x/cs/break_continue.cs
+++ b/tests/machine/x/cs/break_continue.cs
@@ -5,7 +5,7 @@ class Program
 {
     static void Main()
     {
-        List<long> numbers = new List<long> { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        List<int> numbers = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         foreach (var n in numbers)
         {
             if ((n % 2) == 0)

--- a/tests/machine/x/cs/closure.cs
+++ b/tests/machine/x/cs/closure.cs
@@ -12,7 +12,7 @@ class Program
 
     static void Main()
     {
-        Func<long, long> add10 = makeAdder(10);
+        Func<int, int> add10 = makeAdder(10);
         Console.WriteLine(add10(7));
     }
 }

--- a/tests/machine/x/cs/count_builtin.cs
+++ b/tests/machine/x/cs/count_builtin.cs
@@ -6,6 +6,6 @@ class Program
 {
     static void Main()
     {
-        Console.WriteLine(Enumerable.Count(new List<long> { 1, 2, 3 }));
+        Console.WriteLine(Enumerable.Count(new List<int> { 1, 2, 3 }));
     }
 }

--- a/tests/machine/x/cs/cross_join.cs
+++ b/tests/machine/x/cs/cross_join.cs
@@ -6,16 +6,16 @@ class Program
 {
     static void Main()
     {
-        var customers = new List<dynamic> { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
-        var orders = new List<dynamic> { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } } };
-        var result = new Func<List<Dictionary<string, dynamic>>>(() =>
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<dynamic, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<dynamic, dynamic> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } } };
+        var result = new Func<List<dynamic>>(() =>
         {
-            var _res = new List<Dictionary<string, dynamic>>();
+            var _res = new List<dynamic>();
             foreach (var o in orders)
             {
                 foreach (var c in customers)
                 {
-                    _res.Add(new Dictionary<string, dynamic> { { "orderId", o.id }, { "orderCustomerId", o.customerId }, { "pairedCustomerName", c.name }, { "orderTotal", o.total } });
+                    _res.Add(new Dictionary<dynamic, dynamic> { { "orderId", o.id }, { "orderCustomerId", o.customerId }, { "pairedCustomerName", c.name }, { "orderTotal", o.total } });
                 }
             }
             return _res;
@@ -23,7 +23,7 @@ class Program
         Console.WriteLine("--- Cross Join: All order-customer pairs ---");
         foreach (var entry in result)
         {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString("Order"), Convert.ToString(entry["orderId"]), Convert.ToString("(customerId:"), Convert.ToString(entry["orderCustomerId"]), Convert.ToString(", total: $"), Convert.ToString(entry["orderTotal"]), Convert.ToString(") paired with"), Convert.ToString(entry["pairedCustomerName"]) }));
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString("Order"), Convert.ToString(entry.orderId), Convert.ToString("(customerId:"), Convert.ToString(entry.orderCustomerId), Convert.ToString(", total: $"), Convert.ToString(entry.orderTotal), Convert.ToString(") paired with"), Convert.ToString(entry.pairedCustomerName) }));
         }
     }
 }

--- a/tests/machine/x/cs/cross_join_filter.cs
+++ b/tests/machine/x/cs/cross_join_filter.cs
@@ -6,11 +6,11 @@ class Program
 {
     static void Main()
     {
-        List<long> nums = new List<long> { 1, 2, 3 };
+        List<int> nums = new List<int> { 1, 2, 3 };
         List<string> letters = new List<string> { "A", "B" };
-        var pairs = new Func<List<Dictionary<string, dynamic>>>(() =>
+        var pairs = new Func<List<dynamic>>(() =>
         {
-            var _res = new List<Dictionary<string, dynamic>>();
+            var _res = new List<dynamic>();
             foreach (var n in nums)
             {
                 if (!(((n % 2) == 0))) continue;
@@ -18,7 +18,7 @@ class Program
                 {
                     if (((n % 2) == 0))
                     {
-                        _res.Add(new Dictionary<string, dynamic> { { "n", n }, { "l", l } });
+                        _res.Add(new Dictionary<dynamic, dynamic> { { "n", n }, { "l", l } });
                     }
                 }
             }
@@ -27,7 +27,7 @@ class Program
         Console.WriteLine("--- Even pairs ---");
         foreach (var p in pairs)
         {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(p["n"]), Convert.ToString(p["l"]) }));
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(p.n), Convert.ToString(p.l) }));
         }
     }
 }

--- a/tests/machine/x/cs/cross_join_triple.cs
+++ b/tests/machine/x/cs/cross_join_triple.cs
@@ -6,19 +6,19 @@ class Program
 {
     static void Main()
     {
-        List<long> nums = new List<long> { 1, 2 };
+        List<int> nums = new List<int> { 1, 2 };
         List<string> letters = new List<string> { "A", "B" };
         List<bool> bools = new List<bool> { true, false };
-        var combos = new Func<List<Dictionary<string, dynamic>>>(() =>
+        var combos = new Func<List<dynamic>>(() =>
         {
-            var _res = new List<Dictionary<string, dynamic>>();
+            var _res = new List<dynamic>();
             foreach (var n in nums)
             {
                 foreach (var l in letters)
                 {
                     foreach (var b in bools)
                     {
-                        _res.Add(new Dictionary<string, dynamic> { { "n", n }, { "l", l }, { "b", b } });
+                        _res.Add(new Dictionary<dynamic, dynamic> { { "n", n }, { "l", l }, { "b", b } });
                     }
                 }
             }
@@ -27,7 +27,7 @@ class Program
         Console.WriteLine("--- Cross Join of three lists ---");
         foreach (var c in combos)
         {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(c["n"]), Convert.ToString(c["l"]), Convert.ToString(c["b"]) }));
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(c.n), Convert.ToString(c.l), Convert.ToString(c.b) }));
         }
     }
 }

--- a/tests/machine/x/cs/dataset_sort_take_limit.cs
+++ b/tests/machine/x/cs/dataset_sort_take_limit.cs
@@ -2,16 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var products = new List<dynamic> { new Dictionary<string, dynamic> { { "name", "Laptop" }, { "price", 1500 } }, new Dictionary<string, dynamic> { { "name", "Smartphone" }, { "price", 900 } }, new Dictionary<string, dynamic> { { "name", "Tablet" }, { "price", 600 } }, new Dictionary<string, dynamic> { { "name", "Monitor" }, { "price", 300 } }, new Dictionary<string, dynamic> { { "name", "Keyboard" }, { "price", 100 } }, new Dictionary<string, dynamic> { { "name", "Mouse" }, { "price", 50 } }, new Dictionary<string, dynamic> { { "name", "Headphones" }, { "price", 200 } } };
+class Program {
+    static void Main() {
+        var products = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "name", "Laptop" }, { "price", 1500 } }, new Dictionary<dynamic, dynamic> { { "name", "Smartphone" }, { "price", 900 } }, new Dictionary<dynamic, dynamic> { { "name", "Tablet" }, { "price", 600 } }, new Dictionary<dynamic, dynamic> { { "name", "Monitor" }, { "price", 300 } }, new Dictionary<dynamic, dynamic> { { "name", "Keyboard" }, { "price", 100 } }, new Dictionary<dynamic, dynamic> { { "name", "Mouse" }, { "price", 50 } }, new Dictionary<dynamic, dynamic> { { "name", "Headphones" }, { "price", 200 } } };
         var expensive = products.OrderBy(p => (-p.price)).Skip(1).Take(3).Select(p => p).ToArray();
         Console.WriteLine("--- Top products (excluding most expensive) ---");
-        foreach (var item in expensive)
-        {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(item.name), Convert.ToString("costs $"), Convert.ToString(item.price) }));
+        foreach (var item in expensive) {
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(item.name), Convert.ToString("costs $"), Convert.ToString(item.price) }));
         }
     }
 }

--- a/tests/machine/x/cs/dataset_where_filter.cs
+++ b/tests/machine/x/cs/dataset_where_filter.cs
@@ -2,16 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var people = new List<dynamic> { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 } } };
-        var adults = people.Where(person => (person.age >= 18)).Select(person => new Dictionary<string, dynamic> { { "name", person.name }, { "age", person.age }, { "is_senior", (person.age >= 60) } }).ToArray();
+class Program {
+    static void Main() {
+        var people = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "name", "Alice" }, { "age", 30 } }, new Dictionary<dynamic, dynamic> { { "name", "Bob" }, { "age", 15 } }, new Dictionary<dynamic, dynamic> { { "name", "Charlie" }, { "age", 65 } }, new Dictionary<dynamic, dynamic> { { "name", "Diana" }, { "age", 45 } } };
+        var adults = people.Where(person => (person.age >= 18)).Select(person => new Dictionary<dynamic, dynamic> { { "name", person.name }, { "age", person.age }, { "is_senior", (person.age >= 60) } }).ToArray();
         Console.WriteLine("--- Adults ---");
-        foreach (var person in adults)
-        {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(person["name"]), Convert.ToString("is"), Convert.ToString(person["age"]), Convert.ToString((person["is_senior"] ? " (senior)" : "")) }));
+        foreach (var person in adults) {
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(person.name), Convert.ToString("is"), Convert.ToString(person.age), Convert.ToString((person.is_senior ? " (senior)" : "")) }));
         }
     }
 }

--- a/tests/machine/x/cs/exists_builtin.cs
+++ b/tests/machine/x/cs/exists_builtin.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        List<long> data = new List<long> { 1, 2 };
+class Program {
+    static void Main() {
+        List<int> data = new List<int> { 1, 2 };
         bool flag = Enumerable.Any(data.Where(x => (x == 1)).Select(x => x).ToArray());
         Console.WriteLine(flag);
     }

--- a/tests/machine/x/cs/for_list_collection.cs
+++ b/tests/machine/x/cs/for_list_collection.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Collections.Generic;
 
-class Program
-{
-    static void Main()
-    {
-        foreach (var n in new List<long> { 1, 2, 3 })
-        {
+class Program {
+    static void Main() {
+        foreach (var n in new List<int> { 1, 2, 3 }) {
             Console.WriteLine(n);
         }
     }

--- a/tests/machine/x/cs/for_loop.cs
+++ b/tests/machine/x/cs/for_loop.cs
@@ -1,11 +1,8 @@
 using System;
 
-class Program
-{
-    static void Main()
-    {
-        for (var i = 1; i < 4; i++)
-        {
+class Program {
+    static void Main() {
+        for (var i = 1; i < 4; i++) {
             Console.WriteLine(i);
         }
     }

--- a/tests/machine/x/cs/for_map_collection.cs
+++ b/tests/machine/x/cs/for_map_collection.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
 
-class Program
-{
-    static void Main()
-    {
-        Dictionary<string, long> m = new Dictionary<string, long> { { "a", 1 }, { "b", 2 } };
-        foreach (var k in m.Keys)
-        {
+class Program {
+    static void Main() {
+        Dictionary<string, int> m = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
+        foreach (var k in m.Keys) {
             Console.WriteLine(k);
         }
     }

--- a/tests/machine/x/cs/fun_call.cs
+++ b/tests/machine/x/cs/fun_call.cs
@@ -1,14 +1,11 @@
 using System;
 
-class Program
-{
-    static long add(long a, long b)
-    {
+class Program {
+    static long add(long a, long b) {
         return (a + b);
     }
-
-    static void Main()
-    {
+    
+    static void Main() {
         Console.WriteLine(add(2, 3));
     }
 }

--- a/tests/machine/x/cs/fun_expr_in_let.cs
+++ b/tests/machine/x/cs/fun_expr_in_let.cs
@@ -1,13 +1,10 @@
 using System;
 
-class Program
-{
-    static void Main()
-    {
-        Func<long, long> square = new Func<long, long>((long x) =>
-        {
-            return (x * x);
-        });
+class Program {
+    static void Main() {
+        Func<int, int> square = new Func<long, long>((long x) => {
+    return (x * x);
+});
         Console.WriteLine(square(6));
     }
 }

--- a/tests/machine/x/cs/fun_three_args.cs
+++ b/tests/machine/x/cs/fun_three_args.cs
@@ -1,14 +1,11 @@
 using System;
 
-class Program
-{
-    static long sum3(long a, long b, long c)
-    {
+class Program {
+    static long sum3(long a, long b, long c) {
         return ((a + b) + c);
     }
-
-    static void Main()
-    {
+    
+    static void Main() {
         Console.WriteLine(sum3(1, 2, 3));
     }
 }

--- a/tests/machine/x/cs/go_auto.cs
+++ b/tests/machine/x/cs/go_auto.cs
@@ -1,16 +1,13 @@
 using System;
 
-static class testpkg
-{
+static class testpkg {
     public static int Add(int a, int b) { return a + b; }
     public const double Pi = 3.14;
     public const int Answer = 42;
 }
 
-class Program
-{
-    static void Main()
-    {
+class Program {
+    static void Main() {
         Console.WriteLine(testpkg.Add(2, 3));
         Console.WriteLine(testpkg.Pi);
         Console.WriteLine(testpkg.Answer);

--- a/tests/machine/x/cs/group_by.cs
+++ b/tests/machine/x/cs/group_by.cs
@@ -2,41 +2,33 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var people = new List<dynamic> { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 15 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Charlie" }, { "age", 65 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Diana" }, { "age", 45 }, { "city", "Hanoi" } }, new Dictionary<string, dynamic> { { "name", "Eve" }, { "age", 70 }, { "city", "Paris" } }, new Dictionary<string, dynamic> { { "name", "Frank" }, { "age", 22 }, { "city", "Hanoi" } } };
-        var stats = _group_by(people, person => person.city).Select(g => new Dictionary<string, dynamic> { { "city", g.Key }, { "count", Enumerable.Count(g) }, { "avg_age", _avg(g.Items.Select(p => p.age).ToArray()) } }).ToList();
+class Program {
+    static void Main() {
+        var people = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "name", "Alice" }, { "age", 30 }, { "city", "Paris" } }, new Dictionary<dynamic, dynamic> { { "name", "Bob" }, { "age", 15 }, { "city", "Hanoi" } }, new Dictionary<dynamic, dynamic> { { "name", "Charlie" }, { "age", 65 }, { "city", "Paris" } }, new Dictionary<dynamic, dynamic> { { "name", "Diana" }, { "age", 45 }, { "city", "Hanoi" } }, new Dictionary<dynamic, dynamic> { { "name", "Eve" }, { "age", 70 }, { "city", "Paris" } }, new Dictionary<dynamic, dynamic> { { "name", "Frank" }, { "age", 22 }, { "city", "Hanoi" } } };
+        var stats = _group_by(people, person => person.city).Select(g => new Dictionary<dynamic, dynamic> { { "city", g.Key }, { "count", Enumerable.Count(g) }, { "avg_age", _avg(g.Items.Select(p => p.age).ToArray()) } }).ToList();
         Console.WriteLine("--- People grouped by city ---");
-        foreach (var s in stats)
-        {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(s["city"]), Convert.ToString(": count ="), Convert.ToString(s["count"]), Convert.ToString(", avg_age ="), Convert.ToString(s["avg_age"]) }));
+        foreach (var s in stats) {
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(s.city), Convert.ToString(": count ="), Convert.ToString(s.count), Convert.ToString(", avg_age ="), Convert.ToString(s.avg_age) }));
         }
     }
-    static double _avg(dynamic v)
-    {
+    static double _avg(dynamic v) {
         if (v == null) return 0.0;
         int _n = 0;
         double _sum = 0;
-        foreach (var it in v)
-        {
+        foreach (var it in v) {
             _sum += Convert.ToDouble(it);
             _n++;
         }
         return _n == 0 ? 0.0 : _sum / _n;
     }
-
-    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn)
-    {
+    
+    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {
         var groups = new Dictionary<string, _Group>();
         var order = new List<string>();
-        foreach (var it in src)
-        {
+        foreach (var it in src) {
             var key = keyfn(it);
             var ks = Convert.ToString(key);
-            if (!groups.TryGetValue(ks, out var g))
-            {
+            if (!groups.TryGetValue(ks, out var g)) {
                 g = new _Group(key);
                 groups[ks] = g;
                 order.Add(ks);
@@ -47,5 +39,5 @@ class Program
         foreach (var k in order) res.Add(groups[k]);
         return res;
     }
-
+    
 }

--- a/tests/machine/x/cs/group_by_conditional_sum.cs
+++ b/tests/machine/x/cs/group_by_conditional_sum.cs
@@ -2,35 +2,28 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var items = new List<dynamic> { new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 10 }, { "flag", true } }, new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 5 }, { "flag", false } }, new Dictionary<string, dynamic> { { "cat", "b" }, { "val", 20 }, { "flag", true } } };
-        var result = _group_by(items, i => i.cat).OrderBy(g => g.Key).Select(g => new Dictionary<string, dynamic> { { "cat", g.Key }, { "share", (_sum(g.Items.Select(x => (x.flag ? x.val : 0)).ToArray()) / _sum(g.Items.Select(x => x.val).ToArray())) } }).ToList();
+class Program {
+    static void Main() {
+        var items = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "cat", "a" }, { "val", 10 }, { "flag", true } }, new Dictionary<dynamic, dynamic> { { "cat", "a" }, { "val", 5 }, { "flag", false } }, new Dictionary<dynamic, dynamic> { { "cat", "b" }, { "val", 20 }, { "flag", true } } };
+        var result = _group_by(items, i => i.cat).OrderBy(g => g.Key).Select(g => new Dictionary<dynamic, dynamic> { { "cat", g.Key }, { "share", (_sum(g.Items.Select(x => (x.flag ? x.val : 0)).ToArray()) / _sum(g.Items.Select(x => x.val).ToArray())) } }).ToList();
         Console.WriteLine(JsonSerializer.Serialize(result));
     }
-    static double _sum(dynamic v)
-    {
+    static double _sum(dynamic v) {
         if (v == null) return 0.0;
         double _sum = 0;
-        foreach (var it in v)
-        {
+        foreach (var it in v) {
             _sum += Convert.ToDouble(it);
         }
         return _sum;
     }
-
-    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn)
-    {
+    
+    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {
         var groups = new Dictionary<string, _Group>();
         var order = new List<string>();
-        foreach (var it in src)
-        {
+        foreach (var it in src) {
             var key = keyfn(it);
             var ks = Convert.ToString(key);
-            if (!groups.TryGetValue(ks, out var g))
-            {
+            if (!groups.TryGetValue(ks, out var g)) {
                 g = new _Group(key);
                 groups[ks] = g;
                 order.Add(ks);
@@ -41,5 +34,5 @@ class Program
         foreach (var k in order) res.Add(groups[k]);
         return res;
     }
-
+    
 }

--- a/tests/machine/x/cs/group_by_having.cs
+++ b/tests/machine/x/cs/group_by_having.cs
@@ -2,24 +2,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var people = new dynamic[] { new Dictionary<string, string> { { "name", "Alice" }, { "city", "Paris" } }, new Dictionary<string, string> { { "name", "Bob" }, { "city", "Hanoi" } }, new Dictionary<string, string> { { "name", "Charlie" }, { "city", "Paris" } }, new Dictionary<string, string> { { "name", "Diana" }, { "city", "Hanoi" } }, new Dictionary<string, string> { { "name", "Eve" }, { "city", "Paris" } }, new Dictionary<string, string> { { "name", "Frank" }, { "city", "Hanoi" } }, new Dictionary<string, string> { { "name", "George" }, { "city", "Paris" } } };
-        var big = _group_by(people, p => p.city).Where(g => (Enumerable.Count(g) >= 4)).Select(g => new Dictionary<string, dynamic> { { "city", g.Key }, { "num", Enumerable.Count(g) } }).ToList();
+class Program {
+    static void Main() {
+        var people = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "name", "Alice" }, { "city", "Paris" } }, new Dictionary<dynamic, dynamic> { { "name", "Bob" }, { "city", "Hanoi" } }, new Dictionary<dynamic, dynamic> { { "name", "Charlie" }, { "city", "Paris" } }, new Dictionary<dynamic, dynamic> { { "name", "Diana" }, { "city", "Hanoi" } }, new Dictionary<dynamic, dynamic> { { "name", "Eve" }, { "city", "Paris" } }, new Dictionary<dynamic, dynamic> { { "name", "Frank" }, { "city", "Hanoi" } }, new Dictionary<dynamic, dynamic> { { "name", "George" }, { "city", "Paris" } } };
+        var big = _group_by(people, p => p.city).Where(g => (Enumerable.Count(g) >= 4)).Select(g => new Dictionary<dynamic, dynamic> { { "city", g.Key }, { "num", Enumerable.Count(g) } }).ToList();
         Console.WriteLine(JsonSerializer.Serialize(big));
     }
-    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn)
-    {
+    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {
         var groups = new Dictionary<string, _Group>();
         var order = new List<string>();
-        foreach (var it in src)
-        {
+        foreach (var it in src) {
             var key = keyfn(it);
             var ks = Convert.ToString(key);
-            if (!groups.TryGetValue(ks, out var g))
-            {
+            if (!groups.TryGetValue(ks, out var g)) {
                 g = new _Group(key);
                 groups[ks] = g;
                 order.Add(ks);
@@ -30,5 +25,5 @@ class Program
         foreach (var k in order) res.Add(groups[k]);
         return res;
     }
-
+    
 }

--- a/tests/machine/x/cs/group_by_join.cs
+++ b/tests/machine/x/cs/group_by_join.cs
@@ -2,52 +2,43 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 1 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 2 } } };
-        var stats = new Func<List<Dictionary<string, dynamic>>>(() =>
-        {
-            var groups = new Dictionary<string, _Group>();
-            var order = new List<string>();
-            foreach (var o in orders)
-            {
-                foreach (var c in customers)
-                {
-                    if (!((o.customerId == c.id))) continue;
-                    var key = c.name;
-                    var ks = Convert.ToString(key);
-                    if (!groups.TryGetValue(ks, out var g))
-                    {
-                        g = new _Group(key);
-                        groups[ks] = g;
-                        order.Add(ks);
-                    }
-                    g.Items.Add(o);
-                }
+class Program {
+    static void Main() {
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 1 } }, new Dictionary<dynamic, dynamic> { { "id", 102 }, { "customerId", 2 } } };
+        var stats = new Func<List<dynamic>>(() => {
+    var groups = new Dictionary<string, _Group>();
+    var order = new List<string>();
+    foreach (var o in orders) {
+        foreach (var c in customers) {
+            if (!((o.customerId == c.id))) continue;
+            var key = c.name;
+            var ks = Convert.ToString(key);
+            if (!groups.TryGetValue(ks, out var g)) {
+                g = new _Group(key);
+                groups[ks] = g;
+                order.Add(ks);
             }
-            var items = new List<_Group>();
-            foreach (var ks in order) items.Add(groups[ks]);
-            var _res = new List<Dictionary<string, dynamic>>();
-            foreach (var g in items)
-            {
-                _res.Add(new Dictionary<string, dynamic> { { "name", g.key }, { "count", Enumerable.Count(g) } });
-            }
-            return _res;
-        })();
-        Console.WriteLine("--- Orders per customer ---");
-        foreach (var s in stats)
-        {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(s["name"]), Convert.ToString("orders:"), Convert.ToString(s["count"]) }));
+            g.Items.Add(o);
         }
     }
-    public class _Group
-    {
+    var items = new List<_Group>();
+    foreach (var ks in order) items.Add(groups[ks]);
+    var _res = new List<dynamic>();
+    foreach (var g in items) {
+        _res.Add(new Dictionary<dynamic, dynamic> { { "name", g.key }, { "count", Enumerable.Count(g) } });
+    }
+    return _res;
+})();
+        Console.WriteLine("--- Orders per customer ---");
+        foreach (var s in stats) {
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(s.name), Convert.ToString("orders:"), Convert.ToString(s.count) }));
+        }
+    }
+    public class _Group {
         public dynamic key;
         public List<dynamic> Items = new List<dynamic>();
         public _Group(dynamic k) { key = k; }
     }
-
+    
 }

--- a/tests/machine/x/cs/group_by_left_join.cs
+++ b/tests/machine/x/cs/group_by_left_join.cs
@@ -2,52 +2,43 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 1 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 2 } } };
-        var stats = new Func<List<Dictionary<string, dynamic>>>(() =>
-        {
-            var groups = new Dictionary<string, _Group>();
-            var order = new List<string>();
-            foreach (var c in customers)
-            {
-                foreach (var o in orders)
-                {
-                    if (!((o.customerId == c.id))) continue;
-                    var key = c.name;
-                    var ks = Convert.ToString(key);
-                    if (!groups.TryGetValue(ks, out var g))
-                    {
-                        g = new _Group(key);
-                        groups[ks] = g;
-                        order.Add(ks);
-                    }
-                    g.Items.Add(c);
-                }
+class Program {
+    static void Main() {
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<dynamic, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 1 } }, new Dictionary<dynamic, dynamic> { { "id", 102 }, { "customerId", 2 } } };
+        var stats = new Func<List<dynamic>>(() => {
+    var groups = new Dictionary<string, _Group>();
+    var order = new List<string>();
+    foreach (var c in customers) {
+        foreach (var o in orders) {
+            if (!((o.customerId == c.id))) continue;
+            var key = c.name;
+            var ks = Convert.ToString(key);
+            if (!groups.TryGetValue(ks, out var g)) {
+                g = new _Group(key);
+                groups[ks] = g;
+                order.Add(ks);
             }
-            var items = new List<_Group>();
-            foreach (var ks in order) items.Add(groups[ks]);
-            var _res = new List<Dictionary<string, dynamic>>();
-            foreach (var g in items)
-            {
-                _res.Add(new Dictionary<string, dynamic> { { "name", g.key }, { "count", Enumerable.Count(g.Where(r => r["o"]).Select(r => r).ToArray()) } });
-            }
-            return _res;
-        })();
-        Console.WriteLine("--- Group Left Join ---");
-        foreach (var s in stats)
-        {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(s["name"]), Convert.ToString("orders:"), Convert.ToString(s["count"]) }));
+            g.Items.Add(c);
         }
     }
-    public class _Group
-    {
+    var items = new List<_Group>();
+    foreach (var ks in order) items.Add(groups[ks]);
+    var _res = new List<dynamic>();
+    foreach (var g in items) {
+        _res.Add(new Dictionary<dynamic, dynamic> { { "name", g.key }, { "count", Enumerable.Count(g.Where(r => r["o"]).Select(r => r).ToArray()) } });
+    }
+    return _res;
+})();
+        Console.WriteLine("--- Group Left Join ---");
+        foreach (var s in stats) {
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(s.name), Convert.ToString("orders:"), Convert.ToString(s.count) }));
+        }
+    }
+    public class _Group {
         public dynamic key;
         public List<dynamic> Items = new List<dynamic>();
         public _Group(dynamic k) { key = k; }
     }
-
+    
 }

--- a/tests/machine/x/cs/group_by_multi_join.cs
+++ b/tests/machine/x/cs/group_by_multi_join.cs
@@ -2,55 +2,44 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var nations = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "A" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "B" } } };
-        var suppliers = new dynamic[] { new Dictionary<string, long> { { "id", 1 }, { "nation", 1 } }, new Dictionary<string, long> { { "id", 2 }, { "nation", 2 } } };
-        var partsupp = new dynamic[] { new Dictionary<string, dynamic> { { "part", 100 }, { "supplier", 1 }, { "cost", 10.000000 }, { "qty", 2 } }, new Dictionary<string, dynamic> { { "part", 100 }, { "supplier", 2 }, { "cost", 20.000000 }, { "qty", 1 } }, new Dictionary<string, dynamic> { { "part", 200 }, { "supplier", 1 }, { "cost", 5.000000 }, { "qty", 3 } } };
-        var filtered = new Func<List<Dictionary<string, dynamic>>>(() =>
-        {
-            var _res = new List<Dictionary<string, dynamic>>();
-            foreach (var ps in partsupp)
-            {
-                foreach (var s in suppliers)
-                {
-                    if (!((s.id == ps.supplier))) continue;
-                    foreach (var n in nations)
-                    {
-                        if (!((n.id == s.nation))) continue;
-                        if (!((n["name"] == "A"))) continue;
-                        _res.Add(new Dictionary<string, dynamic> { { "part", ps.part }, { "value", (ps.cost * ps.qty) } });
-                    }
-                }
+class Program {
+    static void Main() {
+        var nations = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "A" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "B" } } };
+        var suppliers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "nation", 1 } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "nation", 2 } } };
+        var partsupp = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "part", 100 }, { "supplier", 1 }, { "cost", 10.000000 }, { "qty", 2 } }, new Dictionary<dynamic, dynamic> { { "part", 100 }, { "supplier", 2 }, { "cost", 20.000000 }, { "qty", 1 } }, new Dictionary<dynamic, dynamic> { { "part", 200 }, { "supplier", 1 }, { "cost", 5.000000 }, { "qty", 3 } } };
+        var filtered = new Func<List<dynamic>>(() => {
+    var _res = new List<dynamic>();
+    foreach (var ps in partsupp) {
+        foreach (var s in suppliers) {
+            if (!((s.id == ps.supplier))) continue;
+            foreach (var n in nations) {
+                if (!((n.id == s.nation))) continue;
+                if (!((n["name"] == "A"))) continue;
+                _res.Add(new Dictionary<dynamic, dynamic> { { "part", ps.part }, { "value", (ps.cost * ps.qty) } });
             }
-            return _res;
-        })();
-        var grouped = _group_by(filtered, x => x["part"]).Select(g => new Dictionary<string, dynamic> { { "part", g.Key }, { "total", _sum(g.Items.Select(r => r["value"]).ToArray()) } }).ToList();
+        }
+    }
+    return _res;
+})();
+        var grouped = _group_by(filtered, x => x.part).Select(g => new Dictionary<dynamic, dynamic> { { "part", g.Key }, { "total", _sum(g.Items.Select(r => r.value).ToArray()) } }).ToList();
         Console.WriteLine(JsonSerializer.Serialize(grouped));
     }
-    static double _sum(dynamic v)
-    {
+    static double _sum(dynamic v) {
         if (v == null) return 0.0;
         double _sum = 0;
-        foreach (var it in v)
-        {
+        foreach (var it in v) {
             _sum += Convert.ToDouble(it);
         }
         return _sum;
     }
-
-    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn)
-    {
+    
+    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {
         var groups = new Dictionary<string, _Group>();
         var order = new List<string>();
-        foreach (var it in src)
-        {
+        foreach (var it in src) {
             var key = keyfn(it);
             var ks = Convert.ToString(key);
-            if (!groups.TryGetValue(ks, out var g))
-            {
+            if (!groups.TryGetValue(ks, out var g)) {
                 g = new _Group(key);
                 groups[ks] = g;
                 order.Add(ks);
@@ -61,5 +50,5 @@ class Program
         foreach (var k in order) res.Add(groups[k]);
         return res;
     }
-
+    
 }

--- a/tests/machine/x/cs/group_by_multi_join_sort.cs
+++ b/tests/machine/x/cs/group_by_multi_join_sort.cs
@@ -2,76 +2,63 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var nation = new dynamic[] { new Dictionary<string, dynamic> { { "n_nationkey", 1 }, { "n_name", "BRAZIL" } } };
-        var customer = new dynamic[] { new Dictionary<string, dynamic> { { "c_custkey", 1 }, { "c_name", "Alice" }, { "c_acctbal", 100.000000 }, { "c_nationkey", 1 }, { "c_address", "123 St" }, { "c_phone", "123-456" }, { "c_comment", "Loyal" } } };
-        var orders = new dynamic[] { new Dictionary<string, dynamic> { { "o_orderkey", 1000 }, { "o_custkey", 1 }, { "o_orderdate", "1993-10-15" } }, new Dictionary<string, dynamic> { { "o_orderkey", 2000 }, { "o_custkey", 1 }, { "o_orderdate", "1994-01-02" } } };
-        var lineitem = new dynamic[] { new Dictionary<string, dynamic> { { "l_orderkey", 1000 }, { "l_returnflag", "R" }, { "l_extendedprice", 1000.000000 }, { "l_discount", 0.100000 } }, new Dictionary<string, dynamic> { { "l_orderkey", 2000 }, { "l_returnflag", "N" }, { "l_extendedprice", 500.000000 }, { "l_discount", 0.000000 } } };
+class Program {
+    static void Main() {
+        var nation = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "n_nationkey", 1 }, { "n_name", "BRAZIL" } } };
+        var customer = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "c_custkey", 1 }, { "c_name", "Alice" }, { "c_acctbal", 100.000000 }, { "c_nationkey", 1 }, { "c_address", "123 St" }, { "c_phone", "123-456" }, { "c_comment", "Loyal" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "o_orderkey", 1000 }, { "o_custkey", 1 }, { "o_orderdate", "1993-10-15" } }, new Dictionary<dynamic, dynamic> { { "o_orderkey", 2000 }, { "o_custkey", 1 }, { "o_orderdate", "1994-01-02" } } };
+        var lineitem = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "l_orderkey", 1000 }, { "l_returnflag", "R" }, { "l_extendedprice", 1000.000000 }, { "l_discount", 0.100000 } }, new Dictionary<dynamic, dynamic> { { "l_orderkey", 2000 }, { "l_returnflag", "N" }, { "l_extendedprice", 500.000000 }, { "l_discount", 0.000000 } } };
         string start_date = "1993-10-01";
         string end_date = "1994-01-01";
-        var result = new Func<List<Dictionary<string, dynamic>>>(() =>
-        {
-            var groups = new Dictionary<string, _Group>();
-            var order = new List<string>();
-            foreach (var c in customer)
-            {
-                foreach (var o in orders)
-                {
-                    if (!((o.o_custkey == c.c_custkey))) continue;
-                    foreach (var l in lineitem)
-                    {
-                        if (!((l.l_orderkey == o.o_orderkey))) continue;
-                        if (!((l["l_returnflag"] == "R"))) continue;
-                        foreach (var n in nation)
-                        {
-                            if (!((n.n_nationkey == c.c_nationkey))) continue;
-                            if ((o["o_orderdate"] >= start_date) && (o["o_orderdate"] < end_date))
-                            {
-                                var key = new Dictionary<string, dynamic> { { "c_custkey", c.c_custkey }, { "c_name", c.c_name }, { "c_acctbal", c.c_acctbal }, { "c_address", c.c_address }, { "c_phone", c.c_phone }, { "c_comment", c.c_comment }, { "n_name", n.n_name } };
-                                var ks = Convert.ToString(key);
-                                if (!groups.TryGetValue(ks, out var g))
-                                {
-                                    g = new _Group(key);
-                                    groups[ks] = g;
-                                    order.Add(ks);
-                                }
-                                g.Items.Add(c);
-                            }
+        var result = new Func<List<dynamic>>(() => {
+    var groups = new Dictionary<string, _Group>();
+    var order = new List<string>();
+    foreach (var c in customer) {
+        foreach (var o in orders) {
+            if (!((o.o_custkey == c.c_custkey))) continue;
+            foreach (var l in lineitem) {
+                if (!((l.l_orderkey == o.o_orderkey))) continue;
+                if (!((l["l_returnflag"] == "R"))) continue;
+                foreach (var n in nation) {
+                    if (!((n.n_nationkey == c.c_nationkey))) continue;
+                    if ((o["o_orderdate"] >= start_date) && (o["o_orderdate"] < end_date)) {
+                        var key = new Dictionary<dynamic, dynamic> { { "c_custkey", c.c_custkey }, { "c_name", c.c_name }, { "c_acctbal", c.c_acctbal }, { "c_address", c.c_address }, { "c_phone", c.c_phone }, { "c_comment", c.c_comment }, { "n_name", n.n_name } };
+                        var ks = Convert.ToString(key);
+                        if (!groups.TryGetValue(ks, out var g)) {
+                            g = new _Group(key);
+                            groups[ks] = g;
+                            order.Add(ks);
                         }
+                        g.Items.Add(c);
                     }
                 }
             }
-            var items = new List<_Group>();
-            foreach (var ks in order) items.Add(groups[ks]);
-            items = items.OrderBy(g => (-_sum(g.Select(x => (x["l"]["l_extendedprice"] * ((1 - x["l"]["l_discount"])))).ToArray()))).ToList();
-            var _res = new List<Dictionary<string, dynamic>>();
-            foreach (var g in items)
-            {
-                _res.Add(new Dictionary<string, dynamic> { { "c_custkey", g.key.c_custkey }, { "c_name", g.key.c_name }, { "revenue", _sum(g.Select(x => (x["l"]["l_extendedprice"] * ((1 - x["l"]["l_discount"])))).ToArray()) }, { "c_acctbal", g.key.c_acctbal }, { "n_name", g.key.n_name }, { "c_address", g.key.c_address }, { "c_phone", g.key.c_phone }, { "c_comment", g.key.c_comment } });
-            }
-            return _res;
-        })();
+        }
+    }
+    var items = new List<_Group>();
+    foreach (var ks in order) items.Add(groups[ks]);
+    items = items.OrderBy(g => (-_sum(g.Select(x => (x["l"]["l_extendedprice"] * ((1 - x["l"]["l_discount"])))).ToArray()))).ToList();
+    var _res = new List<dynamic>();
+    foreach (var g in items) {
+        _res.Add(new Dictionary<dynamic, dynamic> { { "c_custkey", g.key.c_custkey }, { "c_name", g.key.c_name }, { "revenue", _sum(g.Select(x => (x["l"]["l_extendedprice"] * ((1 - x["l"]["l_discount"])))).ToArray()) }, { "c_acctbal", g.key.c_acctbal }, { "n_name", g.key.n_name }, { "c_address", g.key.c_address }, { "c_phone", g.key.c_phone }, { "c_comment", g.key.c_comment } });
+    }
+    return _res;
+})();
         Console.WriteLine(JsonSerializer.Serialize(result));
     }
-    static double _sum(dynamic v)
-    {
+    static double _sum(dynamic v) {
         if (v == null) return 0.0;
         double _sum = 0;
-        foreach (var it in v)
-        {
+        foreach (var it in v) {
             _sum += Convert.ToDouble(it);
         }
         return _sum;
     }
-
-    public class _Group
-    {
+    
+    public class _Group {
         public dynamic key;
         public List<dynamic> Items = new List<dynamic>();
         public _Group(dynamic k) { key = k; }
     }
-
+    
 }

--- a/tests/machine/x/cs/group_by_sort.cs
+++ b/tests/machine/x/cs/group_by_sort.cs
@@ -2,35 +2,28 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var items = new dynamic[] { new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 3 } }, new Dictionary<string, dynamic> { { "cat", "a" }, { "val", 1 } }, new Dictionary<string, dynamic> { { "cat", "b" }, { "val", 5 } }, new Dictionary<string, dynamic> { { "cat", "b" }, { "val", 2 } } };
-        var grouped = _group_by(items, i => i.cat).OrderBy(g => (-_sum(g.Items.Select(x => x.val).ToArray()))).Select(g => new Dictionary<string, dynamic> { { "cat", g.Key }, { "total", _sum(g.Items.Select(x => x.val).ToArray()) } }).ToList();
+class Program {
+    static void Main() {
+        var items = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "cat", "a" }, { "val", 3 } }, new Dictionary<dynamic, dynamic> { { "cat", "a" }, { "val", 1 } }, new Dictionary<dynamic, dynamic> { { "cat", "b" }, { "val", 5 } }, new Dictionary<dynamic, dynamic> { { "cat", "b" }, { "val", 2 } } };
+        var grouped = _group_by(items, i => i.cat).OrderBy(g => (-_sum(g.Items.Select(x => x.val).ToArray()))).Select(g => new Dictionary<dynamic, dynamic> { { "cat", g.Key }, { "total", _sum(g.Items.Select(x => x.val).ToArray()) } }).ToList();
         Console.WriteLine(JsonSerializer.Serialize(grouped));
     }
-    static double _sum(dynamic v)
-    {
+    static double _sum(dynamic v) {
         if (v == null) return 0.0;
         double _sum = 0;
-        foreach (var it in v)
-        {
+        foreach (var it in v) {
             _sum += Convert.ToDouble(it);
         }
         return _sum;
     }
-
-    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn)
-    {
+    
+    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {
         var groups = new Dictionary<string, _Group>();
         var order = new List<string>();
-        foreach (var it in src)
-        {
+        foreach (var it in src) {
             var key = keyfn(it);
             var ks = Convert.ToString(key);
-            if (!groups.TryGetValue(ks, out var g))
-            {
+            if (!groups.TryGetValue(ks, out var g)) {
                 g = new _Group(key);
                 groups[ks] = g;
                 order.Add(ks);
@@ -41,5 +34,5 @@ class Program
         foreach (var k in order) res.Add(groups[k]);
         return res;
     }
-
+    
 }

--- a/tests/machine/x/cs/group_items_iteration.cs
+++ b/tests/machine/x/cs/group_items_iteration.cs
@@ -1,21 +1,38 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 
 class Program {
     static void Main() {
-        var data = new dynamic[] { new Dictionary<string, dynamic> { { "tag", "a" }, { "val", 1 } }, new Dictionary<string, dynamic> { { "tag", "a" }, { "val", 2 } }, new Dictionary<string, dynamic> { { "tag", "b" }, { "val", 3 } } };
-        var groups = data.GroupBy(d => d["tag"]).Select(g => g).ToList();
-        var tmp = new dynamic[] { };
+        var data = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "tag", "a" }, { "val", 1 } }, new Dictionary<dynamic, dynamic> { { "tag", "a" }, { "val", 2 } }, new Dictionary<dynamic, dynamic> { { "tag", "b" }, { "val", 3 } } };
+        var groups = _group_by(data, d => d.tag).Select(g => g).ToList();
+        var tmp = new List<dynamic>();
         foreach (var g in groups) {
-            long total = 0;
+            int total = 0;
             foreach (var x in g.Items) {
-                total = (total + x["val"]);
+                total = (total + x.val);
             }
-            tmp = (new Func<List<dynamic>>(() => {var _tmp0=new List<dynamic>(tmp);_tmp0.Add(new Dictionary<string, dynamic> { { "tag", g.Key }, { "total", total } });return _tmp0;}))();
+            tmp = new List<dynamic>(tmp){new Dictionary<dynamic, dynamic> { { "tag", g.Key }, { "total", total } }};
         }
-        var result = tmp.OrderBy(r => r["tag"]).Select(r => r);
+        var result = tmp.OrderBy(r => r["tag"]).Select(r => r).ToArray();
         Console.WriteLine(JsonSerializer.Serialize(result));
     }
+    static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {
+        var groups = new Dictionary<string, _Group>();
+        var order = new List<string>();
+        foreach (var it in src) {
+            var key = keyfn(it);
+            var ks = Convert.ToString(key);
+            if (!groups.TryGetValue(ks, out var g)) {
+                g = new _Group(key);
+                groups[ks] = g;
+                order.Add(ks);
+            }
+            g.Items.Add(it);
+        }
+        var res = new List<_Group>();
+        foreach (var k in order) res.Add(groups[k]);
+        return res;
+    }
+    
 }

--- a/tests/machine/x/cs/if_else.cs
+++ b/tests/machine/x/cs/if_else.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void Main() {
-        long x = 5;
+        int x = 5;
         if (x > 3) {
             Console.WriteLine("big");
         } else {
@@ -10,4 +10,3 @@ class Program {
         }
     }
 }
-

--- a/tests/machine/x/cs/if_then_else.cs
+++ b/tests/machine/x/cs/if_then_else.cs
@@ -2,9 +2,8 @@ using System;
 
 class Program {
     static void Main() {
-        long x = 12;
+        int x = 12;
         string msg = ((x > 10) ? "yes" : "no");
         Console.WriteLine(msg);
     }
 }
-

--- a/tests/machine/x/cs/if_then_else_nested.cs
+++ b/tests/machine/x/cs/if_then_else_nested.cs
@@ -2,9 +2,8 @@ using System;
 
 class Program {
     static void Main() {
-        long x = 8;
+        int x = 8;
         string msg = ((x > 10) ? "big" : ((x > 5) ? "medium" : "small"));
         Console.WriteLine(msg);
     }
 }
-

--- a/tests/machine/x/cs/in_operator.cs
+++ b/tests/machine/x/cs/in_operator.cs
@@ -1,11 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        long[] xs = new long[] { 1, 2, 3 };
+class Program {
+    static void Main() {
+        List<int> xs = new List<int> { 1, 2, 3 };
         Console.WriteLine(xs.Contains(2));
         Console.WriteLine((!(xs.Contains(5))));
     }

--- a/tests/machine/x/cs/in_operator_extended.cs
+++ b/tests/machine/x/cs/in_operator_extended.cs
@@ -2,19 +2,33 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        long[] xs = new long[] { 1, 2, 3 };
-        long[] ys = xs.Where(x => ((x % 2) == 1)).Select(x => x).ToArray();
+class Program {
+    static void Main() {
+        List<int> xs = new List<int> { 1, 2, 3 };
+        List<int> ys = xs.Where(x => ((x % 2) == 1)).Select(x => x).ToArray();
         Console.WriteLine(ys.Contains(1));
         Console.WriteLine(ys.Contains(2));
-        Dictionary<string, long> m = new Dictionary<string, long> { { "a", 1 } };
-        Console.WriteLine(m.ContainsKey("a"));
-        Console.WriteLine(m.ContainsKey("b"));
+        var m = new Dictionary<dynamic, dynamic> { { "a", 1 } };
+        Console.WriteLine(_in("a", m));
+        Console.WriteLine(_in("b", m));
         string s = "hello";
         Console.WriteLine(s.Contains("ell"));
         Console.WriteLine(s.Contains("foo"));
     }
+    static bool _in(dynamic item, dynamic col) {
+        if (col is string s && item is string sub) {
+            return s.Contains(sub);
+        }
+        if (col is System.Collections.IDictionary d) {
+            return d.Contains(item);
+        }
+        if (col is System.Collections.IEnumerable e) {
+            foreach (var it in e) {
+                if (Equals(it, item)) return true;
+            }
+            return false;
+        }
+        return false;
+    }
+    
 }

--- a/tests/machine/x/cs/inner_join.cs
+++ b/tests/machine/x/cs/inner_join.cs
@@ -4,21 +4,12 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } }, new Dictionary<string, long> { { "id", 103 }, { "customerId", 4 }, { "total", 80 } } };
-        var result = new Func<List<Dictionary<string, dynamic>>>(() => {
-    var _res = new List<Dictionary<string, dynamic>>();
-    foreach (var o in orders) {
-        foreach (var c in customers) {
-            if (!((o["customerId"] == c["id"]))) continue;
-            _res.Add(new Dictionary<string, dynamic> { { "orderId", o["id"] }, { "customerName", c["name"] }, { "total", o["total"] } });
-        }
-    }
-    return _res;
-})();
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<dynamic, dynamic> { { "id", 3 }, { "name", "Charlie" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<dynamic, dynamic> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } }, new Dictionary<dynamic, dynamic> { { "id", 103 }, { "customerId", 4 }, { "total", 80 } } };
+        var result = orders.Join(customers, o => o.customerId, c => c.id, (o, c) => new Dictionary<dynamic, dynamic> { { "orderId", o.id }, { "customerName", c.name }, { "total", o.total } }).ToList();
         Console.WriteLine("--- Orders with customer info ---");
         foreach (var entry in result) {
-            Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(entry["orderId"]), Convert.ToString("by"), Convert.ToString(entry["customerName"]), Convert.ToString("- $"), Convert.ToString(entry["total"]) }));
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(entry.orderId), Convert.ToString("by"), Convert.ToString(entry.customerName), Convert.ToString("- $"), Convert.ToString(entry.total) }));
         }
     }
 }

--- a/tests/machine/x/cs/join_multi.cs
+++ b/tests/machine/x/cs/join_multi.cs
@@ -4,17 +4,17 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 } } };
-        var items = new dynamic[] { new Dictionary<string, dynamic> { { "orderId", 100 }, { "sku", "a" } }, new Dictionary<string, dynamic> { { "orderId", 101 }, { "sku", "b" } } };
-        var result = new Func<List<Dictionary<string, dynamic>>>(() => {
-    var _res = new List<Dictionary<string, dynamic>>();
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 2 } } };
+        var items = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "orderId", 100 }, { "sku", "a" } }, new Dictionary<dynamic, dynamic> { { "orderId", 101 }, { "sku", "b" } } };
+        var result = new Func<List<dynamic>>(() => {
+    var _res = new List<dynamic>();
     foreach (var o in orders) {
         foreach (var c in customers) {
-            if (!((o["customerId"] == c["id"]))) continue;
+            if (!((o.customerId == c.id))) continue;
             foreach (var i in items) {
-                if (!((o["id"] == i["orderId"]))) continue;
-                _res.Add(new Dictionary<string, dynamic> { { "name", c["name"] }, { "sku", i["sku"] } });
+                if (!((o.id == i.orderId))) continue;
+                _res.Add(new Dictionary<dynamic, dynamic> { { "name", c.name }, { "sku", i.sku } });
             }
         }
     }
@@ -22,7 +22,7 @@ class Program {
 })();
         Console.WriteLine("--- Multi Join ---");
         foreach (var r in result) {
-            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(r["name"]), Convert.ToString("bought item"), Convert.ToString(r["sku"]) }));
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(r.name), Convert.ToString("bought item"), Convert.ToString(r.sku) }));
         }
     }
 }

--- a/tests/machine/x/cs/json_builtin.cs
+++ b/tests/machine/x/cs/json_builtin.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        Dictionary<string, long> m = new Dictionary<string, long> { { "a", 1 }, { "b", 2 } };
+        var m = new Dictionary<dynamic, dynamic> { { "a", 1 }, { "b", 2 } };
         Console.WriteLine(JsonSerializer.Serialize(m));
     }
 }

--- a/tests/machine/x/cs/left_join.cs
+++ b/tests/machine/x/cs/left_join.cs
@@ -4,27 +4,27 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 3 }, { "total", 80 } } };
-        var result = new Func<List<Dictionary<string, dynamic>>>(() => {
-    var _res = new List<Dictionary<string, dynamic>>();
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 3 }, { "total", 80 } } };
+        var result = new Func<List<dynamic>>(() => {
+    var _res = new List<dynamic>();
     foreach (var o in orders) {
         bool _matched = false;
         foreach (var c in customers) {
-            if (!((o["customerId"] == c["id"]))) continue;
+            if (!((o.customerId == c.id))) continue;
             _matched = true;
-            _res.Add(new Dictionary<string, dynamic> { { "orderId", o["id"] }, { "customer", c }, { "total", o["total"] } });
+            _res.Add(new Dictionary<dynamic, dynamic> { { "orderId", o.id }, { "customer", c }, { "total", o.total } });
         }
         if (!_matched) {
-            Dictionary<string, dynamic> c = default;
-            _res.Add(new Dictionary<string, dynamic> { { "orderId", o["id"] }, { "customer", c }, { "total", o["total"] } });
+            dynamic c = default;
+            _res.Add(new Dictionary<dynamic, dynamic> { { "orderId", o.id }, { "customer", c }, { "total", o.total } });
         }
     }
     return _res;
 })();
         Console.WriteLine("--- Left Join ---");
         foreach (var entry in result) {
-            Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(entry["orderId"]), Convert.ToString("customer"), Convert.ToString(entry["customer"]), Convert.ToString("total"), Convert.ToString(entry["total"]) }));
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(entry.orderId), Convert.ToString("customer"), Convert.ToString(entry.customer), Convert.ToString("total"), Convert.ToString(entry.total) }));
         }
     }
 }

--- a/tests/machine/x/cs/left_join_multi.cs
+++ b/tests/machine/x/cs/left_join_multi.cs
@@ -4,17 +4,17 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 } } };
-        var items = new dynamic[] { new Dictionary<string, dynamic> { { "orderId", 100 }, { "sku", "a" } } };
-        var result = new Func<List<Dictionary<string, dynamic>>>(() => {
-    var _res = new List<Dictionary<string, dynamic>>();
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 2 } } };
+        var items = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "orderId", 100 }, { "sku", "a" } } };
+        var result = new Func<List<dynamic>>(() => {
+    var _res = new List<dynamic>();
     foreach (var o in orders) {
         foreach (var c in customers) {
-            if (!((o["customerId"] == c["id"]))) continue;
+            if (!((o.customerId == c.id))) continue;
             foreach (var i in items) {
-                if (!((o["id"] == i["orderId"]))) continue;
-                _res.Add(new Dictionary<string, dynamic> { { "orderId", o["id"] }, { "name", c["name"] }, { "item", i } });
+                if (!((o.id == i.orderId))) continue;
+                _res.Add(new Dictionary<dynamic, dynamic> { { "orderId", o.id }, { "name", c.name }, { "item", i } });
             }
         }
     }
@@ -22,7 +22,7 @@ class Program {
 })();
         Console.WriteLine("--- Left Join Multi ---");
         foreach (var r in result) {
-            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(r["orderId"]), Convert.ToString(r["name"]), Convert.ToString(r["item"]) }));
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(r.orderId), Convert.ToString(r.name), Convert.ToString(r.item) }));
         }
     }
 }

--- a/tests/machine/x/cs/len_builtin.cs
+++ b/tests/machine/x/cs/len_builtin.cs
@@ -1,9 +1,8 @@
 using System;
+using System.Collections.Generic;
 
-class Program
-{
-    static void Main()
-    {
-        Console.WriteLine(new long[] { 1, 2, 3 }.Length);
+class Program {
+    static void Main() {
+        Console.WriteLine(new List<int> { 1, 2, 3 }.Length);
     }
 }

--- a/tests/machine/x/cs/len_map.cs
+++ b/tests/machine/x/cs/len_map.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 
-class Program
-{
-    static void Main()
-    {
-        Console.WriteLine(new Dictionary<string, long> { { "a", 1 }, { "b", 2 } }.Count);
+class Program {
+    static void Main() {
+        Console.WriteLine(new Dictionary<string, int> { { "a", 1 }, { "b", 2 } }.Count);
     }
 }

--- a/tests/machine/x/cs/len_string.cs
+++ b/tests/machine/x/cs/len_string.cs
@@ -1,9 +1,7 @@
 using System;
 
-class Program
-{
-    static void Main()
-    {
+class Program {
+    static void Main() {
         Console.WriteLine("mochi".Length);
     }
 }

--- a/tests/machine/x/cs/let_and_print.cs
+++ b/tests/machine/x/cs/let_and_print.cs
@@ -1,10 +1,8 @@
 using System;
 
-class Program
-{
-    static void Main()
-    {
-        long a = 10;
+class Program {
+    static void Main() {
+        int a = 10;
         long b = 20;
         Console.WriteLine((a + b));
     }

--- a/tests/machine/x/cs/list_assign.cs
+++ b/tests/machine/x/cs/list_assign.cs
@@ -1,20 +1,18 @@
 using System;
+using System.Collections.Generic;
 
-class Program
-{
-    static void Main()
-    {
-        long[] nums = new long[] { 1, 2 };
+class Program {
+    static void Main() {
+        List<int> nums = new List<int> { 1, 2 };
         nums[1] = 3;
         Console.WriteLine(_indexList(nums, 1));
     }
-    static dynamic _indexList(dynamic l, long i)
-    {
+    static dynamic _indexList(dynamic l, long i) {
         var list = l as System.Collections.IList;
         if (list == null) throw new Exception("index() expects list");
         if (i < 0) i += list.Count;
         if (i < 0 || i >= list.Count) throw new Exception("index out of range");
         return list[(int)i];
     }
-
+    
 }

--- a/tests/machine/x/cs/list_index.cs
+++ b/tests/machine/x/cs/list_index.cs
@@ -1,19 +1,17 @@
 using System;
+using System.Collections.Generic;
 
-class Program
-{
-    static void Main()
-    {
-        long[] xs = new long[] { 10, 20, 30 };
+class Program {
+    static void Main() {
+        List<int> xs = new List<int> { 10, 20, 30 };
         Console.WriteLine(_indexList(xs, 1));
     }
-    static dynamic _indexList(dynamic l, long i)
-    {
+    static dynamic _indexList(dynamic l, long i) {
         var list = l as System.Collections.IList;
         if (list == null) throw new Exception("index() expects list");
         if (i < 0) i += list.Count;
         if (i < 0 || i >= list.Count) throw new Exception("index out of range");
         return list[(int)i];
     }
-
+    
 }

--- a/tests/machine/x/cs/list_nested_assign.cs
+++ b/tests/machine/x/cs/list_nested_assign.cs
@@ -1,20 +1,18 @@
 using System;
+using System.Collections.Generic;
 
-class Program
-{
-    static void Main()
-    {
-        long[][] matrix = new long[][] { new long[] { 1, 2 }, new long[] { 3, 4 } };
+class Program {
+    static void Main() {
+        List<List<int>> matrix = new List<List<int>> { new List<int> { 1, 2 }, new List<int> { 3, 4 } };
         matrix[1][0] = 5;
         Console.WriteLine(_indexList(_indexList(matrix, 1), 0));
     }
-    static dynamic _indexList(dynamic l, long i)
-    {
+    static dynamic _indexList(dynamic l, long i) {
         var list = l as System.Collections.IList;
         if (list == null) throw new Exception("index() expects list");
         if (i < 0) i += list.Count;
         if (i < 0 || i >= list.Count) throw new Exception("index out of range");
         return list[(int)i];
     }
-
+    
 }

--- a/tests/machine/x/cs/list_set_ops.cs
+++ b/tests/machine/x/cs/list_set_ops.cs
@@ -1,13 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        Console.WriteLine(string.Join(" ", Enumerable.Union(new long[] { 1, 2 }, new long[] { 2, 3 }).ToArray()));
-        Console.WriteLine(string.Join(" ", Enumerable.Except(new long[] { 1, 2, 3 }, new long[] { 2 }).ToArray()));
-        Console.WriteLine(string.Join(" ", Enumerable.Intersect(new long[] { 1, 2, 3 }, new long[] { 2, 4 }).ToArray()));
-        Console.WriteLine(Enumerable.Concat(new long[] { 1, 2 }, new long[] { 2, 3 }).ToArray().Length);
+class Program {
+    static void Main() {
+        Console.WriteLine("[" + string.Join(", ", Enumerable.Union(new List<int> { 1, 2 }, new List<int> { 2, 3 }).ToArray()) + "]");
+        Console.WriteLine("[" + string.Join(", ", Enumerable.Except(new List<int> { 1, 2, 3 }, new List<int> { 2 }).ToArray()) + "]");
+        Console.WriteLine("[" + string.Join(", ", Enumerable.Intersect(new List<int> { 1, 2, 3 }, new List<int> { 2, 4 }).ToArray()) + "]");
+        Console.WriteLine(Enumerable.Concat(new List<int> { 1, 2 }, new List<int> { 2, 3 }).ToArray().Length);
     }
 }

--- a/tests/machine/x/cs/load_yaml.cs
+++ b/tests/machine/x/cs/load_yaml.cs
@@ -4,119 +4,100 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 
-public struct Person
-{
+public struct Person {
     public string name;
     public long age;
     public string email;
 }
 
-class Program
-{
-    static void Main()
-    {
-        Person[] people = _load("../interpreter/valid/people.yaml", new Dictionary<string, string> { { "format", "yaml" } }).Select(e => _cast<Person>(e)).ToList();
-        Dictionary<string, string>[] adults = people.Where(p => (p.age >= 18)).Select(p => new Dictionary<string, string> { { "name", p.name }, { "email", p.email } }).ToArray();
-        foreach (var a in adults)
-        {
-            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(a["name"]), Convert.ToString(a["email"]) }));
+class Program {
+    static void Main() {
+        List<Person> people = _load("../interpreter/valid/people.yaml", new Dictionary<dynamic, dynamic> { { "format", "yaml" } }).Select(e => _cast<Person>(e)).ToList();
+        var adults = people.Where(p => (p.age >= 18)).Select(p => new Dictionary<dynamic, dynamic> { { "name", p.name }, { "email", p.email } }).ToArray();
+        foreach (var a in adults) {
+            Console.WriteLine(string.Join(" ", new [] { Convert.ToString(a.name), Convert.ToString(a.email) }));
         }
     }
-    static List<dynamic> _load(string path, Dictionary<string, object> opts)
-    {
+    static List<dynamic> _load(string path, Dictionary<string, object> opts) {
         var format = opts != null && opts.ContainsKey("format") ? Convert.ToString(opts["format"]) : "csv";
         var header = opts != null && opts.ContainsKey("header") ? Convert.ToBoolean(opts["header"]) : true;
         var delim = opts != null && opts.ContainsKey("delimiter") ? Convert.ToString(opts["delimiter"])[0] : ',';
         string text;
-        if (string.IsNullOrEmpty(path) || path == "-")
-        {
+        if (string.IsNullOrEmpty(path) || path == "-") {
             text = Console.In.ReadToEnd();
-        }
-        else
-        {
+        } else {
             text = File.ReadAllText(path);
         }
-        switch (format)
-        {
-            case "jsonl":
-                var list = new List<dynamic>();
-                foreach (var line in text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)) list.Add(JsonSerializer.Deserialize<dynamic>(line));
-                return list;
-            case "json":
-                return JsonSerializer.Deserialize<List<dynamic>>(text);
-            case "yaml":
-                var deser = new DeserializerBuilder().Build();
-                var obj = deser.Deserialize<object>(new StringReader(text));
-                if (obj is IList<object> lst) return lst.Cast<dynamic>().ToList();
-                if (obj is IDictionary<object, object> m)
-                {
-                    var d = new Dictionary<string, object>();
-                    foreach (var kv in m) d[Convert.ToString(kv.Key)] = kv.Value;
-                    return new List<dynamic> { d };
+        switch (format) {
+        case "jsonl":
+            var list = new List<dynamic>();
+            foreach (var line in text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)) list.Add(JsonSerializer.Deserialize<dynamic>(line));
+            return list;
+        case "json":
+            return JsonSerializer.Deserialize<List<dynamic>>(text);
+        case "yaml":
+            var deser = new DeserializerBuilder().Build();
+            var obj = deser.Deserialize<object>(new StringReader(text));
+            if (obj is IList<object> lst) return lst.Cast<dynamic>().ToList();
+            if (obj is IDictionary<object, object> m) {
+                var d = new Dictionary<string, object>();
+                foreach (var kv in m) d[Convert.ToString(kv.Key)] = kv.Value;
+                return new List<dynamic> { d };
+            }
+            return new List<dynamic>();
+        case "tsv":
+            delim = '    '; goto default;
+        default:
+            var lines = text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            var out = new List<dynamic>();
+            string[] headers = null;
+            for (int i = 0; i < lines.Length; i++) {
+                var parts = lines[i].Split(delim);
+                if (i == 0 && header) { headers = parts; continue; }
+                var obj = new Dictionary<string, object>();
+                for (int j = 0; j < parts.Length; j++) {
+                    var key = headers != null && j < headers.Length ? headers[j] : $"col{j}";
+                    obj[key] = parts[j];
                 }
-                return new List<dynamic>();
-            case "tsv":
-                delim = '    '; goto default;
-            default:
-                var lines = text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-                var out = new List<dynamic>();
-                string[] headers = null;
-                for (int i = 0; i < lines.Length; i++)
-                {
-                    var parts = lines[i].Split(delim);
-                    if (i == 0 && header) { headers = parts; continue; }
-                    var obj = new Dictionary<string, object>();
-                    for (int j = 0; j < parts.Length; j++)
-                    {
-                        var key = headers != null && j < headers.Length ? headers[j] : $"col{j}";
-                        obj[key] = parts[j];
-                    }
                 out.Add(obj);
-                }
-                return out;
+            }
+            return out;
         }
     }
-
-    static T _cast<T>(dynamic v)
-    {
+    
+    static T _cast<T>(dynamic v) {
         if (v is T tv) return tv;
-        if (typeof(T) == typeof(long))
-        {
+        if (typeof(T) == typeof(long)) {
             if (v is long) return (T)v;
             if (v is int) return (T)(object)(long)(int)v;
             if (v is double) return (T)(object)(long)(double)v;
             if (v is float) return (T)(object)(long)(float)v;
             if (v is string) return (T)(object)long.Parse((string)v);
         }
-        if (typeof(T) == typeof(double))
-        {
+        if (typeof(T) == typeof(double)) {
             if (v is int) return (T)(object)(double)(int)v;
             if (v is double) return (T)v;
             if (v is float) return (T)(object)(double)(float)v;
             if (v is string) return (T)(object)double.Parse((string)v);
         }
-        if (typeof(T) == typeof(float))
-        {
+        if (typeof(T) == typeof(float)) {
             if (v is int) return (T)(object)(float)(int)v;
             if (v is double) return (T)(object)(float)(double)v;
             if (v is float) return (T)v;
             if (v is string) return (T)(object)float.Parse((string)v);
         }
-        if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Dictionary<,>) && v is System.Collections.IDictionary d)
-        {
+        if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Dictionary<,>) && v is System.Collections.IDictionary d) {
             var args = typeof(T).GetGenericArguments();
             var res = (System.Collections.IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(args));
             var mCast = typeof(Program).GetMethod("_cast");
-            foreach (System.Collections.DictionaryEntry kv in d)
-            {
-                var k = mCast.MakeGenericMethod(args[0]).Invoke(null, new object[] { kv.Key });
-                var val = mCast.MakeGenericMethod(args[1]).Invoke(null, new object[] { kv.Value });
+            foreach (System.Collections.DictionaryEntry kv in d) {
+                var k = mCast.MakeGenericMethod(args[0]).Invoke(null, new object[]{kv.Key});
+                var val = mCast.MakeGenericMethod(args[1]).Invoke(null, new object[]{kv.Value});
                 res.Add(k, val);
             }
             return (T)res;
         }
-        if (v is System.Collections.Generic.IDictionary<object, object> dm)
-        {
+        if (v is System.Collections.Generic.IDictionary<object, object> dm) {
             var m = new Dictionary<string, object>();
             foreach (var kv in dm) m[Convert.ToString(kv.Key)] = kv.Value;
             v = m;
@@ -124,5 +105,5 @@ class Program
         var json = JsonSerializer.Serialize(v);
         return JsonSerializer.Deserialize<T>(json);
     }
-
+    
 }

--- a/tests/machine/x/cs/map_assign.cs
+++ b/tests/machine/x/cs/map_assign.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        Dictionary<string, long> scores = new Dictionary<string, long> { { "alice", 1 } };
+        Dictionary<string, int> scores = new Dictionary<string, int> { { "alice", 1 } };
         scores["bob"] = 2;
         Console.WriteLine(scores["bob"]);
     }

--- a/tests/machine/x/cs/map_in_operator.cs
+++ b/tests/machine/x/cs/map_in_operator.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        Dictionary<long, string> m = new Dictionary<long, string> { { 1, "a" }, { 2, "b" } };
+        Dictionary<int, string> m = new Dictionary<int, string> { { 1, "a" }, { 2, "b" } };
         Console.WriteLine(m.ContainsKey(1));
         Console.WriteLine(m.ContainsKey(3));
     }

--- a/tests/machine/x/cs/map_index.cs
+++ b/tests/machine/x/cs/map_index.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        Dictionary<string, long> m = new Dictionary<string, long> { { "a", 1 }, { "b", 2 } };
+        Dictionary<string, int> m = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
         Console.WriteLine(m["b"]);
     }
 }

--- a/tests/machine/x/cs/map_int_key.cs
+++ b/tests/machine/x/cs/map_int_key.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        Dictionary<long, string> m = new Dictionary<long, string> { { 1, "a" }, { 2, "b" } };
+        Dictionary<int, string> m = new Dictionary<int, string> { { 1, "a" }, { 2, "b" } };
         Console.WriteLine(m[1]);
     }
 }

--- a/tests/machine/x/cs/map_literal_dynamic.cs
+++ b/tests/machine/x/cs/map_literal_dynamic.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        long x = 3;
-        long y = 4;
-        Dictionary<string, long> m = new Dictionary<string, long> { { "a", x }, { "b", y } };
+        int x = 3;
+        int y = 4;
+        Dictionary<string, int> m = new Dictionary<string, int> { { "a", x }, { "b", y } };
         Console.WriteLine(string.Join(" ", new [] { Convert.ToString(m["a"]), Convert.ToString(m["b"]) }));
     }
 }

--- a/tests/machine/x/cs/map_membership.cs
+++ b/tests/machine/x/cs/map_membership.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        Dictionary<string, long> m = new Dictionary<string, long> { { "a", 1 }, { "b", 2 } };
+        Dictionary<string, int> m = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
         Console.WriteLine(m.ContainsKey("a"));
         Console.WriteLine(m.ContainsKey("c"));
     }

--- a/tests/machine/x/cs/map_nested_assign.cs
+++ b/tests/machine/x/cs/map_nested_assign.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 class Program {
     static void Main() {
-        Dictionary<string, Dictionary<string, long>> data = new Dictionary<string, Dictionary<string, long>> { { "outer", new Dictionary<string, long> { { "inner", 1 } } } };
+        Dictionary<string, Dictionary<string, int>> data = new Dictionary<string, Dictionary<string, int>> { { "outer", new Dictionary<string, int> { { "inner", 1 } } } };
         data["outer"]["inner"] = 2;
         Console.WriteLine(data["outer"]["inner"]);
     }

--- a/tests/machine/x/cs/match_expr.cs
+++ b/tests/machine/x/cs/match_expr.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void Main() {
-        long x = 2;
+        int x = 2;
         string label = new Func<string>(() => {
         var _t = x;
         if (_equal(_t, 1)) return "one";

--- a/tests/machine/x/cs/match_full.cs
+++ b/tests/machine/x/cs/match_full.cs
@@ -11,7 +11,7 @@ class Program {
     }
     
     static void Main() {
-        long x = 2;
+        int x = 2;
         string label = new Func<string>(() => {
         var _t = x;
         if (_equal(_t, 1)) return "one";

--- a/tests/machine/x/cs/membership.cs
+++ b/tests/machine/x/cs/membership.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 class Program {
     static void Main() {
-        long[] nums = new long[] { 1, 2, 3 };
+        List<int> nums = new List<int> { 1, 2, 3 };
         Console.WriteLine(nums.Contains(2));
         Console.WriteLine(nums.Contains(4));
     }

--- a/tests/machine/x/cs/min_max_builtin.cs
+++ b/tests/machine/x/cs/min_max_builtin.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 class Program {
     static void Main() {
-        long[] nums = new long[] { 3, 1, 4 };
+        List<int> nums = new List<int> { 3, 1, 4 };
         Console.WriteLine(Enumerable.Min(nums));
         Console.WriteLine(Enumerable.Max(nums));
     }

--- a/tests/machine/x/cs/order_by_map.cs
+++ b/tests/machine/x/cs/order_by_map.cs
@@ -4,8 +4,8 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        var data = new dynamic[] { new Dictionary<string, long> { { "a", 1 }, { "b", 2 } }, new Dictionary<string, long> { { "a", 1 }, { "b", 1 } }, new Dictionary<string, long> { { "a", 0 }, { "b", 5 } } };
-        Dictionary<string, long>[] sorted = data.OrderBy(x => new Dictionary<string, long> { { "a", x["a"] }, { "b", x["b"] } }).Select(x => x).ToArray();
-        Console.WriteLine(string.Join(" ", sorted));
+        var data = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "a", 1 }, { "b", 2 } }, new Dictionary<dynamic, dynamic> { { "a", 1 }, { "b", 1 } }, new Dictionary<dynamic, dynamic> { { "a", 0 }, { "b", 5 } } };
+        var sorted = data.OrderBy(x => new Dictionary<dynamic, dynamic> { { "a", x.a }, { "b", x.b } }).Select(x => x).ToArray();
+        Console.WriteLine(JsonSerializer.Serialize(sorted));
     }
 }

--- a/tests/machine/x/cs/outer_join.cs
+++ b/tests/machine/x/cs/outer_join.cs
@@ -4,32 +4,32 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } }, new Dictionary<string, dynamic> { { "id", 4 }, { "name", "Diana" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } }, new Dictionary<string, long> { { "id", 103 }, { "customerId", 5 }, { "total", 80 } } };
-        var result = new Func<List<Dictionary<string, dynamic>>>(() => {
-    var _res = new List<Dictionary<string, dynamic>>();
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<dynamic, dynamic> { { "id", 3 }, { "name", "Charlie" } }, new Dictionary<dynamic, dynamic> { { "id", 4 }, { "name", "Diana" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<dynamic, dynamic> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } }, new Dictionary<dynamic, dynamic> { { "id", 103 }, { "customerId", 5 }, { "total", 80 } } };
+        var result = new Func<List<dynamic>>(() => {
+    var _res = new List<dynamic>();
     foreach (var o in orders) {
-        var _joinItems = new List<Dictionary<string, dynamic>>(customers);
+        var _joinItems = new List<dynamic>(customers);
         var _matched = new bool[_joinItems.Count];
         foreach (var o in orders) {
             bool _m = false;
             for (int i = 0; i < _joinItems.Count; i++) {
                 var c = _joinItems[i];
-                if (!((o["customerId"] == c["id"]))) continue;
+                if (!((o.customerId == c.id))) continue;
                 _m = true;
                 _matched[i] = true;
-                _res.Add(new Dictionary<string, dynamic> { { "order", o }, { "customer", c } });
+                _res.Add(new Dictionary<dynamic, dynamic> { { "order", o }, { "customer", c } });
             }
             if (!_m) {
-                Dictionary<string, dynamic> c = default;
-                _res.Add(new Dictionary<string, dynamic> { { "order", o }, { "customer", c } });
+                dynamic c = default;
+                _res.Add(new Dictionary<dynamic, dynamic> { { "order", o }, { "customer", c } });
             }
         }
         for (int i = 0; i < _joinItems.Count; i++) {
             if (!_matched[i]) {
-                Dictionary<string, long> o = default;
+                dynamic o = default;
                 var c = _joinItems[i];
-                _res.Add(new Dictionary<string, dynamic> { { "order", o }, { "customer", c } });
+                _res.Add(new Dictionary<dynamic, dynamic> { { "order", o }, { "customer", c } });
             }
         }
     }
@@ -37,14 +37,14 @@ class Program {
 })();
         Console.WriteLine("--- Outer Join using syntax ---");
         foreach (var row in result) {
-            if (row["order"]) {
-                if (row["customer"]) {
-                    Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(row["order"].id), Convert.ToString("by"), Convert.ToString(row["customer"].name), Convert.ToString("- $"), Convert.ToString(row["order"].total) }));
+            if (row.order) {
+                if (row.customer) {
+                    Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(row.order.id), Convert.ToString("by"), Convert.ToString(row.customer.name), Convert.ToString("- $"), Convert.ToString(row.order.total) }));
                 } else {
-                    Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(row["order"].id), Convert.ToString("by"), Convert.ToString("Unknown"), Convert.ToString("- $"), Convert.ToString(row["order"].total) }));
+                    Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Order"), Convert.ToString(row.order.id), Convert.ToString("by"), Convert.ToString("Unknown"), Convert.ToString("- $"), Convert.ToString(row.order.total) }));
                 }
             } else {
-                Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Customer"), Convert.ToString(row["customer"].name), Convert.ToString("has no orders") }));
+                Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Customer"), Convert.ToString(row.customer.name), Convert.ToString("has no orders") }));
             }
         }
     }

--- a/tests/machine/x/cs/partial_application.cs
+++ b/tests/machine/x/cs/partial_application.cs
@@ -1,15 +1,12 @@
 using System;
 
-class Program
-{
-    static long add(long a, long b)
-    {
+class Program {
+    static long add(long a, long b) {
         return (a + b);
     }
-
-    static void Main()
-    {
-        long add5 = new Func<long, long>((long p0) => { return add(5, p0); });
+    
+    static void Main() {
+        int add5 = new Func<int, int>((int p0) => { return add(5, p0); });
         Console.WriteLine(add5(3));
     }
 }

--- a/tests/machine/x/cs/print_hello.cs
+++ b/tests/machine/x/cs/print_hello.cs
@@ -1,9 +1,7 @@
 using System;
 
-class Program
-{
-    static void Main()
-    {
+class Program {
+    static void Main() {
         Console.WriteLine("hello");
     }
 }

--- a/tests/machine/x/cs/pure_global_fold.cs
+++ b/tests/machine/x/cs/pure_global_fold.cs
@@ -6,7 +6,7 @@ class Program {
     }
     
     static void Main() {
-        long k = 2;
+        int k = 2;
         Console.WriteLine(inc(3));
     }
 }

--- a/tests/machine/x/cs/python_auto.cs
+++ b/tests/machine/x/cs/python_auto.cs
@@ -1,7 +1,6 @@
 using System;
 
-static class math
-{
+static class math {
     public const double pi = Math.PI;
     public const double e = Math.E;
     public static double sqrt(double x) { return Math.Sqrt(x); }
@@ -10,10 +9,8 @@ static class math
     public static double log(double x) { return Math.Log(x); }
 }
 
-class Program
-{
-    static void Main()
-    {
+class Program {
+    static void Main() {
         Console.WriteLine(math.sqrt(16.000000));
         Console.WriteLine(math.pi);
     }

--- a/tests/machine/x/cs/python_math.cs
+++ b/tests/machine/x/cs/python_math.cs
@@ -1,7 +1,6 @@
 using System;
 
-static class math
-{
+static class math {
     public const double pi = Math.PI;
     public const double e = Math.E;
     public static double sqrt(double x) { return Math.Sqrt(x); }
@@ -10,18 +9,16 @@ static class math
     public static double log(double x) { return Math.Log(x); }
 }
 
-class Program
-{
-    static void Main()
-    {
+class Program {
+    static void Main() {
         double r = 3.000000;
         double area = (math.pi * math.pow(r, 2.000000));
         double root = math.sqrt(49.000000);
         double sin45 = math.sin((math.pi / 4.000000));
         double log_e = math.log(math.e);
-        Console.WriteLine(string.Join(" ", new[] { Convert.ToString("Circle area with r ="), Convert.ToString(r), Convert.ToString("=>"), Convert.ToString(area) }));
-        Console.WriteLine(string.Join(" ", new[] { Convert.ToString("Square root of 49:"), Convert.ToString(root) }));
-        Console.WriteLine(string.Join(" ", new[] { Convert.ToString("sin(π/4):"), Convert.ToString(sin45) }));
-        Console.WriteLine(string.Join(" ", new[] { Convert.ToString("log(e):"), Convert.ToString(log_e) }));
+        Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Circle area with r ="), Convert.ToString(r), Convert.ToString("=>"), Convert.ToString(area) }));
+        Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Square root of 49:"), Convert.ToString(root) }));
+        Console.WriteLine(string.Join(" ", new [] { Convert.ToString("sin(π/4):"), Convert.ToString(sin45) }));
+        Console.WriteLine(string.Join(" ", new [] { Convert.ToString("log(e):"), Convert.ToString(log_e) }));
     }
 }

--- a/tests/machine/x/cs/query_sum_select.cs
+++ b/tests/machine/x/cs/query_sum_select.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 class Program {
     static void Main() {
-        long[] nums = new long[] { 1, 2, 3 };
-        double[] result = nums.Where(n => (n > 1)).Select(n => _sum(n)).ToArray();
-        Console.WriteLine(result);
+        List<int> nums = new List<int> { 1, 2, 3 };
+        List<int> result = nums.Where(n => (n > 1)).Select(n => _sum(n)).ToArray();
+        Console.WriteLine("[" + string.Join(", ", result) + "]");
     }
     static double _sum(dynamic v) {
         if (v == null) return 0.0;

--- a/tests/machine/x/cs/record_assign.cs
+++ b/tests/machine/x/cs/record_assign.cs
@@ -1,19 +1,15 @@
 using System;
 
-public struct Counter
-{
+public struct Counter {
     public long n;
 }
 
-class Program
-{
-    static void inc(Counter c)
-    {
+class Program {
+    static void inc(Counter c) {
         c.n = (c.n + 1);
     }
-
-    static void Main()
-    {
+    
+    static void Main() {
         Counter c = new Counter { n = 0 };
         inc(c);
         Console.WriteLine(c.n);

--- a/tests/machine/x/cs/right_join.cs
+++ b/tests/machine/x/cs/right_join.cs
@@ -4,21 +4,21 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        var customers = new dynamic[] { new Dictionary<string, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<string, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<string, dynamic> { { "id", 3 }, { "name", "Charlie" } }, new Dictionary<string, dynamic> { { "id", 4 }, { "name", "Diana" } } };
-        var orders = new dynamic[] { new Dictionary<string, long> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<string, long> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<string, long> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } } };
-        var result = new Func<List<Dictionary<string, dynamic>>>(() => {
-    var _res = new List<Dictionary<string, dynamic>>();
+        var customers = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 1 }, { "name", "Alice" } }, new Dictionary<dynamic, dynamic> { { "id", 2 }, { "name", "Bob" } }, new Dictionary<dynamic, dynamic> { { "id", 3 }, { "name", "Charlie" } }, new Dictionary<dynamic, dynamic> { { "id", 4 }, { "name", "Diana" } } };
+        var orders = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "id", 100 }, { "customerId", 1 }, { "total", 250 } }, new Dictionary<dynamic, dynamic> { { "id", 101 }, { "customerId", 2 }, { "total", 125 } }, new Dictionary<dynamic, dynamic> { { "id", 102 }, { "customerId", 1 }, { "total", 300 } } };
+        var result = new Func<List<dynamic>>(() => {
+    var _res = new List<dynamic>();
     foreach (var c in customers) {
         bool _matched = false;
         foreach (var o in orders) {
             foreach (var c in customers) {
-                if (!((o["customerId"] == c["id"]))) continue;
+                if (!((o.customerId == c.id))) continue;
                 _matched = true;
-                _res.Add(new Dictionary<string, dynamic> { { "customerName", c["name"] }, { "order", o } });
+                _res.Add(new Dictionary<dynamic, dynamic> { { "customerName", c.name }, { "order", o } });
             }
             if (!_matched) {
-                Dictionary<string, dynamic> c = default;
-                _res.Add(new Dictionary<string, dynamic> { { "customerName", c["name"] }, { "order", o } });
+                dynamic c = default;
+                _res.Add(new Dictionary<dynamic, dynamic> { { "customerName", c.name }, { "order", o } });
             }
         }
     }
@@ -26,10 +26,10 @@ class Program {
 })();
         Console.WriteLine("--- Right Join using syntax ---");
         foreach (var entry in result) {
-            if (entry["order"]) {
-                Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Customer"), Convert.ToString(entry["customerName"]), Convert.ToString("has order"), Convert.ToString(entry["order"].id), Convert.ToString("- $"), Convert.ToString(entry["order"].total) }));
+            if (entry.order) {
+                Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Customer"), Convert.ToString(entry.customerName), Convert.ToString("has order"), Convert.ToString(entry.order.id), Convert.ToString("- $"), Convert.ToString(entry.order.total) }));
             } else {
-                Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Customer"), Convert.ToString(entry["customerName"]), Convert.ToString("has no orders") }));
+                Console.WriteLine(string.Join(" ", new [] { Convert.ToString("Customer"), Convert.ToString(entry.customerName), Convert.ToString("has no orders") }));
             }
         }
     }

--- a/tests/machine/x/cs/save_jsonl_stdout.cs
+++ b/tests/machine/x/cs/save_jsonl_stdout.cs
@@ -5,8 +5,8 @@ using System.IO;
 
 class Program {
     static void Main() {
-        var people = new dynamic[] { new Dictionary<string, dynamic> { { "name", "Alice" }, { "age", 30 } }, new Dictionary<string, dynamic> { { "name", "Bob" }, { "age", 25 } } };
-        _save(people, "-", new Dictionary<string, string> { { "format", "jsonl" } });
+        var people = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "name", "Alice" }, { "age", 30 } }, new Dictionary<dynamic, dynamic> { { "name", "Bob" }, { "age", 25 } } };
+        _save(people, "-", new Dictionary<dynamic, dynamic> { { "format", "jsonl" } });
     }
     static void _save(dynamic src, string path, Dictionary<string, object> opts) {
         var rows = src as IEnumerable<dynamic>; if (rows == null) return;

--- a/tests/machine/x/cs/slice.cs
+++ b/tests/machine/x/cs/slice.cs
@@ -4,8 +4,8 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        Console.WriteLine(string.Join(" ", _sliceList(new long[] { 1, 2, 3 }, 1, 3)));
-        Console.WriteLine(string.Join(" ", _sliceList(new long[] { 1, 2, 3 }, 0, 2)));
+        Console.WriteLine("[" + string.Join(", ", _sliceList(new List<int> { 1, 2, 3 }, 1, 3)) + "]");
+        Console.WriteLine("[" + string.Join(", ", _sliceList(new List<int> { 1, 2, 3 }, 0, 2)) + "]");
         Console.WriteLine(_sliceString("hello", 1, 4));
     }
     static List<dynamic> _sliceList(dynamic l, long i, long j) {

--- a/tests/machine/x/cs/sort_stable.cs
+++ b/tests/machine/x/cs/sort_stable.cs
@@ -2,12 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program
-{
-    static void Main()
-    {
-        var items = new dynamic[] { new Dictionary<string, dynamic> { { "n", 1 }, { "v", "a" } }, new Dictionary<string, dynamic> { { "n", 1 }, { "v", "b" } }, new Dictionary<string, dynamic> { { "n", 2 }, { "v", "c" } } };
-        var result = items.OrderBy(i => i["n"]).Select(i => i["v"]).ToArray();
-        Console.WriteLine(string.Join(" ", result));
+class Program {
+    static void Main() {
+        var items = new List<dynamic> { new Dictionary<dynamic, dynamic> { { "n", 1 }, { "v", "a" } }, new Dictionary<dynamic, dynamic> { { "n", 1 }, { "v", "b" } }, new Dictionary<dynamic, dynamic> { { "n", 2 }, { "v", "c" } } };
+        List<string> result = items.OrderBy(i => i.n).Select(i => i.v).ToArray();
+        Console.WriteLine("[" + string.Join(", ", result) + "]");
     }
 }

--- a/tests/machine/x/cs/str_builtin.cs
+++ b/tests/machine/x/cs/str_builtin.cs
@@ -1,9 +1,7 @@
 using System;
 
-class Program
-{
-    static void Main()
-    {
+class Program {
+    static void Main() {
         Console.WriteLine(Convert.ToString(123));
     }
 }

--- a/tests/machine/x/cs/sum_builtin.cs
+++ b/tests/machine/x/cs/sum_builtin.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 class Program {
     static void Main() {
-        Console.WriteLine(Enumerable.Sum(new long[] { 1, 2, 3 }.Select(_tmp0=>Convert.ToDouble(_tmp0))));
+        Console.WriteLine(Enumerable.Sum(new List<int> { 1, 2, 3 }.Select(_tmp0=>Convert.ToDouble(_tmp0))));
     }
 }

--- a/tests/machine/x/cs/test_block.cs
+++ b/tests/machine/x/cs/test_block.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void test_addition_works() {
-        long x = (1 + 2);
+        int x = (1 + 2);
         expect((x == 3));
     }
     

--- a/tests/machine/x/cs/two-sum.cs
+++ b/tests/machine/x/cs/two-sum.cs
@@ -1,20 +1,21 @@
 using System;
+using System.Collections.Generic;
 
 class Program {
-    static long[] twoSum(long[] nums, long target) {
-        long n = nums.Length;
+    static List<long> twoSum(List<long> nums, long target) {
+        int n = nums.Length;
         for (var i = 0; i < n; i++) {
             for (var j = (i + 1); j < n; j++) {
                 if ((_indexList(nums, i) + _indexList(nums, j)) == target) {
-                    return new dynamic[] { i, j };
+                    return new List<dynamic> { i, j };
                 }
             }
         }
-        return new long[] { (-1), (-1) };
+        return new List<int> { (-1), (-1) };
     }
     
     static void Main() {
-        long[] result = twoSum(new long[] { 2, 7, 11, 15 }, 9);
+        List<int> result = twoSum(new List<int> { 2, 7, 11, 15 }, 9);
         Console.WriteLine(_indexList(result, 0));
         Console.WriteLine(_indexList(result, 1));
     }

--- a/tests/machine/x/cs/update_stmt.cs
+++ b/tests/machine/x/cs/update_stmt.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 public struct Person {
     public string name;
@@ -8,11 +9,11 @@ public struct Person {
 
 class Program {
     static void test_update_adult_status() {
-        expect((people == new Person[] { new Person { name = "Alice", age = 17, status = "minor" }, new Person { name = "Bob", age = 26, status = "adult" }, new Person { name = "Charlie", age = 19, status = "adult" }, new Person { name = "Diana", age = 16, status = "minor" } }));
+        expect((people == new List<Person> { new Person { name = "Alice", age = 17, status = "minor" }, new Person { name = "Bob", age = 26, status = "adult" }, new Person { name = "Charlie", age = 19, status = "adult" }, new Person { name = "Diana", age = 16, status = "minor" } }));
     }
     
     static void Main() {
-        Person[] people = new Person[] { new Person { name = "Alice", age = 17, status = "minor" }, new Person { name = "Bob", age = 25, status = "unknown" }, new Person { name = "Charlie", age = 18, status = "unknown" }, new Person { name = "Diana", age = 16, status = "minor" } };
+        List<Person> people = new List<Person> { new Person { name = "Alice", age = 17, status = "minor" }, new Person { name = "Bob", age = 25, status = "unknown" }, new Person { name = "Charlie", age = 18, status = "unknown" }, new Person { name = "Diana", age = 16, status = "minor" } };
         for (int _tmp0 = 0; _tmp0 < people.Length; _tmp0++) {
             var _tmp1 = people[_tmp0];
             var name = _tmp1.name;

--- a/tests/machine/x/cs/values_builtin.cs
+++ b/tests/machine/x/cs/values_builtin.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 class Program {
     static void Main() {
-        Dictionary<string, long> m = new Dictionary<string, long> { { "a", 1 }, { "b", 2 }, { "c", 3 } };
-        Console.WriteLine(string.Join(" ", (new Func<List<long>>(() => {var _tmp0=new List<long>();foreach(System.Collections.DictionaryEntry kv in m){_tmp0.Add(kv.Value);}return _tmp0;}))()));
+        Dictionary<string, int> m = new Dictionary<string, int> { { "a", 1 }, { "b", 2 }, { "c", 3 } };
+        Console.WriteLine("[" + string.Join(", ", m.Values.ToList()) + "]");
     }
 }

--- a/tests/machine/x/cs/var_assignment.cs
+++ b/tests/machine/x/cs/var_assignment.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void Main() {
-        long x = 1;
+        int x = 1;
         x = 2;
         Console.WriteLine(x);
     }

--- a/tests/machine/x/cs/while_loop.cs
+++ b/tests/machine/x/cs/while_loop.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void Main() {
-        long i = 0;
+        int i = 0;
         while (i < 3) {
             Console.WriteLine(i);
             i = (i + 1);


### PR DESCRIPTION
## Summary
- map `IntType` to `int` instead of `long`
- regenerate C# machine outputs

## Testing
- `go test -tags=slow ./compiler/x/cs -run TestPlaceholder`

------
https://chatgpt.com/codex/tasks/task_e_6870919463c8832082a254c9dc3665d8