### PR TITLE
Update TypeScript compiler for externs

### DIFF
--- a/compiler/x/typescript/compiler.go
+++ b/compiler/x/typescript/compiler.go
@@ -268,6 +268,9 @@ func (c *Compiler) stmt(s *parser.Statement) error {
 		}
 	case s.Type != nil:
 		return c.typeDecl(s.Type)
+	case s.ExternVar != nil, s.ExternFun != nil, s.ExternObject != nil, s.ExternType != nil:
+		// extern declarations do not affect generated TypeScript code
+		return nil
 	default:
 		return fmt.Errorf("unsupported statement at line %d", s.Pos.Line)
 	}

--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -4,7 +4,7 @@ This directory contains TypeScript code compiled from Mochi programs in `tests/v
 
 ## Progress
 
-Compiled: 99/100 programs
+Compiled: 100/100 programs
 
 ## Checklist
 
@@ -79,7 +79,7 @@ Compiled: 99/100 programs
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
 - [x] python_auto.mochi
-- [ ] python_math.mochi
+- [x] python_math.mochi
 - [x] query_sum_select.mochi
 - [x] record_assign.mochi
 - [x] right_join.mochi

--- a/tests/machine/x/typescript/python_math.out
+++ b/tests/machine/x/typescript/python_math.out
@@ -1,0 +1,4 @@
+Circle area with r = 3 => 28.274333882308138
+Square root of 49: 7
+sin(π/4): 0.7071067811865475
+log(e): 1

--- a/tests/machine/x/typescript/python_math.ts
+++ b/tests/machine/x/typescript/python_math.ts
@@ -1,0 +1,11 @@
+const math = { pi: Math.PI, e: Math.E, sqrt: Math.sqrt, pow: Math.pow, sin: Math.sin, log: Math.log };
+
+const r = 3;
+const area = (math.pi * math.pow(r, 2));
+const root = math.sqrt(49);
+const sin45 = math.sin((math.pi / 4));
+const log_e = math.log(math.e);
+console.log("Circle area with r =", r, "=>", area);
+console.log("Square root of 49:", root);
+console.log("sin(π/4):", sin45);
+console.log("log(e):", log_e);


### PR DESCRIPTION
## Summary
- support extern declarations in the TypeScript compiler
- generate TypeScript for `python_math.mochi`
- update progress in machine README

## Testing
- `go test ./...` *(fails: gcc signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68709440b3cc83208b20e12d44717193