### PR TITLE
Improve Zig compiler string concat helper

### DIFF
--- a/compiler/x/zig/builtins.go
+++ b/compiler/x/zig/builtins.go
@@ -384,11 +384,7 @@ func (c *Compiler) writeBuiltins() {
 	if c.needsConcatString {
 		c.writeln("fn _concat_string(a: []const u8, b: []const u8) []const u8 {")
 		c.indent++
-		c.writeln("var res = std.ArrayList(u8).init(std.heap.page_allocator);")
-		c.writeln("defer res.deinit();")
-		c.writeln("res.appendSlice(a) catch unreachable;")
-		c.writeln("res.appendSlice(b) catch unreachable;")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("return std.mem.concat(u8, &[_][]const u8{ a, b }) catch unreachable;")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -109,6 +109,6 @@ Compiled programs: 100/100
 ## Remaining Tasks
 
  - Keep generated outputs in sync with compiler improvements.
- - Add more idiomatic mappings for built-in functions (e.g. string concatenation).
+ - [x] Add more idiomatic mappings for built-in functions (e.g. string concatenation).
  - Improve idiomatic mappings for Zig built-ins.
  - [x] Generate named structs from constant map literals for readability.


### PR DESCRIPTION
## Summary
- make Zig `_concat_string` use `std.mem.concat`
- mark builtin improvement task complete in the Zig machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870a6456ba083208c3d3c531cfb973d