### PR TITLE
Update Zig compiler and tasks

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -2735,7 +2735,7 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		b.WriteString("defer " + tmp + ".deinit(); ")
 		b.WriteString(tmp + ".appendSlice(" + listArg + ") catch unreachable; ")
 		b.WriteString(tmp + ".append(" + elemArg + ") catch unreachable; ")
-		b.WriteString("break :" + lbl + " " + tmp + ".toOwnedSlice() catch unreachable; }")
+		b.WriteString("break :" + lbl + " " + tmp + ".items; }")
 		return b.String(), nil
 	}
 	if name == "min" && len(call.Args) == 1 {

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -120,3 +120,13 @@ Compiled programs: 100/100
 - [ ] Handle recursive type definitions.
 - [ ] Emit comments describing inferred variable types.
 - [ ] Provide CLI to compile individual Mochi programs.
+- [ ] Add benchmarks for Zig compiler output performance.
+- [ ] Refactor code generation to use templates for readability.
+- [ ] Investigate using Zig generics for map operations.
+- [ ] Document differences between Mochi semantics and Zig translations.
+- [ ] Add CI step to verify Zig code compiles.
+- [ ] Support streaming JSON encoding.
+- [ ] Improve error messages when compilation fails.
+- [ ] Add support for customizing allocator.
+- [ ] Introduce command line options for optimization levels.
+- [ ] Provide examples demonstrating interop with C libraries.

--- a/tests/machine/x/zig/append_builtin.zig
+++ b/tests/machine/x/zig/append_builtin.zig
@@ -6,5 +6,5 @@ const a = &[_]i32{
 };
 
 pub fn main() void {
-    std.debug.print("{any}\n", .{blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); defer _tmp0.deinit(); _tmp0.appendSlice(a) catch unreachable; _tmp0.append(3) catch unreachable; break :blk0 _tmp0.toOwnedSlice() catch unreachable; }});
+    std.debug.print("{any}\n", .{blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); defer _tmp0.deinit(); _tmp0.appendSlice(a) catch unreachable; _tmp0.append(3) catch unreachable; break :blk0 _tmp0.items; }});
 }

--- a/tests/machine/x/zig/group_items_iteration.zig
+++ b/tests/machine/x/zig/group_items_iteration.zig
@@ -42,7 +42,7 @@ pub fn main() void {
 }{
     .tag = g.key,
     .total = total,
-}) catch unreachable; break :blk2 _tmp8.toOwnedSlice() catch unreachable; };
+}) catch unreachable; break :blk2 _tmp8.items; };
     }
     std.debug.print("{any}\n", .{result});
 }


### PR DESCRIPTION
## Summary
- improve `append` builtin in the Zig compiler to return `.items`
- regenerate affected machine outputs
- expand Zig machine README with additional tasks

## Testing
- `go vet ./...`
- `go test ./...`
- `go run -tags slow scripts/compile_zig.go`

------
https://chatgpt.com/codex/tasks/task_e_6870df0b622c832082a102d2a25dc3bb