### PR TITLE
Improve C backend sort in grouping

### DIFF
--- a/tests/machine/x/c/go_auto.c
+++ b/tests/machine/x/c/go_auto.c
@@ -2,8 +2,8 @@
 #include <stdlib.h>
 
 int main() {
-  printf("%d\n", testpkg.Add(2, 3));
-  printf("%d\n", testpkg.Pi);
-  printf("%d\n", testpkg.Answer);
+  printf("%d\n", (2 + 3));
+  printf("%d\n", 3.14);
+  printf("%d\n", 42);
   return 0;
 }

--- a/tests/machine/x/c/go_auto.error
+++ b/tests/machine/x/c/go_auto.error
@@ -1,9 +1,11 @@
 line: 0
-error: cc error: exit status 1
-/workspace/mochi/tests/machine/x/c/go_auto.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/go_auto.c:5:18: error: ‘testpkg’ undeclared (first use in this function)
-    5 |   printf("%d\n", testpkg.Add(2, 3));
-      |                  ^~~~~~~
-/workspace/mochi/tests/machine/x/c/go_auto.c:5:18: note: each undeclared identifier is reported only once for each function it appears in
-
+error: output mismatch
+-- got --
+5
+-1416462912
+42
+-- want --
+5
+3.14
+42
    1: #include <stdio.h>

--- a/tests/machine/x/c/group_by_conditional_sum.c
+++ b/tests/machine/x/c/group_by_conditional_sum.c
@@ -1,6 +1,72 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+static int _sum_int(list_int v) {
+  int sum = 0;
+  for (int i = 0; i < v.len; i++)
+    sum += v.data[i];
+  return sum;
+}
+typedef struct {
+  char *key;
+  list_int items;
+} _GroupString;
+typedef struct {
+  int len;
+  int cap;
+  _GroupString *data;
+} list_group_string;
+static list_group_string _group_by_string(list_string src) {
+  list_group_string res;
+  res.len = 0;
+  res.cap = 0;
+  res.data = NULL;
+  for (int i = 0; i < src.len; i++) {
+    char *key = src.data[i];
+    int idx = -1;
+    for (int j = 0; j < res.len; j++)
+      if (strcmp(res.data[j].key, key) == 0) {
+        idx = j;
+        break;
+      }
+    if (idx == -1) {
+      if (res.len >= res.cap) {
+        res.cap = res.cap ? res.cap * 2 : 4;
+        res.data =
+            (_GroupString *)realloc(res.data, sizeof(_GroupString) * res.cap);
+      }
+      res.data[res.len].key = key;
+      res.data[res.len].items = list_int_create(0);
+      idx = res.len++;
+    }
+    _GroupString *g = &res.data[idx];
+    g->items.data =
+        (int *)realloc(g->items.data, sizeof(int) * (g->items.len + 1));
+    g->items.data[g->items.len++] = i;
+  }
+  return res;
+}
 typedef struct {
   char *cat;
   int val;
@@ -38,7 +104,67 @@ int main() {
                           (itemsItem){.cat = "b", .val = 20, .flag = 1}};
   list_itemsItem _t1 = {3, _t1_data};
   list_itemsItem items = _t1;
-  list_resultItem result = 0;
+  list_itemsItem _t2 = list_itemsItem_create(items.len);
+  list_string _t3 = list_string_create(items.len);
+  int _t4 = 0;
+  for (int i = 0; i < items.len; i++) {
+    itemsItem i = items.data[i];
+    _t2.data[_t4] = i;
+    _t3.data[_t4] = i.cat;
+    _t4++;
+  }
+  _t2.len = _t4;
+  _t3.len = _t4;
+  list_group_string _t5 = _group_by_string(_t3);
+  list_resultItem _t6 = list_resultItem_create(_t5.len);
+  int *_t8 = (int *)malloc(sizeof(int) * _t5.len);
+  int _t7 = 0;
+  for (int gi = 0; gi < _t5.len; gi++) {
+    _GroupString _gp = _t5.data[gi];
+    list_itemsItem _t9 = list_itemsItem_create(_gp.items.len);
+    for (int j = 0; j < _gp.items.len; j++) {
+      _t9.data[j] = _t2.data[_gp.items.data[j]];
+    }
+    _t9.len = _gp.items.len;
+    struct {
+      char *key;
+      list_itemsItem items;
+    } g = {_gp.key, _t9};
+    list_int _t10 = list_int_create(g.items.len);
+    int _t11 = 0;
+    for (int i = 0; i < g.items.len; i++) {
+      itemsItem x = g.items.data[i];
+      _t10.data[_t11] = (x.flag ? x.val : 0);
+      _t11++;
+    }
+    _t10.len = _t11;
+    list_int _t12 = list_int_create(g.items.len);
+    int _t13 = 0;
+    for (int i = 0; i < g.items.len; i++) {
+      itemsItem x = g.items.data[i];
+      _t12.data[_t13] = x.val;
+      _t13++;
+    }
+    _t12.len = _t13;
+    _t6.data[_t7] =
+        (resultItem){.cat = g.key, .share = _sum_int(_t10) / _sum_int(_t12)};
+    _t8[_t7] = g.key;
+    _t7++;
+  }
+  _t6.len = _t7;
+  for (int i = 0; i < _t7 - 1; i++) {
+    for (int j = i + 1; j < _t7; j++) {
+      if (_t8[i] > _t8[j]) {
+        int _t14 = _t8[i];
+        _t8[i] = _t8[j];
+        _t8[j] = _t14;
+        resultItem _t15 = _t6.data[i];
+        _t6.data[i] = _t6.data[j];
+        _t6.data[j] = _t15;
+      }
+    }
+  }
+  list_resultItem result = _t6;
   printf("%d\n", result);
   return 0;
 }

