### PR TITLE
Improve C# query result typing

### DIFF
--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -109,3 +109,4 @@ Checklist:
 
 ## Remaining work
 - [x] Improve automatic class generation for complex nested structures
+- [ ] Refine struct field type inference to remove remaining dynamic fields


### PR DESCRIPTION
## Summary
- enhance CS compiler to name structs produced by query select expressions
- document remaining work for struct field inference

## Testing
- `go test -tags slow ./compiler/x/cs -run TestCompileValidPrograms/cross_join -count=1 -timeout 120s`

------
https://chatgpt.com/codex/tasks/task_e_68709c7475948320a6155d50f41470e9