### PR TITLE
Improve C backend constant list handling

### DIFF
--- a/tests/machine/x/c/group_items_iteration.c
+++ b/tests/machine/x/c/group_items_iteration.c
@@ -155,7 +155,8 @@ int main() {
   }
   _t6.len = _t7;
   list_int groups = _t6;
-  list_int _t9 = list_int_create(0);
+  int _t9_data[] = {};
+  list_int _t9 = {0, _t9_data};
   list_int tmp = _t9;
   for (int _t10 = 0; _t10 < groups.len; _t10++) {
     int g = groups.data[_t10];

--- a/tests/machine/x/c/group_items_iteration.error
+++ b/tests/machine/x/c/group_items_iteration.error
@@ -4,39 +4,39 @@ error: cc error: exit status 1
 /workspace/mochi/tests/machine/x/c/group_items_iteration.c:153:21: error: incompatible types when assigning to type ‘int’ from type ‘struct <anonymous>’
   153 |     _t6.data[_t7] = g;
       |                     ^
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:163:32: error: request for member ‘items’ in something not a structure or union
-  163 |     for (int _t11 = 0; _t11 < g.items.len; _t11++) {
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:164:32: error: request for member ‘items’ in something not a structure or union
+  164 |     for (int _t11 = 0; _t11 < g.items.len; _t11++) {
       |                                ^
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:164:21: error: request for member ‘items’ in something not a structure or union
-  164 |       dataItem x = g.items.data[_t11];
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:165:21: error: request for member ‘items’ in something not a structure or union
+  165 |       dataItem x = g.items.data[_t11];
       |                     ^
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:168:37: error: request for member ‘key’ in something not a structure or union
-  168 |     map_int_bool_put(&_t12, "tag", g.key);
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:169:37: error: request for member ‘key’ in something not a structure or union
+  169 |     map_int_bool_put(&_t12, "tag", g.key);
       |                                     ^
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:168:29: warning: passing argument 2 of ‘map_int_bool_put’ makes integer from pointer without a cast [-Wint-conversion]
-  168 |     map_int_bool_put(&_t12, "tag", g.key);
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:169:29: warning: passing argument 2 of ‘map_int_bool_put’ makes integer from pointer without a cast [-Wint-conversion]
+  169 |     map_int_bool_put(&_t12, "tag", g.key);
       |                             ^~~~~
       |                             |
       |                             char *
 /workspace/mochi/tests/machine/x/c/group_items_iteration.c:49:51: note: expected ‘int’ but argument is of type ‘char *’
    49 | static void map_int_bool_put(map_int_bool *m, int key, int value) {
       |                                               ~~~~^~~
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:169:29: warning: passing argument 2 of ‘map_int_bool_put’ makes integer from pointer without a cast [-Wint-conversion]
-  169 |     map_int_bool_put(&_t12, "total", total);
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:170:29: warning: passing argument 2 of ‘map_int_bool_put’ makes integer from pointer without a cast [-Wint-conversion]
+  170 |     map_int_bool_put(&_t12, "total", total);
       |                             ^~~~~~~
       |                             |
       |                             char *
 /workspace/mochi/tests/machine/x/c/group_items_iteration.c:49:51: note: expected ‘int’ but argument is of type ‘char *’
    49 | static void map_int_bool_put(map_int_bool *m, int key, int value) {
       |                                               ~~~~^~~
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:170:11: error: incompatible types when assigning to type ‘list_int’ from type ‘int’
-  170 |     tmp = 0;
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:171:11: error: incompatible types when assigning to type ‘list_int’ from type ‘int’
+  171 |     tmp = 0;
       |           ^
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:178:19: error: request for member ‘tag’ in something not a structure or union
-  178 |     _t16[_t14] = r.tag;
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:179:19: error: request for member ‘tag’ in something not a structure or union
+  179 |     _t16[_t14] = r.tag;
       |                   ^
-/workspace/mochi/tests/machine/x/c/group_items_iteration.c:195:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘list_int’ [-Wformat=]
-  195 |   printf("%d\n", result);
+/workspace/mochi/tests/machine/x/c/group_items_iteration.c:196:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘list_int’ [-Wformat=]
+  196 |   printf("%d\n", result);
       |           ~^     ~~~~~~
       |            |     |
       |            int   list_int

--- a/tests/machine/x/c/len_builtin.c
+++ b/tests/machine/x/c/len_builtin.c
@@ -1,19 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef struct {
-  int len;
-  int *data;
-} list_int;
-static list_int list_int_create(int len) {
-  list_int l;
-  l.len = len;
-  l.data = (int *)malloc(sizeof(int) * len);
-  return l;
-}
 int main() {
-  int _t1_data[] = {1, 2, 3};
-  list_int _t1 = {3, _t1_data};
-  printf("%d\n", _t1.len);
+  printf("%d\n", 3);
   return 0;
 }

--- a/tests/machine/x/c/list_set_ops.c
+++ b/tests/machine/x/c/list_set_ops.c
@@ -21,80 +21,6 @@ static list_list_int list_list_int_create(int len) {
   l.data = (list_int *)malloc(sizeof(list_int) * len);
   return l;
 }
-static list_int concat_list_int(list_int a, list_int b) {
-  list_int r = list_int_create(a.len + b.len);
-  for (int i = 0; i < a.len; i++)
-    r.data[i] = a.data[i];
-  for (int i = 0; i < b.len; i++)
-    r.data[a.len + i] = b.data[i];
-  return r;
-}
-static list_int union_list_int(list_int a, list_int b) {
-  list_int r = list_int_create(a.len + b.len);
-  int idx = 0;
-  for (int i = 0; i < a.len; i++) {
-    int found = 0;
-    for (int j = 0; j < idx; j++)
-      if (r.data[j] == a.data[i]) {
-        found = 1;
-        break;
-      }
-    if (!found)
-      r.data[idx++] = a.data[i];
-  }
-  for (int i = 0; i < b.len; i++) {
-    int found = 0;
-    for (int j = 0; j < idx; j++)
-      if (r.data[j] == b.data[i]) {
-        found = 1;
-        break;
-      }
-    if (!found)
-      r.data[idx++] = b.data[i];
-  }
-  r.len = idx;
-  return r;
-}
-static list_int except_list_int(list_int a, list_int b) {
-  list_int r = list_int_create(a.len);
-  int idx = 0;
-  for (int i = 0; i < a.len; i++) {
-    int found = 0;
-    for (int j = 0; j < b.len; j++)
-      if (a.data[i] == b.data[j]) {
-        found = 1;
-        break;
-      }
-    if (!found)
-      r.data[idx++] = a.data[i];
-  }
-  r.len = idx;
-  return r;
-}
-static list_int intersect_list_int(list_int a, list_int b) {
-  list_int r = list_int_create(a.len);
-  int idx = 0;
-  for (int i = 0; i < a.len; i++) {
-    int found = 0;
-    for (int j = 0; j < b.len; j++)
-      if (a.data[i] == b.data[j]) {
-        found = 1;
-        break;
-      }
-    if (found) {
-      int dup = 0;
-      for (int j = 0; j < idx; j++)
-        if (r.data[j] == a.data[i]) {
-          dup = 1;
-          break;
-        }
-      if (!dup)
-        r.data[idx++] = a.data[i];
-    }
-  }
-  r.len = idx;
-  return r;
-}
 static void _print_list_int(list_int v) {
   for (int i = 0; i < v.len; i++) {
     if (i > 0)
@@ -103,32 +29,18 @@ static void _print_list_int(list_int v) {
   }
 }
 int main() {
-  int _t1_data[] = {1, 2};
-  list_int _t1 = {2, _t1_data};
-  int _t2_data[] = {2, 3};
+  int _t1_data[] = {1, 2, 3};
+  list_int _t1 = {3, _t1_data};
+  _print_list_int(_t1);
+  printf("\n");
+  int _t2_data[] = {1, 3};
   list_int _t2 = {2, _t2_data};
-  list_int _t3 = union_list_int(_t1, _t2);
+  _print_list_int(_t2);
+  printf("\n");
+  int _t3_data[] = {2};
+  list_int _t3 = {1, _t3_data};
   _print_list_int(_t3);
   printf("\n");
-  int _t4_data[] = {1, 2, 3};
-  list_int _t4 = {3, _t4_data};
-  int _t5_data[] = {2};
-  list_int _t5 = {1, _t5_data};
-  list_int _t6 = except_list_int(_t4, _t5);
-  _print_list_int(_t6);
-  printf("\n");
-  int _t7_data[] = {1, 2, 3};
-  list_int _t7 = {3, _t7_data};
-  int _t8_data[] = {2, 4};
-  list_int _t8 = {2, _t8_data};
-  list_int _t9 = intersect_list_int(_t7, _t8);
-  _print_list_int(_t9);
-  printf("\n");
-  int _t10_data[] = {1, 2};
-  list_int _t10 = {2, _t10_data};
-  int _t11_data[] = {2, 3};
-  list_int _t11 = {2, _t11_data};
-  list_int _t12 = concat_list_int(_t10, _t11);
-  printf("%d\n", _t12.len);
+  printf("%d\n", 4);
   return 0;
 }

--- a/tests/machine/x/c/match_full.error
+++ b/tests/machine/x/c/match_full.error
@@ -2,8 +2,8 @@ line: 0
 error: output mismatch
 -- got --
 two
--471719888
--471719848
+-191868880
+-191868840
 zero
 many
 -- want --


### PR DESCRIPTION
## Summary
- fold constant list operations at compile time in the C backend
- emit preallocated arrays instead of runtime helpers for simple `len` and set ops
- update generated C for affected machine tests

## Testing
- `go test ./compiler/x/c -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68709676553c8320a3d2ab2b091f7e71