### PR TITLE
Improve C compiler join support

### DIFF
--- a/compiler/x/c/helpers.go
+++ b/compiler/x/c/helpers.go
@@ -49,6 +49,14 @@ func isString(t types.Type) bool {
 	return ok
 }
 
+func sanitizeTypeName(name string) string {
+	s := sanitizeName(name)
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
 func cTypeFromType(t types.Type) string {
 	switch tt := t.(type) {
 	case types.IntType, types.BoolType:
@@ -58,9 +66,9 @@ func cTypeFromType(t types.Type) string {
 	case types.StringType:
 		return "char*"
 	case types.UnionType:
-		return sanitizeName(tt.Name)
+		return sanitizeTypeName(tt.Name)
 	case types.StructType:
-		return sanitizeName(tt.Name)
+		return sanitizeTypeName(tt.Name)
 	case types.ListType:
 		if _, ok := tt.Elem.(types.AnyType); ok {
 			return "list_int"
@@ -82,7 +90,7 @@ func cTypeFromType(t types.Type) string {
 			return "list_group_int"
 		}
 		if st, ok := tt.Elem.(types.StructType); ok {
-			return "list_" + sanitizeName(st.Name)
+			return "list_" + sanitizeTypeName(st.Name)
 		}
 	case types.MapType:
 		if isMapIntBoolType(tt) {
@@ -208,7 +216,7 @@ func defaultCValue(t types.Type) string {
 	case types.FloatType, types.IntType, types.BoolType:
 		return "0"
 	case types.StructType:
-		return fmt.Sprintf("(%s){0}", sanitizeName(tt.Name))
+		return fmt.Sprintf("(%s){0}", sanitizeTypeName(tt.Name))
 	default:
 		return "0"
 	}

--- a/tests/machine/x/c/outer_join.c
+++ b/tests/machine/x/c/outer_join.c
@@ -4,15 +4,15 @@
 typedef struct {
   int id;
   char *name;
-} customersItem;
+} CustomersItem;
 typedef struct {
   int len;
-  customersItem *data;
-} list_customersItem;
-static list_customersItem list_customersItem_create(int len) {
-  list_customersItem l;
+  CustomersItem *data;
+} list_CustomersItem;
+static list_CustomersItem list_CustomersItem_create(int len) {
+  list_CustomersItem l;
   l.len = len;
-  l.data = calloc(len, sizeof(customersItem));
+  l.data = calloc(len, sizeof(CustomersItem));
   if (!l.data && len > 0) {
     fprintf(stderr, "alloc failed\n");
     exit(1);
@@ -24,15 +24,15 @@ typedef struct {
   int id;
   int customerId;
   int total;
-} ordersItem;
+} OrdersItem;
 typedef struct {
   int len;
-  ordersItem *data;
-} list_ordersItem;
-static list_ordersItem list_ordersItem_create(int len) {
-  list_ordersItem l;
+  OrdersItem *data;
+} list_OrdersItem;
+static list_OrdersItem list_OrdersItem_create(int len) {
+  list_OrdersItem l;
   l.len = len;
-  l.data = calloc(len, sizeof(ordersItem));
+  l.data = calloc(len, sizeof(OrdersItem));
   if (!l.data && len > 0) {
     fprintf(stderr, "alloc failed\n");
     exit(1);
@@ -41,17 +41,17 @@ static list_ordersItem list_ordersItem_create(int len) {
 }
 
 typedef struct {
-  ordersItem order;
-  customersItem customer;
-} resultItem;
+  OrdersItem order;
+  CustomersItem customer;
+} ResultItem;
 typedef struct {
   int len;
-  resultItem *data;
-} list_resultItem;
-static list_resultItem list_resultItem_create(int len) {
-  list_resultItem l;
+  ResultItem *data;
+} list_ResultItem;
+static list_ResultItem list_ResultItem_create(int len) {
+  list_ResultItem l;
   l.len = len;
-  l.data = calloc(len, sizeof(resultItem));
+  l.data = calloc(len, sizeof(ResultItem));
   if (!l.data && len > 0) {
     fprintf(stderr, "alloc failed\n");
     exit(1);
@@ -60,37 +60,60 @@ static list_resultItem list_resultItem_create(int len) {
 }
 
 int main() {
-  customersItem tmp1_data[] = {(customersItem){.id = 1, .name = "Alice"},
-                               (customersItem){.id = 2, .name = "Bob"},
-                               (customersItem){.id = 3, .name = "Charlie"},
-                               (customersItem){.id = 4, .name = "Diana"}};
-  list_customersItem tmp1 = {4, tmp1_data};
-  list_customersItem customers = tmp1;
-  ordersItem tmp2_data[] = {
-      (ordersItem){.id = 100, .customerId = 1, .total = 250},
-      (ordersItem){.id = 101, .customerId = 2, .total = 125},
-      (ordersItem){.id = 102, .customerId = 1, .total = 300},
-      (ordersItem){.id = 103, .customerId = 5, .total = 80}};
-  list_ordersItem tmp2 = {4, tmp2_data};
-  list_ordersItem orders = tmp2;
-  list_resultItem tmp3 = list_resultItem_create(orders.len * customers.len);
+  CustomersItem tmp1_data[] = {(CustomersItem){.id = 1, .name = "Alice"},
+                               (CustomersItem){.id = 2, .name = "Bob"},
+                               (CustomersItem){.id = 3, .name = "Charlie"},
+                               (CustomersItem){.id = 4, .name = "Diana"}};
+  list_CustomersItem tmp1 = {4, tmp1_data};
+  list_CustomersItem customers = tmp1;
+  OrdersItem tmp2_data[] = {
+      (OrdersItem){.id = 100, .customerId = 1, .total = 250},
+      (OrdersItem){.id = 101, .customerId = 2, .total = 125},
+      (OrdersItem){.id = 102, .customerId = 1, .total = 300},
+      (OrdersItem){.id = 103, .customerId = 5, .total = 80}};
+  list_OrdersItem tmp2 = {4, tmp2_data};
+  list_OrdersItem orders = tmp2;
+  list_ResultItem tmp3 = list_ResultItem_create(orders.len * customers.len +
+                                                orders.len + customers.len);
   int tmp4 = 0;
-  for (int tmp5 = 0; tmp5 < orders.len; tmp5++) {
-    ordersItem o = orders.data[tmp5];
-    for (int tmp6 = 0; tmp6 < customers.len; tmp6++) {
-      customersItem c = customers.data[tmp6];
+  int *tmp5 = calloc(orders.len, sizeof(int));
+  int *tmp6 = calloc(customers.len, sizeof(int));
+  for (int tmp7 = 0; tmp7 < orders.len; tmp7++) {
+    OrdersItem o = orders.data[tmp7];
+    for (int tmp8 = 0; tmp8 < customers.len; tmp8++) {
+      CustomersItem c = customers.data[tmp8];
       if (!(o.customerId == c.id)) {
         continue;
       }
-      tmp3.data[tmp4] = (resultItem){.order = o, .customer = c};
+      tmp5[tmp7] = 1;
+      tmp6[tmp8] = 1;
+      tmp3.data[tmp4] = (ResultItem){.order = o, .customer = c};
       tmp4++;
     }
   }
+  for (int tmp7 = 0; tmp7 < orders.len; tmp7++) {
+    if (tmp5[tmp7])
+      continue;
+    OrdersItem o = orders.data[tmp7];
+    CustomersItem c = (CustomersItem){0};
+    tmp3.data[tmp4] = (ResultItem){.order = o, .customer = c};
+    tmp4++;
+  }
+  for (int tmp9 = 0; tmp9 < customers.len; tmp9++) {
+    if (tmp6[tmp9])
+      continue;
+    CustomersItem c = customers.data[tmp9];
+    OrdersItem o = (OrdersItem){0};
+    tmp3.data[tmp4] = (ResultItem){.order = o, .customer = c};
+    tmp4++;
+  }
+  free(tmp5);
+  free(tmp6);
   tmp3.len = tmp4;
-  list_resultItem result = tmp3;
+  list_ResultItem result = tmp3;
   printf("%s\n", "--- Outer Join using syntax ---");
-  for (int tmp7 = 0; tmp7 < result.len; tmp7++) {
-    resultItem row = result.data[tmp7];
+  for (int tmp10 = 0; tmp10 < result.len; tmp10++) {
+    ResultItem row = result.data[tmp10];
     if (row.order) {
       if (row.customer) {
         printf("%s ", "Order");

--- a/tests/machine/x/c/outer_join.error
+++ b/tests/machine/x/c/outer_join.error
@@ -1,35 +1,31 @@
-line: 0
-error: cc error: exit status 1
-/workspace/mochi/tests/machine/x/c/outer_join.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/outer_join.c:94:9: error: used struct type value where scalar is required
-   94 |     if (row.order) {
+tests/machine/x/c/outer_join.c: In function ‘main’:
+tests/machine/x/c/outer_join.c:117:9: error: used struct type value where scalar is required
+  117 |     if (row.order) {
       |         ^~~
-/workspace/mochi/tests/machine/x/c/outer_join.c:95:11: error: used struct type value where scalar is required
-   95 |       if (row.customer) {
+tests/machine/x/c/outer_join.c:118:11: error: used struct type value where scalar is required
+  118 |       if (row.customer) {
       |           ^~~
-/workspace/mochi/tests/machine/x/c/outer_join.c:97:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
-   97 |         printf("%.16g ", row.order.id);
+tests/machine/x/c/outer_join.c:120:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
+  120 |         printf("%.16g ", row.order.id);
       |                 ~~~~^    ~~~~~~~~~~~~
       |                     |             |
       |                     double        int
       |                 %.16d
-/workspace/mochi/tests/machine/x/c/outer_join.c:101:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
-  101 |         printf("%.16g\n", row.order.total);
+tests/machine/x/c/outer_join.c:124:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
+  124 |         printf("%.16g\n", row.order.total);
       |                 ~~~~^     ~~~~~~~~~~~~~~~
       |                     |              |
       |                     double         int
       |                 %.16d
-/workspace/mochi/tests/machine/x/c/outer_join.c:104:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
-  104 |         printf("%.16g ", row.order.id);
+tests/machine/x/c/outer_join.c:127:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
+  127 |         printf("%.16g ", row.order.id);
       |                 ~~~~^    ~~~~~~~~~~~~
       |                     |             |
       |                     double        int
       |                 %.16d
-/workspace/mochi/tests/machine/x/c/outer_join.c:108:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
-  108 |         printf("%.16g\n", row.order.total);
+tests/machine/x/c/outer_join.c:131:21: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
+  131 |         printf("%.16g\n", row.order.total);
       |                 ~~~~^     ~~~~~~~~~~~~~~~
       |                     |              |
       |                     double         int
       |                 %.16d
-
-   1: #include <stdio.h>

--- a/tests/machine/x/c/right_join.c
+++ b/tests/machine/x/c/right_join.c
@@ -4,15 +4,15 @@
 typedef struct {
   int id;
   char *name;
-} customersItem;
+} CustomersItem;
 typedef struct {
   int len;
-  customersItem *data;
-} list_customersItem;
-static list_customersItem list_customersItem_create(int len) {
-  list_customersItem l;
+  CustomersItem *data;
+} list_CustomersItem;
+static list_CustomersItem list_CustomersItem_create(int len) {
+  list_CustomersItem l;
   l.len = len;
-  l.data = calloc(len, sizeof(customersItem));
+  l.data = calloc(len, sizeof(CustomersItem));
   if (!l.data && len > 0) {
     fprintf(stderr, "alloc failed\n");
     exit(1);
@@ -24,15 +24,15 @@ typedef struct {
   int id;
   int customerId;
   int total;
-} ordersItem;
+} OrdersItem;
 typedef struct {
   int len;
-  ordersItem *data;
-} list_ordersItem;
-static list_ordersItem list_ordersItem_create(int len) {
-  list_ordersItem l;
+  OrdersItem *data;
+} list_OrdersItem;
+static list_OrdersItem list_OrdersItem_create(int len) {
+  list_OrdersItem l;
   l.len = len;
-  l.data = calloc(len, sizeof(ordersItem));
+  l.data = calloc(len, sizeof(OrdersItem));
   if (!l.data && len > 0) {
     fprintf(stderr, "alloc failed\n");
     exit(1);
@@ -42,16 +42,16 @@ static list_ordersItem list_ordersItem_create(int len) {
 
 typedef struct {
   char *customerName;
-  ordersItem order;
-} resultItem;
+  OrdersItem order;
+} ResultItem;
 typedef struct {
   int len;
-  resultItem *data;
-} list_resultItem;
-static list_resultItem list_resultItem_create(int len) {
-  list_resultItem l;
+  ResultItem *data;
+} list_ResultItem;
+static list_ResultItem list_ResultItem_create(int len) {
+  list_ResultItem l;
   l.len = len;
-  l.data = calloc(len, sizeof(resultItem));
+  l.data = calloc(len, sizeof(ResultItem));
   if (!l.data && len > 0) {
     fprintf(stderr, "alloc failed\n");
     exit(1);
@@ -60,43 +60,43 @@ static list_resultItem list_resultItem_create(int len) {
 }
 
 int main() {
-  customersItem tmp1_data[] = {(customersItem){.id = 1, .name = "Alice"},
-                               (customersItem){.id = 2, .name = "Bob"},
-                               (customersItem){.id = 3, .name = "Charlie"},
-                               (customersItem){.id = 4, .name = "Diana"}};
-  list_customersItem tmp1 = {4, tmp1_data};
-  list_customersItem customers = tmp1;
-  ordersItem tmp2_data[] = {
-      (ordersItem){.id = 100, .customerId = 1, .total = 250},
-      (ordersItem){.id = 101, .customerId = 2, .total = 125},
-      (ordersItem){.id = 102, .customerId = 1, .total = 300}};
-  list_ordersItem tmp2 = {3, tmp2_data};
-  list_ordersItem orders = tmp2;
-  list_int tmp3 = list_int_create(orders.len * customers.len);
+  CustomersItem tmp1_data[] = {(CustomersItem){.id = 1, .name = "Alice"},
+                               (CustomersItem){.id = 2, .name = "Bob"},
+                               (CustomersItem){.id = 3, .name = "Charlie"},
+                               (CustomersItem){.id = 4, .name = "Diana"}};
+  list_CustomersItem tmp1 = {4, tmp1_data};
+  list_CustomersItem customers = tmp1;
+  OrdersItem tmp2_data[] = {
+      (OrdersItem){.id = 100, .customerId = 1, .total = 250},
+      (OrdersItem){.id = 101, .customerId = 2, .total = 125},
+      (OrdersItem){.id = 102, .customerId = 1, .total = 300}};
+  list_OrdersItem tmp2 = {3, tmp2_data};
+  list_OrdersItem orders = tmp2;
+  list_ResultItem tmp3 = list_ResultItem_create(orders.len * customers.len);
   int tmp4 = 0;
   for (int tmp5 = 0; tmp5 < orders.len; tmp5++) {
-    ordersItem o = orders.data[tmp5];
+    OrdersItem o = orders.data[tmp5];
     int tmp6 = 0;
     for (int tmp7 = 0; tmp7 < customers.len; tmp7++) {
-      customersItem c = customers.data[tmp7];
+      CustomersItem c = customers.data[tmp7];
       if (!(o.customerId == c.id)) {
         continue;
       }
       tmp6 = 1;
-      tmp3.data[tmp4] = (resultItem){.customerName = c.name, .order = o};
+      tmp3.data[tmp4] = (ResultItem){.customerName = c.name, .order = o};
       tmp4++;
     }
     if (!tmp6) {
-      customersItem c = (customersItem){0};
-      tmp3.data[tmp4] = (resultItem){.customerName = c.name, .order = o};
+      CustomersItem c = (CustomersItem){0};
+      tmp3.data[tmp4] = (ResultItem){.customerName = c.name, .order = o};
       tmp4++;
     }
   }
   tmp3.len = tmp4;
-  list_resultItem result = tmp3;
+  list_ResultItem result = tmp3;
   printf("%s\n", "--- Right Join using syntax ---");
   for (int tmp8 = 0; tmp8 < result.len; tmp8++) {
-    resultItem entry = result.data[tmp8];
+    ResultItem entry = result.data[tmp8];
     if (entry.order) {
       printf("%s ", "Customer");
       printf("%s ", entry.customerName);

--- a/tests/machine/x/c/right_join.error
+++ b/tests/machine/x/c/right_join.error
@@ -1,38 +1,16 @@
-line: 0
-error: cc error: exit status 1
-/workspace/mochi/tests/machine/x/c/right_join.c: In function ‘main’:
-/workspace/mochi/tests/machine/x/c/right_join.c:75:3: error: unknown type name ‘list_int’
-   75 |   list_int tmp3 = list_int_create(orders.len * customers.len);
-      |   ^~~~~~~~
-/workspace/mochi/tests/machine/x/c/right_join.c:75:19: warning: implicit declaration of function ‘list_int_create’ [-Wimplicit-function-declaration]
-   75 |   list_int tmp3 = list_int_create(orders.len * customers.len);
-      |                   ^~~~~~~~~~~~~~~
-/workspace/mochi/tests/machine/x/c/right_join.c:86:11: error: request for member ‘data’ in something not a structure or union
-   86 |       tmp3.data[tmp4] = (resultItem){.customerName = c.name, .order = o};
-      |           ^
-/workspace/mochi/tests/machine/x/c/right_join.c:91:11: error: request for member ‘data’ in something not a structure or union
-   91 |       tmp3.data[tmp4] = (resultItem){.customerName = c.name, .order = o};
-      |           ^
-/workspace/mochi/tests/machine/x/c/right_join.c:95:7: error: request for member ‘len’ in something not a structure or union
-   95 |   tmp3.len = tmp4;
-      |       ^
-/workspace/mochi/tests/machine/x/c/right_join.c:96:28: error: invalid initializer
-   96 |   list_resultItem result = tmp3;
-      |                            ^~~~
-/workspace/mochi/tests/machine/x/c/right_join.c:100:9: error: used struct type value where scalar is required
+tests/machine/x/c/right_join.c: In function ‘main’:
+tests/machine/x/c/right_join.c:100:9: error: used struct type value where scalar is required
   100 |     if (entry.order) {
       |         ^~~~~
-/workspace/mochi/tests/machine/x/c/right_join.c:104:19: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
+tests/machine/x/c/right_join.c:104:19: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
   104 |       printf("%.16g ", entry.order.id);
       |               ~~~~^    ~~~~~~~~~~~~~~
       |                   |               |
       |                   double          int
       |               %.16d
-/workspace/mochi/tests/machine/x/c/right_join.c:106:19: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
+tests/machine/x/c/right_join.c:106:19: warning: format ‘%g’ expects argument of type ‘double’, but argument 2 has type ‘int’ [-Wformat=]
   106 |       printf("%.16g\n", entry.order.total);
       |               ~~~~^     ~~~~~~~~~~~~~~~~~
       |                   |                |
       |                   double           int
       |               %.16d
-
-   1: #include <stdio.h>


### PR DESCRIPTION
## Summary
- normalize struct type names with `sanitizeTypeName`
- start adding support for right joins and outer joins
- regenerate right_join.c and outer_join.c machine outputs

## Testing
- `gofmt -w compiler/x/c/helpers.go compiler/x/c/compiler.go`
- `go run -tags slow /tmp/compile_c_single.go tests/vm/valid/right_join.mochi tests/machine/x/c`
- `go run -tags slow /tmp/compile_c_single.go tests/vm/valid/outer_join.mochi tests/machine/x/c`

------
https://chatgpt.com/codex/tasks/task_e_6870d4506478832090f55cfde7db1228