--- a/tests/machine/x/c/group_by_conditional_sum.error
+++ b/tests/machine/x/c/group_by_conditional_sum.error
@@ -1,11 +1,14 @@
 line: 0
 error: cc error: exit status 1
 /workspace/mochi/tests/machine/x/c/group_by_conditional_sum.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/group_by_conditional_sum.c:41:28: error: invalid initializer
-   41 |   list_resultItem result = 0;
-      |                            ^
-/workspace/mochi/tests/machine/x/c/group_by_conditional_sum.c:42:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘list_resultItem’ [-Wformat=]
-   42 |   printf("%d\n", result);
+/workspace/mochi/tests/machine/x/c/group_by_conditional_sum.c:111:29: error: array subscript is not an integer
+  111 |     itemsItem i = items.data[i];
+      |                             ^
+/workspace/mochi/tests/machine/x/c/group_by_conditional_sum.c:151:14: warning: assignment to ‘int’ from ‘char *’ makes integer from pointer without a cast [-Wint-conversion]
+  151 |     _t8[_t7] = g.key;
+      |              ^
+/workspace/mochi/tests/machine/x/c/group_by_conditional_sum.c:168:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘list_resultItem’ [-Wformat=]
+  168 |   printf("%d\n", result);
       |           ~^     ~~~~~~
       |            |     |
       |            int   list_resultItem

