### PR TITLE
Update C++ test data and tasks

### DIFF
--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -2,7 +2,7 @@
 
 This directory contains C++ source code generated from Mochi programs and the corresponding outputs or error logs.
 
-Compiled programs: 100/100
+Compiled programs: 99/100
 
 ## Checklist
 
@@ -37,7 +37,7 @@ Compiled programs: 100/100
 - [x] group_by_multi_join
 - [x] group_by_multi_join_sort
 - [x] group_by_sort
-- [x] group_items_iteration
+- [ ] group_items_iteration
 - [x] if_else
 - [x] if_then_else
 - [x] if_then_else_nested
@@ -119,3 +119,13 @@ Compiled programs: 100/100
 - [ ] Integrate CMake build generation
 - [ ] Support user defined modules
 - [ ] Document the C++ backend
+- [ ] Support enumeration types
+- [ ] Optimize recursive functions
+- [ ] Add error handling macros
+- [ ] Provide container iterators
+- [ ] Add templates for math utilities
+- [ ] Support asynchronous IO
+- [ ] Improve compile-time warnings
+- [ ] Provide FFI to C libraries
+- [ ] Support large dataset streaming
+- [ ] Implement constant folding

--- a/tests/machine/x/cpp/group_items_iteration.error
+++ b/tests/machine/x/cpp/group_items_iteration.error
@@ -1,0 +1,35 @@
+line 27: ../../../tests/machine/x/cpp/group_items_iteration.cpp:27:33: error: ‘struct Data’ has no member named ‘key’
+   27 |   decltype(std::declval<Data>().key) tag;
+      |                                 ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:27:33: error: ‘struct Data’ has no member named ‘key’
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In function ‘int main()’:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:63:37: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+   63 |     tmp = __append(tmp, __struct3{g.key, total});
+      |                                   ~~^~~
+      |                                     |
+      |                                     std::string {aka std::__cxx11::basic_string<char>}
+../../../tests/machine/x/cpp/group_items_iteration.cpp: In lambda function:
+../../../tests/machine/x/cpp/group_items_iteration.cpp:69:28: error: request for member ‘tag’ in ‘r’, which is of non-class type ‘int’
+   69 |       __items.push_back({r.tag, r});
+      |                            ^~~
+../../../tests/machine/x/cpp/group_items_iteration.cpp:69:24: error: no matching function for call to ‘std::vector<std::pair<int, __struct3> >::push_back(<brace-enclosed initializer list>)’
+   69 |       __items.push_back({r.tag, r});
+      |       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from ../../../tests/machine/x/cpp/group_items_iteration.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<int, __struct3>; _Alloc = std::allocator<std::pair<int, __struct3> >; value_type = std::pair<int, __struct3>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<int, __struct3> >::value_type&’ {aka ‘const std::pair<int, __struct3>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<int, __struct3>; _Alloc = std::allocator<std::pair<int, __struct3> >; value_type = std::pair<int, __struct3>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<int, __struct3> >::value_type&&’ {aka ‘std::pair<int, __struct3>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+
+ 26 | struct __struct3 {
+ 27 |   decltype(std::declval<Data>().key) tag;
+ 28 |   int total;


### PR DESCRIPTION
## Summary
- regenerate C++ README to show 99 compiled programs
- mark `group_items_iteration` as failing and keep its compiler error
- extend the TODO list with additional C++ tasks

## Testing
- `go test ./compiler/x/cpp -run=^$ -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6870e7891e7483208f6fe3a255d3745b