### PR TITLE
Improve Erlang compiler

### DIFF
--- a/compiler/x/erlang/compiler.go
+++ b/compiler/x/erlang/compiler.go
@@ -543,7 +543,7 @@ func (c *Compiler) compileIfStmt(ifst *parser.IfStmt) (string, error) {
 			elseCode = "ok"
 		}
 	}
-	return fmt.Sprintf("(if %s -> %s; true -> %s end)", cond, thenCode, elseCode), nil
+	return fmt.Sprintf("(case %s of true -> %s; _ -> %s end)", cond, thenCode, elseCode), nil
 }
 
 func (c *Compiler) compileFor(fr *parser.ForStmt) (string, error) {
@@ -1473,19 +1473,8 @@ func (c *Compiler) compileLiteral(l *parser.Literal) string {
 }
 
 func (c *Compiler) compileMapKey(e *parser.Expr) (string, error) {
-	if e != nil && e.Binary != nil && len(e.Binary.Right) == 0 {
-		u := e.Binary.Left
-		if len(u.Ops) == 0 && u.Value != nil && len(u.Value.Ops) == 0 {
-			if u.Value.Target.Lit != nil && u.Value.Target.Lit.Str != nil {
-				// Keep quoted keys to avoid converting strings
-				// that look like identifiers into atoms.
-				return c.compileExpr(e)
-			}
-			if u.Value.Target.Selector != nil && len(u.Value.Target.Selector.Tail) == 0 {
-				return u.Value.Target.Selector.Root, nil
-			}
-		}
-	}
+	// Map keys may be arbitrary expressions. Delegate to compileExpr so
+	// that quoted string keys remain quoted in the output.
 	return c.compileExpr(e)
 }
 

--- a/tests/machine/x/erlang/README.md
+++ b/tests/machine/x/erlang/README.md
@@ -111,3 +111,13 @@ Checklist:
 - [ ] Add code generation for remaining Mochi examples
 - [ ] Track parameter types for more accurate list/map access
 - [x] Ensure string keys in maps remain quoted
+- [ ] Handle nested map updates with mixed key types
+- [ ] Detect guard-safe conditions to use `if` where possible
+- [ ] Improve error messages for unsupported syntax
+- [ ] Write unit tests for runtime join helpers
+- [ ] Optimize generated comprehension expressions
+- [ ] Document limitations of the current compiler
+- [ ] Expose CLI tool for compiling individual programs
+- [ ] Support pattern matching in let bindings
+- [ ] Add constant propagation for simple expressions
+- [ ] Investigate generating specs for dialyzer


### PR DESCRIPTION
## Summary
- handle general expressions in `if` statements using `case`
- simplify map key compilation to preserve quoted keys
- expand TODO checklist for Erlang machine output

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870defd73148320a04cdd3d23b25d1f