### PR TITLE
Improve TypeScript compiler output

### DIFF
--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -1,6 +1,6 @@
 # Machine-generated TypeScript Programs
 
-This directory contains TypeScript code compiled from Mochi programs in `tests/vm/valid` using the experimental compiler. The compiler now emits simpler `from` query loops with explicit result types and generates type annotations for variables without initial values.
+This directory contains TypeScript code compiled from Mochi programs in `tests/vm/valid` using the experimental compiler. The compiler generates simpler `from` query loops and adds basic type annotations for query results.
 
 ## Progress
 
@@ -108,9 +108,11 @@ Compiled: 100/100 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
 ## Remaining Tasks
 
 - Integrate with Node runtime for dataset queries and joins
 - Support asynchronous `fetch` statements
 - Finish improving formatting to match human examples
 - Improve type inference for query results
+

--- a/tests/machine/x/typescript/cross_join.ts
+++ b/tests/machine/x/typescript/cross_join.ts
@@ -32,7 +32,7 @@ const result = (() => {
 });
     }
   }
-  return res;
+  return _tmp1;
 })()
 ;
 console.log("--- Cross Join: All order-customer pairs ---");

--- a/tests/machine/x/typescript/group_by.ts
+++ b/tests/machine/x/typescript/group_by.ts
@@ -31,7 +31,7 @@ const people = [
 }
 ];
 const stats = (() => {
-  const _tmp1: Array<{ avg_age: any; city: any; count: any }> = [];
+  const _tmp1: Array<{ avg_age: number; city: any; count: number }> = [];
   const groups = {};
   for (const person of people) {
     const _k = JSON.stringify(person.city);
@@ -41,13 +41,13 @@ const stats = (() => {
   }
   for (const _k in groups) {
     const g = groups[_k];
-    res.push({
+    _tmp1.push({
   city: g.key,
   count: g.length,
   avg_age: (g.map((p) => p.age).reduce((a,b)=>a+b,0)/g.map((p) => p.age).length)
 });
   }
-  return res;
+  return _tmp1;
 })()
 ;
 console.log("--- People grouped by city ---");


### PR DESCRIPTION
## Summary
- enhance `simpleExprType` to infer types for common builtin calls
- fix query result variable name usage and slicing logic
- regenerate sample TypeScript output
- document new behaviour in README

## Testing
- `go test ./compiler/x/typescript -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_6870c90a8f288320a2bb301d77cc6484