### PR TITLE
Improve Go compiler map checks

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -2366,7 +2366,7 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if isStringAnyMap(c.inferExprType(f.With)) {
+		if isStringMap(c.inferExprType(f.With)) {
 			withStr = w
 		} else {
 			c.use("_toAnyMap")
@@ -2464,7 +2464,7 @@ func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if isStringAnyMap(c.inferExprType(l.With)) {
+		if isStringMap(c.inferExprType(l.With)) {
 			opts = v
 		} else {
 			c.use("_toAnyMap")
@@ -2516,7 +2516,7 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if isStringAnyMap(c.inferExprType(s.With)) {
+		if isStringMap(c.inferExprType(s.With)) {
 			opts = v
 		} else {
 			c.use("_toAnyMap")
@@ -2625,7 +2625,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr, hint types.Type) (strin
 		elemType = lt.Elem
 		directRange = true
 	}
-	elemIsMap := isStringAnyMap(elemType)
+	elemIsMap := isStringMap(elemType)
 	original := c.env
 	child := types.NewEnv(c.env)
 	child.SetVar(q.Var, elemType, true)
@@ -2638,7 +2638,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr, hint types.Type) (strin
 			felem = lt.Elem
 		}
 		child.SetVar(f.Var, felem, true)
-		fromIsMap[i] = isStringAnyMap(felem)
+		fromIsMap[i] = isStringMap(felem)
 	}
 	// Add join variables to environment
 	joinIsMap := make([]bool, len(q.Joins))
@@ -2649,7 +2649,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr, hint types.Type) (strin
 			jelem = lt.Elem
 		}
 		child.SetVar(j.Var, jelem, true)
-		joinIsMap[i] = isStringAnyMap(jelem)
+		joinIsMap[i] = isStringMap(jelem)
 	}
 
 	var groupKey string

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -248,6 +248,14 @@ func isStringAnyMap(t types.Type) bool {
 	return false
 }
 
+// isStringMap reports whether t is a map with string keys regardless of value type.
+func isStringMap(t types.Type) bool {
+	if mt, ok := t.(types.MapType); ok {
+		return isString(mt.Key)
+	}
+	return false
+}
+
 func isMap(t types.Type) bool {
 	_, ok := t.(types.MapType)
 	return ok

--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -106,3 +106,8 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining Tasks
+
+- [ ] Fix `right_join` compilation errors.
+- [ ] Enhance type inference to avoid unnecessary `_toAnyMap` conversions.


### PR DESCRIPTION
## Summary
- add helper to detect any map with string keys
- use new helper in the Go compiler
- note remaining tasks for Go machine tests

## Testing
- `go test ./compiler/x/go -run TestGoCompiler_ValidPrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870c8a076588320b501b6e68a408fdc