### PR TITLE
Improve Go compiler type inference

### DIFF
--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -237,6 +237,17 @@ func containsAny(t types.Type) bool {
 	return false
 }
 
+func isStringAnyMap(t types.Type) bool {
+	if mt, ok := t.(types.MapType); ok {
+		if isString(mt.Key) {
+			if _, ok := mt.Value.(types.AnyType); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func isMap(t types.Type) bool {
 	_, ok := t.(types.MapType)
 	return ok

--- a/tests/machine/x/go/cross_join.go
+++ b/tests/machine/x/go/cross_join.go
@@ -50,10 +50,10 @@ func main() {
 	}
 
 	var result []Result = func() []Result {
-		_res := []Result{}
+		results := []Result{}
 		for _, o := range orders {
 			for _, c := range customers {
-				_res = append(_res, Result{
+				results = append(results, Result{
 					OrderId:            o.Id,
 					OrderCustomerId:    o.CustomerId,
 					PairedCustomerName: c.Name,
@@ -61,7 +61,7 @@ func main() {
 				})
 			}
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- Cross Join: All order-customer pairs ---")
 	for _, entry := range result {

--- a/tests/machine/x/go/cross_join_filter.go
+++ b/tests/machine/x/go/cross_join_filter.go
@@ -16,18 +16,18 @@ func main() {
 	}
 
 	var pairs []Pairs = func() []Pairs {
-		_res := []Pairs{}
+		results := []Pairs{}
 		for _, n := range nums {
 			if (n % 2) == 0 {
 				for _, l := range letters {
-					_res = append(_res, Pairs{
+					results = append(results, Pairs{
 						N: n,
 						L: l,
 					})
 				}
 			}
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- Even pairs ---")
 	for _, p := range pairs {

--- a/tests/machine/x/go/cross_join_triple.go
+++ b/tests/machine/x/go/cross_join_triple.go
@@ -19,11 +19,11 @@ func main() {
 	}
 
 	var combos []Combos = func() []Combos {
-		_res := []Combos{}
+		results := []Combos{}
 		for _, n := range nums {
 			for _, l := range letters {
 				for _, b := range bools {
-					_res = append(_res, Combos{
+					results = append(results, Combos{
 						N: n,
 						L: l,
 						B: b,
@@ -31,7 +31,7 @@ func main() {
 				}
 			}
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- Cross Join of three lists ---")
 	for _, c := range combos {

--- a/tests/machine/x/go/dataset_where_filter.go
+++ b/tests/machine/x/go/dataset_where_filter.go
@@ -37,11 +37,11 @@ func main() {
 	}
 
 	var adults []Adults = func() []Adults {
-		_res := []Adults{}
+		results := []Adults{}
 		for _, person := range people {
 			if person.Age >= 18 {
 				if person.Age >= 18 {
-					_res = append(_res, Adults{
+					results = append(results, Adults{
 						Name:      person.Name,
 						Age:       person.Age,
 						Is_senior: (person.Age >= 60),
@@ -49,7 +49,7 @@ func main() {
 				}
 			}
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- Adults ---")
 	for _, person := range adults {

--- a/tests/machine/x/go/exists_builtin.go
+++ b/tests/machine/x/go/exists_builtin.go
@@ -9,15 +9,15 @@ import (
 func main() {
 	var dataVar []int = []int{1, 2}
 	var flag bool = len(func() []int {
-		_res := []int{}
+		results := []int{}
 		for _, x := range dataVar {
 			if x == 1 {
 				if x == 1 {
-					_res = append(_res, x)
+					results = append(results, x)
 				}
 			}
 		}
-		return _res
+		return results
 	}()) > 0
 	fmt.Println(flag)
 }

--- a/tests/machine/x/go/group_by.go
+++ b/tests/machine/x/go/group_by.go
@@ -66,22 +66,22 @@ func main() {
 			}
 			g.Items = append(g.Items, person)
 		}
-		_res := []Stats{}
+		results := []Stats{}
 		for _, ks := range order {
 			g := groups[ks]
-			_res = append(_res, Stats{
+			results = append(results, Stats{
 				City:  g.Key,
 				Count: len(g.Items),
 				Avg_age: _avg(func() []any {
-					_res := []any{}
+					results := []any{}
 					for _, p := range g.Items {
-						_res = append(_res, (p).(map[string]any)["age"])
+						results = append(results, (p).(map[string]any)["age"])
 					}
-					return _res
+					return results
 				}()),
 			})
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- People grouped by city ---")
 	for _, s := range stats {

--- a/tests/machine/x/go/group_by_conditional_sum.error
+++ b/tests/machine/x/go/group_by_conditional_sum.error
@@ -1,13 +1,6 @@
-Error on line 0: run error: exit status 1
-panic: sum() expects numbers
-
-goroutine 1 [running]:
-main._sum({0x207ca60?, 0xc00021ff10?})
-	/workspace/mochi/tests/machine/x/go/group_by_conditional_sum.go:198 +0x2ac
-main.main.func1(...)
-	/workspace/mochi/tests/machine/x/go/group_by_conditional_sum.go:112
-main.main()
-	/workspace/mochi/tests/machine/x/go/group_by_conditional_sum.go:122 +0x8da
-exit status 2
-
+Error on line 0: output mismatch
+-- got --
+{a 0} {b 0}
+-- want --
+map[cat:a share:0.6666666666666666] map[cat:b share:1]
 1: //go:build ignore

--- a/tests/machine/x/go/group_by_conditional_sum.go
+++ b/tests/machine/x/go/group_by_conditional_sum.go
@@ -93,14 +93,14 @@ func main() {
 		for idx, p := range pairs {
 			items[idx] = p.item
 		}
-		_res := []Result{}
+		results := []Result{}
 		for _, g := range items {
-			_res = append(_res, Result{
+			results = append(results, Result{
 				Cat: g.Key,
 				Share: (float64(_sum(func() []any {
-					_res := []any{}
+					results := []any{}
 					for _, x := range g.Items {
-						_res = append(_res, func() any {
+						results = append(results, func() any {
 							if _exists((x).(map[string]any)["flag"]) {
 								return (x).(map[string]any)["val"]
 							} else {
@@ -108,17 +108,17 @@ func main() {
 							}
 						}())
 					}
-					return _res
+					return results
 				}())) / float64(_sum(func() []any {
-					_res := []any{}
+					results := []any{}
 					for _, x := range g.Items {
-						_res = append(_res, (x).(map[string]any)["val"])
+						results = append(results, (x).(map[string]any)["val"])
 					}
-					return _res
+					return results
 				}()))),
 			})
 		}
-		return _res
+		return results
 	}()
 	fmt.Println(strings.TrimSuffix(strings.TrimPrefix(fmt.Sprint(result), "["), "]"))
 }
@@ -156,7 +156,7 @@ func _exists(v any) bool {
 	case reflect.Pointer:
 		return !rv.IsNil()
 	case reflect.Struct:
-		return true
+		return !rv.IsZero()
 	}
 	return false
 }
@@ -212,6 +212,25 @@ func _toAnyMap(m any) map[string]any {
 		}
 		return out
 	default:
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Struct {
+			out := make(map[string]any, rv.NumField())
+			rt := rv.Type()
+			for i := 0; i < rv.NumField(); i++ {
+				name := rt.Field(i).Name
+				if tag := rt.Field(i).Tag.Get("json"); tag != "" {
+					comma := strings.Index(tag, ",")
+					if comma >= 0 {
+						tag = tag[:comma]
+					}
+					if tag != "-" {
+						name = tag
+					}
+				}
+				out[name] = rv.Field(i).Interface()
+			}
+			return out
+		}
 		return nil
 	}
 }

--- a/tests/machine/x/go/group_by_having.go
+++ b/tests/machine/x/go/group_by_having.go
@@ -63,18 +63,18 @@ func main() {
 			}
 			g.Items = append(g.Items, p)
 		}
-		_res := []Big{}
+		results := []Big{}
 		for _, ks := range order {
 			g := groups[ks]
 			if !(len(g.Items) >= 4) {
 				continue
 			}
-			_res = append(_res, Big{
+			results = append(results, Big{
 				City: g.Key,
 				Num:  len(g.Items),
 			})
 		}
-		return _res
+		return results
 	}()
 	func() { b, _ := json.Marshal(big); fmt.Println(string(b)) }()
 }

--- a/tests/machine/x/go/group_by_join.go
+++ b/tests/machine/x/go/group_by_join.go
@@ -5,6 +5,8 @@ package main
 import (
 	"fmt"
 	"mochi/runtime/data"
+	"reflect"
+	"strings"
 )
 
 func main() {
@@ -73,14 +75,14 @@ func main() {
 		for _, ks := range order {
 			items = append(items, groups[ks])
 		}
-		_res := []Stats{}
+		results := []Stats{}
 		for _, g := range items {
-			_res = append(_res, Stats{
+			results = append(results, Stats{
 				Name:  g.Key,
 				Count: len(g.Items),
 			})
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- Orders per customer ---")
 	for _, s := range stats {
@@ -99,6 +101,25 @@ func _toAnyMap(m any) map[string]any {
 		}
 		return out
 	default:
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Struct {
+			out := make(map[string]any, rv.NumField())
+			rt := rv.Type()
+			for i := 0; i < rv.NumField(); i++ {
+				name := rt.Field(i).Name
+				if tag := rt.Field(i).Tag.Get("json"); tag != "" {
+					comma := strings.Index(tag, ",")
+					if comma >= 0 {
+						tag = tag[:comma]
+					}
+					if tag != "-" {
+						name = tag
+					}
+				}
+				out[name] = rv.Field(i).Interface()
+			}
+			return out
+		}
 		return nil
 	}
 }

--- a/tests/machine/x/go/group_by_multi_join.go
+++ b/tests/machine/x/go/group_by_multi_join.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	var filtered []Filtered = func() []Filtered {
-		_res := []Filtered{}
+		results := []Filtered{}
 		for _, ps := range partsupp {
 			for _, s := range suppliers {
 				if !(s.Id == ps.Supplier) {
@@ -76,7 +76,7 @@ func main() {
 					}
 					if n.Name == "A" {
 						if n.Name == "A" {
-							_res = append(_res, Filtered{
+							results = append(results, Filtered{
 								Part:  ps.Part,
 								Value: (ps.Cost * float64(ps.Qty)),
 							})
@@ -85,7 +85,7 @@ func main() {
 				}
 			}
 		}
-		return _res
+		return results
 	}()
 	type Grouped struct {
 		Part  any `json:"part"`
@@ -106,21 +106,21 @@ func main() {
 			}
 			g.Items = append(g.Items, x)
 		}
-		_res := []Grouped{}
+		results := []Grouped{}
 		for _, ks := range order {
 			g := groups[ks]
-			_res = append(_res, Grouped{
+			results = append(results, Grouped{
 				Part: g.Key,
 				Total: _sum(func() []any {
-					_res := []any{}
+					results := []any{}
 					for _, r := range g.Items {
-						_res = append(_res, (r).(map[string]any)["value"])
+						results = append(results, (r).(map[string]any)["value"])
 					}
-					return _res
+					return results
 				}()),
 			})
 		}
-		return _res
+		return results
 	}()
 	fmt.Println(strings.TrimSuffix(strings.TrimPrefix(fmt.Sprint(grouped), "["), "]"))
 }

--- a/tests/machine/x/go/group_by_multi_join_sort.error
+++ b/tests/machine/x/go/group_by_multi_join_sort.error
@@ -1,7 +1,7 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_multi_join_sort.go:170:105: invalid operation: (float64(1) - (((x).(map[string]any)["l"]).(map[string]any)["l_discount"]).(float64)) (value of type float64) is not an interface
-../../../tests/machine/x/go/group_by_multi_join_sort.go:206:14: cannot use _sum(func() []any {…}()) (value of type float64) as int value in struct literal
-../../../tests/machine/x/go/group_by_multi_join_sort.go:209:106: invalid operation: (float64(1) - (((x).(map[string]any)["l"]).(map[string]any)["l_discount"]).(float64)) (value of type float64) is not an interface
+../../../tests/machine/x/go/group_by_multi_join_sort.go:171:111: invalid operation: (float64(1) - (((x).(map[string]any)["l"]).(map[string]any)["l_discount"]).(float64)) (value of type float64) is not an interface
+../../../tests/machine/x/go/group_by_multi_join_sort.go:207:14: cannot use _sum(func() []any {…}()) (value of type float64) as int value in struct literal
+../../../tests/machine/x/go/group_by_multi_join_sort.go:210:112: invalid operation: (float64(1) - (((x).(map[string]any)["l"]).(map[string]any)["l_discount"]).(float64)) (value of type float64) is not an interface
 
 1: //go:build ignore

--- a/tests/machine/x/go/group_by_sort.error
+++ b/tests/machine/x/go/group_by_sort.error
@@ -1,5 +1,5 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_sort.go:109:12: cannot use _sum(func() []any {…}()) (value of type float64) as int value in struct literal
+../../../tests/machine/x/go/group_by_sort.go:110:12: cannot use _sum(func() []any {…}()) (value of type float64) as int value in struct literal
 
 1: //go:build ignore

--- a/tests/machine/x/go/group_items_iteration.go
+++ b/tests/machine/x/go/group_items_iteration.go
@@ -39,12 +39,12 @@ func main() {
 			}
 			g.Items = append(g.Items, d)
 		}
-		_res := []*data.Group{}
+		results := []*data.Group{}
 		for _, ks := range order {
 			g := groups[ks]
-			_res = append(_res, g)
+			results = append(results, g)
 		}
-		return _res
+		return results
 	}()
 	var tmp []any = []any{}
 	for _, g := range groups {

--- a/tests/machine/x/go/inner_join.go
+++ b/tests/machine/x/go/inner_join.go
@@ -58,20 +58,20 @@ func main() {
 	}
 
 	var result []Result = func() []Result {
-		_res := []Result{}
+		results := []Result{}
 		for _, o := range orders {
 			for _, c := range customers {
 				if !(o.CustomerId == c.Id) {
 					continue
 				}
-				_res = append(_res, Result{
+				results = append(results, Result{
 					OrderId:      o.Id,
 					CustomerName: c.Name,
 					Total:        o.Total,
 				})
 			}
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- Orders with customer info ---")
 	for _, entry := range result {

--- a/tests/machine/x/go/join_multi.go
+++ b/tests/machine/x/go/join_multi.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	var result []Result = func() []Result {
-		_res := []Result{}
+		results := []Result{}
 		for _, o := range orders {
 			for _, c := range customers {
 				if !(o.CustomerId == c.Id) {
@@ -61,14 +61,14 @@ func main() {
 					if !(o.Id == i.OrderId) {
 						continue
 					}
-					_res = append(_res, Result{
+					results = append(results, Result{
 						Name: c.Name,
 						Sku:  i.Sku,
 					})
 				}
 			}
 		}
-		return _res
+		return results
 	}()
 	fmt.Println("--- Multi Join ---")
 	for _, r := range result {

--- a/tests/machine/x/go/load_yaml.error
+++ b/tests/machine/x/go/load_yaml.error
@@ -1,5 +1,5 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/load_yaml.go:26:13: invalid operation: r (variable of type map[string]any) is not an interface
+../../../tests/machine/x/go/load_yaml.go:28:13: invalid operation: r (variable of type map[string]any) is not an interface
 
 1: //go:build ignore

--- a/tests/machine/x/go/load_yaml.go
+++ b/tests/machine/x/go/load_yaml.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"os"
+	"reflect"
+	"strings"
 )
 
 type Person struct {
@@ -33,18 +35,18 @@ func main() {
 	}
 
 	var adults []Adults = func() []Adults {
-		_res := []Adults{}
+		results := []Adults{}
 		for _, p := range people {
 			if p.Age >= 18 {
 				if p.Age >= 18 {
-					_res = append(_res, Adults{
+					results = append(results, Adults{
 						Name:  p.Name,
 						Email: p.Email,
 					})
 				}
 			}
 		}
-		return _res
+		return results
 	}()
 	for _, a := range adults {
 		fmt.Println(a.Name, a.Email)
@@ -114,6 +116,25 @@ func _toAnyMap(m any) map[string]any {
 		}
 		return out
 	default:
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Struct {
+			out := make(map[string]any, rv.NumField())
+			rt := rv.Type()
+			for i := 0; i < rv.NumField(); i++ {
+				name := rt.Field(i).Name
+				if tag := rt.Field(i).Tag.Get("json"); tag != "" {
+					comma := strings.Index(tag, ",")
+					if comma >= 0 {
+						tag = tag[:comma]
+					}
+					if tag != "-" {
+						name = tag
+					}
+				}
+				out[name] = rv.Field(i).Interface()
+			}
+			return out
+		}
 		return nil
 	}
 }

--- a/tests/machine/x/go/match_full.go
+++ b/tests/machine/x/go/match_full.go
@@ -61,8 +61,8 @@ func main() {
 		if _equal(_t, false) {
 			return "denied"
 		}
-		var _zero string
-		return _zero
+		var zeroVal string
+		return zeroVal
 	}()
 	fmt.Println(status)
 	fmt.Println(classify(0))

--- a/tests/machine/x/go/query_sum_select.go
+++ b/tests/machine/x/go/query_sum_select.go
@@ -13,15 +13,15 @@ import (
 func main() {
 	var nums []int = []int{1, 2, 3}
 	var result []int = _sumOrdered[int](func() []int {
-		_res := []int{}
+		results := []int{}
 		for _, n := range nums {
 			if n > 1 {
 				if n > 1 {
-					_res = append(_res, n)
+					results = append(results, n)
 				}
 			}
 		}
-		return _res
+		return results
 	}())
 	fmt.Println(strings.TrimSuffix(strings.TrimPrefix(fmt.Sprint(result), "["), "]"))
 }

--- a/tests/machine/x/go/right_join.go
+++ b/tests/machine/x/go/right_join.go
@@ -151,7 +151,7 @@ func _exists(v any) bool {
 	case reflect.Pointer:
 		return !rv.IsNil()
 	case reflect.Struct:
-		return true
+		return !rv.IsZero()
 	}
 	return false
 }

--- a/tests/machine/x/go/save_jsonl_stdout.go
+++ b/tests/machine/x/go/save_jsonl_stdout.go
@@ -7,6 +7,7 @@ import (
 	"mochi/runtime/data"
 	"os"
 	"reflect"
+	"strings"
 )
 
 func main() {
@@ -94,6 +95,25 @@ func _toAnyMap(m any) map[string]any {
 		}
 		return out
 	default:
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Struct {
+			out := make(map[string]any, rv.NumField())
+			rt := rv.Type()
+			for i := 0; i < rv.NumField(); i++ {
+				name := rt.Field(i).Name
+				if tag := rt.Field(i).Tag.Get("json"); tag != "" {
+					comma := strings.Index(tag, ",")
+					if comma >= 0 {
+						tag = tag[:comma]
+					}
+					if tag != "-" {
+						name = tag
+					}
+				}
+				out[name] = rv.Field(i).Interface()
+			}
+			return out
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary
- infer map types in the Go backend so `_toAnyMap` isn't emitted for `map[string]any` expressions
- update generated Go code in `tests/machine/x/go`

## Testing
- `go test -tags slow ./compiler/x/go -run TestGoCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870a25f47788320b6bd8724e0975754