### PR TITLE
Improve Go compiler variable names

### DIFF
--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -73,11 +73,12 @@ func sanitizeName(name string) string {
 		}
 	}
 	sanitized := b.String()
-	if sanitized == "" || !((sanitized[0] >= 'A' && sanitized[0] <= 'Z') || (sanitized[0] >= 'a' && sanitized[0] <= 'z') || sanitized[0] == '_') {
-		sanitized = "_" + sanitized
+	sanitized = strings.TrimLeft(sanitized, "_")
+	if sanitized == "" || !((sanitized[0] >= 'A' && sanitized[0] <= 'Z') || (sanitized[0] >= 'a' && sanitized[0] <= 'z')) {
+		sanitized = "v" + sanitized
 	}
 	if goReserved[sanitized] || sanitized == "data" {
-		sanitized = "_" + sanitized
+		sanitized = sanitized + "Var"
 	}
 	return sanitized
 }
@@ -382,7 +383,13 @@ func (c *Compiler) eqJoinKeys(e *parser.Expr, leftVar, rightVar string) (string,
 }
 
 func (c *Compiler) newVar() string {
-	name := fmt.Sprintf("_tmp%d", c.tempVarCount)
+	name := fmt.Sprintf("tmp%d", c.tempVarCount)
+	c.tempVarCount++
+	return name
+}
+
+func (c *Compiler) newNamedVar(prefix string) string {
+	name := fmt.Sprintf("%s%d", prefix, c.tempVarCount)
 	c.tempVarCount++
 	return name
 }

