### PR TITLE
Improve CS compiler generics

### DIFF
--- a/compiler/x/cs/runtime.go
+++ b/compiler/x/cs/runtime.go
@@ -311,17 +311,19 @@ func (c *Compiler) emitRuntime() {
 				c.indent--
 				c.writeln("}")
 			case "_group":
-				c.writeln("public class _Group {")
+				c.writeln("public interface _IGroup { System.Collections.IEnumerable Items { get; } }")
+				c.writeln("public class _Group<TKey, TItem> : _IGroup {")
 				c.indent++
-				c.writeln("public dynamic key;")
-				c.writeln("public List<dynamic> Items = new List<dynamic>();")
-				c.writeln("public _Group(dynamic k) { key = k; }")
+				c.writeln("public TKey key;")
+				c.writeln("public List<TItem> Items = new List<TItem>();")
+				c.writeln("public _Group(TKey k) { key = k; }")
+				c.writeln("System.Collections.IEnumerable _IGroup.Items => Items;")
 				c.indent--
 				c.writeln("}")
 			case "_group_by":
-				c.writeln("static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {")
+				c.writeln("static List<_Group<TKey, TItem>> _group_by<TItem, TKey>(IEnumerable<TItem> src, Func<TItem, TKey> keyfn) {")
 				c.indent++
-				c.writeln("var groups = new Dictionary<string, _Group>();")
+				c.writeln("var groups = new Dictionary<string, _Group<TKey, TItem>>();")
 				c.writeln("var order = new List<string>();")
 				c.writeln("foreach (var it in src) {")
 				c.indent++
@@ -329,7 +331,7 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("var ks = Convert.ToString(key);")
 				c.writeln("if (!groups.TryGetValue(ks, out var g)) {")
 				c.indent++
-				c.writeln("g = new _Group(key);")
+				c.writeln("g = new _Group<TKey, TItem>(key);")
 				c.writeln("groups[ks] = g;")
 				c.writeln("order.Add(ks);")
 				c.indent--
@@ -337,7 +339,7 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("g.Items.Add(it);")
 				c.indent--
 				c.writeln("}")
-				c.writeln("var res = new List<_Group>();")
+				c.writeln("var res = new List<_Group<TKey, TItem>>();")
 				c.writeln("foreach (var k in order) res.Add(groups[k]);")
 				c.writeln("return res;")
 				c.indent--

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -109,3 +109,4 @@ Checklist:
 
 ## Remaining work
 - [ ] Improve LINQ query formatting for complex joins
+- [ ] Further reduce dynamic usage in helper runtime


### PR DESCRIPTION
## Summary
- implement typed `_Group` and `_group_by` runtime helpers
- use key/value types for grouping in the CS compiler
- document remaining work for the CS machine output

## Testing
- `go test -tags slow ./compiler/x/cs -run TestCompileValidPrograms -count=1` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6870d0e2ca2883209c08dbaca3640250