### PR TITLE
Improve C++ compiler struct handling

### DIFF
--- a/tests/machine/x/cpp/append_builtin.cpp
+++ b/tests/machine/x/cpp/append_builtin.cpp
@@ -8,7 +8,7 @@ std::vector<T> __append(const std::vector<T> &v, const U &x) {
   return r;
 }
 int main() {
-  auto a = std::vector<int>{1, 2};
+  std::vector<int> a = std::vector<int>{1, 2};
   {
     auto __tmp1 = __append(a, 3);
     bool first = true;

--- a/tests/machine/x/cpp/break_continue.cpp
+++ b/tests/machine/x/cpp/break_continue.cpp
@@ -1,9 +1,56 @@
 #include <iostream>
+#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
+template <typename T> void __json(const T &);
+inline void __json(int v) { std::cout << v; }
+inline void __json(double v) { std::cout << v; }
+inline void __json(bool v) { std::cout << (v ? "true" : "false"); }
+inline void __json(const std::string &v) { std::cout << "\"" << v << "\""; }
+inline void __json(const char *v) { std::cout << "\"" << v << "\""; }
+template <typename T> void __json(const std::vector<T> &v) {
+  std::cout << "[";
+  bool first = true;
+  for (const auto &x : v) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(x);
+  }
+  std::cout << "]";
+}
+template <typename K, typename V> void __json(const std::map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
+template <typename K, typename V>
+void __json(const std::unordered_map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
+
 int main() {
-  auto numbers = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<int> numbers = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
   for (auto n : numbers) {
     if (((n % 2) == 0)) {
       continue;
@@ -14,7 +61,7 @@ int main() {
     {
       std::cout << std::string("odd number:");
       std::cout << ' ';
-      std::cout << std::boolalpha << n;
+      __json(n);
       std::cout << std::endl;
     }
   }

--- a/tests/machine/x/cpp/cross_join.cpp
+++ b/tests/machine/x/cpp/cross_join.cpp
@@ -24,10 +24,10 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(o.id) orderId;
-  decltype(o.customerId) orderCustomerId;
-  decltype(c.name) pairedCustomerName;
-  decltype(o.total) orderTotal;
+  decltype(std::declval<__struct2>().id) orderId;
+  decltype(std::declval<__struct2>().customerId) orderCustomerId;
+  decltype(std::declval<__struct1>().name) pairedCustomerName;
+  decltype(std::declval<__struct2>().total) orderTotal;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.orderId == b.orderId && a.orderCustomerId == b.orderCustomerId &&
@@ -38,10 +38,10 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 int main() {
-  auto customers = std::vector<__struct1>{__struct1{1, std::string("Alice")},
-                                          __struct1{2, std::string("Bob")},
-                                          __struct1{3, std::string("Charlie")}};
-  auto orders = std::vector<__struct2>{
+  std::vector<__struct1> customers = std::vector<__struct1>{
+      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
+      __struct1{3, std::string("Charlie")}};
+  std::vector<__struct2> orders = std::vector<__struct2>{
       __struct2{100, 1, 250}, __struct2{101, 2, 125}, __struct2{102, 1, 300}};
   auto result = ([&]() {
     std::vector<__struct3> __items;

--- a/tests/machine/x/cpp/cross_join_filter.cpp
+++ b/tests/machine/x/cpp/cross_join_filter.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 struct __struct1 {
-  decltype(n) n;
+  int n;
   std::string l;
 };
 inline bool operator==(const __struct1 &a, const __struct1 &b) {
@@ -13,7 +13,7 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 int main() {
-  auto nums = std::vector<int>{1, 2, 3};
+  std::vector<int> nums = std::vector<int>{1, 2, 3};
   std::vector<std::string> letters =
       std::vector<std::string>{std::string("A"), std::string("B")};
   auto pairs = ([&]() {

--- a/tests/machine/x/cpp/cross_join_triple.cpp
+++ b/tests/machine/x/cpp/cross_join_triple.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 struct __struct1 {
-  decltype(n) n;
+  int n;
   std::string l;
   bool b;
 };
@@ -14,7 +14,7 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 int main() {
-  auto nums = std::vector<int>{1, 2};
+  std::vector<int> nums = std::vector<int>{1, 2};
   std::vector<std::string> letters =
       std::vector<std::string>{std::string("A"), std::string("B")};
   std::vector<bool> bools = std::vector<decltype(true)>{true, false};

--- a/tests/machine/x/cpp/dataset_sort_take_limit.cpp
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.cpp
@@ -15,7 +15,7 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 int main() {
-  auto products =
+  std::vector<__struct1> products =
       std::vector<__struct1>{__struct1{std::string("Laptop"), 1500},
                              __struct1{std::string("Smartphone"), 900},
                              __struct1{std::string("Tablet"), 600},
@@ -24,7 +24,8 @@ int main() {
                              __struct1{std::string("Mouse"), 50},
                              __struct1{std::string("Headphones"), 200}};
   auto expensive = ([&]() {
-    std::vector<std::pair<decltype((-p.price)), decltype(p)>> __items;
+    std::vector<std::pair<decltype(std::declval<__struct1>().price), __struct1>>
+        __items;
     for (auto p : products) {
       __items.push_back({(-p.price), p});
     }
@@ -34,7 +35,7 @@ int main() {
       __items.erase(__items.begin(), __items.begin() + 1);
     if ((size_t)3 < __items.size())
       __items.resize(3);
-    std::vector<decltype(p)> __res;
+    std::vector<__struct1> __res;
     for (auto &p : __items)
       __res.push_back(p.second);
     return __res;

--- a/tests/machine/x/cpp/dataset_where_filter.cpp
+++ b/tests/machine/x/cpp/dataset_where_filter.cpp
@@ -13,8 +13,8 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 struct __struct2 {
-  decltype(person.name) name;
-  decltype(person.age) age;
+  decltype(std::declval<__struct1>().name) name;
+  decltype(std::declval<__struct1>().age) age;
   bool is_senior;
 };
 inline bool operator==(const __struct2 &a, const __struct2 &b) {
@@ -24,10 +24,10 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 int main() {
-  auto people = std::vector<__struct1>{__struct1{std::string("Alice"), 30},
-                                       __struct1{std::string("Bob"), 15},
-                                       __struct1{std::string("Charlie"), 65},
-                                       __struct1{std::string("Diana"), 45}};
+  std::vector<__struct1> people = std::vector<__struct1>{
+      __struct1{std::string("Alice"), 30}, __struct1{std::string("Bob"), 15},
+      __struct1{std::string("Charlie"), 65},
+      __struct1{std::string("Diana"), 45}};
   auto adults = ([&]() {
     std::vector<__struct2> __items;
     for (auto person : people) {

--- a/tests/machine/x/cpp/exists_builtin.cpp
+++ b/tests/machine/x/cpp/exists_builtin.cpp
@@ -1,10 +1,57 @@
 #include <iostream>
+#include <map>
+#include <unordered_map>
 #include <vector>
 
+template <typename T> void __json(const T &);
+inline void __json(int v) { std::cout << v; }
+inline void __json(double v) { std::cout << v; }
+inline void __json(bool v) { std::cout << (v ? "true" : "false"); }
+inline void __json(const std::string &v) { std::cout << "\"" << v << "\""; }
+inline void __json(const char *v) { std::cout << "\"" << v << "\""; }
+template <typename T> void __json(const std::vector<T> &v) {
+  std::cout << "[";
+  bool first = true;
+  for (const auto &x : v) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(x);
+  }
+  std::cout << "]";
+}
+template <typename K, typename V> void __json(const std::map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
+template <typename K, typename V>
+void __json(const std::unordered_map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
+
 int main() {
-  auto data = std::vector<int>{1, 2};
+  std::vector<int> data = std::vector<int>{1, 2};
   auto flag = (!([&]() {
-                  std::vector<decltype(x)> __items;
+                  std::vector<int> __items;
                   for (auto x : data) {
                     if (!((x == 1)))
                       continue;
@@ -13,6 +60,7 @@ int main() {
                   return __items;
                 })()
                     .empty());
-  std::cout << std::boolalpha << flag << std::endl;
+  __json(flag);
+  std::cout << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/group_by.cpp
+++ b/tests/machine/x/cpp/group_by.cpp
@@ -14,22 +14,13 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 struct __struct2 {
-  decltype(person) person;
+  decltype(std::declval<__struct1>().city) key;
+  std::vector<__struct1> items;
 };
 inline bool operator==(const __struct2 &a, const __struct2 &b) {
-  return a.person == b.person;
-}
-inline bool operator!=(const __struct2 &a, const __struct2 &b) {
-  return !(a == b);
-}
-struct __struct3 {
-  decltype(person.city) key;
-  std::vector<__struct2> items;
-};
-inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.key == b.key && a.items == b.items;
 }
-inline bool operator!=(const __struct3 &a, const __struct3 &b) {
+inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 template <typename T> double __avg(const std::vector<T> &v) {
@@ -40,19 +31,19 @@ template <typename T> double __avg(const std::vector<T> &v) {
     s += x;
   return s / v.size();
 }
-struct __struct4 {
-  decltype(std::declval<__struct3>().key) city;
+struct __struct3 {
+  decltype(std::declval<__struct2>().key) city;
   int count;
   bool avg_age;
 };
-inline bool operator==(const __struct4 &a, const __struct4 &b) {
+inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.city == b.city && a.count == b.count && a.avg_age == b.avg_age;
 }
-inline bool operator!=(const __struct4 &a, const __struct4 &b) {
+inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 int main() {
-  auto people = std::vector<__struct1>{
+  std::vector<__struct1> people = std::vector<__struct1>{
       __struct1{std::string("Alice"), 30, std::string("Paris")},
       __struct1{std::string("Bob"), 15, std::string("Hanoi")},
       __struct1{std::string("Charlie"), 65, std::string("Paris")},
@@ -60,27 +51,27 @@ int main() {
       __struct1{std::string("Eve"), 70, std::string("Paris")},
       __struct1{std::string("Frank"), 22, std::string("Hanoi")}};
   auto stats = ([&]() {
-    std::vector<__struct3> __groups;
+    std::vector<__struct2> __groups;
     for (auto person : people) {
       auto __key = person.city;
       bool __found = false;
       for (auto &__g : __groups) {
         if (__g.key == __key) {
-          __g.items.push_back(__struct2{person});
+          __g.items.push_back(__struct1{person});
           __found = true;
           break;
         }
       }
       if (!__found) {
         __groups.push_back(
-            __struct3{__key, std::vector<__struct2>{__struct2{person}}});
+            __struct2{__key, std::vector<__struct1>{__struct1{person}}});
       }
     }
-    std::vector<__struct4> __items;
+    std::vector<__struct3> __items;
     for (auto &g : __groups) {
-      __items.push_back(__struct4{
+      __items.push_back(__struct3{
           g.key, ((int)g.items.size()), __avg(([&]() {
-            std::vector<decltype(std::declval<__struct2>().age)> __items;
+            std::vector<decltype(std::declval<__struct1>().age)> __items;
             for (auto p : g.items) {
               __items.push_back(p.age);
             }

--- a/tests/machine/x/cpp/group_by_conditional_sum.cpp
+++ b/tests/machine/x/cpp/group_by_conditional_sum.cpp
@@ -17,67 +17,59 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 struct __struct2 {
-  decltype(i) i;
+  decltype(std::declval<__struct1>().cat) key;
+  std::vector<__struct1> items;
 };
 inline bool operator==(const __struct2 &a, const __struct2 &b) {
-  return a.i == b.i;
+  return a.key == b.key && a.items == b.items;
 }
 inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(i.cat) key;
-  std::vector<__struct2> items;
+  decltype(std::declval<__struct2>().key) cat;
+  bool share;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
-  return a.key == b.key && a.items == b.items;
+  return a.cat == b.cat && a.share == b.share;
 }
 inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
-struct __struct4 {
-  decltype(std::declval<__struct3>().key) cat;
-  bool share;
-};
-inline bool operator==(const __struct4 &a, const __struct4 &b) {
-  return a.cat == b.cat && a.share == b.share;
-}
-inline bool operator!=(const __struct4 &a, const __struct4 &b) {
-  return !(a == b);
-}
 int main() {
-  auto items = std::vector<__struct1>{__struct1{std::string("a"), 10, true},
-                                      __struct1{std::string("a"), 5, false},
-                                      __struct1{std::string("b"), 20, true}};
+  std::vector<__struct1> items =
+      std::vector<__struct1>{__struct1{std::string("a"), 10, true},
+                             __struct1{std::string("a"), 5, false},
+                             __struct1{std::string("b"), 20, true}};
   auto result = ([&]() {
-    std::vector<__struct3> __groups;
+    std::vector<__struct2> __groups;
     for (auto i : items) {
       auto __key = i.cat;
       bool __found = false;
       for (auto &__g : __groups) {
         if (__g.key == __key) {
-          __g.items.push_back(__struct2{i});
+          __g.items.push_back(__struct1{i});
           __found = true;
           break;
         }
       }
       if (!__found) {
         __groups.push_back(
-            __struct3{__key, std::vector<__struct2>{__struct2{i}}});
+            __struct2{__key, std::vector<__struct1>{__struct1{i}}});
       }
     }
-    std::vector<std::pair<decltype(std::declval<__struct3>().key), __struct4>>
+    std::vector<std::pair<decltype(std::declval<__struct2>().key), __struct3>>
         __items;
     for (auto &g : __groups) {
       __items.push_back(
           {g.key,
-           __struct4{
+           __struct3{
                g.key,
                (([&](auto v) {
                   return std::accumulate(v.begin(), v.end(), 0);
                 })(([&]() {
-                  std::vector<decltype((std::declval<__struct2>().flag
-                                            ? std::declval<__struct2>().val
+                  std::vector<decltype((std::declval<__struct1>().flag
+                                            ? std::declval<__struct1>().val
                                             : 0))>
                       __items;
                   for (auto x : g.items) {
@@ -88,7 +80,7 @@ int main() {
                 ([&](auto v) {
                   return std::accumulate(v.begin(), v.end(), 0);
                 })(([&]() {
-                  std::vector<decltype(std::declval<__struct2>().val)> __items;
+                  std::vector<decltype(std::declval<__struct1>().val)> __items;
                   for (auto x : g.items) {
                     __items.push_back(x.val);
                   }
@@ -97,7 +89,7 @@ int main() {
     }
     std::sort(__items.begin(), __items.end(),
               [](auto &a, auto &b) { return a.first < b.first; });
-    std::vector<__struct4> __res;
+    std::vector<__struct3> __res;
     for (auto &p : __items)
       __res.push_back(p.second);
     return __res;

--- a/tests/machine/x/cpp/group_by_having.cpp
+++ b/tests/machine/x/cpp/group_by_having.cpp
@@ -60,35 +60,26 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 struct __struct2 {
-  decltype(p) p;
+  decltype(std::declval<__struct1>().city) key;
+  std::vector<__struct1> items;
 };
 inline bool operator==(const __struct2 &a, const __struct2 &b) {
-  return a.p == b.p;
+  return a.key == b.key && a.items == b.items;
 }
 inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(p.city) key;
-  std::vector<__struct2> items;
+  decltype(std::declval<__struct2>().key) city;
+  int num;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
-  return a.key == b.key && a.items == b.items;
+  return a.city == b.city && a.num == b.num;
 }
 inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
-struct __struct4 {
-  decltype(std::declval<__struct3>().key) city;
-  int num;
-};
-inline bool operator==(const __struct4 &a, const __struct4 &b) {
-  return a.city == b.city && a.num == b.num;
-}
-inline bool operator!=(const __struct4 &a, const __struct4 &b) {
-  return !(a == b);
-}
-inline void __json(const __struct4 &v) {
+inline void __json(const __struct3 &v) {
   bool first = true;
   std::cout << "{";
   if (!first)
@@ -118,18 +109,8 @@ inline void __json(const __struct1 &v) {
   __json(v.city);
   std::cout << "}";
 }
-inline void __json(const __struct2 &v) {
-  bool first = true;
-  std::cout << "{";
-  if (!first)
-    std::cout << ",";
-  first = false;
-  std::cout << "\"p\":";
-  __json(v.p);
-  std::cout << "}";
-}
 int main() {
-  auto people = std::vector<__struct1>{
+  std::vector<__struct1> people = std::vector<__struct1>{
       __struct1{std::string("Alice"), std::string("Paris")},
       __struct1{std::string("Bob"), std::string("Hanoi")},
       __struct1{std::string("Charlie"), std::string("Paris")},
@@ -138,27 +119,27 @@ int main() {
       __struct1{std::string("Frank"), std::string("Hanoi")},
       __struct1{std::string("George"), std::string("Paris")}};
   auto big = ([&]() {
-    std::vector<__struct3> __groups;
+    std::vector<__struct2> __groups;
     for (auto p : people) {
       auto __key = p.city;
       bool __found = false;
       for (auto &__g : __groups) {
         if (__g.key == __key) {
-          __g.items.push_back(__struct2{p});
+          __g.items.push_back(__struct1{p});
           __found = true;
           break;
         }
       }
       if (!__found) {
         __groups.push_back(
-            __struct3{__key, std::vector<__struct2>{__struct2{p}}});
+            __struct2{__key, std::vector<__struct1>{__struct1{p}}});
       }
     }
-    std::vector<__struct4> __items;
+    std::vector<__struct3> __items;
     for (auto &g : __groups) {
       if (!((((int)g.items.size()) >= 4)))
         continue;
-      __items.push_back(__struct4{g.key, ((int)g.items.size())});
+      __items.push_back(__struct3{g.key, ((int)g.items.size())});
     }
     return __items;
   })();

--- a/tests/machine/x/cpp/group_by_join.cpp
+++ b/tests/machine/x/cpp/group_by_join.cpp
@@ -23,8 +23,8 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(o) o;
-  decltype(c) c;
+  __struct2 o;
+  __struct1 c;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.o == b.o && a.c == b.c;
@@ -33,7 +33,7 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 struct __struct4 {
-  decltype(c.name) key;
+  decltype(std::declval<__struct1>().name) key;
   std::vector<__struct3> items;
 };
 inline bool operator==(const __struct4 &a, const __struct4 &b) {
@@ -53,10 +53,10 @@ inline bool operator!=(const __struct5 &a, const __struct5 &b) {
   return !(a == b);
 }
 int main() {
-  auto customers = std::vector<__struct1>{__struct1{1, std::string("Alice")},
-                                          __struct1{2, std::string("Bob")}};
-  auto orders = std::vector<__struct2>{__struct2{100, 1}, __struct2{101, 1},
-                                       __struct2{102, 2}};
+  std::vector<__struct1> customers = std::vector<__struct1>{
+      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")}};
+  std::vector<__struct2> orders = std::vector<__struct2>{
+      __struct2{100, 1}, __struct2{101, 1}, __struct2{102, 2}};
   auto stats = ([&]() {
     std::vector<__struct4> __groups;
     for (auto o : orders) {

--- a/tests/machine/x/cpp/group_by_left_join.cpp
+++ b/tests/machine/x/cpp/group_by_left_join.cpp
@@ -23,8 +23,8 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(c) c;
-  decltype(o) o;
+  __struct1 c;
+  __struct2 o;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.c == b.c && a.o == b.o;
@@ -33,7 +33,7 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 struct __struct4 {
-  decltype(c.name) key;
+  decltype(std::declval<__struct1>().name) key;
   std::vector<__struct3> items;
 };
 inline bool operator==(const __struct4 &a, const __struct4 &b) {
@@ -53,11 +53,11 @@ inline bool operator!=(const __struct5 &a, const __struct5 &b) {
   return !(a == b);
 }
 int main() {
-  auto customers = std::vector<__struct1>{__struct1{1, std::string("Alice")},
-                                          __struct1{2, std::string("Bob")},
-                                          __struct1{3, std::string("Charlie")}};
-  auto orders = std::vector<__struct2>{__struct2{100, 1}, __struct2{101, 1},
-                                       __struct2{102, 2}};
+  std::vector<__struct1> customers = std::vector<__struct1>{
+      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
+      __struct1{3, std::string("Charlie")}};
+  std::vector<__struct2> orders = std::vector<__struct2>{
+      __struct2{100, 1}, __struct2{101, 1}, __struct2{102, 2}};
   auto stats = ([&]() {
     std::vector<__struct4> __groups;
     for (auto c : customers) {
@@ -104,7 +104,7 @@ int main() {
       __items.push_back(__struct5{g.key, ((int)([&]() {
                                             std::vector<__struct3> __items;
                                             for (auto r : g.items) {
-                                              if (!(r.o))
+                                              if (!((r.o != __struct2{})))
                                                 continue;
                                               __items.push_back(r);
                                             }

--- a/tests/machine/x/cpp/group_by_multi_join.cpp
+++ b/tests/machine/x/cpp/group_by_multi_join.cpp
@@ -37,8 +37,9 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 struct __struct4 {
-  decltype(ps.part) part;
-  decltype((ps.cost * ps.qty)) value;
+  decltype(std::declval<__struct3>().part) part;
+  decltype((std::declval<__struct3>().cost *
+            std::declval<__struct3>().qty)) value;
 };
 inline bool operator==(const __struct4 &a, const __struct4 &b) {
   return a.part == b.part && a.value == b.value;
@@ -67,10 +68,11 @@ inline bool operator!=(const __struct6 &a, const __struct6 &b) {
   return !(a == b);
 }
 int main() {
-  auto nations = std::vector<__struct1>{__struct1{1, std::string("A")},
-                                        __struct1{2, std::string("B")}};
-  auto suppliers = std::vector<__struct2>{__struct2{1, 1}, __struct2{2, 2}};
-  auto partsupp =
+  std::vector<__struct1> nations = std::vector<__struct1>{
+      __struct1{1, std::string("A")}, __struct1{2, std::string("B")}};
+  std::vector<__struct2> suppliers =
+      std::vector<__struct2>{__struct2{1, 1}, __struct2{2, 2}};
+  std::vector<__struct3> partsupp =
       std::vector<__struct3>{__struct3{100, 1, 10, 2}, __struct3{100, 2, 20, 1},
                              __struct3{200, 1, 5, 3}};
   auto filtered = ([&]() {

--- a/tests/machine/x/cpp/group_by_multi_join_sort.cpp
+++ b/tests/machine/x/cpp/group_by_multi_join_sort.cpp
@@ -59,13 +59,13 @@ inline bool operator!=(const __struct4 &a, const __struct4 &b) {
   return !(a == b);
 }
 struct __struct5 {
-  decltype(c.c_custkey) c_custkey;
-  decltype(c.c_name) c_name;
-  decltype(c.c_acctbal) c_acctbal;
-  decltype(c.c_address) c_address;
-  decltype(c.c_phone) c_phone;
-  decltype(c.c_comment) c_comment;
-  decltype(n.n_name) n_name;
+  decltype(std::declval<__struct2>().c_custkey) c_custkey;
+  decltype(std::declval<__struct2>().c_name) c_name;
+  decltype(std::declval<__struct2>().c_acctbal) c_acctbal;
+  decltype(std::declval<__struct2>().c_address) c_address;
+  decltype(std::declval<__struct2>().c_phone) c_phone;
+  decltype(std::declval<__struct2>().c_comment) c_comment;
+  decltype(std::declval<__struct1>().n_name) n_name;
 };
 inline bool operator==(const __struct5 &a, const __struct5 &b) {
   return a.c_custkey == b.c_custkey && a.c_name == b.c_name &&
@@ -77,10 +77,10 @@ inline bool operator!=(const __struct5 &a, const __struct5 &b) {
   return !(a == b);
 }
 struct __struct6 {
-  decltype(c) c;
-  decltype(o) o;
-  decltype(l) l;
-  decltype(n) n;
+  __struct2 c;
+  __struct3 o;
+  __struct4 l;
+  __struct1 n;
 };
 inline bool operator==(const __struct6 &a, const __struct6 &b) {
   return a.c == b.c && a.o == b.o && a.l == b.l && a.n == b.n;
@@ -118,14 +118,15 @@ inline bool operator!=(const __struct8 &a, const __struct8 &b) {
   return !(a == b);
 }
 int main() {
-  auto nation = std::vector<__struct1>{__struct1{1, std::string("BRAZIL")}};
-  auto customer = std::vector<__struct2>{
+  std::vector<__struct1> nation =
+      std::vector<__struct1>{__struct1{1, std::string("BRAZIL")}};
+  std::vector<__struct2> customer = std::vector<__struct2>{
       __struct2{1, std::string("Alice"), 100, 1, std::string("123 St"),
                 std::string("123-456"), std::string("Loyal")}};
-  auto orders =
+  std::vector<__struct3> orders =
       std::vector<__struct3>{__struct3{1000, 1, std::string("1993-10-15")},
                              __struct3{2000, 1, std::string("1994-01-02")}};
-  auto lineitem =
+  std::vector<__struct4> lineitem =
       std::vector<__struct4>{__struct4{1000, std::string("R"), 1000, 0.1},
                              __struct4{2000, std::string("N"), 500, 0}};
   auto start_date = std::string("1993-10-01");

--- a/tests/machine/x/cpp/group_by_sort.cpp
+++ b/tests/machine/x/cpp/group_by_sort.cpp
@@ -16,71 +16,62 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 struct __struct2 {
-  decltype(i) i;
+  decltype(std::declval<__struct1>().cat) key;
+  std::vector<__struct1> items;
 };
 inline bool operator==(const __struct2 &a, const __struct2 &b) {
-  return a.i == b.i;
+  return a.key == b.key && a.items == b.items;
 }
 inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(i.cat) key;
-  std::vector<__struct2> items;
+  decltype(std::declval<__struct2>().key) cat;
+  bool total;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
-  return a.key == b.key && a.items == b.items;
+  return a.cat == b.cat && a.total == b.total;
 }
 inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
-struct __struct4 {
-  decltype(std::declval<__struct3>().key) cat;
-  bool total;
-};
-inline bool operator==(const __struct4 &a, const __struct4 &b) {
-  return a.cat == b.cat && a.total == b.total;
-}
-inline bool operator!=(const __struct4 &a, const __struct4 &b) {
-  return !(a == b);
-}
 int main() {
-  auto items = std::vector<__struct1>{
+  std::vector<__struct1> items = std::vector<__struct1>{
       __struct1{std::string("a"), 3}, __struct1{std::string("a"), 1},
       __struct1{std::string("b"), 5}, __struct1{std::string("b"), 2}};
   auto grouped = ([&]() {
-    std::vector<__struct3> __groups;
+    std::vector<__struct2> __groups;
     for (auto i : items) {
       auto __key = i.cat;
       bool __found = false;
       for (auto &__g : __groups) {
         if (__g.key == __key) {
-          __g.items.push_back(__struct2{i});
+          __g.items.push_back(__struct1{i});
           __found = true;
           break;
         }
       }
       if (!__found) {
         __groups.push_back(
-            __struct3{__key, std::vector<__struct2>{__struct2{i}}});
+            __struct2{__key, std::vector<__struct1>{__struct1{i}}});
       }
     }
-    std::vector<std::pair<double, __struct4>> __items;
+    std::vector<std::pair<double, __struct3>> __items;
     for (auto &g : __groups) {
       __items.push_back(
           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0); })(
                ([&]() {
-                 std::vector<decltype(std::declval<__struct2>().val)> __items;
+                 std::vector<decltype(std::declval<__struct1>().val)> __items;
                  for (auto x : g.items) {
                    __items.push_back(x.val);
                  }
                  return __items;
                })())),
-           __struct4{
+           __struct3{
                g.key, ([&](auto v) {
                  return std::accumulate(v.begin(), v.end(), 0);
                })(([&]() {
-                 std::vector<decltype(std::declval<__struct2>().val)> __items;
+                 std::vector<decltype(std::declval<__struct1>().val)> __items;
                  for (auto x : g.items) {
                    __items.push_back(x.val);
                  }
@@ -89,7 +80,7 @@ int main() {
     }
     std::sort(__items.begin(), __items.end(),
               [](auto &a, auto &b) { return a.first < b.first; });
-    std::vector<__struct4> __res;
+    std::vector<__struct3> __res;
     for (auto &p : __items)
       __res.push_back(p.second);
     return __res;

--- a/tests/machine/x/cpp/group_items_iteration.cpp
+++ b/tests/machine/x/cpp/group_items_iteration.cpp
@@ -5,9 +5,29 @@
 #include <utility>
 #include <vector>
 
+struct __struct1 {
+  decltype(std::string("a")) tag;
+  decltype(1) val;
+};
+inline bool operator==(const __struct1 &a, const __struct1 &b) {
+  return a.tag == b.tag && a.val == b.val;
+}
+inline bool operator!=(const __struct1 &a, const __struct1 &b) {
+  return !(a == b);
+}
+struct __struct2 {
+  decltype(d.tag) key;
+  std::vector<__struct1> items;
+};
+inline bool operator==(const __struct2 &a, const __struct2 &b) {
+  return a.key == b.key && a.items == b.items;
+}
+inline bool operator!=(const __struct2 &a, const __struct2 &b) {
+  return !(a == b);
+}
 struct __struct3 {
-  decltype(g.key) tag;
-  decltype(total) total;
+  decltype(std::declval<__struct1>().key) tag;
+  int total;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.tag == b.tag && a.total == b.total;
@@ -21,25 +41,14 @@ std::vector<T> __append(const std::vector<T> &v, const U &x) {
   r.push_back(x);
   return r;
 }
-y == b.key &&a.items == b.items;
-}
-inline bool operator!=(const __struct2 &a, const __struct2 &b) {
-  return !(a == b);
-}
-template <typename T, typename U>
-std::vector<T> __append(const std::vector<T> &v, const U &x) {
-  auto r = v;
-  r.push_back(x);
-  return r;
-}
 int main() {
-  auto data = std::vector<__struct1>{__struct1{std::string("a"), 1},
-                                     __struct1{std::string("a"), 2},
-                                     __struct1{std::string("b"), 3}};
+  std::vector<__struct1> data = std::vector<__struct1>{
+      __struct1{std::string("a"), 1}, __struct1{std::string("a"), 2},
+      __struct1{std::string("b"), 3}};
   auto groups = ([&]() {
-    std::map<decltype(d.tag), std::vector<auto>> __groups;
+    std::map<decltype(d.tag), std::vector<__struct1>> __groups;
     for (auto d : data) {
-      __groups[d.tag].push_back(auto{d});
+      __groups[d.tag].push_back(__struct1{d});
     }
     std::vector<__struct2> __items;
     for (auto &kv : __groups) {
@@ -47,7 +56,7 @@ int main() {
     }
     return __items;
   })();
-  std::vector<__struct3> tmp = std::vector<__struct3>{};
+  std::vector<int> tmp = std::vector<int>{};
   for (auto g : groups) {
     auto total = 0;
     for (auto x : g.items) {

--- a/tests/machine/x/cpp/in_operator.cpp
+++ b/tests/machine/x/cpp/in_operator.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 int main() {
-  auto xs = std::vector<int>{1, 2, 3};
+  std::vector<int> xs = std::vector<int>{1, 2, 3};
   std::cout << std::boolalpha
             << (std::find(xs.begin(), xs.end(), 2) != xs.end()) << std::endl;
   std::cout << std::boolalpha

--- a/tests/machine/x/cpp/in_operator_extended.cpp
+++ b/tests/machine/x/cpp/in_operator_extended.cpp
@@ -5,9 +5,9 @@
 #include <vector>
 
 int main() {
-  auto xs = std::vector<int>{1, 2, 3};
+  std::vector<int> xs = std::vector<int>{1, 2, 3};
   auto ys = ([&]() {
-    std::vector<decltype(x)> __items;
+    std::vector<int> __items;
     for (auto x : xs) {
       if (!(((x % 2) == 1)))
         continue;

--- a/tests/machine/x/cpp/inner_join.cpp
+++ b/tests/machine/x/cpp/inner_join.cpp
@@ -24,9 +24,9 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(o.id) orderId;
-  decltype(c.name) customerName;
-  decltype(o.total) total;
+  decltype(std::declval<__struct2>().id) orderId;
+  decltype(std::declval<__struct1>().name) customerName;
+  decltype(std::declval<__struct2>().total) total;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.orderId == b.orderId && a.customerName == b.customerName &&
@@ -36,10 +36,10 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 int main() {
-  auto customers = std::vector<__struct1>{__struct1{1, std::string("Alice")},
-                                          __struct1{2, std::string("Bob")},
-                                          __struct1{3, std::string("Charlie")}};
-  auto orders =
+  std::vector<__struct1> customers = std::vector<__struct1>{
+      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
+      __struct1{3, std::string("Charlie")}};
+  std::vector<__struct2> orders =
       std::vector<__struct2>{__struct2{100, 1, 250}, __struct2{101, 2, 125},
                              __struct2{102, 1, 300}, __struct2{103, 4, 80}};
   auto result = ([&]() {

--- a/tests/machine/x/cpp/join_multi.cpp
+++ b/tests/machine/x/cpp/join_multi.cpp
@@ -33,8 +33,8 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 struct __struct4 {
-  decltype(c.name) name;
-  decltype(i.sku) sku;
+  decltype(std::declval<__struct1>().name) name;
+  decltype(std::declval<__struct3>().sku) sku;
 };
 inline bool operator==(const __struct4 &a, const __struct4 &b) {
   return a.name == b.name && a.sku == b.sku;
@@ -43,11 +43,12 @@ inline bool operator!=(const __struct4 &a, const __struct4 &b) {
   return !(a == b);
 }
 int main() {
-  auto customers = std::vector<__struct1>{__struct1{1, std::string("Alice")},
-                                          __struct1{2, std::string("Bob")}};
-  auto orders = std::vector<__struct2>{__struct2{100, 1}, __struct2{101, 2}};
-  auto items = std::vector<__struct3>{__struct3{100, std::string("a")},
-                                      __struct3{101, std::string("b")}};
+  std::vector<__struct1> customers = std::vector<__struct1>{
+      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")}};
+  std::vector<__struct2> orders =
+      std::vector<__struct2>{__struct2{100, 1}, __struct2{101, 2}};
+  std::vector<__struct3> items = std::vector<__struct3>{
+      __struct3{100, std::string("a")}, __struct3{101, std::string("b")}};
   auto result = ([&]() {
     std::vector<__struct4> __items;
     for (auto o : orders) {

--- a/tests/machine/x/cpp/left_join.cpp
+++ b/tests/machine/x/cpp/left_join.cpp
@@ -1,6 +1,53 @@
 #include <iostream>
+#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+template <typename T> void __json(const T &);
+inline void __json(int v) { std::cout << v; }
+inline void __json(double v) { std::cout << v; }
+inline void __json(bool v) { std::cout << (v ? "true" : "false"); }
+inline void __json(const std::string &v) { std::cout << "\"" << v << "\""; }
+inline void __json(const char *v) { std::cout << "\"" << v << "\""; }
+template <typename T> void __json(const std::vector<T> &v) {
+  std::cout << "[";
+  bool first = true;
+  for (const auto &x : v) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(x);
+  }
+  std::cout << "]";
+}
+template <typename K, typename V> void __json(const std::map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
+template <typename K, typename V>
+void __json(const std::unordered_map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
 
 struct __struct1 {
   decltype(1) id;
@@ -24,9 +71,9 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(o.id) orderId;
-  decltype(c) customer;
-  decltype(o.total) total;
+  decltype(std::declval<__struct2>().id) orderId;
+  __struct1 customer;
+  decltype(std::declval<__struct2>().total) total;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.orderId == b.orderId && a.customer == b.customer &&
@@ -35,10 +82,65 @@ inline bool operator==(const __struct3 &a, const __struct3 &b) {
 inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
+inline void __json(const __struct2 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"id\":";
+  __json(v.id);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"customerId\":";
+  __json(v.customerId);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"total\":";
+  __json(v.total);
+  std::cout << "}";
+}
+inline void __json(const __struct1 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"id\":";
+  __json(v.id);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"name\":";
+  __json(v.name);
+  std::cout << "}";
+}
+inline void __json(const __struct3 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"orderId\":";
+  __json(v.orderId);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"customer\":";
+  __json(v.customer);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"total\":";
+  __json(v.total);
+  std::cout << "}";
+}
 int main() {
-  auto customers = std::vector<__struct1>{__struct1{1, std::string("Alice")},
-                                          __struct1{2, std::string("Bob")}};
-  auto orders =
+  std::vector<__struct1> customers = std::vector<__struct1>{
+      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")}};
+  std::vector<__struct2> orders =
       std::vector<__struct2>{__struct2{100, 1, 250}, __struct2{101, 3, 80}};
   auto result = ([&]() {
     std::vector<__struct3> __items;
@@ -68,7 +170,7 @@ int main() {
       std::cout << ' ';
       std::cout << std::string("customer");
       std::cout << ' ';
-      std::cout << std::boolalpha << entry.customer;
+      __json(entry.customer);
       std::cout << ' ';
       std::cout << std::string("total");
       std::cout << ' ';

--- a/tests/machine/x/cpp/left_join_multi.cpp
+++ b/tests/machine/x/cpp/left_join_multi.cpp
@@ -1,6 +1,53 @@
 #include <iostream>
+#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+template <typename T> void __json(const T &);
+inline void __json(int v) { std::cout << v; }
+inline void __json(double v) { std::cout << v; }
+inline void __json(bool v) { std::cout << (v ? "true" : "false"); }
+inline void __json(const std::string &v) { std::cout << "\"" << v << "\""; }
+inline void __json(const char *v) { std::cout << "\"" << v << "\""; }
+template <typename T> void __json(const std::vector<T> &v) {
+  std::cout << "[";
+  bool first = true;
+  for (const auto &x : v) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(x);
+  }
+  std::cout << "]";
+}
+template <typename K, typename V> void __json(const std::map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
+template <typename K, typename V>
+void __json(const std::unordered_map<K, V> &m) {
+  std::cout << "{";
+  bool first = true;
+  for (const auto &kv : m) {
+    if (!first)
+      std::cout << ",";
+    first = false;
+    __json(kv.first);
+    std::cout << ":";
+    __json(kv.second);
+  }
+  std::cout << "}";
+}
 
 struct __struct1 {
   decltype(1) id;
@@ -33,9 +80,9 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 struct __struct4 {
-  decltype(o.id) orderId;
-  decltype(c.name) name;
-  decltype(i) item;
+  decltype(std::declval<__struct2>().id) orderId;
+  decltype(std::declval<__struct1>().name) name;
+  __struct3 item;
 };
 inline bool operator==(const __struct4 &a, const __struct4 &b) {
   return a.orderId == b.orderId && a.name == b.name && a.item == b.item;
@@ -43,11 +90,78 @@ inline bool operator==(const __struct4 &a, const __struct4 &b) {
 inline bool operator!=(const __struct4 &a, const __struct4 &b) {
   return !(a == b);
 }
+inline void __json(const __struct2 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"id\":";
+  __json(v.id);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"customerId\":";
+  __json(v.customerId);
+  std::cout << "}";
+}
+inline void __json(const __struct1 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"id\":";
+  __json(v.id);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"name\":";
+  __json(v.name);
+  std::cout << "}";
+}
+inline void __json(const __struct4 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"orderId\":";
+  __json(v.orderId);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"name\":";
+  __json(v.name);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"item\":";
+  __json(v.item);
+  std::cout << "}";
+}
+inline void __json(const __struct3 &v) {
+  bool first = true;
+  std::cout << "{";
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"orderId\":";
+  __json(v.orderId);
+  if (!first)
+    std::cout << ",";
+  first = false;
+  std::cout << "\"sku\":";
+  __json(v.sku);
+  std::cout << "}";
+}
 int main() {
-  auto customers = std::vector<__struct1>{__struct1{1, std::string("Alice")},
-                                          __struct1{2, std::string("Bob")}};
-  auto orders = std::vector<__struct2>{__struct2{100, 1}, __struct2{101, 2}};
-  auto items = std::vector<__struct3>{__struct3{100, std::string("a")}};
+  std::vector<__struct1> customers = std::vector<__struct1>{
+      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")}};
+  std::vector<__struct2> orders =
+      std::vector<__struct2>{__struct2{100, 1}, __struct2{101, 2}};
+  std::vector<__struct3> items =
+      std::vector<__struct3>{__struct3{100, std::string("a")}};
   auto result = ([&]() {
     std::vector<__struct4> __items;
     for (auto o : orders) {
@@ -78,7 +192,7 @@ int main() {
       std::cout << ' ';
       std::cout << std::boolalpha << r.name;
       std::cout << ' ';
-      std::cout << std::boolalpha << r.item;
+      __json(r.item);
       std::cout << std::endl;
     }
   }

--- a/tests/machine/x/cpp/list_assign.cpp
+++ b/tests/machine/x/cpp/list_assign.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<int>{1, 2};
+  std::vector<int> nums = std::vector<int>{1, 2};
   nums[1] = 3;
   std::cout << std::boolalpha << nums[1] << std::endl;
   return 0;

--- a/tests/machine/x/cpp/list_index.cpp
+++ b/tests/machine/x/cpp/list_index.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 int main() {
-  auto xs = std::vector<int>{10, 20, 30};
+  std::vector<int> xs = std::vector<int>{10, 20, 30};
   std::cout << std::boolalpha << xs[1] << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/membership.cpp
+++ b/tests/machine/x/cpp/membership.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<int>{1, 2, 3};
+  std::vector<int> nums = std::vector<int>{1, 2, 3};
   std::cout << std::boolalpha
             << (std::find(nums.begin(), nums.end(), 2) != nums.end())
             << std::endl;

--- a/tests/machine/x/cpp/min_max_builtin.cpp
+++ b/tests/machine/x/cpp/min_max_builtin.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<int>{3, 1, 4};
+  std::vector<int> nums = std::vector<int>{3, 1, 4};
   std::cout << std::boolalpha << (*std::min_element(nums.begin(), nums.end()))
             << std::endl;
   std::cout << std::boolalpha << (*std::max_element(nums.begin(), nums.end()))

--- a/tests/machine/x/cpp/order_by_map.cpp
+++ b/tests/machine/x/cpp/order_by_map.cpp
@@ -14,17 +14,17 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 int main() {
-  auto data =
+  std::vector<__struct1> data =
       std::vector<__struct1>{__struct1{1, 2}, __struct1{1, 1}, __struct1{0, 5}};
   auto sorted = ([&]() {
-    std::vector<std::pair<__struct1, decltype(x)>> __items;
+    std::vector<std::pair<__struct1, __struct1>> __items;
     for (auto x : data) {
       __items.push_back({__struct1{x.a, x.b}, x});
     }
     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
       return std::tie(a.first.a, a.first.b) < std::tie(b.first.a, b.first.b);
     });
-    std::vector<decltype(x)> __res;
+    std::vector<__struct1> __res;
     for (auto &p : __items)
       __res.push_back(p.second);
     return __res;
@@ -36,7 +36,7 @@ int main() {
       if (!first)
         std::cout << ' ';
       first = false;
-      std::cout << std::boolalpha << _x;
+      std::cout << "<struct>";
     }
     std::cout << std::endl;
   }

--- a/tests/machine/x/cpp/outer_join.cpp
+++ b/tests/machine/x/cpp/outer_join.cpp
@@ -24,8 +24,8 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(o) order;
-  decltype(c) customer;
+  __struct2 order;
+  __struct1 customer;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.order == b.order && a.customer == b.customer;
@@ -34,10 +34,10 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 int main() {
-  auto customers = std::vector<__struct1>{
+  std::vector<__struct1> customers = std::vector<__struct1>{
       __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
       __struct1{3, std::string("Charlie")}, __struct1{4, std::string("Diana")}};
-  auto orders =
+  std::vector<__struct2> orders =
       std::vector<__struct2>{__struct2{100, 1, 250}, __struct2{101, 2, 125},
                              __struct2{102, 1, 300}, __struct2{103, 5, 80}};
   auto result = ([&]() {
@@ -61,8 +61,8 @@ int main() {
   })();
   std::cout << std::string("--- Outer Join using syntax ---") << std::endl;
   for (auto row : result) {
-    if (row.order) {
-      if (row.customer) {
+    if ((row.order != __struct2{})) {
+      if ((row.customer != __struct1{})) {
         {
           std::cout << std::string("Order");
           std::cout << ' ';

--- a/tests/machine/x/cpp/query_sum_select.cpp
+++ b/tests/machine/x/cpp/query_sum_select.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 int main() {
-  auto nums = std::vector<int>{1, 2, 3};
+  std::vector<int> nums = std::vector<int>{1, 2, 3};
   auto result = ([&]() {
     int __sum = 0;
     for (auto n : nums) {

--- a/tests/machine/x/cpp/right_join.cpp
+++ b/tests/machine/x/cpp/right_join.cpp
@@ -24,8 +24,8 @@ inline bool operator!=(const __struct2 &a, const __struct2 &b) {
   return !(a == b);
 }
 struct __struct3 {
-  decltype(c.name) customerName;
-  decltype(o) order;
+  decltype(std::declval<__struct1>().name) customerName;
+  __struct2 order;
 };
 inline bool operator==(const __struct3 &a, const __struct3 &b) {
   return a.customerName == b.customerName && a.order == b.order;
@@ -34,10 +34,10 @@ inline bool operator!=(const __struct3 &a, const __struct3 &b) {
   return !(a == b);
 }
 int main() {
-  auto customers = std::vector<__struct1>{
+  std::vector<__struct1> customers = std::vector<__struct1>{
       __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
       __struct1{3, std::string("Charlie")}, __struct1{4, std::string("Diana")}};
-  auto orders = std::vector<__struct2>{
+  std::vector<__struct2> orders = std::vector<__struct2>{
       __struct2{100, 1, 250}, __struct2{101, 2, 125}, __struct2{102, 1, 300}};
   auto result = ([&]() {
     std::vector<__struct3> __items;
@@ -60,7 +60,7 @@ int main() {
   })();
   std::cout << std::string("--- Right Join using syntax ---") << std::endl;
   for (auto entry : result) {
-    if (entry.order) {
+    if ((entry.order != __struct2{})) {
       {
         std::cout << std::string("Customer");
         std::cout << ' ';

--- a/tests/machine/x/cpp/save_jsonl_stdout.cpp
+++ b/tests/machine/x/cpp/save_jsonl_stdout.cpp
@@ -75,8 +75,8 @@ inline void __json(const __struct1 &v) {
   std::cout << "}";
 }
 int main() {
-  auto people = std::vector<__struct1>{__struct1{std::string("Alice"), 30},
-                                       __struct1{std::string("Bob"), 25}};
+  std::vector<__struct1> people = std::vector<__struct1>{
+      __struct1{std::string("Alice"), 30}, __struct1{std::string("Bob"), 25}};
   ([&]() {
     for (auto &x : people) {
       __json(x);

--- a/tests/machine/x/cpp/slice.cpp
+++ b/tests/machine/x/cpp/slice.cpp
@@ -5,8 +5,7 @@
 int main() {
   {
     auto __tmp1 = ([&](auto v) {
-      return std::vector<decltype(std::vector<int>{1, 2, 3}[0])>(v.begin() + 1,
-                                                                 v.begin() + 3);
+      return std::vector<int>(v.begin() + 1, v.begin() + 3);
     })(std::vector<int>{1, 2, 3});
     bool first = true;
     for (const auto &_x : __tmp1) {
@@ -19,8 +18,7 @@ int main() {
   }
   {
     auto __tmp2 = ([&](auto v) {
-      return std::vector<decltype(std::vector<int>{1, 2, 3}[0])>(v.begin() + 0,
-                                                                 v.begin() + 2);
+      return std::vector<int>(v.begin() + 0, v.begin() + 2);
     })(std::vector<int>{1, 2, 3});
     bool first = true;
     for (const auto &_x : __tmp2) {

--- a/tests/machine/x/cpp/sort_stable.cpp
+++ b/tests/machine/x/cpp/sort_stable.cpp
@@ -15,17 +15,19 @@ inline bool operator!=(const __struct1 &a, const __struct1 &b) {
   return !(a == b);
 }
 int main() {
-  auto items = std::vector<__struct1>{__struct1{1, std::string("a")},
-                                      __struct1{1, std::string("b")},
-                                      __struct1{2, std::string("c")}};
+  std::vector<__struct1> items = std::vector<__struct1>{
+      __struct1{1, std::string("a")}, __struct1{1, std::string("b")},
+      __struct1{2, std::string("c")}};
   auto result = ([&]() {
-    std::vector<std::pair<decltype(i.n), decltype(i.v)>> __items;
+    std::vector<std::pair<decltype(std::declval<__struct1>().n),
+                          decltype(std::declval<__struct1>().v)>>
+        __items;
     for (auto i : items) {
       __items.push_back({i.n, i.v});
     }
     std::sort(__items.begin(), __items.end(),
               [](auto &a, auto &b) { return a.first < b.first; });
-    std::vector<decltype(i.v)> __res;
+    std::vector<decltype(std::declval<__struct1>().v)> __res;
     for (auto &p : __items)
       __res.push_back(p.second);
     return __res;


### PR DESCRIPTION
## Summary
- improve element type inference for vectors in the C++ backend
- fall back to primitive types when deriving query key types
- regenerate C++ machine outputs

## Testing
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870cb73f8bc83209db1fc6d94a95096