### PR TITLE
Add Base64 decode task and runtime support

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -24,7 +24,7 @@ The VM supports a small but useful subset of Mochi:
 * Function definitions
 * Function calls with any number of arguments
 * Anonymous function expressions
-* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `first`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min`, `max`, `substring`, `substr`, `upper` and `lower`
+* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `first`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min`, `max`, `substring`, `substr`, `upper`, `lower`, `b64encode` and `b64decode`
 * Dataset loading with `load` (optionally casting rows to a type) and saving with `save`
 * HTTP requests using the `fetch` expression
 * Loops internally use specialised integer instructions for indexing to improve performance

--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"encoding/base64"
 	"fmt"
 	"math"
 	"sort"
@@ -609,7 +610,7 @@ func constFold(fn *Function) bool {
 			} else {
 				consts[ins.A] = cinfo{}
 			}
-		case OpNeg, OpNegInt, OpNegFloat, OpNot, OpStr, OpUpper, OpLower, OpFirst, OpLen,
+		case OpNeg, OpNegInt, OpNegFloat, OpNot, OpStr, OpUpper, OpLower, OpB64Encode, OpB64Decode, OpFirst, OpLen,
 			OpCount, OpExists, OpAvg, OpSum, OpMin, OpMax, OpValues, OpSort:
 			b := consts[ins.B]
 			if b.known {
@@ -790,6 +791,17 @@ func evalUnaryConst(op Op, v Value) (Value, bool) {
 			return Value{Tag: ValueStr, Str: strings.ToLower(v.Str)}, true
 		}
 		return Value{Tag: ValueStr, Str: strings.ToLower(fmt.Sprint(v.ToAny()))}, true
+	case OpB64Encode:
+		if v.Tag == ValueStr {
+			return Value{Tag: ValueStr, Str: base64.StdEncoding.EncodeToString([]byte(v.Str))}, true
+		}
+	case OpB64Decode:
+		if v.Tag == ValueStr {
+			data, err := base64.StdEncoding.DecodeString(v.Str)
+			if err == nil {
+				return Value{Tag: ValueStr, Str: string(data)}, true
+			}
+		}
 	case OpFirst:
 		if lst, ok := toList(v); ok {
 			if len(lst) > 0 {

--- a/tests/rosetta/x/Mochi/base64-decode-data.mochi
+++ b/tests/rosetta/x/Mochi/base64-decode-data.mochi
@@ -1,0 +1,6 @@
+let msg = "Rosetta Code Base64 decode data task"
+print("Original :", msg)
+let enc = b64encode(msg)
+print("\nEncoded  :", enc)
+let dec = b64decode(enc)
+print("\nDecoded  :", dec)

--- a/tests/rosetta/x/Mochi/base64-decode-data.out
+++ b/tests/rosetta/x/Mochi/base64-decode-data.out
@@ -1,0 +1,5 @@
+Original : Rosetta Code Base64 decode data task
+
+Encoded  : Um9zZXR0YSBDb2RlIEJhc2U2NCBkZWNvZGUgZGF0YSB0YXNr
+
+Decoded  : Rosetta Code Base64 decode data task

--- a/types/check.go
+++ b/types/check.go
@@ -441,6 +441,16 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: StringType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("b64encode", FuncType{
+		Params: []Type{StringType{}},
+		Return: StringType{},
+		Pure:   true,
+	}, false)
+	env.SetVar("b64decode", FuncType{
+		Params: []Type{StringType{}},
+		Return: StringType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("trim", FuncType{
 		Params: []Type{StringType{}},
 		Return: StringType{},
@@ -2323,6 +2333,8 @@ var builtinArity = map[string]int{
 	"reverse":   1,
 	"distinct":  1,
 	"trim":      1,
+	"b64encode": 1,
+	"b64decode": 1,
 	"contains":  2,
 	"split":     2,
 	"join":      2,
@@ -2353,7 +2365,7 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 			return errArgCount(pos, name, 0, len(args))
 		}
 		return nil
-	case "json", "to_json", "str", "upper", "lower", "eval":
+	case "json", "to_json", "str", "upper", "lower", "b64encode", "b64decode", "eval":
 		if len(args) != 1 {
 			return errArgCount(pos, name, 1, len(args))
 		}


### PR DESCRIPTION
## Summary
- add new Rosetta task `Base64-decode-data` in Mochi
- support `b64encode` and `b64decode` builtins in the VM
- constant folding and liveness support for new ops
- document new built-ins

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/base64-decode-data.mochi`
- `go test -tags slow ./tools/rosetta -run Base64 -count=1` *(no tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_6870d96d2b1c83208fd5e903842b195a