### PR TITLE
Enhance Kotlin compiler

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -456,6 +456,20 @@ func (c *Compiler) stmt(s *parser.Statement) error {
 }
 
 func (c *Compiler) funDecl(f *parser.FunStmt) error {
+	// emit basic KDoc with parameter and return type information
+	c.writeln("/**")
+	c.writeln(" * Auto-generated from Mochi")
+	for _, p := range f.Params {
+		typ := "Any"
+		if p.Type != nil {
+			typ = c.typeName(p.Type)
+		}
+		c.writeln(fmt.Sprintf(" * @param %s %s", p.Name, typ))
+	}
+	if f.Return != nil {
+		c.writeln(fmt.Sprintf(" * @return %s", c.typeName(f.Return)))
+	}
+	c.writeln(" */")
 	params := make([]string, len(f.Params))
 	for i, p := range f.Params {
 		if p.Type != nil {

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -143,3 +143,13 @@ Successfully ran: 97/100 programs
 - [ ] Add integration tests for generated programs
 - [ ] Provide Gradle build scripts for compiled code
 - [ ] Explore Kotlin/Native backends for cross-platform
+- [ ] Support compile-time constant folding
+- [ ] Generate better error messages for type mismatches
+- [ ] Auto-format generated code with ktfmt
+- [ ] Provide CLI option for custom runtime path
+- [ ] Offer debug mode with verbose compiler logs
+- [ ] Integrate static analyzers for generated Kotlin
+- [ ] Reduce temporary variable allocations
+- [ ] Emit top-level properties as `const val` when possible
+- [ ] Validate generated code using `kotlinc` before output
+- [ ] Document compiler flags in this README


### PR DESCRIPTION
## Summary
- generate simple KDoc comments for each function in the Kotlin compiler
- expand the Kotlin machine README with more TODO items

## Testing
- `go test -tags=slow ./...` *(fails: package mochi/archived/x/... is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_6870e7968008832090ece339f8f918c5