### PR TITLE
Update OCaml compiler outputs

### DIFF
--- a/compiler/x/ocaml/compiler.go
+++ b/compiler/x/ocaml/compiler.go
@@ -1995,7 +1995,11 @@ func (c *Compiler) ocamlType(t types.Type) string {
 	case types.MapType:
 		return fmt.Sprintf("(%s * Obj.t) list", c.ocamlType(tt.Key))
 	case types.GroupType:
-		return c.ocamlType(tt.Elem) + " list"
+		key := c.ocamlType(tt.Key)
+		if key == "" {
+			key = "Obj.t"
+		}
+		return fmt.Sprintf("(%s,%s) group", key, c.ocamlType(tt.Elem))
 	case types.StructType:
 		name := tt.Name
 		if name == "" {

--- a/tests/machine/x/ocaml/README.md
+++ b/tests/machine/x/ocaml/README.md
@@ -2,7 +2,7 @@
 
 This directory contains OCaml code generated from the Mochi programs in `tests/vm/valid` using the OCaml compiler. Each program was compiled and executed with `ocamlc`. Successful runs produced an `.out` file while failures produced an `.error` file.
 
-Compiled programs: 68/97 successful.
+Compiled programs: 68/100 successful.
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -26,6 +26,7 @@ Compiled programs: 68/97 successful.
 - [x] fun_call.mochi
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
+- [ ] go_auto.mochi
 - [ ] group_by.mochi
 - [ ] group_by_conditional_sum.mochi
 - [ ] group_by_having.mochi
@@ -73,6 +74,8 @@ Compiled programs: 68/97 successful.
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
+- [ ] python_auto.mochi
+- [ ] python_math.mochi
 - [ ] query_sum_select.mochi
 - [x] record_assign.mochi
 - [ ] right_join.mochi
@@ -107,3 +110,13 @@ Compiled programs: 68/97 successful.
 - [ ] Integrate an OCaml runtime to execute compiled programs in CI
 - [x] Expand anonymous record typing for clearer generated code
 - [x] Emit native `for` loops when iterating over numeric ranges
+- [ ] Optimize tail recursion to loops
+- [ ] Support OCaml modules for multi-file outputs
+- [ ] Generate variant types for union constructs
+- [ ] Improve runtime error messages with context
+- [ ] Comment code with inferred types
+- [ ] Provide CLI tool `mochi-ocaml` for users
+- [ ] Offer interactive REPL using OCaml backend
+- [ ] Add property-based tests for compiler output
+- [ ] Document mapping between Mochi and OCaml
+- [ ] Benchmark compiled code performance

--- a/tests/machine/x/ocaml/cross_join.ml
+++ b/tests/machine/x/ocaml/cross_join.ml
@@ -25,7 +25,7 @@
 
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" };{ id = 3; name = "Charlie" }]
 let orders : record2 list = [{ id = 100; customerId = 1; total = 250 };{ id = 101; customerId = 2; total = 125 };{ id = 102; customerId = 1; total = 300 }]
-let result : (string * Obj.t) list list = (let __res0 = ref [] in
+let result : record3 list = (let __res0 = ref [] in
   List.iter (fun o ->
       List.iter (fun c ->
               __res0 := { orderId = Obj.obj (List.assoc "id" o); orderCustomerId = Obj.obj (List.assoc "customerId" o); pairedCustomerName = Obj.obj (List.assoc "name" c); orderTotal = Obj.obj (List.assoc "total" o) } :: !__res0;

--- a/tests/machine/x/ocaml/cross_join_filter.error
+++ b/tests/machine/x/ocaml/cross_join_filter.error
@@ -1,16 +1,15 @@
 stage: compile
 error:
-File "/workspace/mochi/tests/machine/x/ocaml/cross_join_filter.ml", line 33, characters 0-16:
-33 | List.rev !__res0)
-     ^^^^^^^^^^^^^^^^
+File "/workspace/mochi/tests/machine/x/ocaml/cross_join_filter.ml", line 47, characters 16-21:
+47 |     try __loop1 pairs with Break -> ()
+                     ^^^^^
 Error: This expression has type record1 list
        but an expression was expected of type (string * Obj.t) list list
        Type record1 is not compatible with type (string * Obj.t) list 
 
 
-Context (around line 33):
-  31 |       ) letters;
-  32 |   ) nums;
-  33 | List.rev !__res0)
-  34 | 
-  35 | 
+Context (around line 47):
+  45 |         ; __loop1 rest
+  46 |     in
+  47 |     try __loop1 pairs with Break -> ()
+  48 | 

--- a/tests/machine/x/ocaml/cross_join_filter.ml
+++ b/tests/machine/x/ocaml/cross_join_filter.ml
@@ -23,7 +23,7 @@
 
 let nums : int list = [1;2;3]
 let letters : string list = ["A";"B"]
-let pairs : (string * Obj.t) list list = (let __res0 = ref [] in
+let pairs : record1 list = (let __res0 = ref [] in
   List.iter (fun n ->
       List.iter (fun l ->
               if ((n mod 2) = 0) then

--- a/tests/machine/x/ocaml/cross_join_triple.error
+++ b/tests/machine/x/ocaml/cross_join_triple.error
@@ -1,16 +1,15 @@
 stage: compile
 error:
-File "/workspace/mochi/tests/machine/x/ocaml/cross_join_triple.ml", line 35, characters 0-16:
-35 | List.rev !__res0)
-     ^^^^^^^^^^^^^^^^
+File "/workspace/mochi/tests/machine/x/ocaml/cross_join_triple.ml", line 49, characters 16-22:
+49 |     try __loop1 combos with Break -> ()
+                     ^^^^^^
 Error: This expression has type record1 list
        but an expression was expected of type (string * Obj.t) list list
        Type record1 is not compatible with type (string * Obj.t) list 
 
 
-Context (around line 35):
-  33 |       ) letters;
-  34 |   ) nums;
-  35 | List.rev !__res0)
-  36 | 
-  37 | 
+Context (around line 49):
+  47 |         ; __loop1 rest
+  48 |     in
+  49 |     try __loop1 combos with Break -> ()
+  50 | 

--- a/tests/machine/x/ocaml/cross_join_triple.ml
+++ b/tests/machine/x/ocaml/cross_join_triple.ml
@@ -24,7 +24,7 @@
 let nums : int list = [1;2]
 let letters : string list = ["A";"B"]
 let bools : bool list = [true;false]
-let combos : (string * Obj.t) list list = (let __res0 = ref [] in
+let combos : record1 list = (let __res0 = ref [] in
   List.iter (fun n ->
       List.iter (fun l ->
             List.iter (fun b ->

--- a/tests/machine/x/ocaml/dataset_where_filter.ml
+++ b/tests/machine/x/ocaml/dataset_where_filter.ml
@@ -23,7 +23,7 @@
   type record2 = { mutable name : Obj.t; mutable age : Obj.t; mutable is_senior : bool }
 
 let people : record1 list = [{ name = "Alice"; age = 30 };{ name = "Bob"; age = 15 };{ name = "Charlie"; age = 65 };{ name = "Diana"; age = 45 }]
-let adults : (string * Obj.t) list list = (let __res0 = ref [] in
+let adults : record2 list = (let __res0 = ref [] in
   List.iter (fun person ->
       if (Obj.obj (List.assoc "age" person) >= 18) then
     __res0 := { name = Obj.obj (List.assoc "name" person); age = Obj.obj (List.assoc "age" person); is_senior = (Obj.obj (List.assoc "age" person) >= 60) } :: !__res0;

--- a/tests/machine/x/ocaml/go_auto.error
+++ b/tests/machine/x/ocaml/go_auto.error
@@ -1,0 +1,8 @@
+stage: compile
+error:
+unsupported statement at line 1
+
+Context (around line 1):
+   1 | import go "mochi/runtime/ffi/go/testpkg" as testpkg auto
+   2 | 
+   3 | print(testpkg.Add(2,3))

--- a/tests/machine/x/ocaml/group_by.ml
+++ b/tests/machine/x/ocaml/group_by.ml
@@ -24,7 +24,7 @@
   type record2 = { mutable city : Obj.t; mutable count : int; mutable avg_age : float }
 
 let people : record1 list = [{ name = "Alice"; age = 30; city = "Paris" };{ name = "Bob"; age = 15; city = "Hanoi" };{ name = "Charlie"; age = 65; city = "Paris" };{ name = "Diana"; age = 45; city = "Hanoi" };{ name = "Eve"; age = 70; city = "Paris" };{ name = "Frank"; age = 22; city = "Hanoi" }]
-let stats : (string * Obj.t) list list = (let __groups0 = ref [] in
+let stats : record2 list = (let __groups0 = ref [] in
   List.iter (fun person ->
       let key = Obj.obj (List.assoc "city" person) in
       let cur = try List.assoc key !__groups0 with Not_found -> [] in

--- a/tests/machine/x/ocaml/group_by_conditional_sum.ml
+++ b/tests/machine/x/ocaml/group_by_conditional_sum.ml
@@ -22,7 +22,7 @@ type record1 = { mutable cat : string; mutable val : int; mutable flag : bool }
 type record2 = { mutable cat : Obj.t; mutable share : float }
 
 let items : record1 list = [{ cat = "a"; val = 10; flag = true };{ cat = "a"; val = 5; flag = false };{ cat = "b"; val = 20; flag = true }]
-let result : (string * Obj.t) list list = (let __groups0 = ref [] in
+let result : record2 list = (let __groups0 = ref [] in
   List.iter (fun i ->
       let key = Obj.obj (List.assoc "cat" i) in
       let cur = try List.assoc key !__groups0 with Not_found -> [] in

--- a/tests/machine/x/ocaml/group_by_having.error
+++ b/tests/machine/x/ocaml/group_by_having.error
@@ -1,16 +1,16 @@
 stage: compile
 error:
-File "/workspace/mochi/tests/machine/x/ocaml/group_by_having.ml", line 12, characters 4-10:
-12 |   ) people;
+File "/workspace/mochi/tests/machine/x/ocaml/group_by_having.ml", line 13, characters 4-10:
+13 |   ) people;
          ^^^^^^
 Error: This expression has type record1 list
        but an expression was expected of type (string * Obj.t) list list
        Type record1 is not compatible with type (string * Obj.t) list 
 
 
-Context (around line 12):
-  10 |       let cur = try List.assoc key !__groups0 with Not_found -> [] in
-  11 |       __groups0 := (key, p :: cur) :: List.remove_assoc key !__groups0;
-  12 |   ) people;
-  13 |   let __res0 = ref [] in
-  14 |   List.iter (fun (gKey,gItems) ->
+Context (around line 13):
+  11 |       let cur = try List.assoc key !__groups0 with Not_found -> [] in
+  12 |       __groups0 := (key, p :: cur) :: List.remove_assoc key !__groups0;
+  13 |   ) people;
+  14 |   let __res0 = ref [] in
+  15 |   List.iter (fun (gKey,gItems) ->

--- a/tests/machine/x/ocaml/group_by_having.ml
+++ b/tests/machine/x/ocaml/group_by_having.ml
@@ -2,9 +2,10 @@ type ('k,'v) group = { key : 'k; items : 'v list }
 
 type record1 = { mutable name : string; mutable city : string }
 type record2 = { mutable city : Obj.t; mutable num : int }
+type record3 = { mutable city : string; mutable num : int }
 
 let people : record1 list = [{ name = "Alice"; city = "Paris" };{ name = "Bob"; city = "Hanoi" };{ name = "Charlie"; city = "Paris" };{ name = "Diana"; city = "Hanoi" };{ name = "Eve"; city = "Paris" };{ name = "Frank"; city = "Hanoi" };{ name = "George"; city = "Paris" }]
-let big : (string * Obj.t) list list = (let __groups0 = ref [] in
+let big : record3 list = (let __groups0 = ref [] in
   List.iter (fun p ->
       let key = Obj.obj (List.assoc "city" p) in
       let cur = try List.assoc key !__groups0 with Not_found -> [] in

--- a/tests/machine/x/ocaml/group_by_join.ml
+++ b/tests/machine/x/ocaml/group_by_join.ml
@@ -26,7 +26,7 @@
 
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" }]
 let orders : record2 list = [{ id = 100; customerId = 1 };{ id = 101; customerId = 1 };{ id = 102; customerId = 2 }]
-let stats : (string * Obj.t) list list = (let __groups0 = ref [] in
+let stats : record3 list = (let __groups0 = ref [] in
   List.iter (fun o ->
       List.iter (fun c ->
               if (Obj.obj (List.assoc "customerId" o) = Obj.obj (List.assoc "id" c)) then (

--- a/tests/machine/x/ocaml/group_by_left_join.ml
+++ b/tests/machine/x/ocaml/group_by_left_join.ml
@@ -26,7 +26,7 @@
 
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" };{ id = 3; name = "Charlie" }]
 let orders : record2 list = [{ id = 100; customerId = 1 };{ id = 101; customerId = 1 };{ id = 102; customerId = 2 }]
-let stats : (string * Obj.t) list list = (let __groups0 = ref [] in
+let stats : record3 list = (let __groups0 = ref [] in
   List.iter (fun c ->
       List.iter (fun o ->
               if (Obj.obj (List.assoc "customerId" o) = Obj.obj (List.assoc "id" c)) then (

--- a/tests/machine/x/ocaml/group_by_multi_join.error
+++ b/tests/machine/x/ocaml/group_by_multi_join.error
@@ -12,5 +12,5 @@ Context (around line 29):
   27 | let nations : record1 list = [{ id = 1; name = "A" };{ id = 2; name = "B" }]
   28 | let suppliers : record2 list = [{ id = 1; nation = 1 };{ id = 2; nation = 2 }]
   29 | let partsupp : record3 list = [{ part = 100; supplier = 1; cost = 10; qty = 2 };{ part = 100; supplier = 2; cost = 20; qty = 1 };{ part = 200; supplier = 1; cost = 5; qty = 3 }]
-  30 | let filtered : (string * Obj.t) list list = (let __res0 = ref [] in
+  30 | let filtered : record4 list = (let __res0 = ref [] in
   31 |   List.iter (fun ps ->

--- a/tests/machine/x/ocaml/group_by_multi_join.ml
+++ b/tests/machine/x/ocaml/group_by_multi_join.ml
@@ -22,12 +22,12 @@ type record1 = { mutable id : int; mutable name : string }
 type record2 = { mutable id : int; mutable nation : int }
 type record3 = { mutable part : int; mutable supplier : int; mutable cost : float; mutable qty : int }
 type record4 = { mutable part : Obj.t; mutable value : Obj.t }
-type record5 = { mutable part : Obj.t; mutable total : float }
+type record5 = { mutable part : Obj.t; mutable total : int }
 
 let nations : record1 list = [{ id = 1; name = "A" };{ id = 2; name = "B" }]
 let suppliers : record2 list = [{ id = 1; nation = 1 };{ id = 2; nation = 2 }]
 let partsupp : record3 list = [{ part = 100; supplier = 1; cost = 10; qty = 2 };{ part = 100; supplier = 2; cost = 20; qty = 1 };{ part = 200; supplier = 1; cost = 5; qty = 3 }]
-let filtered : (string * Obj.t) list list = (let __res0 = ref [] in
+let filtered : record4 list = (let __res0 = ref [] in
   List.iter (fun ps ->
       List.iter (fun s ->
             List.iter (fun n ->
@@ -38,7 +38,7 @@ let filtered : (string * Obj.t) list list = (let __res0 = ref [] in
   ) partsupp;
 List.rev !__res0)
 
-let grouped : (string * Obj.t) list list = (let __groups1 = ref [] in
+let grouped : record5 list = (let __groups1 = ref [] in
   List.iter (fun x ->
       let key = Obj.obj (List.assoc "part" x) in
       let cur = try List.assoc key !__groups1 with Not_found -> [] in

--- a/tests/machine/x/ocaml/group_by_multi_join_sort.ml
+++ b/tests/machine/x/ocaml/group_by_multi_join_sort.ml
@@ -23,7 +23,7 @@ type record2 = { mutable c_custkey : int; mutable c_name : string; mutable c_acc
 type record3 = { mutable o_orderkey : int; mutable o_custkey : int; mutable o_orderdate : string }
 type record4 = { mutable l_orderkey : int; mutable l_returnflag : string; mutable l_extendedprice : float; mutable l_discount : float }
 type record5 = { mutable c_custkey : Obj.t; mutable c_name : Obj.t; mutable c_acctbal : Obj.t; mutable c_address : Obj.t; mutable c_phone : Obj.t; mutable c_comment : Obj.t; mutable n_name : Obj.t }
-type record6 = { mutable c_custkey : Obj.t; mutable c_name : Obj.t; mutable revenue : float; mutable c_acctbal : Obj.t; mutable n_name : Obj.t; mutable c_address : Obj.t; mutable c_phone : Obj.t; mutable c_comment : Obj.t }
+type record6 = { mutable c_custkey : Obj.t; mutable c_name : Obj.t; mutable revenue : int; mutable c_acctbal : Obj.t; mutable n_name : Obj.t; mutable c_address : Obj.t; mutable c_phone : Obj.t; mutable c_comment : Obj.t }
 
 let nation : record1 list = [{ n_nationkey = 1; n_name = "BRAZIL" }]
 let customer : record2 list = [{ c_custkey = 1; c_name = "Alice"; c_acctbal = 100; c_nationkey = 1; c_address = "123 St"; c_phone = "123-456"; c_comment = "Loyal" }]
@@ -31,7 +31,7 @@ let orders : record3 list = [{ o_orderkey = 1000; o_custkey = 1; o_orderdate = "
 let lineitem : record4 list = [{ l_orderkey = 1000; l_returnflag = "R"; l_extendedprice = 1000; l_discount = 0.1 };{ l_orderkey = 2000; l_returnflag = "N"; l_extendedprice = 500; l_discount = 0 }]
 let start_date : string = "1993-10-01"
 let end_date : string = "1994-01-01"
-let result : (string * Obj.t) list list = (let __groups0 = ref [] in
+let result : record6 list = (let __groups0 = ref [] in
   List.iter (fun c ->
       List.iter (fun o ->
             List.iter (fun l ->

--- a/tests/machine/x/ocaml/group_by_sort.error
+++ b/tests/machine/x/ocaml/group_by_sort.error
@@ -10,5 +10,5 @@ Context (around line 21):
   19 | type ('k,'v) group = { key : 'k; items : 'v list }
   20 | 
   21 | type record1 = { mutable cat : string; mutable val : int }
-  22 | type record2 = { mutable cat : Obj.t; mutable total : float }
+  22 | type record2 = { mutable cat : Obj.t; mutable total : int }
   23 | 

--- a/tests/machine/x/ocaml/group_by_sort.ml
+++ b/tests/machine/x/ocaml/group_by_sort.ml
@@ -19,10 +19,10 @@ let sum lst = List.fold_left (+) 0 lst
 type ('k,'v) group = { key : 'k; items : 'v list }
 
 type record1 = { mutable cat : string; mutable val : int }
-type record2 = { mutable cat : Obj.t; mutable total : float }
+type record2 = { mutable cat : Obj.t; mutable total : int }
 
 let items : record1 list = [{ cat = "a"; val = 3 };{ cat = "a"; val = 1 };{ cat = "b"; val = 5 };{ cat = "b"; val = 2 }]
-let grouped : (string * Obj.t) list list = (let __groups0 = ref [] in
+let grouped : record2 list = (let __groups0 = ref [] in
   List.iter (fun i ->
       let key = Obj.obj (List.assoc "cat" i) in
       let cur = try List.assoc key !__groups0 with Not_found -> [] in

--- a/tests/machine/x/ocaml/group_items_iteration.ml
+++ b/tests/machine/x/ocaml/group_items_iteration.ml
@@ -24,7 +24,7 @@
     type record2 = { mutable tag : Obj.t; mutable total : Obj.t }
 
 let data : record1 list = [{ tag = "a"; val = 1 };{ tag = "a"; val = 2 };{ tag = "b"; val = 3 }]
-let groups : Obj.t list = (let __groups0 = ref [] in
+let groups : (Obj.t,(string * Obj.t) list) group list = (let __groups0 = ref [] in
   List.iter (fun d ->
       let key = Obj.obj (List.assoc "tag" d) in
       let cur = try List.assoc key !__groups0 with Not_found -> [] in
@@ -57,7 +57,7 @@ let () =
               | [] -> ()
               | x::rest ->
                 try
-                  total := ((!total) + x.val);
+                  total := ((!total) + Obj.obj (List.assoc "val" x));
                 with Continue -> ()
                 ; __loop3 rest
             in

--- a/tests/machine/x/ocaml/in_operator_extended.error
+++ b/tests/machine/x/ocaml/in_operator_extended.error
@@ -1,15 +1,15 @@
 stage: compile
 error:
-File "/workspace/mochi/tests/machine/x/ocaml/in_operator_extended.ml", line 29, characters 32-41:
-29 | let m : (string * Obj.t) list = { a = 1 }
-                                     ^^^^^^^^^
-Error: This expression should not be a record, the expected type is
-       (string * Obj.t) list
+File "/workspace/mochi/tests/machine/x/ocaml/in_operator_extended.ml", line 35, characters 36-37:
+35 |   print_endline (List.mem_assoc "a" m);
+                                         ^
+Error: This expression has type record1
+       but an expression was expected of type (string * 'a) list
 
 
-Context (around line 29):
-  27 | List.rev !__res0)
-  28 | 
-  29 | let m : (string * Obj.t) list = { a = 1 }
-  30 | let s : string = "hello"
-  31 | 
+Context (around line 35):
+  33 |   print_endline (__show ((List.mem 1 ys)));
+  34 |   print_endline (__show ((List.mem 2 ys)));
+  35 |   print_endline (List.mem_assoc "a" m);
+  36 |   print_endline (List.mem_assoc "b" m);
+  37 |   print_endline (List.mem "ell" s);

--- a/tests/machine/x/ocaml/in_operator_extended.ml
+++ b/tests/machine/x/ocaml/in_operator_extended.ml
@@ -26,7 +26,7 @@ let ys : int list = (let __res0 = ref [] in
   ) xs;
 List.rev !__res0)
 
-let m : (string * Obj.t) list = { a = 1 }
+let m : record1 = { a = 1 }
 let s : string = "hello"
 
 let () =

--- a/tests/machine/x/ocaml/inner_join.ml
+++ b/tests/machine/x/ocaml/inner_join.ml
@@ -25,7 +25,7 @@
 
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" };{ id = 3; name = "Charlie" }]
 let orders : record2 list = [{ id = 100; customerId = 1; total = 250 };{ id = 101; customerId = 2; total = 125 };{ id = 102; customerId = 1; total = 300 };{ id = 103; customerId = 4; total = 80 }]
-let result : (string * Obj.t) list list = (let __res0 = ref [] in
+let result : record3 list = (let __res0 = ref [] in
   List.iter (fun o ->
     List.iter (fun c ->
       if (Obj.obj (List.assoc "customerId" o) = Obj.obj (List.assoc "id" c)) then (

--- a/tests/machine/x/ocaml/join_multi.ml
+++ b/tests/machine/x/ocaml/join_multi.ml
@@ -27,7 +27,7 @@
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" }]
 let orders : record2 list = [{ id = 100; customerId = 1 };{ id = 101; customerId = 2 }]
 let items : record3 list = [{ orderId = 100; sku = "a" };{ orderId = 101; sku = "b" }]
-let result : (string * Obj.t) list list = (let __res0 = ref [] in
+let result : record4 list = (let __res0 = ref [] in
   List.iter (fun o ->
       List.iter (fun c ->
             List.iter (fun i ->

--- a/tests/machine/x/ocaml/json_builtin.error
+++ b/tests/machine/x/ocaml/json_builtin.error
@@ -1,15 +1,13 @@
 stage: compile
 error:
-File "/workspace/mochi/tests/machine/x/ocaml/json_builtin.ml", line 3, characters 32-48:
-3 | let m : (string * Obj.t) list = { a = 1; b = 2 }
-                                    ^^^^^^^^^^^^^^^^
-Error: This expression should not be a record, the expected type is
-       (string * Obj.t) list
+File "/workspace/mochi/tests/machine/x/ocaml/json_builtin.ml", line 6, characters 2-6:
+6 |   json m;
+      ^^^^
+Error: Unbound value json
 
 
-Context (around line 3):
-   1 | type record1 = { mutable a : int; mutable b : int }
-   2 | 
-   3 | let m : (string * Obj.t) list = { a = 1; b = 2 }
+Context (around line 6):
    4 | 
    5 | let () =
+   6 |   json m;
+   7 | 

--- a/tests/machine/x/ocaml/json_builtin.ml
+++ b/tests/machine/x/ocaml/json_builtin.ml
@@ -1,6 +1,6 @@
 type record1 = { mutable a : int; mutable b : int }
 
-let m : (string * Obj.t) list = { a = 1; b = 2 }
+let m : record1 = { a = 1; b = 2 }
 
 let () =
   json m;

--- a/tests/machine/x/ocaml/left_join.ml
+++ b/tests/machine/x/ocaml/left_join.ml
@@ -25,7 +25,7 @@
 
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" }]
 let orders : record2 list = [{ id = 100; customerId = 1; total = 250 };{ id = 101; customerId = 3; total = 80 }]
-let result : (string * Obj.t) list list = (let __res0 = ref [] in
+let result : record3 list = (let __res0 = ref [] in
   List.iter (fun o ->
     let matched = ref false in
     List.iter (fun c ->

--- a/tests/machine/x/ocaml/left_join_multi.ml
+++ b/tests/machine/x/ocaml/left_join_multi.ml
@@ -27,7 +27,7 @@
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" }]
 let orders : record2 list = [{ id = 100; customerId = 1 };{ id = 101; customerId = 2 }]
 let items : record3 list = [{ orderId = 100; sku = "a" }]
-let result : (string * Obj.t) list list = (let __res0 = ref [] in
+let result : record4 list = (let __res0 = ref [] in
   List.iter (fun o ->
       List.iter (fun c ->
       let matched = ref false in

--- a/tests/machine/x/ocaml/load_yaml.error
+++ b/tests/machine/x/ocaml/load_yaml.error
@@ -1,16 +1,15 @@
 stage: compile
 error:
-File "/workspace/mochi/tests/machine/x/ocaml/load_yaml.ml", line 59, characters 0-16:
-59 | List.rev !__res0)
-     ^^^^^^^^^^^^^^^^
+File "/workspace/mochi/tests/machine/x/ocaml/load_yaml.ml", line 72, characters 16-22:
+72 |     try __loop1 adults with Break -> ()
+                     ^^^^^^
 Error: This expression has type record1 list
        but an expression was expected of type (string * Obj.t) list list
        Type record1 is not compatible with type (string * Obj.t) list 
 
 
-Context (around line 59):
-  57 |     __res0 := { name = p.name; email = p.email } :: !__res0;
-  58 |   ) people;
-  59 | List.rev !__res0)
-  60 | 
-  61 | 
+Context (around line 72):
+  70 |         ; __loop1 rest
+  71 |     in
+  72 |     try __loop1 adults with Break -> ()
+  73 | 

--- a/tests/machine/x/ocaml/load_yaml.ml
+++ b/tests/machine/x/ocaml/load_yaml.ml
@@ -51,7 +51,7 @@
 
 type person = { mutable name : string; mutable age : int; mutable email : string }
 let people : person list = List.map (fun m -> { name = (Obj.obj (List.assoc "name" m) : string); age = (Obj.obj (List.assoc "age" m) : int); email = (Obj.obj (List.assoc "email" m) : string) }) (load_yaml "../interpreter/valid/people.yaml")
-let adults : (string * Obj.t) list list = (let __res0 = ref [] in
+let adults : record1 list = (let __res0 = ref [] in
   List.iter (fun p ->
       if (p.age >= 18) then
     __res0 := { name = p.name; email = p.email } :: !__res0;

--- a/tests/machine/x/ocaml/outer_join.ml
+++ b/tests/machine/x/ocaml/outer_join.ml
@@ -25,7 +25,7 @@
 
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" };{ id = 3; name = "Charlie" };{ id = 4; name = "Diana" }]
 let orders : record2 list = [{ id = 100; customerId = 1; total = 250 };{ id = 101; customerId = 2; total = 125 };{ id = 102; customerId = 1; total = 300 };{ id = 103; customerId = 5; total = 80 }]
-let result : (string * Obj.t) list list = (let __res0 = ref [] in
+let result : record3 list = (let __res0 = ref [] in
   List.iter (fun o ->
     let matched = ref false in
     List.iter (fun c ->

--- a/tests/machine/x/ocaml/python_auto.error
+++ b/tests/machine/x/ocaml/python_auto.error
@@ -1,0 +1,8 @@
+stage: compile
+error:
+unsupported statement at line 1
+
+Context (around line 1):
+   1 | import python "math" as math auto
+   2 | 
+   3 | print(math.sqrt(16.0))

--- a/tests/machine/x/ocaml/python_math.error
+++ b/tests/machine/x/ocaml/python_math.error
@@ -1,0 +1,9 @@
+stage: compile
+error:
+unsupported statement at line 2
+
+Context (around line 2):
+   1 | // math_import_extern_fun.mochi
+   2 | import python "math" as math
+   3 | 
+   4 | extern let math.pi: float

--- a/tests/machine/x/ocaml/query_sum_select.ml
+++ b/tests/machine/x/ocaml/query_sum_select.ml
@@ -18,7 +18,7 @@ let rec __show v =
 let sum lst = List.fold_left (+) 0 lst
 
 let nums : int list = [1;2;3]
-let result : float list = (let __res0 = ref [] in
+let result : int list = (let __res0 = ref [] in
   List.iter (fun n ->
       if (n > 1) then
     __res0 := (sum n) :: !__res0;

--- a/tests/machine/x/ocaml/right_join.ml
+++ b/tests/machine/x/ocaml/right_join.ml
@@ -25,7 +25,7 @@
 
 let customers : record1 list = [{ id = 1; name = "Alice" };{ id = 2; name = "Bob" };{ id = 3; name = "Charlie" };{ id = 4; name = "Diana" }]
 let orders : record2 list = [{ id = 100; customerId = 1; total = 250 };{ id = 101; customerId = 2; total = 125 };{ id = 102; customerId = 1; total = 300 }]
-let result : (string * Obj.t) list list = (let __res0 = ref [] in
+let result : record3 list = (let __res0 = ref [] in
   List.iter (fun o ->
     let matched = ref false in
     List.iter (fun c ->


### PR DESCRIPTION
## Summary
- improve OCaml compiler type generation for group expressions
- regenerate OCaml machine outputs
- update compilation checklist and TODOs
- add new error logs for unsupported programs

## Testing
- `go test -tags slow ./compiler/x/ocaml -run TestPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870df06de4c83209bff4aedb80a104a