### PR TITLE
Improve Scala compiler struct naming

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -1,6 +1,6 @@
 # Scala Machine Translations
 
-This directory contains Scala code generated from the Mochi programs in `tests/vm/valid` using the Scala compiler. Each program was compiled with `scalac`. Successful runs produced an `.out` file while failures produced an `.error` file. The compiler infers element types for lists and maps and emits `case class` definitions whenever possible. Group-by queries now preserve the key type when generating case classes, and complex query results are converted into case classes instead of raw `Map` objects. Function parameters are now tracked in the type environment so simple functions can be rendered as single-expression methods without casts.
+This directory contains Scala code generated from the Mochi programs in `tests/vm/valid` using the Scala compiler. Each program was compiled with `scalac`. Successful runs produced an `.out` file while failures produced an `.error` file. The compiler infers element types for lists and maps and emits `case class` definitions whenever possible. Case class names are now derived from the assigned variable for more readable code. Group-by queries now preserve the key type when generating case classes, and complex query results are converted into case classes instead of raw `Map` objects. Function parameters are now tracked in the type environment so simple functions can be rendered as single-expression methods without casts.
 
 Compiled programs: 100/100
 Executed successfully: 82/100


### PR DESCRIPTION
## Summary
- tweak Scala compiler to derive case class names from the assigned variable
- record struct name hint during let/var compilation
- document the new behaviour in the Scala machine README

## Testing
- `go test ./compiler/x/scala -run TestScalaCompilerMachine/append_builtin -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6870976997508320820cfa5f8c3eacf1