### PR TITLE
Improve C++ struct naming

### DIFF
--- a/compiler/x/cpp/helpers.go
+++ b/compiler/x/cpp/helpers.go
@@ -1,6 +1,33 @@
 package cpp
 
-import "mochi/parser"
+import (
+	"strings"
+
+	"mochi/parser"
+)
+
+// toPascalCase converts snake_case or lowercase names to PascalCase.
+func toPascalCase(s string) string {
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+// structNameFromVar derives a struct name from a variable name using a simple
+// singularization heuristic.
+func structNameFromVar(name string) string {
+	if strings.HasSuffix(name, "ies") && len(name) > 3 {
+		name = name[:len(name)-3] + "y"
+	} else if strings.HasSuffix(name, "s") && len(name) > 1 {
+		name = name[:len(name)-1]
+	}
+	return toPascalCase(name)
+}
 
 func identName(e *parser.Expr) (string, bool) {
 	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {

--- a/tests/machine/x/cpp/cross_join.cpp
+++ b/tests/machine/x/cpp/cross_join.cpp
@@ -2,52 +2,48 @@
 #include <string>
 #include <vector>
 
-struct __struct1 {
+struct Customer {
   decltype(1) id;
   decltype(std::string("Alice")) name;
 };
-inline bool operator==(const __struct1 &a, const __struct1 &b) {
+inline bool operator==(const Customer &a, const Customer &b) {
   return a.id == b.id && a.name == b.name;
 }
-inline bool operator!=(const __struct1 &a, const __struct1 &b) {
+inline bool operator!=(const Customer &a, const Customer &b) {
   return !(a == b);
 }
-struct __struct2 {
+struct Order {
   decltype(100) id;
   decltype(1) customerId;
   decltype(250) total;
 };
-inline bool operator==(const __struct2 &a, const __struct2 &b) {
+inline bool operator==(const Order &a, const Order &b) {
   return a.id == b.id && a.customerId == b.customerId && a.total == b.total;
 }
-inline bool operator!=(const __struct2 &a, const __struct2 &b) {
-  return !(a == b);
-}
-struct __struct3 {
-  decltype(std::declval<__struct2>().id) orderId;
-  decltype(std::declval<__struct2>().customerId) orderCustomerId;
-  decltype(std::declval<__struct1>().name) pairedCustomerName;
-  decltype(std::declval<__struct2>().total) orderTotal;
+inline bool operator!=(const Order &a, const Order &b) { return !(a == b); }
+struct Result {
+  decltype(std::declval<Order>().id) orderId;
+  decltype(std::declval<Order>().customerId) orderCustomerId;
+  decltype(std::declval<Customer>().name) pairedCustomerName;
+  decltype(std::declval<Order>().total) orderTotal;
 };
-inline bool operator==(const __struct3 &a, const __struct3 &b) {
+inline bool operator==(const Result &a, const Result &b) {
   return a.orderId == b.orderId && a.orderCustomerId == b.orderCustomerId &&
          a.pairedCustomerName == b.pairedCustomerName &&
          a.orderTotal == b.orderTotal;
 }
-inline bool operator!=(const __struct3 &a, const __struct3 &b) {
-  return !(a == b);
-}
+inline bool operator!=(const Result &a, const Result &b) { return !(a == b); }
 int main() {
-  std::vector<__struct1> customers = std::vector<__struct1>{
-      __struct1{1, std::string("Alice")}, __struct1{2, std::string("Bob")},
-      __struct1{3, std::string("Charlie")}};
-  std::vector<__struct2> orders = std::vector<__struct2>{
-      __struct2{100, 1, 250}, __struct2{101, 2, 125}, __struct2{102, 1, 300}};
+  std::vector<Customer> customers = std::vector<Customer>{
+      Customer{1, std::string("Alice")}, Customer{2, std::string("Bob")},
+      Customer{3, std::string("Charlie")}};
+  std::vector<Order> orders = std::vector<Order>{
+      Order{100, 1, 250}, Order{101, 2, 125}, Order{102, 1, 300}};
   auto result = ([&]() {
-    std::vector<__struct3> __items;
+    std::vector<Result> __items;
     for (auto o : orders) {
       for (auto c : customers) {
-        __items.push_back(__struct3{o.id, o.customerId, c.name, o.total});
+        __items.push_back(Result{o.id, o.customerId, c.name, o.total});
       }
     }
     return __items;

--- a/tests/machine/x/cpp/cross_join_filter.cpp
+++ b/tests/machine/x/cpp/cross_join_filter.cpp
@@ -2,27 +2,25 @@
 #include <string>
 #include <vector>
 
-struct __struct1 {
+struct Pair {
   int n;
   std::string l;
 };
-inline bool operator==(const __struct1 &a, const __struct1 &b) {
+inline bool operator==(const Pair &a, const Pair &b) {
   return a.n == b.n && a.l == b.l;
 }
-inline bool operator!=(const __struct1 &a, const __struct1 &b) {
-  return !(a == b);
-}
+inline bool operator!=(const Pair &a, const Pair &b) { return !(a == b); }
 int main() {
   std::vector<int> nums = std::vector<int>{1, 2, 3};
   std::vector<std::string> letters =
       std::vector<std::string>{std::string("A"), std::string("B")};
   auto pairs = ([&]() {
-    std::vector<__struct1> __items;
+    std::vector<Pair> __items;
     for (auto n : nums) {
       for (auto l : letters) {
         if (!(((n % 2) == 0)))
           continue;
-        __items.push_back(__struct1{n, l});
+        __items.push_back(Pair{n, l});
       }
     }
     return __items;

--- a/tests/machine/x/cpp/cross_join_triple.cpp
+++ b/tests/machine/x/cpp/cross_join_triple.cpp
@@ -2,28 +2,26 @@
 #include <string>
 #include <vector>
 
-struct __struct1 {
+struct Combo {
   int n;
   std::string l;
   bool b;
 };
-inline bool operator==(const __struct1 &a, const __struct1 &b) {
+inline bool operator==(const Combo &a, const Combo &b) {
   return a.n == b.n && a.l == b.l && a.b == b.b;
 }
-inline bool operator!=(const __struct1 &a, const __struct1 &b) {
-  return !(a == b);
-}
+inline bool operator!=(const Combo &a, const Combo &b) { return !(a == b); }
 int main() {
   std::vector<int> nums = std::vector<int>{1, 2};
   std::vector<std::string> letters =
       std::vector<std::string>{std::string("A"), std::string("B")};
   std::vector<bool> bools = std::vector<decltype(true)>{true, false};
   auto combos = ([&]() {
-    std::vector<__struct1> __items;
+    std::vector<Combo> __items;
     for (auto n : nums) {
       for (auto l : letters) {
         for (auto b : bools) {
-          __items.push_back(__struct1{n, l, b});
+          __items.push_back(Combo{n, l, b});
         }
       }
     }


### PR DESCRIPTION
## Summary
- enhance C++ backend to derive struct names from variable names
- add helper functions for PascalCase and singularization
- update type inference helpers to recognise custom struct names
- regenerate machine outputs for cross join examples

## Testing
- `go build ./...`
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms/cross_join -v`

------
https://chatgpt.com/codex/tasks/task_e_6870d46d800c83209150d00118855d17