### PR TITLE
Add Mochi implementation for Rosetta task 99

### DIFF
--- a/tests/rosetta/x/Mochi/binary-strings.mochi
+++ b/tests/rosetta/x/Mochi/binary-strings.mochi
@@ -1,0 +1,59 @@
+fun char(n: int): string {
+  let letters = "abcdefghijklmnopqrstuvwxyz"
+  let idx = n - 97
+  if idx < 0 || idx >= len(letters) {
+    return "?"
+  }
+  return substring(letters, idx, idx + 1)
+}
+
+fun fromBytes(bs: list<int>): string {
+  var s = ""
+  var i = 0
+  while i < len(bs) {
+    s = s + char(bs[i])
+    i = i + 1
+  }
+  return s
+}
+
+var b: list<int> = [98, 105, 110, 97, 114, 121]
+print(str(b))
+var c: list<int> = b
+print(str(c))
+print(str(b == c))
+var d: list<int> = []
+var i = 0
+while i < len(b) {
+  d = append(d, b[i])
+  i = i + 1
+}
+d[1] = 97
+ d[4] = 110
+print(fromBytes(b))
+print(fromBytes(d))
+print(str(len(b) == 0))
+var z = append(b, 122)
+print(fromBytes(z))
+var sub = b[1:3]
+print(fromBytes(sub))
+var f: list<int> = []
+i = 0
+while i < len(d) {
+  let val = d[i]
+  if val == 110 {
+    f = append(f, 109)
+  } else {
+    f = append(f, val)
+  }
+  i = i + 1
+}
+print(fromBytes(d) + " -> " + fromBytes(f))
+var rem: list<int> = []
+rem = append(rem, b[0])
+i = 3
+while i < len(b) {
+  rem = append(rem, b[i])
+  i = i + 1
+}
+print(fromBytes(rem))

--- a/tests/rosetta/x/Mochi/binary-strings.out
+++ b/tests/rosetta/x/Mochi/binary-strings.out
@@ -1,0 +1,10 @@
+[98 105 110 97 114 121]
+[98 105 110 97 114 121]
+true
+binary
+banany
+false
+binaryz
+in
+banany -> bamamy
+bary


### PR DESCRIPTION
## Summary
- add new Mochi solution for Rosetta task "Binary-strings"
- include golden output for the example

## Testing
- `go test -tags slow ./tools/rosetta -run TestMochiTasks/binary-strings -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870cc194a0883208304413854768622