--- a/tests/machine/x/c/group_by_sort.c
+++ b/tests/machine/x/c/group_by_sort.c
@@ -1,6 +1,72 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+static int _sum_int(list_int v) {
+  int sum = 0;
+  for (int i = 0; i < v.len; i++)
+    sum += v.data[i];
+  return sum;
+}
+typedef struct {
+  char *key;
+  list_int items;
+} _GroupString;
+typedef struct {
+  int len;
+  int cap;
+  _GroupString *data;
+} list_group_string;
+static list_group_string _group_by_string(list_string src) {
+  list_group_string res;
+  res.len = 0;
+  res.cap = 0;
+  res.data = NULL;
+  for (int i = 0; i < src.len; i++) {
+    char *key = src.data[i];
+    int idx = -1;
+    for (int j = 0; j < res.len; j++)
+      if (strcmp(res.data[j].key, key) == 0) {
+        idx = j;
+        break;
+      }
+    if (idx == -1) {
+      if (res.len >= res.cap) {
+        res.cap = res.cap ? res.cap * 2 : 4;
+        res.data =
+            (_GroupString *)realloc(res.data, sizeof(_GroupString) * res.cap);
+      }
+      res.data[res.len].key = key;
+      res.data[res.len].items = list_int_create(0);
+      idx = res.len++;
+    }
+    _GroupString *g = &res.data[idx];
+    g->items.data =
+        (int *)realloc(g->items.data, sizeof(int) * (g->items.len + 1));
+    g->items.data[g->items.len++] = i;
+  }
+  return res;
+}
 typedef struct {
   char *cat;
   int val;
@@ -37,7 +103,66 @@ int main() {
       (itemsItem){.cat = "b", .val = 5}, (itemsItem){.cat = "b", .val = 2}};
   list_itemsItem _t1 = {4, _t1_data};
   list_itemsItem items = _t1;
-  list_groupedItem grouped = 0;
+  list_itemsItem _t2 = list_itemsItem_create(items.len);
+  list_string _t3 = list_string_create(items.len);
+  int _t4 = 0;
+  for (int i = 0; i < items.len; i++) {
+    itemsItem i = items.data[i];
+    _t2.data[_t4] = i;
+    _t3.data[_t4] = i.cat;
+    _t4++;
+  }
+  _t2.len = _t4;
+  _t3.len = _t4;
+  list_group_string _t5 = _group_by_string(_t3);
+  list_groupedItem _t6 = list_groupedItem_create(_t5.len);
+  double *_t8 = (double *)malloc(sizeof(double) * _t5.len);
+  int _t7 = 0;
+  for (int gi = 0; gi < _t5.len; gi++) {
+    _GroupString _gp = _t5.data[gi];
+    list_itemsItem _t9 = list_itemsItem_create(_gp.items.len);
+    for (int j = 0; j < _gp.items.len; j++) {
+      _t9.data[j] = _t2.data[_gp.items.data[j]];
+    }
+    _t9.len = _gp.items.len;
+    struct {
+      char *key;
+      list_itemsItem items;
+    } g = {_gp.key, _t9};
+    list_int _t10 = list_int_create(g.items.len);
+    int _t11 = 0;
+    for (int i = 0; i < g.items.len; i++) {
+      itemsItem x = g.items.data[i];
+      _t10.data[_t11] = x.val;
+      _t11++;
+    }
+    _t10.len = _t11;
+    _t6.data[_t7] = (groupedItem){.cat = g.key, .total = _sum_int(_t10)};
+    list_int _t12 = list_int_create(g.items.len);
+    int _t13 = 0;
+    for (int i = 0; i < g.items.len; i++) {
+      itemsItem x = g.items.data[i];
+      _t12.data[_t13] = x.val;
+      _t13++;
+    }
+    _t12.len = _t13;
+    _t8[_t7] = (-_sum_int(_t12));
+    _t7++;
+  }
+  _t6.len = _t7;
+  for (int i = 0; i < _t7 - 1; i++) {
+    for (int j = i + 1; j < _t7; j++) {
+      if (_t8[i] > _t8[j]) {
+        double _t14 = _t8[i];
+        _t8[i] = _t8[j];
+        _t8[j] = _t14;
+        groupedItem _t15 = _t6.data[i];
+        _t6.data[i] = _t6.data[j];
+        _t6.data[j] = _t15;
+      }
+    }
+  }
+  list_groupedItem grouped = _t6;
   printf("%d\n", grouped);
   return 0;
 }

--- a/tests/machine/x/c/group_by_sort.error
+++ b/tests/machine/x/c/group_by_sort.error
@@ -1,11 +1,11 @@
 line: 0
 error: cc error: exit status 1
 /workspace/mochi/tests/machine/x/c/group_by_sort.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/group_by_sort.c:40:30: error: invalid initializer
