### PR TITLE
Enhance PHP compiler runtime output

### DIFF
--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -178,9 +178,13 @@ func (c *Compiler) emitRuntime() {
 		names = append(names, n)
 	}
 	sort.Strings(names)
-	for _, n := range names {
+	for i, n := range names {
 		if code, ok := helperMap[n]; ok {
+			if i > 0 {
+				c.buf.WriteByte('\n')
+			}
 			c.buf.WriteString(code)
+			c.buf.WriteByte('\n')
 		}
 	}
 }

--- a/tests/machine/x/php/README.md
+++ b/tests/machine/x/php/README.md
@@ -3,7 +3,7 @@
 This directory stores PHP code produced by the compiler tests. Each Mochi program from `tests/vm/valid` is compiled and executed. On success a `.out` file is written. Failures generate a `.error` file.
 
 ## Summary
-97/97 files compiled successfully
+97/100 files compiled successfully
 
 ## Checklist
 - [x] append_builtin.mochi
@@ -28,6 +28,7 @@ This directory stores PHP code produced by the compiler tests. Each Mochi progra
 - [x] fun_call.mochi
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
+- [ ] go_auto.mochi
 - [x] group_by.mochi
 - [x] group_by_conditional_sum.mochi
 - [x] group_by_having.mochi
@@ -75,6 +76,8 @@ This directory stores PHP code produced by the compiler tests. Each Mochi progra
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
+- [ ] python_auto.mochi
+- [ ] python_math.mochi
 - [x] query_sum_select.mochi
 - [x] record_assign.mochi
 - [x] right_join.mochi
@@ -103,3 +106,14 @@ This directory stores PHP code produced by the compiler tests. Each Mochi progra
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+## Remaining Tasks
+- [ ] Implement FFI imports for Go packages
+- [ ] Implement automatic Python module imports
+- [ ] Support `extern` declarations in PHP output
+- [ ] Simplify dataset query translation
+- [ ] Optimize grouping and aggregation helpers
+- [ ] Improve runtime helper formatting
+- [ ] Add support for pattern matching
+- [ ] Handle union and option types
+- [ ] Add module and import support
+- [ ] Better error messages for unsupported features

--- a/tests/machine/x/php/closure.out
+++ b/tests/machine/x/php/closure.out
@@ -1,2 +1,3 @@
-PHP Warning:  Undefined variable $n in /workspace/mochi/tests/machine/x/php/closure.php on line 3
+
+Warning: Undefined variable $n in /workspace/mochi/tests/machine/x/php/closure.php on line 3
 int(7)

--- a/tests/machine/x/php/go_auto.error
+++ b/tests/machine/x/php/go_auto.error
@@ -1,0 +1,1 @@
+unsupported statement at line 1

--- a/tests/machine/x/php/group_by_left_join.out
+++ b/tests/machine/x/php/group_by_left_join.out
@@ -1,7 +1,11 @@
-PHP Warning:  Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
-PHP Warning:  Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
-PHP Warning:  Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
-PHP Warning:  Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
+
+Warning: Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
+
+Warning: Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
+
+Warning: Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
+
+Warning: Undefined array key "o" in /workspace/mochi/tests/machine/x/php/group_by_left_join.php on line 13
 string(23) "--- Group Left Join ---"
 string(5) "Alice"
 string(7) "orders:"

--- a/tests/machine/x/php/group_by_left_join.php
+++ b/tests/machine/x/php/group_by_left_join.php
@@ -36,7 +36,9 @@ function _group_by($src, $keyfn) {
     $res = [];
     foreach ($order as $k) { $res[] = $groups[$k]; }
     return $res;
-}function _query($src, $joins, $opts) {
+}
+
+function _query($src, $joins, $opts) {
     $items = [];
     foreach ($src as $v) { $items[] = [$v]; }
     foreach ($joins as $j) {
@@ -119,4 +121,5 @@ function _group_by($src, $keyfn) {
     $sel = $opts['select'];
     foreach ($items as $r) { $res[] = $sel(...$r); }
     return $res;
-}?>
+}
+?>

--- a/tests/machine/x/php/left_join.php
+++ b/tests/machine/x/php/left_join.php
@@ -89,4 +89,5 @@ function _query($src, $joins, $opts) {
     $sel = $opts['select'];
     foreach ($items as $r) { $res[] = $sel(...$r); }
     return $res;
-}?>
+}
+?>

