### PR TITLE
Improve Go backend string handling

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -2058,8 +2058,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					val = fmt.Sprintf("%s[%s]", val, keyExpr)
 					typ = tt.Value
 				case types.StringType:
-					c.use("_indexString")
-					val = fmt.Sprintf("_indexString(%s, %s)", val, key)
+					val = fmt.Sprintf("string([]rune(%s)[%s])", val, key)
 					typ = types.StringType{}
 				default:
 					return "", fmt.Errorf("cannot index into type %s", typ)
@@ -2091,8 +2090,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					if idx.End == nil {
 						end = fmt.Sprintf("len([]rune(%s))", val)
 					}
-					c.use("_sliceString")
-					val = fmt.Sprintf("_sliceString(%s, %s, %s)", val, start, end)
+					val = fmt.Sprintf("string([]rune(%s)[%s:%s])", val, start, end)
 				default:
 					if idx.End == nil {
 						end = fmt.Sprintf("len(%s)", val)
@@ -4057,8 +4055,7 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(call.Args) != 3 {
 			return "", fmt.Errorf("substring expects 3 args")
 		}
-		c.use("_sliceString")
-		return fmt.Sprintf("_sliceString(%s)", argStr), nil
+		return fmt.Sprintf("string([]rune(%s)[%s:%s])", args[0], args[1], args[2]), nil
 	case "avg":
 		if len(call.Args) == 1 {
 			at := c.inferExprType(call.Args[0])

--- a/tests/machine/x/go/slice.go
+++ b/tests/machine/x/go/slice.go
@@ -10,27 +10,5 @@ import (
 func main() {
 	fmt.Println(strings.TrimSuffix(strings.TrimPrefix(fmt.Sprint([]int{1, 2, 3}[1:3]), "["), "]"))
 	fmt.Println(strings.TrimSuffix(strings.TrimPrefix(fmt.Sprint([]int{1, 2, 3}[0:2]), "["), "]"))
-	fmt.Println(_sliceString("hello", 1, 4))
-}
-
-func _sliceString(s string, i, j int) string {
-	start := i
-	end := j
-	n := len([]rune(s))
-	if start < 0 {
-		start += n
-	}
-	if end < 0 {
-		end += n
-	}
-	if start < 0 {
-		start = 0
-	}
-	if end > n {
-		end = n
-	}
-	if end < start {
-		end = start
-	}
-	return string([]rune(s)[start:end])
+	fmt.Println(string([]rune("hello")[1:4]))
 }

--- a/tests/machine/x/go/string_index.go
+++ b/tests/machine/x/go/string_index.go
@@ -8,16 +8,5 @@ import (
 
 func main() {
 	var s string = "mochi"
-	fmt.Println(_indexString(s, 1))
-}
-
-func _indexString(s string, i int) string {
-	runes := []rune(s)
-	if i < 0 {
-		i += len(runes)
-	}
-	if i < 0 || i >= len(runes) {
-		panic("index out of range")
-	}
-	return string(runes[i])
+	fmt.Println(string([]rune(s)[1]))
 }

--- a/tests/machine/x/go/string_prefix_slice.go
+++ b/tests/machine/x/go/string_prefix_slice.go
@@ -9,29 +9,7 @@ import (
 func main() {
 	var prefix string = "fore"
 	var s1 string = "forest"
-	fmt.Println((_sliceString(s1, 0, 4) == prefix))
+	fmt.Println((string([]rune(s1)[0:4]) == prefix))
 	var s2 string = "desert"
-	fmt.Println((_sliceString(s2, 0, 4) == prefix))
-}
-
-func _sliceString(s string, i, j int) string {
-	start := i
-	end := j
-	n := len([]rune(s))
-	if start < 0 {
-		start += n
-	}
-	if end < 0 {
-		end += n
-	}
-	if start < 0 {
-		start = 0
-	}
-	if end > n {
-		end = n
-	}
-	if end < start {
-		end = start
-	}
-	return string([]rune(s)[start:end])
+	fmt.Println((string([]rune(s2)[0:4]) == prefix))
 }


### PR DESCRIPTION
## Summary
- enhance Go compiler to use built-in operations for string indexing and slicing
- update generated Go code in machine tests

## Testing
- `go test ./compiler/x/go -run TestGoCompiler_ValidPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6870cbeb454c8320aff477cce1c55d68