### PR TITLE
Add local constants for Rosetta mean time task

### DIFF
--- a/tests/rosetta/x/Mochi/averages-mean-time-of-day.mochi
+++ b/tests/rosetta/x/Mochi/averages-mean-time-of-day.mochi
@@ -1,8 +1,6 @@
 // Mochi implementation of Rosetta "Averages - Mean time of day" task
 // Computes the circular mean of times given as HH:MM:SS strings.
 
-let PI = 3.141592653589793
-
 fun sinApprox(x: float): float {
   var term = x
   var sum = x
@@ -35,12 +33,14 @@ fun abs(x: float): float {
 }
 
 fun atanApprox(x: float): float {
+  let PI = 3.141592653589793
   if x > 1.0 { return PI/2.0 - x/(x*x + 0.28) }
   if x < (-1.0) { return -PI/2.0 - x/(x*x + 0.28) }
   return x/(1.0 + 0.28*x*x)
 }
 
 fun atan2Approx(y: float, x: float): float {
+  let PI = 3.141592653589793
   if x > 0.0 { return atanApprox(y / x) }
   if x < 0.0 {
     if y >= 0.0 { return atanApprox(y / x) + PI }
@@ -97,6 +97,7 @@ fun pad2zero(n: int): string {
 }
 
 fun meanTime(times: list<string>): string {
+  let PI = 3.141592653589793
   var ssum = 0.0
   var csum = 0.0
   var i = 0


### PR DESCRIPTION
## Summary
- avoid using global variables in `averages-mean-time-of-day.mochi`
- embed `PI` inside functions so the script runs correctly

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks/averages-mean-time-of-day -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6870d80b6d288320af300dcc030a1b79