### PR TITLE
Add optional type hints and docstrings to Python compiler

### DIFF
--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -115,3 +115,13 @@ Compiled programs: 100/100 successful.
 - [ ] Expand test coverage for edge cases
 - [ ] Reduce external module dependencies
 - [ ] Document compiler flags and environment setup
+- [ ] Add concurrency support
+- [ ] Provide CLI for custom output directory
+- [ ] Implement caching for compiled modules
+- [ ] Support incremental compilation
+- [ ] Add logging for compiler phases
+- [ ] Enhance error messages with line numbers
+- [ ] Provide option to suppress runtime imports
+- [ ] Add plugin architecture for new targets
+- [ ] Provide integration tests with dataset examples
+- [ ] Document embedding compiled code in larger projects


### PR DESCRIPTION
## Summary
- allow toggling Python type annotations via `SetTypeHints`
- emit simple docstrings for functions and methods
- update Python machine README with more TODO tasks

## Testing
- `go test ./compiler/x/python -tags=slow -run TestPyCompiler_SubsetPrograms -count=1` *(fails: TypeError during Python execution)*

------
https://chatgpt.com/codex/tasks/task_e_6870e783f80c8320b4febe31eed32ef6