### PR TITLE
Add Rosetta task 72 in Mochi

### DIFF
--- a/tests/rosetta/x/Mochi/associative-array-merging.mochi
+++ b/tests/rosetta/x/Mochi/associative-array-merging.mochi
@@ -1,0 +1,19 @@
+fun merge(base: map<string, any>, update: map<string, any>): map<string, any> {
+  var result: map<string, any> = {}
+  for k in base {
+    result[k] = base[k]
+  }
+  for k in update {
+    result[k] = update[k]
+  }
+  return result
+}
+
+fun main() {
+  let base: map<string, any> = {"name": "Rocket Skates", "price": 12.75, "color": "yellow"}
+  let update: map<string, any> = {"price": 15.25, "color": "red", "year": 1974}
+  let result = merge(base, update)
+  print(result)
+}
+
+main()

--- a/tests/rosetta/x/Mochi/associative-array-merging.out
+++ b/tests/rosetta/x/Mochi/associative-array-merging.out
@@ -1,0 +1,1 @@
+map[color:red name:Rocket Skates price:15.25 year:1974]


### PR DESCRIPTION
## Summary
- implement Rosetta task 72 (Associative-array-Merging) in Mochi
- add expected output for the new task

## Testing
- `go test -tags slow ./tools/rosetta -run TestMochiTasks/associative-array-merging -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6870a52358e48320a5efa3d301678078