-   40 |   list_groupedItem grouped = 0;
-      |                              ^
-/workspace/mochi/tests/machine/x/c/group_by_sort.c:41:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘list_groupedItem’ [-Wformat=]
-   41 |   printf("%d\n", grouped);
+/workspace/mochi/tests/machine/x/c/group_by_sort.c:110:29: error: array subscript is not an integer
+  110 |     itemsItem i = items.data[i];
+      |                             ^
+/workspace/mochi/tests/machine/x/c/group_by_sort.c:166:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘list_groupedItem’ [-Wformat=]
+  166 |   printf("%d\n", grouped);
       |           ~^     ~~~~~~~
       |            |     |
       |            int   list_groupedItem

--- a/tests/machine/x/c/match_full.error
+++ b/tests/machine/x/c/match_full.error
@@ -2,8 +2,8 @@ line: 0
 error: output mismatch
 -- got --
 two
-410791984
-410792024
+1390481456
+1390481496
 zero
 many
 -- want --

--- a/tests/machine/x/c/python_auto.c
+++ b/tests/machine/x/c/python_auto.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 int main() {
-  printf("%d\n", math.sqrt(16.0));
-  printf("%d\n", math.pi);
+  printf("%d\n", 4);
+  printf("%d\n", 3.141592653589793);
   return 0;
 }

--- a/tests/machine/x/c/python_auto.error
+++ b/tests/machine/x/c/python_auto.error
@@ -1,9 +1,9 @@
 line: 0
-error: cc error: exit status 1
-/workspace/mochi/tests/machine/x/c/python_auto.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/python_auto.c:5:18: error: ‘math’ undeclared (first use in this function)
-    5 |   printf("%d\n", math.sqrt(16.0));
-      |                  ^~~~
-/workspace/mochi/tests/machine/x/c/python_auto.c:5:18: note: each undeclared identifier is reported only once for each function it appears in
-
+error: output mismatch
+-- got --
+4
+496538048
+-- want --
+4
+3.141592653589793
    1: #include <stdio.h>

--- a/tests/machine/x/c/python_math.c
+++ b/tests/machine/x/c/python_math.c
@@ -11,10 +11,10 @@ extern double math_log(double x);
 static double r = 3;
 
 int main() {
-  int area = math.pi * math.pow(r, 2.0);
-  double root = math.sqrt(49.0);
-  double sin45 = math.sin(math.pi / 4.0);
-  double log_e = math.log(math.e);
+  int area = 3.141592653589793 * (r * r);
+  double root = 7;
+  double sin45 = __builtin_sin(3.141592653589793 / 4.0);
+  double log_e = __builtin_log(2.718281828459045);
   printf("%s ", "Circle area with r =");
   printf("%d ", r);
   printf("%s ", "=>");

--- a/tests/machine/x/c/python_math.error
+++ b/tests/machine/x/c/python_math.error
@@ -1,15 +1,13 @@
 line: 0
-error: cc error: exit status 1
-/workspace/mochi/tests/machine/x/c/python_math.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/python_math.c:14:14: error: ‘math’ undeclared (first use in this function)
-   14 |   int area = math.pi * math.pow(r, 2.0);
-      |              ^~~~
-/workspace/mochi/tests/machine/x/c/python_math.c:14:14: note: each undeclared identifier is reported only once for each function it appears in
-/workspace/mochi/tests/machine/x/c/python_math.c:19:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘double’ [-Wformat=]
-   19 |   printf("%d ", r);
-      |           ~^    ~
-      |            |    |
-      |            int  double
-      |           %f
-
+error: output mismatch
+-- got --
+Circle area with r = -8588752 => 28
+Square root of 49: 7
+sin(π/4): 0.70710678118654746
+log(e): 1
+-- want --
+Circle area with r = 3 => 28.274333882308138
+Square root of 49: 7
+sin(π/4): 0.7071067811865475
+log(e): 1
    1: #include <stdio.h>


### PR DESCRIPTION
## Summary
- allow `group by` queries to specify `sort by` fields
- generate sorting logic for grouped queries in the C compiler
- refresh generated machine output for C

## Testing
- `go test ./...`
- `go test ./compiler/x/c -tags=slow -run TestCCompiler_ValidPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6870a675382483209c303981953172c4