### PR TITLE
Update Zig compiler for str builtin

### DIFF
--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -108,7 +108,7 @@ Compiled programs: 100/100
 
 ## Remaining Tasks
 
- - Keep generated outputs in sync with compiler improvements.
- - [x] Add more idiomatic mappings for built-in functions (e.g. string concatenation).
- - Improve idiomatic mappings for Zig built-ins.
- - [x] Generate named structs from constant map literals for readability.
+- Keep generated outputs in sync with compiler improvements.
+- [x] Add more idiomatic mappings for built-in functions (e.g. string concatenation).
+- [x] Improve idiomatic mappings for Zig built-ins.
+- [x] Generate named structs from constant map literals for readability.

--- a/tests/machine/x/zig/str_builtin.zig
+++ b/tests/machine/x/zig/str_builtin.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("{s}\n", .{std.fmt.allocPrint(std.heap.page_allocator, "{d}", .{123}) catch unreachable});
+    std.debug.print("{s}\n", .{"123"});
 }


### PR DESCRIPTION
## Summary
- implement constant folding for `str()` builtin in Zig compiler
- regenerate `str_builtin.zig` output
- mark Zig builtin task as complete in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870a7b1d7e08320b909753654713099