### PR TITLE
Add improved Mochi Active Directory Connect example

### DIFF
--- a/tests/rosetta/x/Mochi/active-directory-connect.mochi
+++ b/tests/rosetta/x/Mochi/active-directory-connect.mochi
@@ -1,23 +1,40 @@
 // Mochi implementation of Rosetta "Active Directory Connect" task
+// Translated from Go version in tests/rosetta/x/Go/active-directory-connect.go
 
-fun connect(client: map<string, any>): bool {
-  return client["Host"] != ""
+// Minimal representation of an LDAP client
+// This example just checks that required fields are present.
+
+type LDAPClient {
+  Base: string
+  Host: string
+  Port: int
+  UseSSL: bool
+  BindDN: string
+  BindPassword: string
+  UserFilter: string
+  GroupFilter: string
+  Attributes: list<string>
+}
+
+fun connect(client: LDAPClient): bool {
+  return client.Host != "" && client.Port > 0
 }
 
 fun main() {
-  let client = {
-    "Base": "dc=example,dc=com",
-    "Host": "ldap.example.com",
-    "Port": 389,
-    "UseSSL": false,
-    "BindDN": "uid=readonlyuser,ou=People,dc=example,dc=com",
-    "BindPassword": "readonlypassword",
-    "UserFilter": "(uid=%s)",
-    "GroupFilter": "(memberUid=%s)",
-    "Attributes": ["givenName", "sn", "mail", "uid"],
+  let client = LDAPClient{
+    Base: "dc=example,dc=com",
+    Host: "ldap.example.com",
+    Port: 389,
+    UseSSL: false,
+    BindDN: "uid=readonlyuser,ou=People,dc=example,dc=com",
+    BindPassword: "readonlypassword",
+    UserFilter: "(uid=%s)",
+    GroupFilter: "(memberUid=%s)",
+    Attributes: ["givenName", "sn", "mail", "uid"],
   }
+
   if connect(client) {
-    print("Connected to " + client["Host"])
+    print("Connected to " + client.Host)
   } else {
     print("Failed to connect")
   }


### PR DESCRIPTION
## Summary
- implement `active-directory-connect.mochi` using a small `LDAPClient` struct
- run the targeted Rosetta test for the updated task

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks/active-directory-connect -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68709b4a92888320bd93d55e8fbad471