### PR TITLE
Improve Zig compiler struct handling

### DIFF
--- a/tests/machine/x/zig/record_assign.zig
+++ b/tests/machine/x/zig/record_assign.zig
@@ -6,11 +6,11 @@ const Counter = struct {
 
 var c = Counter{ .n = 0 };
 
-fn inc(c: Counter) void {
-    c = (c.n + 1);
+fn inc(c: *Counter) void {
+    c.n = (c.n + 1);
 }
 
 pub fn main() void {
-    inc(c);
+    inc(&c);
     std.debug.print("{d}\n", .{c.n});
 }


### PR DESCRIPTION
## Summary
- support pointer params when structs are passed to Zig functions
- keep track of pointer variables inside the Zig compiler
- handle field assignment expressions
- update generated Zig code for `record_assign`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68709c05b51483208e57bbc0cb15e99b