### PR TITLE
Improve TypeScript query compilation

### DIFF
--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -108,7 +108,6 @@ Compiled: 100/100 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
-
 ## Remaining Tasks
 
 - Integrate with Node runtime for dataset queries and joins


### PR DESCRIPTION
## Summary
- support TypeScript type generation for user defined types and declarations
- add helpers to infer simple query result structures
- improve query code generation to declare typed result arrays
- restore remaining tasks list in machine README

## Testing
- `go test ./compiler/x/typescript -run TestCompilePrograms -tags slow -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68709dccee608320b09e88b54f517b44