--- a/tests/machine/x/php/left_join_multi.php
+++ b/tests/machine/x/php/left_join_multi.php
@@ -90,4 +90,5 @@ function _query($src, $joins, $opts) {
     $sel = $opts['select'];
     foreach ($items as $r) { $res[] = $sel(...$r); }
     return $res;
-}?>
+}
+?>

--- a/tests/machine/x/php/load_yaml.out
+++ b/tests/machine/x/php/load_yaml.out
@@ -1,2 +1,4 @@
-PHP Warning:  file(/workspace/mochi/tests/machine/x/php/../interpreter/valid/people.yaml): Failed to open stream: No such file or directory in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 33
-PHP Warning:  foreach() argument must be of type array|object, false given in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 36
+
+Warning: file(/workspace/mochi/tests/machine/x/php/../interpreter/valid/people.yaml): Failed to open stream: No such file or directory in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 33
+
+Warning: foreach() argument must be of type array|object, false given in /workspace/mochi/tests/machine/x/php/load_yaml.php on line 36

--- a/tests/machine/x/php/load_yaml.php
+++ b/tests/machine/x/php/load_yaml.php
@@ -52,4 +52,5 @@ function _load($path = null, $opts = []) {
         return $rows;
     }
     return [];
-}?>
+}
+?>

--- a/tests/machine/x/php/nested_function.out
+++ b/tests/machine/x/php/nested_function.out
@@ -1,2 +1,3 @@
-PHP Warning:  Undefined variable $x in /workspace/mochi/tests/machine/x/php/nested_function.php on line 4
+
+Warning: Undefined variable $x in /workspace/mochi/tests/machine/x/php/nested_function.php on line 4
 int(5)

--- a/tests/machine/x/php/outer_join.php
+++ b/tests/machine/x/php/outer_join.php
@@ -97,4 +97,5 @@ function _query($src, $joins, $opts) {
     $sel = $opts['select'];
     foreach ($items as $r) { $res[] = $sel(...$r); }
     return $res;
-}?>
+}
+?>

--- a/tests/machine/x/php/pure_global_fold.out
+++ b/tests/machine/x/php/pure_global_fold.out
@@ -1,2 +1,3 @@
-PHP Warning:  Undefined variable $k in /workspace/mochi/tests/machine/x/php/pure_global_fold.php on line 4
+
+Warning: Undefined variable $k in /workspace/mochi/tests/machine/x/php/pure_global_fold.php on line 4
 int(3)

--- a/tests/machine/x/php/python_auto.error
+++ b/tests/machine/x/php/python_auto.error
@@ -1,0 +1,1 @@
+unsupported statement at line 1

--- a/tests/machine/x/php/python_math.error
+++ b/tests/machine/x/php/python_math.error
@@ -1,0 +1,1 @@
+unsupported statement at line 2

--- a/tests/machine/x/php/right_join.php
+++ b/tests/machine/x/php/right_join.php
@@ -93,4 +93,5 @@ function _query($src, $joins, $opts) {
     $sel = $opts['select'];
     foreach ($items as $r) { $res[] = $sel(...$r); }
     return $res;
-}?>
+}
+?>

--- a/tests/machine/x/php/save_jsonl_stdout.php
+++ b/tests/machine/x/php/save_jsonl_stdout.php
@@ -11,4 +11,5 @@ function _save($rows, $path = null, $opts = []) {
         }
         if ($out !== STDOUT) fclose($out);
     }
-}?>
+}
+?>


### PR DESCRIPTION
## Summary
- tidy PHP runtime helper emission to add spacing between helpers
- regenerate machine PHP output after tests
- document PHP compilation progress and remaining tasks
- record compile errors for Go/Python auto import examples

## Testing
- `go test ./compiler/x/php -run TestPHPCompiler_ValidPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6870df1558408320beca800530fc9487