### PR TITLE
Fix clj runtime helper

### DIFF
--- a/compiler/x/clj/runtime.go
+++ b/compiler/x/clj/runtime.go
@@ -362,7 +362,7 @@ const (
                it)
           it (if (contains? opts :skip) (vec (drop (:skip opts) it)) it)
           it (if (contains? opts :take) (vec (take (:take opts) it)) it)]
-      (mapv #(apply (:select opts) %) it))))))))))))`
+      (mapv #(apply (:select opts) %) it)))))))))))))`
 )
 
 var helperMap = map[string]string{
@@ -408,11 +408,11 @@ var helperOrder = []string{
 	"_max",
 	"_Group",
 	"_group_by",
-        "_parse_csv",
-        "_load",
-        "_escape_json",
-        "_to_json",
-        "_save",
+	"_parse_csv",
+	"_load",
+	"_escape_json",
+	"_to_json",
+	"_save",
 	"_json",
 	"_sort_key",
 	"_in",
@@ -432,11 +432,11 @@ var helperOrder = []string{
 // helperDeps lists transitive helper dependencies.
 // When a helper is used, its dependencies are also emitted.
 var helperDeps = map[string][]string{
-        "_json":             {"_to_json"},
-        "_to_json":          {"_escape_json"},
-        "_load":             {"_parse_csv"},
-        "_save":             {"_to_json"},
-        "_cast_struct_list": {"_cast_struct"},
+	"_json":             {"_to_json"},
+	"_to_json":          {"_escape_json"},
+	"_load":             {"_parse_csv"},
+	"_save":             {"_to_json"},
+	"_cast_struct_list": {"_cast_struct"},
 }
 
 func (c *Compiler) use(name string) {

--- a/tests/machine/x/clj/README.md
+++ b/tests/machine/x/clj/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Clojure code generated from the Mochi programs in `tests/vm/valid` using the Clojure compiler. Each program was compiled and executed. Successful runs produced an `.out` file while failures produced an `.error` file.
 
-Compiled programs: 95/100 successful.
+Compiled programs: 96/100 successful.
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -68,7 +68,7 @@ Compiled programs: 95/100 successful.
 - [x] min_max_builtin.mochi
 - [x] nested_function.mochi
 - [x] order_by_map.mochi
-- [ ] outer_join.mochi
+ - [x] outer_join.mochi
 - [x] partial_application.mochi
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
@@ -105,7 +105,7 @@ Compiled programs: 95/100 successful.
 - [x] while_loop.mochi
 
 ## Status
-5 programs failed.
+4 programs failed.
 
 ## Remaining tasks
 - [ ] Fix failing examples


### PR DESCRIPTION
## Summary
- fix closing paren in `helperQuery` runtime helper
- mark `outer_join.mochi` as compiled in Clojure test README
- update count of compiled programs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870e78cef008320808aa25950f3e87e