### PR TITLE
Add v0.10.23 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # 📦 CHANGELOG.md
+## [0.10.23] – 2025-07-11T15:23:14+07:00
+
+### Added
+
+* Basic Go and Python FFI support in the virtual machine
+* Builtin module infrastructure for the C backend with JSON struct support
+* Numerous Rosetta Code tasks including 15-puzzle, Active Directory search and arithmetic examples
+* TypeScript compiler generates typed queries and supports builtin imports
+* Rust and Java compilers handle FFI imports with improved output
+
+### Changed
+
+* Automatic struct inference across C#, Kotlin, Python, Scala, Swift, Java and Go
+* C backend uses `calloc` with allocation checks and stack-based list literals
+* Go compiler features sprint helper and improved variable naming
+* C++ and Zig compilers improve type inference and constant string operations
+* Java compiler provides descriptive class names and better struct naming
+
+### Fixed
+
+* Java compiler map handling and helper issues
+* Scala map membership bugs and case class derivation
+* Swift group query logic
+* Rust `in` operator semantics and environment typing
+* Python compiler map literal handling
 ## [0.10.22] – 2025-07-10T17:45:54+07:00
 
 ### Added

--- a/releases/v0.10.23.md
+++ b/releases/v0.10.23.md
@@ -1,0 +1,35 @@
+# Jul 2025 (v0.10.23)
+
+Released on Fri Jul 11 15:23:14 2025 +0700.
+
+Mochi v0.10.23 extends foreign function interfaces across languages, boosts
+struct inference and improves memory handling in the C backend. Numerous Rosetta
+Code examples showcase these capabilities with updated compiler outputs.
+
+## Examples
+
+- Added a wide range of Rosetta Code tasks such as arithmetic operations,
+  array processing and puzzles including 15‑puzzle and 2048
+- Updated Go and Python tasks with automatic FFI compilation helpers
+- New examples demonstrating Active Directory search and attractive numbers
+
+## Compilers
+
+- Automatic struct inference for C#, Kotlin, Python, Scala, Swift, Java and Go
+- TypeScript compiler generates stronger types with simpler query chains
+- C backend now uses `calloc` with allocation checks, supports JSON structs and
+  stack‑based list literals
+- Java compiler improves FFI imports, struct naming and descriptive class names
+- C++ compiler adds group‑by support with better type inference and JSON output
+- Zig compiler handles struct mutation and constant string operations
+- Rust compiler compiles FFI imports and refines `in` operator logic
+- Go compiler features sprint helper, auto FFI and improved variable names
+
+## Runtime
+
+- Virtual machine introduces basic Go and Python FFI support
+- Builtin module infrastructure for the C backend
+
+## Documentation
+
+- Machine READMEs refreshed with updated task lists and outputs


### PR DESCRIPTION
## Summary
- document new release v0.10.23 in CHANGELOG
- add detailed release notes for v0.10.23

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6870ca9a07008320b2b67fd49a29b2cd