### PR TITLE
Improve Scala compiler map handling

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -3,7 +3,7 @@
 This directory contains Scala code generated from the Mochi programs in `tests/vm/valid` using the Scala compiler. Each source file was compiled with `scalac` and executed with `scala`. Successful runs produced an `.out` file while failures produced an `.error` file.
 
 Compiled programs: 100
-Executed successfully: 79
+Executed successfully: 80
 
 ## Program checklist
 - [x] append_builtin.mochi
@@ -42,7 +42,7 @@ Executed successfully: 79
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
 - [x] in_operator.mochi
-- [ ] in_operator_extended.mochi
+- [x] in_operator_extended.mochi
 - [x] inner_join.mochi
 - [x] join_multi.mochi
 - [x] json_builtin.mochi
@@ -106,3 +106,9 @@ Executed successfully: 79
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## Remaining Tasks
+- [ ] Support automatic imports for Go/Python packages.
+- [ ] Implement dataset joins and YAML helpers.
+- [ ] Improve JSON saving helpers.
+

--- a/tests/machine/x/scala/in_operator_extended.error
+++ b/tests/machine/x/scala/in_operator_extended.error
@@ -1,1 +1,0 @@
-line 7: unsupported operator in

--- a/tests/machine/x/scala/in_operator_extended.out
+++ b/tests/machine/x/scala/in_operator_extended.out
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false

--- a/tests/machine/x/scala/in_operator_extended.scala
+++ b/tests/machine/x/scala/in_operator_extended.scala
@@ -1,0 +1,16 @@
+object in_operator_extended {
+  case class M(a: Int)
+
+  val xs = List[Int](1, 2, 3)
+  val ys = for { x <- xs; if (x % 2).asInstanceOf[Int] == 1 } yield x
+  val m = Map[String, Int]("a" -> (1))
+  val s = "hello"
+  def main(args: Array[String]): Unit = {
+    println((ys.contains(1)))
+    println((ys.contains(2)))
+    println((m.contains("a")))
+    println((m.contains("b")))
+    println((s.contains("ell")))
+    println((s.contains("foo")))
+  }
+}


### PR DESCRIPTION
## Summary
- adjust Scala compiler to keep map types when used with `in`
- regenerate machine code and output for `in_operator_extended`
- mark the program as working and update counts
- note remaining Scala tasks

## Testing
- `go test -tags slow ./compiler/x/scala -run TestScalaCompilerMachine/in_operator_extended -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_6870a5e21c3083209c9311da2392a11a