### PR TITLE
Add Mochi solution for associative-array iteration

### DIFF
--- a/tests/rosetta/x/Mochi/associative-array-iteration.mochi
+++ b/tests/rosetta/x/Mochi/associative-array-iteration.mochi
@@ -1,0 +1,17 @@
+fun main() {
+  let m: map<string, int> = {"hello": 13, "world": 31, "!": 71}
+  # iterating over key-value pairs
+  for k in keys(m) {
+    print("key = " + k + ", value = " + str(m[k]))
+  }
+  # iterating over keys
+  for k in keys(m) {
+    print("key = " + k)
+  }
+  # iterating over values
+  for k in keys(m) {
+    print("value = " + str(m[k]))
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/associative-array-iteration.out
+++ b/tests/rosetta/x/Mochi/associative-array-iteration.out
@@ -1,0 +1,9 @@
+key = !, value = 71
+key = hello, value = 13
+key = world, value = 31
+key = !
+key = hello
+key = world
+value = 71
+value = 13
+value = 31


### PR DESCRIPTION
## Summary
- add Mochi implementation for the "Associative array/Iteration" Rosetta task
- provide golden output for the new example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870a5178b8083209c290fbea125e403