### PR TITLE
Improve TypeScript compiler output

### DIFF
--- a/compiler/x/typescript/compiler.go
+++ b/compiler/x/typescript/compiler.go
@@ -519,7 +519,18 @@ func (c *Compiler) typeDecl(td *parser.TypeDecl) error {
 				fields = append(fields, fmt.Sprintf("%s: %s;", m.Field.Name, tsTypeRef(m.Field.Type)))
 			}
 		}
-		c.writeln(fmt.Sprintf("type %s = { %s };", td.Name, strings.Join(fields, " ")))
+		flat := fmt.Sprintf("interface %s { %s }", td.Name, strings.Join(fields, " "))
+		if len(fields) > 2 || len(flat) > 60 {
+			c.writeln(fmt.Sprintf("interface %s {", td.Name))
+			c.indent++
+			for _, f := range fields {
+				c.writeln(f)
+			}
+			c.indent--
+			c.writeln("}")
+		} else {
+			c.writeln(flat)
+		}
 		return nil
 	}
 	if len(td.Variants) > 0 {

--- a/tests/machine/x/ts/README.md
+++ b/tests/machine/x/ts/README.md
@@ -108,3 +108,15 @@ Compiled: 100/100 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## Remaining Tasks
+- [ ] Improve formatting of generated interfaces
+- [ ] Use template strings for string concatenation
+- [ ] Leverage built-in array helpers instead of manual loops
+- [ ] Add async function support for I/O operations
+- [ ] Preserve comments from source Mochi code
+- [ ] Generate discriminated union helpers
+- [ ] Optimize query translations to use map/reduce
+- [ ] Support optional chaining and nullish coalescing
+- [ ] Emit type annotations for loaded YAML data
+- [ ] Reduce temporary variables in simple expressions

--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -1,6 +1,6 @@
 # Machine-generated TypeScript Programs
 
-This directory contains TypeScript code compiled from Mochi programs in `tests/vm/valid` using the experimental compiler. The compiler generates simpler `from` query loops and adds basic type annotations for query results.
+This directory contains TypeScript code compiled from Mochi programs in `tests/vm/valid` using the experimental compiler.
 
 ## Progress
 
@@ -110,9 +110,13 @@ Compiled: 100/100 programs
 - [x] while_loop.mochi
 
 ## Remaining Tasks
-
-- Integrate with Node runtime for dataset queries and joins
-- Support asynchronous `fetch` statements
-- Finish improving formatting to match human examples
-- Improve type inference for query results
-
+- [ ] Improve formatting of generated interfaces
+- [ ] Use template strings for string concatenation
+- [ ] Leverage built-in array helpers instead of manual loops
+- [ ] Add async function support for I/O operations
+- [ ] Preserve comments from source Mochi code
+- [ ] Generate discriminated union helpers
+- [ ] Optimize query translations to use map/reduce
+- [ ] Support optional chaining and nullish coalescing
+- [ ] Emit type annotations for loaded YAML data
+- [ ] Reduce temporary variables in simple expressions


### PR DESCRIPTION
## Summary
- format struct type declarations as `interface` blocks for readability
- document progress and TODO items for the TypeScript compiler

## Testing
- `go test ./compiler/x/typescript -run Test -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870df291ee08320b2ae37d95bef7ea5