--- a/tests/machine/x/go/dataset_sort_take_limit.go
+++ b/tests/machine/x/go/dataset_sort_take_limit.go
@@ -46,18 +46,18 @@ func main() {
 	var expensive []ProductsItem = func() []ProductsItem {
 		src := _toAnySlice(products)
 		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var p ProductsItem
-			if _tmp0 != nil {
-				p = _tmp0.(ProductsItem)
+			if tmp0 != nil {
+				p = tmp0.(ProductsItem)
 			}
 			_ = p
 			return p
 		}, sortKey: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var p ProductsItem
-			if _tmp0 != nil {
-				p = _tmp0.(ProductsItem)
+			if tmp0 != nil {
+				p = tmp0.(ProductsItem)
 			}
 			_ = p
 			return -p.Price

--- a/tests/machine/x/go/exists_builtin.go
+++ b/tests/machine/x/go/exists_builtin.go
@@ -7,10 +7,10 @@ import (
 )
 
 func main() {
-	var _data []int = []int{1, 2}
+	var dataVar []int = []int{1, 2}
 	var flag bool = len(func() []int {
 		_res := []int{}
-		for _, x := range _data {
+		for _, x := range dataVar {
 			if x == 1 {
 				if x == 1 {
 					_res = append(_res, x)

--- a/tests/machine/x/go/group_by_multi_join_sort.error
+++ b/tests/machine/x/go/group_by_multi_join_sort.error
@@ -1,6 +1,5 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_multi_join_sort.go:117:15: cannot use _ as value or type
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:170:105: invalid operation: (float64(1) - (((x).(map[string]any)["l"]).(map[string]any)["l_discount"]).(float64)) (value of type float64) is not an interface
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:206:14: cannot use _sum(func() []any {…}()) (value of type float64) as int value in struct literal
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:209:106: invalid operation: (float64(1) - (((x).(map[string]any)["l"]).(map[string]any)["l_discount"]).(float64)) (value of type float64) is not an interface

--- a/tests/machine/x/go/group_by_multi_join_sort.go
+++ b/tests/machine/x/go/group_by_multi_join_sort.go
@@ -87,7 +87,7 @@ func main() {
 		C_comment any `json:"c_comment"`
 	}
 
-	type _ struct {
+	type v struct {
 		C_custkey int     `json:"c_custkey"`
 		C_name    string  `json:"c_name"`
 		C_acctbal float64 `json:"c_acctbal"`
@@ -114,7 +114,7 @@ func main() {
 							continue
 						}
 						if ((o.O_orderdate >= start_date) && (o.O_orderdate < end_date)) && (l.L_returnflag == "R") {
-							key := _{
+							key := v{
 								C_custkey: c.C_custkey,
 								C_name:    c.C_name,
 								C_acctbal: c.C_acctbal,

--- a/tests/machine/x/go/group_items_iteration.error
+++ b/tests/machine/x/go/group_items_iteration.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
 ../../../tests/machine/x/go/group_items_iteration.go:53:23: x.Val undefined (type any has no field or method Val)
-../../../tests/machine/x/go/group_items_iteration.go:60:21: cannot use _ as value or type
+../../../tests/machine/x/go/group_items_iteration.go:61:11: cannot use g.Key (variable of interface type any) as string value in struct literal: need type assertion
 
 1: //go:build ignore

--- a/tests/machine/x/go/group_items_iteration.go
+++ b/tests/machine/x/go/group_items_iteration.go
@@ -10,25 +10,25 @@ import (
 )
 
 func main() {
-	type _dataItem struct {
+	type DataVarItem struct {
 		Tag string `json:"tag"`
 		Val int    `json:"val"`
 	}
 
-	var _data []_dataItem = []_dataItem{_dataItem{
+	var dataVar []DataVarItem = []DataVarItem{DataVarItem{
 		Tag: "a",
 		Val: 1,
-	}, _dataItem{
+	}, DataVarItem{
 		Tag: "a",
 		Val: 2,
-	}, _dataItem{
+	}, DataVarItem{
 		Tag: "b",
 		Val: 3,
 	}}
 	var groups []*data.Group = func() []*data.Group {
 		groups := map[string]*data.Group{}
 		order := []string{}
-		for _, d := range _data {
+		for _, d := range dataVar {
 			key := d.Tag
 			ks := fmt.Sprint(key)
 			g, ok := groups[ks]
@@ -52,12 +52,12 @@ func main() {
 		for _, x := range g.Items {
 			total = (total + x.Val)
 		}
-		type _ struct {
+		type v struct {
 			Tag   string `json:"tag"`
 			Total int    `json:"total"`
 		}
 
-		tmp = append(tmp, _{
+		tmp = append(tmp, v{
 			Tag:   g.Key,
 			Total: total,
 		})

--- a/tests/machine/x/go/left_join.go
+++ b/tests/machine/x/go/left_join.go
@@ -46,39 +46,39 @@ func main() {
 		src := _toAnySlice(orders)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(customers), on: func(_a ...any) bool {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
-				_tmp1 := _a[1]
+				tmp1 := _a[1]
 				var c CustomersItem
-				if _tmp1 != nil {
-					c = _tmp1.(CustomersItem)
+				if tmp1 != nil {
+					c = tmp1.(CustomersItem)
 				}
 				_ = c
 				return (o.CustomerId == c.Id)
 			}, leftKey: func(_a ...any) any {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
 				return o.CustomerId
 			}, rightKey: func(_v any) any { c := _v.(CustomersItem); _ = c; return c.Id }, left: true},
 		}, _queryOpts{selectFn: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var o OrdersItem
-			if _tmp0 != nil {
-				o = _tmp0.(OrdersItem)
+			if tmp0 != nil {
+				o = tmp0.(OrdersItem)
 			}
 			_ = o
-			_tmp1 := _a[1]
+			tmp1 := _a[1]
 			var c CustomersItem
-			if _tmp1 != nil {
-				c = _tmp1.(CustomersItem)
+			if tmp1 != nil {
+				c = tmp1.(CustomersItem)
 			}
 			_ = c
 			return Result{

--- a/tests/machine/x/go/left_join_multi.go
+++ b/tests/machine/x/go/left_join_multi.go
@@ -53,80 +53,80 @@ func main() {
 		src := _toAnySlice(orders)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(customers), on: func(_a ...any) bool {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
-				_tmp1 := _a[1]
+				tmp1 := _a[1]
 				var c CustomersItem
-				if _tmp1 != nil {
-					c = _tmp1.(CustomersItem)
+				if tmp1 != nil {
+					c = tmp1.(CustomersItem)
 				}
 				_ = c
 				return (o.CustomerId == c.Id)
 			}, leftKey: func(_a ...any) any {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
 				return o.CustomerId
 			}, rightKey: func(_v any) any { c := _v.(CustomersItem); _ = c; return c.Id }},
 			{items: _toAnySlice(items), on: func(_a ...any) bool {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
-				_tmp1 := _a[1]
+				tmp1 := _a[1]
 				var c CustomersItem
-				if _tmp1 != nil {
-					c = _tmp1.(CustomersItem)
+				if tmp1 != nil {
+					c = tmp1.(CustomersItem)
 				}
 				_ = c
-				_tmp2 := _a[2]
+				tmp2 := _a[2]
 				var i ItemsItem
-				if _tmp2 != nil {
-					i = _tmp2.(ItemsItem)
+				if tmp2 != nil {
+					i = tmp2.(ItemsItem)
 				}
 				_ = i
 				return (o.Id == i.OrderId)
 			}, leftKey: func(_a ...any) any {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
-				_tmp1 := _a[1]
+				tmp1 := _a[1]
 				var c CustomersItem
-				if _tmp1 != nil {
-					c = _tmp1.(CustomersItem)
+				if tmp1 != nil {
+					c = tmp1.(CustomersItem)
 				}
 				_ = c
 				return o.Id
 			}, rightKey: func(_v any) any { i := _v.(ItemsItem); _ = i; return i.OrderId }, left: true},
 		}, _queryOpts{selectFn: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var o OrdersItem
-			if _tmp0 != nil {
-				o = _tmp0.(OrdersItem)
+			if tmp0 != nil {
+				o = tmp0.(OrdersItem)
 			}
 			_ = o
-			_tmp1 := _a[1]
+			tmp1 := _a[1]
 			var c CustomersItem
-			if _tmp1 != nil {
-				c = _tmp1.(CustomersItem)
+			if tmp1 != nil {
+				c = tmp1.(CustomersItem)
 			}
 			_ = c
-			_tmp2 := _a[2]
+			tmp2 := _a[2]
 			var i ItemsItem
-			if _tmp2 != nil {
-				i = _tmp2.(ItemsItem)
+			if tmp2 != nil {
+				i = tmp2.(ItemsItem)
 			}
 			_ = i
 			return Result{

--- a/tests/machine/x/go/load_yaml.error
+++ b/tests/machine/x/go/load_yaml.error
@@ -1,6 +1,5 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/load_yaml.go:23:75: cannot use _ as value or type
 ../../../tests/machine/x/go/load_yaml.go:26:13: invalid operation: r (variable of type map[string]any) is not an interface
 
 1: //go:build ignore

--- a/tests/machine/x/go/load_yaml.go
+++ b/tests/machine/x/go/load_yaml.go
@@ -15,12 +15,12 @@ type Person struct {
 }
 
 func main() {
-	type _ struct {
+	type v struct {
 		Format string `json:"format"`
 	}
 
 	var people []Person = func() []Person {
-		rows := _load("../../../tests/interpreter/valid/people.yaml", _toAnyMap(_{Format: "yaml"}))
+		rows := _load("../../../tests/interpreter/valid/people.yaml", _toAnyMap(v{Format: "yaml"}))
 		out := make([]Person, len(rows))
 		for i, r := range rows {
 			out[i] = r.(Person)

--- a/tests/machine/x/go/map_in_operator.go
+++ b/tests/machine/x/go/map_in_operator.go
@@ -8,12 +8,12 @@ import (
 
 func main() {
 	var m map[int]string = map[int]string{1: "a", 2: "b"}
-	_tmp0 := 1
-	_tmp1 := m
-	_, _tmp2 := _tmp1[_tmp0]
-	fmt.Println(_tmp2)
-	_tmp3 := 3
-	_tmp4 := m
-	_, _tmp5 := _tmp4[_tmp3]
-	fmt.Println(_tmp5)
+	key0 := 1
+	m1 := m
+	_, ok2 := m1[key0]
+	fmt.Println(ok2)
+	key3 := 3
+	m4 := m
+	_, ok5 := m4[key3]
+	fmt.Println(ok5)
 }

--- a/tests/machine/x/go/map_nested_assign.error
+++ b/tests/machine/x/go/map_nested_assign.error
@@ -1,2 +1,2 @@
-Error on line 0: compile error: cannot index into type _data
+Error on line 0: compile error: cannot index into type DataVar
 1: var data = {"outer": {"inner": 1}}

--- a/tests/machine/x/go/order_by_map.error
+++ b/tests/machine/x/go/order_by_map.error
@@ -1,5 +1,6 @@
-Error on line 0: run error: exit status 1
-# command-line-arguments
-../../../tests/machine/x/go/order_by_map.go:49:11: cannot use _ as value or type
-
+Error on line 0: output mismatch
+-- got --
+{0 5} {1 1} {1 2}
+-- want --
+map[a:0 b:5] map[a:1 b:1] map[a:1 b:2]
 1: //go:build ignore

--- a/tests/machine/x/go/order_by_map.go
+++ b/tests/machine/x/go/order_by_map.go
@@ -9,51 +9,51 @@ import (
 )
 
 func main() {
-	type _dataItem struct {
+	type DataVarItem struct {
 		A int `json:"a"`
 		B int `json:"b"`
 	}
 
-	var _data []_dataItem = []_dataItem{_dataItem{
+	var dataVar []DataVarItem = []DataVarItem{DataVarItem{
 		A: 1,
 		B: 2,
-	}, _dataItem{
+	}, DataVarItem{
 		A: 1,
 		B: 1,
-	}, _dataItem{
+	}, DataVarItem{
 		A: 0,
 		B: 5,
 	}}
-	type _ struct {
+	type v struct {
 		A int `json:"a"`
 		B int `json:"b"`
 	}
 
-	var sorted []_dataItem = func() []_dataItem {
-		src := _toAnySlice(_data)
+	var sorted []DataVarItem = func() []DataVarItem {
+		src := _toAnySlice(dataVar)
 		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any {
-			_tmp0 := _a[0]
-			var x _dataItem
-			if _tmp0 != nil {
-				x = _tmp0.(_dataItem)
+			tmp0 := _a[0]
+			var x DataVarItem
+			if tmp0 != nil {
+				x = tmp0.(DataVarItem)
 			}
 			_ = x
 			return x
 		}, sortKey: func(_a ...any) any {
-			_tmp0 := _a[0]
-			var x _dataItem
-			if _tmp0 != nil {
-				x = _tmp0.(_dataItem)
+			tmp0 := _a[0]
+			var x DataVarItem
+			if tmp0 != nil {
+				x = tmp0.(DataVarItem)
 			}
 			_ = x
-			return _{
+			return v{
 				A: x.A,
 				B: x.B,
 			}
 		}, skip: -1, take: -1})
-		out := make([]_dataItem, len(resAny))
+		out := make([]DataVarItem, len(resAny))
 		for i, v := range resAny {
-			out[i] = v.(_dataItem)
+			out[i] = v.(DataVarItem)
 		}
 		return out
 	}()

--- a/tests/machine/x/go/outer_join.go
+++ b/tests/machine/x/go/outer_join.go
@@ -71,39 +71,39 @@ func main() {
 		src := _toAnySlice(orders)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(customers), on: func(_a ...any) bool {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
-				_tmp1 := _a[1]
+				tmp1 := _a[1]
 				var c CustomersItem
-				if _tmp1 != nil {
-					c = _tmp1.(CustomersItem)
+				if tmp1 != nil {
+					c = tmp1.(CustomersItem)
 				}
 				_ = c
 				return (o.CustomerId == c.Id)
 			}, leftKey: func(_a ...any) any {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var o OrdersItem
-				if _tmp0 != nil {
-					o = _tmp0.(OrdersItem)
+				if tmp0 != nil {
+					o = tmp0.(OrdersItem)
 				}
 				_ = o
 				return o.CustomerId
 			}, rightKey: func(_v any) any { c := _v.(CustomersItem); _ = c; return c.Id }, left: true, right: true},
 		}, _queryOpts{selectFn: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var o OrdersItem
-			if _tmp0 != nil {
-				o = _tmp0.(OrdersItem)
+			if tmp0 != nil {
+				o = tmp0.(OrdersItem)
 			}
 			_ = o
-			_tmp1 := _a[1]
+			tmp1 := _a[1]
 			var c CustomersItem
-			if _tmp1 != nil {
-				c = _tmp1.(CustomersItem)
+			if tmp1 != nil {
+				c = tmp1.(CustomersItem)
 			}
 			_ = c
 			return Result{

--- a/tests/machine/x/go/right_join.go
+++ b/tests/machine/x/go/right_join.go
@@ -62,39 +62,39 @@ func main() {
 		src := _toAnySlice(customers)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(orders), on: func(_a ...any) bool {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var c CustomersItem
-				if _tmp0 != nil {
-					c = _tmp0.(CustomersItem)
+				if tmp0 != nil {
+					c = tmp0.(CustomersItem)
 				}
 				_ = c
-				_tmp1 := _a[1]
+				tmp1 := _a[1]
 				var o OrdersItem
-				if _tmp1 != nil {
-					o = _tmp1.(OrdersItem)
+				if tmp1 != nil {
+					o = tmp1.(OrdersItem)
 				}
 				_ = o
 				return (o.CustomerId == c.Id)
 			}, leftKey: func(_a ...any) any {
-				_tmp0 := _a[0]
+				tmp0 := _a[0]
 				var c CustomersItem
-				if _tmp0 != nil {
-					c = _tmp0.(CustomersItem)
+				if tmp0 != nil {
+					c = tmp0.(CustomersItem)
 				}
 				_ = c
 				return c.Id
 			}, rightKey: func(_v any) any { o := _v.(OrdersItem); _ = o; return o.CustomerId }, right: true},
 		}, _queryOpts{selectFn: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var c CustomersItem
-			if _tmp0 != nil {
-				c = _tmp0.(CustomersItem)
+			if tmp0 != nil {
+				c = tmp0.(CustomersItem)
 			}
 			_ = c
-			_tmp1 := _a[1]
+			tmp1 := _a[1]
 			var o OrdersItem
-			if _tmp1 != nil {
-				o = _tmp1.(OrdersItem)
+			if tmp1 != nil {
+				o = tmp1.(OrdersItem)
 			}
 			_ = o
 			return Result{

--- a/tests/machine/x/go/save_jsonl_stdout.error
+++ b/tests/machine/x/go/save_jsonl_stdout.error
@@ -1,5 +1,8 @@
-Error on line 0: run error: exit status 1
-# command-line-arguments
-../../../tests/machine/x/go/save_jsonl_stdout.go:29:31: cannot use _ as value or type
-
+Error on line 0: output mismatch
+-- got --
+30,Alice
+25,Bob
+-- want --
+{"age":30,"name":"Alice"}
+{"age":25,"name":"Bob"}
 1: //go:build ignore

--- a/tests/machine/x/go/save_jsonl_stdout.go
+++ b/tests/machine/x/go/save_jsonl_stdout.go
@@ -22,11 +22,11 @@ func main() {
 		Name: "Bob",
 		Age:  25,
 	}}
-	type _ struct {
+	type v struct {
 		Format string `json:"format"`
 	}
 
-	_save(people, "-", _toAnyMap(_{Format: "jsonl"}))
+	_save(people, "-", _toAnyMap(v{Format: "jsonl"}))
 }
 
 func _save(src any, path string, opts map[string]any) {

--- a/tests/machine/x/go/sort_stable.go
+++ b/tests/machine/x/go/sort_stable.go
@@ -27,18 +27,18 @@ func main() {
 	var result []string = func() []string {
 		src := _toAnySlice(items)
 		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var i ItemsItem
-			if _tmp0 != nil {
-				i = _tmp0.(ItemsItem)
+			if tmp0 != nil {
+				i = tmp0.(ItemsItem)
 			}
 			_ = i
 			return i.V
 		}, sortKey: func(_a ...any) any {
-			_tmp0 := _a[0]
+			tmp0 := _a[0]
 			var i ItemsItem
-			if _tmp0 != nil {
-				i = _tmp0.(ItemsItem)
+			if tmp0 != nil {
+				i = tmp0.(ItemsItem)
 			}
 			_ = i
 			return i.N

--- a/tests/machine/x/go/tree_sum.go
+++ b/tests/machine/x/go/tree_sum.go
@@ -27,10 +27,10 @@ func sum_tree(t Tree) int {
 		if _, ok := _t.(Leaf); ok {
 			return 0
 		}
-		if _tmp0, ok := _t.(Node); ok {
-			left := _tmp0.Left
-			value := _tmp0.Value
-			right := _tmp0.Right
+		if tmp0, ok := _t.(Node); ok {
+			left := tmp0.Left
+			value := tmp0.Value
+			right := tmp0.Right
 			return ((sum_tree(left) + value) + sum_tree(right))
 		}
 		return nil

--- a/tests/machine/x/go/update_stmt.go
+++ b/tests/machine/x/go/update_stmt.go
@@ -63,14 +63,14 @@ func main() {
 		Person{Name: "Charlie", Age: 18, Status: "unknown"},
 		Person{Name: "Diana", Age: 16, Status: "minor"},
 	}
-	for _tmp0, _tmp1 := range people {
-		age := _tmp1.Age
+	for i0, v1 := range people {
+		age := v1.Age
 		if !(age >= 18) {
 			continue
 		}
-		_tmp1.Status = "adult"
-		_tmp1.Age = (age + 1)
-		people[_tmp0] = _tmp1
+		v1.Status = "adult"
+		v1.Age = (age + 1)
+		people[i0] = v1
 	}
 	fmt.Println("ok")
 	test_update_adult_status()


### PR DESCRIPTION
## Summary
- tweak Go backend variable naming to avoid leading underscores
- add helper to generate named temp vars
- regenerate machine Go outputs

## Testing
- `go test ./compiler/x/go -run TestGoCompiler_ValidPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687095ddf044832098fc4aab33bd7882