### PR TITLE
Improve Scala code generation

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -45,7 +45,7 @@ Executed successfully: 82/100
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi
 - [x] json_builtin.mochi
-- [ ] left_join.mochi
+ - [x] left_join.mochi
 - [ ] left_join_multi.mochi
 - [x] len_builtin.mochi
 - [x] len_map.mochi
@@ -55,7 +55,7 @@ Executed successfully: 82/100
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
 - [x] list_set_ops.mochi
-- [ ] load_yaml.mochi
+ - [x] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi
@@ -94,7 +94,7 @@ Executed successfully: 82/100
 - [x] tail_recursion.mochi
 - [x] test_block.mochi
 - [x] tree_sum.mochi
-- [ ] two-sum.mochi
+ - [x] two-sum.mochi
 - [x] typed_let.mochi
 - [x] typed_var.mochi
 - [x] unary_neg.mochi

--- a/tests/machine/x/scala/closure.scala
+++ b/tests/machine/x/scala/closure.scala
@@ -1,7 +1,5 @@
 object closure {
-  def makeAdder(n: Int): (Int) => Int = {
-    return (x: Int) => (x).asInstanceOf[Int] + (n).asInstanceOf[Int]
-  }
+  def makeAdder(n: Int): (Int) => Int = (x: Int) => x + n
   
   def main(args: Array[String]): Unit = {
     val add10 = makeAdder(10)

--- a/tests/machine/x/scala/cross_join.scala
+++ b/tests/machine/x/scala/cross_join.scala
@@ -2,7 +2,6 @@ object cross_join {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int, total: Int)
   case class Auto3(orderId: Int, orderCustomerId: Int, pairedCustomerName: String, orderTotal: Int)
-  case class Auto4(orderId: Any, orderCustomerId: Any, pairedCustomerName: Any, orderTotal: Any)
 
   val customers = List[Auto1](Auto1(id = 1, name = "Alice"), Auto1(id = 2, name = "Bob"), Auto1(id = 3, name = "Charlie"))
   val orders = List[Auto2](Auto2(id = 100, customerId = 1, total = 250), Auto2(id = 101, customerId = 2, total = 125), Auto2(id = 102, customerId = 1, total = 300))

--- a/tests/machine/x/scala/cross_join_filter.scala
+++ b/tests/machine/x/scala/cross_join_filter.scala
@@ -1,6 +1,5 @@
 object cross_join_filter {
   case class Auto1(n: Int, l: String)
-  case class Auto2(n: Any, l: Any)
 
   val nums = List[Int](1, 2, 3)
   val letters = List[String]("A", "B")

--- a/tests/machine/x/scala/cross_join_triple.scala
+++ b/tests/machine/x/scala/cross_join_triple.scala
@@ -1,6 +1,5 @@
 object cross_join_triple {
   case class Auto1(n: Int, l: String, b: Boolean)
-  case class Auto2(n: Any, l: Any, b: Any)
 
   val nums = List[Int](1, 2)
   val letters = List[String]("A", "B")

--- a/tests/machine/x/scala/dataset_where_filter.scala
+++ b/tests/machine/x/scala/dataset_where_filter.scala
@@ -1,7 +1,6 @@
 object dataset_where_filter {
   case class Auto1(name: String, age: Int)
   case class Auto2(name: String, age: Int, is_senior: Boolean)
-  case class Auto3(name: Any, age: Any, is_senior: Boolean)
 
   val people = List[Auto1](Auto1(name = "Alice", age = 30), Auto1(name = "Bob", age = 15), Auto1(name = "Charlie", age = 65), Auto1(name = "Diana", age = 45))
   val adults = for { person <- people; if person.age >= 18 } yield Auto2(name = person.name, age = person.age, is_senior = person.age >= 60)

--- a/tests/machine/x/scala/for_loop.scala
+++ b/tests/machine/x/scala/for_loop.scala
@@ -1,6 +1,6 @@
 object for_loop {
   def main(args: Array[String]): Unit = {
-    for(i <- 1 to 4) {
+    for(i <- 1 until 4) {
       println((i))
     }
   }

--- a/tests/machine/x/scala/fun_call.scala
+++ b/tests/machine/x/scala/fun_call.scala
@@ -1,7 +1,5 @@
 object fun_call {
-  def add(a: Int, b: Int): Int = {
-    return (a).asInstanceOf[Int] + (b).asInstanceOf[Int]
-  }
+  def add(a: Int, b: Int): Int = a + b
   
   def main(args: Array[String]): Unit = {
     println((add(2, 3)))

--- a/tests/machine/x/scala/fun_expr_in_let.scala
+++ b/tests/machine/x/scala/fun_expr_in_let.scala
@@ -1,5 +1,5 @@
 object fun_expr_in_let {
-  val square = (x: Int) => (x).asInstanceOf[Int] * (x).asInstanceOf[Int]
+  val square = (x: Int) => x * x
   def main(args: Array[String]): Unit = {
     println((square(6)))
   }

--- a/tests/machine/x/scala/fun_three_args.scala
+++ b/tests/machine/x/scala/fun_three_args.scala
@@ -1,7 +1,5 @@
 object fun_three_args {
-  def sum3(a: Int, b: Int, c: Int): Int = {
-    return ((a).asInstanceOf[Int] + (b).asInstanceOf[Int]).asInstanceOf[Int] + (c).asInstanceOf[Int]
-  }
+  def sum3(a: Int, b: Int, c: Int): Int = (a + b).asInstanceOf[Int] + c
   
   def main(args: Array[String]): Unit = {
     println((sum3(1, 2, 3)))

--- a/tests/machine/x/scala/group_by_conditional_sum.scala
+++ b/tests/machine/x/scala/group_by_conditional_sum.scala
@@ -1,6 +1,6 @@
 object group_by_conditional_sum {
   case class Auto1(cat: String, `val`: Int, flag: Boolean)
-  case class Auto2(cat: Any, share: Double)
+  case class Auto2(cat: String, share: Double)
 
   def _truthy(v: Any): Boolean = v match {
     case null => false

--- a/tests/machine/x/scala/group_by_having.scala
+++ b/tests/machine/x/scala/group_by_having.scala
@@ -1,6 +1,6 @@
 object group_by_having {
   case class Auto1(name: String, city: String)
-  case class Auto2(city: Any, num: Int)
+  case class Auto2(city: String, num: Int)
 
   val people = List[Auto1](Auto1(name = "Alice", city = "Paris"), Auto1(name = "Bob", city = "Hanoi"), Auto1(name = "Charlie", city = "Paris"), Auto1(name = "Diana", city = "Hanoi"), Auto1(name = "Eve", city = "Paris"), Auto1(name = "Frank", city = "Hanoi"), Auto1(name = "George", city = "Paris"))
   val big = (((for { p <- people } yield (p.city, (p))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).filter{ case(gKey,gItems) => { val g = (gKey, gItems); (g._2).size >= 4 } }).map{ case(gKey,gItems) => { val g = (gKey, gItems); Auto2(city = g._1, num = (g._2).size) } }.toList

--- a/tests/machine/x/scala/group_by_join.scala
+++ b/tests/machine/x/scala/group_by_join.scala
@@ -1,7 +1,7 @@
 object group_by_join {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int)
-  case class Auto3(name: Any, count: Int)
+  case class Auto3(name: String, count: Int)
 
   val customers = List[Auto1](Auto1(id = 1, name = "Alice"), Auto1(id = 2, name = "Bob"))
   val orders = List[Auto2](Auto2(id = 100, customerId = 1), Auto2(id = 101, customerId = 1), Auto2(id = 102, customerId = 2))

--- a/tests/machine/x/scala/group_by_left_join.scala
+++ b/tests/machine/x/scala/group_by_left_join.scala
@@ -1,7 +1,7 @@
 object group_by_left_join {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int)
-  case class Auto3(name: Any, count: Int)
+  case class Auto3(name: String, count: Int)
 
   val customers = List[Auto1](Auto1(id = 1, name = "Alice"), Auto1(id = 2, name = "Bob"), Auto1(id = 3, name = "Charlie"))
   val orders = List[Auto2](Auto2(id = 100, customerId = 1), Auto2(id = 101, customerId = 1), Auto2(id = 102, customerId = 2))

--- a/tests/machine/x/scala/group_by_multi_join.scala
+++ b/tests/machine/x/scala/group_by_multi_join.scala
@@ -3,14 +3,13 @@ object group_by_multi_join {
   case class Auto2(id: Int, nation: Int)
   case class Auto3(part: Int, supplier: Int, cost: Double, qty: Int)
   case class Auto4(part: Int, value: Double)
-  case class Auto5(part: Any, value: Any)
-  case class Auto6(part: Any, total: Int)
+  case class Auto5(part: Int, total: Int)
 
   val nations = List[Auto1](Auto1(id = 1, name = "A"), Auto1(id = 2, name = "B"))
   val suppliers = List[Auto2](Auto2(id = 1, nation = 1), Auto2(id = 2, nation = 2))
   val partsupp = List[Auto3](Auto3(part = 100, supplier = 1, cost = 10, qty = 2), Auto3(part = 100, supplier = 2, cost = 20, qty = 1), Auto3(part = 200, supplier = 1, cost = 5, qty = 3))
   val filtered = for { ps <- partsupp; s <- suppliers; if (s.id).asInstanceOf[Int] == ps.supplier; n <- nations; if (n.id).asInstanceOf[Int] == s.nation; if n.name == "A" } yield Auto4(part = ps.part, value = ps.cost * ps.qty)
-  val grouped = ((for { x <- filtered } yield (x.part, (x))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Auto6(part = g._1, total = (for { r <- g._2 } yield r.value).sum) } }.toList
+  val grouped = ((for { x <- filtered } yield (x.part, (x))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Auto5(part = g._1, total = (for { r <- g._2 } yield r.value).sum) } }.toList
   def main(args: Array[String]): Unit = {
     println((grouped))
   }

--- a/tests/machine/x/scala/group_by_multi_join_sort.scala
+++ b/tests/machine/x/scala/group_by_multi_join_sort.scala
@@ -4,7 +4,7 @@ object group_by_multi_join_sort {
   case class Auto3(o_orderkey: Int, o_custkey: Int, o_orderdate: String)
   case class Auto4(l_orderkey: Int, l_returnflag: String, l_extendedprice: Double, l_discount: Double)
   case class Auto5(c_custkey: Int, c_name: String, c_acctbal: Double, c_address: String, c_phone: String, c_comment: String, n_name: String)
-  case class Auto6(c_custkey: Any, c_name: Any, revenue: Int, c_acctbal: Any, n_name: Any, c_address: Any, c_phone: Any, c_comment: Any)
+  case class Auto6(c_custkey: Int, c_name: String, revenue: Int, c_acctbal: Double, n_name: String, c_address: String, c_phone: String, c_comment: String)
 
   val nation = List[Auto1](Auto1(n_nationkey = 1, n_name = "BRAZIL"))
   val customer = List[Auto2](Auto2(c_custkey = 1, c_name = "Alice", c_acctbal = 100, c_nationkey = 1, c_address = "123 St", c_phone = "123-456", c_comment = "Loyal"))

--- a/tests/machine/x/scala/group_by_sort.scala
+++ b/tests/machine/x/scala/group_by_sort.scala
@@ -1,6 +1,6 @@
 object group_by_sort {
   case class Auto1(cat: String, `val`: Int)
-  case class Auto2(cat: Any, total: Int)
+  case class Auto2(cat: String, total: Int)
 
   val items = List[Auto1](Auto1(cat = "a", `val` = 3), Auto1(cat = "a", `val` = 1), Auto1(cat = "b", `val` = 5), Auto1(cat = "b", `val` = 2))
   val grouped = (((for { i <- items } yield (i.cat, (i))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g } yield x.`val`).sum)).map{ case(gKey,gItems) => { val g = (gKey, gItems); Auto2(cat = g._1, total = (for { x <- g._2 } yield x.`val`).sum) } }.toList

--- a/tests/machine/x/scala/group_items_iteration.scala
+++ b/tests/machine/x/scala/group_items_iteration.scala
@@ -1,6 +1,6 @@
 object group_items_iteration {
   case class Auto1(tag: String, `val`: Int)
-  case class Auto2(tag: Any, total: Int)
+  case class Auto2(tag: String, total: Int)
 
   val data = List[Auto1](Auto1(tag = "a", `val` = 1), Auto1(tag = "a", `val` = 2), Auto1(tag = "b", `val` = 3))
   val groups = ((for { d <- data } yield (d.tag, (d))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); g._2 } }.toList

--- a/tests/machine/x/scala/inner_join.scala
+++ b/tests/machine/x/scala/inner_join.scala
@@ -2,7 +2,6 @@ object inner_join {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int, total: Int)
   case class Auto3(orderId: Int, customerName: String, total: Int)
-  case class Auto4(orderId: Any, customerName: Any, total: Any)
 
   val customers = List[Auto1](Auto1(id = 1, name = "Alice"), Auto1(id = 2, name = "Bob"), Auto1(id = 3, name = "Charlie"))
   val orders = List[Auto2](Auto2(id = 100, customerId = 1, total = 250), Auto2(id = 101, customerId = 2, total = 125), Auto2(id = 102, customerId = 1, total = 300), Auto2(id = 103, customerId = 4, total = 80))

--- a/tests/machine/x/scala/join_multi.scala
+++ b/tests/machine/x/scala/join_multi.scala
@@ -3,7 +3,6 @@ object join_multi {
   case class Auto2(id: Int, customerId: Int)
   case class Auto3(orderId: Int, sku: String)
   case class Auto4(name: String, sku: String)
-  case class Auto5(name: Any, sku: Any)
 
   val customers = List[Auto1](Auto1(id = 1, name = "Alice"), Auto1(id = 2, name = "Bob"))
   val orders = List[Auto2](Auto2(id = 100, customerId = 1), Auto2(id = 101, customerId = 2))

--- a/tests/machine/x/scala/left_join.scala
+++ b/tests/machine/x/scala/left_join.scala
@@ -1,8 +1,8 @@
 object left_join {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int, total: Int)
-  case class Auto3(orderId: Int, customer: Auto1, total: Int)
-  case class Auto4(orderId: Any, customer: Any, total: Any)
+  case class Auto3(orderId: Int, customer: Any, total: Int)
+  case class Auto4(orderId: Int, customer: Auto1, total: Int)
 
   val customers = List[Auto1](Auto1(id = 1, name = "Alice"), Auto1(id = 2, name = "Bob"))
   val orders = List[Auto2](Auto2(id = 100, customerId = 1, total = 250), Auto2(id = 101, customerId = 3, total = 80))

--- a/tests/machine/x/scala/left_join_multi.scala
+++ b/tests/machine/x/scala/left_join_multi.scala
@@ -2,8 +2,8 @@ object left_join_multi {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int)
   case class Auto3(orderId: Int, sku: String)
-  case class Auto4(orderId: Int, name: String, item: Auto3)
-  case class Auto5(orderId: Any, name: Any, item: Any)
+  case class Auto4(orderId: Int, name: String, item: Any)
+  case class Auto5(orderId: Int, name: String, item: Auto3)
 
   val customers = List[Auto1](Auto1(id = 1, name = "Alice"), Auto1(id = 2, name = "Bob"))
   val orders = List[Auto2](Auto2(id = 100, customerId = 1), Auto2(id = 101, customerId = 2))

--- a/tests/machine/x/scala/load_yaml.scala
+++ b/tests/machine/x/scala/load_yaml.scala
@@ -2,11 +2,10 @@ case class Person(var name: String, var age: Int, var email: String)
 
 object load_yaml {
   case class Auto1(name: String, email: String)
-  case class Auto2(name: Any, email: Any)
 
   def _load_yaml(path: String): List[Map[String, String]] = { val lines = scala.io.Source.fromFile(path).getLines().toList; lines.grouped(3).flatMap { case List(n,a,e) => Some(Map("name"->n.split(':')(1).trim, "age"->a.split(':')(1).trim, "email"->e.split(':')(1).trim)); case _ => None }.toList }
 
-  val people = _load_yaml("../interpreter/valid/people.yaml")
+  val people = _load_yaml("../interpreter/valid/people.yaml").map(r => Person(name = r("name"), age = r("age").toInt, email = r("email")))
   val adults = for { p <- people; if p.age >= 18 } yield Auto1(name = p.name, email = p.email)
   def main(args: Array[String]): Unit = {
     for(a <- adults) {

--- a/tests/machine/x/scala/match_full.scala
+++ b/tests/machine/x/scala/match_full.scala
@@ -18,12 +18,10 @@ object match_full {
     case true => "confirmed"
     case false => "denied"
   }
-  def classify(n: Int): String = {
-    return n match {
-      case 0 => "zero"
-      case 1 => "one"
-      case _ => "many"
-    }
+  def classify(n: Int): String = n match {
+    case 0 => "zero"
+    case 1 => "one"
+    case _ => "many"
   }
   
   def main(args: Array[String]): Unit = {

--- a/tests/machine/x/scala/nested_function.scala
+++ b/tests/machine/x/scala/nested_function.scala
@@ -1,8 +1,6 @@
 object nested_function {
   def outer(x: Int): Int = {
-    def inner(y: Int): Int = {
-      return (x).asInstanceOf[Int] + (y).asInstanceOf[Int]
-    }
+    def inner(y: Int): Int = x + y
     return inner(5)
   }
   

--- a/tests/machine/x/scala/outer_join.scala
+++ b/tests/machine/x/scala/outer_join.scala
@@ -1,8 +1,8 @@
 object outer_join {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int, total: Int)
-  case class Auto3(order: Auto2, customer: Auto1)
-  case class Auto4(order: Any, customer: Any)
+  case class Auto3(order: Auto2, customer: Any)
+  case class Auto4(order: Auto2, customer: Auto1)
 
   def _truthy(v: Any): Boolean = v match {
     case null => false

--- a/tests/machine/x/scala/partial_application.scala
+++ b/tests/machine/x/scala/partial_application.scala
@@ -1,7 +1,5 @@
 object partial_application {
-  def add(a: Int, b: Int): Int = {
-    return (a).asInstanceOf[Int] + (b).asInstanceOf[Int]
-  }
+  def add(a: Int, b: Int): Int = a + b
   
   def main(args: Array[String]): Unit = {
     val add5 = (p0: Int) => add(5, p0)

--- a/tests/machine/x/scala/pure_fold.scala
+++ b/tests/machine/x/scala/pure_fold.scala
@@ -1,7 +1,5 @@
 object pure_fold {
-  def triple(x: Int): Int = {
-    return (x).asInstanceOf[Int] * 3
-  }
+  def triple(x: Int): Int = x * 3
   
   def main(args: Array[String]): Unit = {
     println((triple(1 + 2)))

--- a/tests/machine/x/scala/pure_global_fold.scala
+++ b/tests/machine/x/scala/pure_global_fold.scala
@@ -1,8 +1,6 @@
 object pure_global_fold {
   val k = 2
-  def inc(x: Int): Int = {
-    return (x).asInstanceOf[Int] + k
-  }
+  def inc(x: Int): Int = x + k
   
   def main(args: Array[String]): Unit = {
     println((inc(3)))

--- a/tests/machine/x/scala/right_join.scala
+++ b/tests/machine/x/scala/right_join.scala
@@ -1,8 +1,8 @@
 object right_join {
   case class Auto1(id: Int, name: String)
   case class Auto2(id: Int, customerId: Int, total: Int)
-  case class Auto3(customerName: String, order: Auto2)
-  case class Auto4(customerName: Any, order: Any)
+  case class Auto3(customerName: String, order: Any)
+  case class Auto4(customerName: String, order: Auto2)
 
   def _truthy(v: Any): Boolean = v match {
     case null => false

--- a/tests/machine/x/scala/tail_recursion.scala
+++ b/tests/machine/x/scala/tail_recursion.scala
@@ -1,9 +1,9 @@
 object tail_recursion {
   def sum_rec(n: Int, acc: Int): Int = {
-    if ((n).asInstanceOf[Int] == 0) {
+    if (n == 0) {
       return acc
     }
-    return sum_rec((n).asInstanceOf[Int] - 1, (acc).asInstanceOf[Int] + (n).asInstanceOf[Int])
+    return sum_rec(n - 1, acc + n)
   }
   
   def main(args: Array[String]): Unit = {

--- a/tests/machine/x/scala/tree_sum.scala
+++ b/tests/machine/x/scala/tree_sum.scala
@@ -3,11 +3,9 @@ case object Leaf extends Tree
 case class Node(left: Tree, value: Int, right: Tree) extends Tree
 
 object tree_sum {
-  def sum_tree(t: Tree): Int = {
-    return t match {
-      case Leaf => 0
-      case Node(left, value, right) => (sum_tree(left) + (value).asInstanceOf[Int]).asInstanceOf[Int] + sum_tree(right)
-    }
+  def sum_tree(t: Tree): Int = t match {
+    case Leaf => 0
+    case Node(left, value, right) => (sum_tree(left) + (value).asInstanceOf[Int]).asInstanceOf[Int] + sum_tree(right)
   }
   
   def main(args: Array[String]): Unit = {

--- a/tests/machine/x/scala/two-sum.scala
+++ b/tests/machine/x/scala/two-sum.scala
@@ -1,10 +1,10 @@
 object two_sum {
   def twoSum(nums: List[Int], target: Int): List[Int] = {
     val n = nums.length
-    for(i <- 0 to n) {
-      for(j <- (i).asInstanceOf[Int] + 1 to n) {
-        if (((nums(i)).asInstanceOf[Int] + (nums(j)).asInstanceOf[Int]).asInstanceOf[Int] == (target).asInstanceOf[Int]) {
-          return List[Any](i, j)
+    for(i <- 0 until n) {
+      for(j <- i + 1 until n) {
+        if ((nums(i) + nums(j)).asInstanceOf[Int] == target) {
+          return List[Int](i, j)
         }
       }
     }


### PR DESCRIPTION
## Summary
- enhance Scala compiler to handle `until` ranges in `for` loops
- generate case class mappings for typed `load` expressions
- support joins with optional records
- regenerate Scala machine translations
- mark several programs as passing in the Scala README

## Testing
- `go build -tags slow ./compiler/x/scala`
- `go test ./...`
- `scalac tests/machine/x/scala/left_join.scala -d /tmp/left_join.jar`
- `scala -cp /tmp/left_join.jar left_join`

------
https://chatgpt.com/codex/tasks/task_e_6870945f99b0832082a9498b531c6411