### PR TITLE
Fix Go compiler dynamic struct access

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -2170,8 +2170,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 						typ = types.AnyType{}
 					}
 				default:
-					// treat as dynamic map
-					base = fmt.Sprintf("(%s).(map[string]any)[%q]", base, field)
+					// treat as dynamic map using helper
+					c.use("_toAnyMap")
+					base = fmt.Sprintf("_toAnyMap(%s)[%q]", base, field)
 					typ = types.AnyType{}
 				}
 				if i == len(p.Selector.Tail)-1 {

--- a/tests/machine/x/go/right_join.error
+++ b/tests/machine/x/go/right_join.error
@@ -1,10 +1,12 @@
-Error on line 0: run error: exit status 1
+Error on line 0: output mismatch
+-- got --
 --- Right Join using syntax ---
-panic: interface conversion: interface {} is main.OrdersItem, not map[string]interface {}
-
-goroutine 1 [running]:
-main.main()
-	/workspace/mochi/tests/machine/x/go/right_join.go:114 +0x7eb
-exit status 2
-
+Customer Alice has order 100 - $ 250
+Customer Alice has order 102 - $ 300
+Customer Bob has order 101 - $ 125
+-- want --
+--- Right Join using syntax ---
+Customer Alice has order 100 - $ 250
+Customer Bob has order 101 - $ 125
+Customer Alice has order 102 - $ 300
 1: //go:build ignore


### PR DESCRIPTION
## Summary
- handle field selection on `any` values by converting to a map
- regenerate the failing Go test case

## Testing
- `go test ./compiler/x/go -tags slow -run 'ValidPrograms/right_join' -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870d49c7900832086feac60e872db01