### PR TITLE
Improve C++ type inference

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -2825,6 +2825,10 @@ func (c *Compiler) compileType(t *parser.TypeRef) (string, error) {
 }
 
 func (c *Compiler) inferType(expr string) string {
+	trimmed := strings.TrimSpace(expr)
+	for len(trimmed) > 1 && trimmed[0] == '(' && trimmed[len(trimmed)-1] == ')' {
+		trimmed = strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	}
 	if strings.HasPrefix(expr, "std::string") {
 		return "string"
 	}
@@ -2836,7 +2840,6 @@ func (c *Compiler) inferType(expr string) string {
 			return "vector"
 		}
 	}
-	trimmed := strings.TrimSpace(expr)
 	if trimmed != "" {
 		if trimmed[0] >= '0' && trimmed[0] <= '9' {
 			if strings.Contains(trimmed, ".") {

--- a/tests/machine/x/cpp/basic_compare.cpp
+++ b/tests/machine/x/cpp/basic_compare.cpp
@@ -3,7 +3,7 @@
 int main() {
   auto a = (10 - 3);
   auto b = (2 + 2);
-  std::cout << std::boolalpha << a << std::endl;
+  std::cout << a << std::endl;
   std::cout << std::boolalpha << (a == 7) << std::endl;
   std::cout << std::boolalpha << (b < 5) << std::endl;
   return 0;

--- a/tests/machine/x/cpp/binary_precedence.cpp
+++ b/tests/machine/x/cpp/binary_precedence.cpp
@@ -1,9 +1,9 @@
 #include <iostream>
 
 int main() {
-  std::cout << std::boolalpha << (1 + (2 * 3)) << std::endl;
+  std::cout << (1 + (2 * 3)) << std::endl;
   std::cout << std::boolalpha << (((1 + 2)) * 3) << std::endl;
   std::cout << std::boolalpha << ((2 * 3) + 1) << std::endl;
-  std::cout << std::boolalpha << (2 * ((3 + 1))) << std::endl;
+  std::cout << (2 * ((3 + 1))) << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/group_items_iteration.error
+++ b/tests/machine/x/cpp/group_items_iteration.error
@@ -1,0 +1,219 @@
+line 8: ../../../tests/machine/x/cpp/group_items_iteration.cpp:8:12: error: ‘g’ was not declared in this scope
+    8 |   decltype(g.key) tag;
+      |            ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:8:12: error: ‘g’ was not declared in this scope
+../../../tests/machine/x/cpp/group_items_iteration.cpp:9:12: error: ‘total’ was not declared in this scope
+    9 |   decltype(total) total;
+      |            ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:9:12: error: ‘total’ was not declared in this scope
+../../../tests/machine/x/cpp/group_items_iteration.cpp:23:1: error: ‘st’ does not name a type
+   23 | st __struct2 &b){ return a.key==b.key && a.items==b.items; }
+      | ^~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:24:30: error: ‘__struct2’ does not name a type; did you mean ‘__struct3’?
+   24 | inline bool operator!=(const __struct2 &a, const __struct2 &b) {
+      |                              ^~~~~~~~~
+      |                              __struct3
+../../../tests/machine/x/cpp/group_items_iteration.cpp:24:50: error: ‘__struct2’ does not name a type; did you mean ‘__struct3’?
+   24 | inline bool operator!=(const __struct2 &a, const __struct2 &b) {
+      |                                                  ^~~~~~~~~
+      |                                                  __struct3
+../../../tests/machine/x/cpp/group_items_iteration.cpp:24:13: error: ‘bool operator!=(const int&, const int&)’ must have an argument of class or enumerated type
+   24 | inline bool operator!=(const __struct2 &a, const __struct2 &b) {
+      |             ^~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:28:16: error: redefinition of ‘template<class T, class U> std::vector<T> __append(const std::vector<T>&, const U&)’
+   28 | std::vector<T> __append(const std::vector<T> &v, const U &x) {
+      |                ^~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:18:16: note: ‘template<class T, class U> std::vector<T> __append(const std::vector<T>&, const U&)’ previously declared here
+   18 | std::vector<T> __append(const std::vector<T> &v, const U &x) {
+      |                ^~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In function ‘int main()’:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:34:15: error: ‘__struct1’ was not declared in this scope; did you mean ‘__struct3’?
+   34 |   std::vector<__struct1> data =
+      |               ^~~~~~~~~
+      |               __struct3
+../../../tests/machine/x/cpp/group_items_iteration.cpp:34:24: error: template argument 1 is invalid
+   34 |   std::vector<__struct1> data =
+      |                        ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:34:24: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/group_items_iteration.cpp:35:37: error: expected ‘)’ before ‘{’ token
+   35 |       std::vector<decltype(__struct1{std::string("a"), 1})>{
+      |                           ~         ^
+      |                                     )
+../../../tests/machine/x/cpp/group_items_iteration.cpp:35:59: error: template argument 1 is invalid
+   35 |       std::vector<decltype(__struct1{std::string("a"), 1})>{
+      |                                                           ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:35:59: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In lambda function:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:39:17: error: ‘__struct2’ was not declared in this scope; did you mean ‘__struct3’?
+   39 |     std::vector<__struct2> __groups;
+      |                 ^~~~~~~~~
+      |                 __struct3
+../../../tests/machine/x/cpp/group_items_iteration.cpp:39:26: error: template argument 1 is invalid
+   39 |     std::vector<__struct2> __groups;
+      |                          ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:39:26: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/group_items_iteration.cpp:40:19: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+   40 |     for (auto d : data) {
+      |                   ^~~~
+      |                   std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from ../../../tests/machine/x/cpp/group_items_iteration.cpp:2:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:40:19: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+   40 |     for (auto d : data) {
+      |                   ^~~~
+      |                   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:43:24: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+   43 |       for (auto &__g : __groups) {
+      |                        ^~~~~~~~
+      |                        std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:43:24: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+   43 |       for (auto &__g : __groups) {
+      |                        ^~~~~~~~
+      |                        std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:51:18: error: request for member ‘push_back’ in ‘__groups’, which is of non-class type ‘int’
+   51 |         __groups.push_back(
+      |                  ^~~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:52:22: error: expected ‘)’ before ‘{’ token
+   52 |             __struct2{__key, std::vector<__struct1>{__struct1{d}}});
+      |                      ^
+      |                      )
+../../../tests/machine/x/cpp/group_items_iteration.cpp:51:27: note: to match this ‘(’
+   51 |         __groups.push_back(
+      |                           ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:55:26: error: template argument 2 is invalid
+   55 |     std::vector<__struct2> __items;
+      |                          ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:56:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+   56 |     for (auto &g : __groups) {
+      |                    ^~~~~~~~
+      |                    std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:56:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+   56 |     for (auto &g : __groups) {
+      |                    ^~~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:57:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   57 |       __items.push_back(g);
+      |               ^~~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In function ‘int main()’:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:61:15: error: ‘__tmp_type’ was not declared in this scope
+   61 |   std::vector<__tmp_type> tmp = std::vector<__tmp_type>{};
+      |               ^~~~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:61:25: error: template argument 1 is invalid
+   61 |   std::vector<__tmp_type> tmp = std::vector<__tmp_type>{};
+      |                         ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:61:25: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/group_items_iteration.cpp:61:55: error: template argument 2 is invalid
+   61 |   std::vector<__tmp_type> tmp = std::vector<__tmp_type>{};
+      |                                                       ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:62:17: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+   62 |   for (auto g : groups) {
+      |                 ^~~~~~
+      |                 std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:62:17: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+   62 |   for (auto g : groups) {
+      |                 ^~~~~~
+      |                 std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In lambda function:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:70:36: error: ‘r’ was not declared in this scope
+   70 |     std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
+      |                                    ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:70:44: error: template argument 1 is invalid
+   70 |     std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
+      |                                            ^~~~~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:70:44: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/group_items_iteration.cpp:70:55: error: template argument 1 is invalid
+   70 |     std::vector<std::pair<decltype(r.tag), decltype(r)>> __items;
+      |                                                       ^~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:70:55: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/group_items_iteration.cpp:71:19: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+   71 |     for (auto r : tmp) {
+      |                   ^~~
+      |                   std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:71:19: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+   71 |     for (auto r : tmp) {
+      |                   ^~~
+      |                   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:72:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   72 |       __items.push_back({r.tag, r});
+      |               ^~~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:74:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+   74 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:74:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+   74 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:76:28: error: template argument 1 is invalid
+   76 |     std::vector<decltype(r)> __res;
+      |                            ^
+../../../tests/machine/x/cpp/group_items_iteration.cpp:76:28: error: template argument 2 is invalid
+../../../tests/machine/x/cpp/group_items_iteration.cpp:77:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+   77 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:77:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+   77 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:78:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
+   78 |       __res.push_back(p.second);
+      |             ^~~~~~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In function ‘int main()’:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:84:27: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+   84 |     for (const auto &_x : __tmp1) {
+      |                           ^~~~~~
+      |                           std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:84:27: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+   84 |     for (const auto &_x : __tmp1) {
+      |                           ^~~~~~
+      |                           std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+
+  7 | struct __struct3 {
+  8 |   decltype(g.key) tag;
+  9 |   decltype(total) total;

--- a/tests/machine/x/cpp/math_ops.cpp
+++ b/tests/machine/x/cpp/math_ops.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
 int main() {
-  std::cout << std::boolalpha << (6 * 7) << std::endl;
-  std::cout << std::boolalpha << (7 / 2) << std::endl;
-  std::cout << std::boolalpha << (7 % 2) << std::endl;
+  std::cout << (6 * 7) << std::endl;
+  std::cout << (7 / 2) << std::endl;
+  std::cout << (7 % 2) << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/unary_neg.cpp
+++ b/tests/machine/x/cpp/unary_neg.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 int main() {
-  std::cout << std::boolalpha << (-3) << std::endl;
-  std::cout << std::boolalpha << (5 + ((-2))) << std::endl;
+  std::cout << (-3) << std::endl;
+  std::cout << (5 + ((-2))) << std::endl;
   return 0;
 }


### PR DESCRIPTION
## Summary
- enhance C++ compiler type inference by stripping outer parentheses
- regenerate C++ machine outputs
- include new compilation error log

## Testing
- `go test ./compiler/x/cpp -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687097092724832085a632e5452f0872