### PR TITLE
Enhance Go compiler type inference

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -2370,7 +2370,7 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if isStringMapLike(c.inferExprType(f.With)) {
+		if isStringAnyMapLike(c.inferExprType(f.With)) {
 			withStr = w
 		} else {
 			c.use("_toAnyMap")
@@ -2468,7 +2468,7 @@ func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if isStringMapLike(c.inferExprType(l.With)) {
+		if isStringAnyMapLike(c.inferExprType(l.With)) {
 			opts = v
 		} else {
 			c.use("_toAnyMap")
@@ -2520,7 +2520,7 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if isStringMapLike(c.inferExprType(s.With)) {
+		if isStringAnyMapLike(c.inferExprType(s.With)) {
 			opts = v
 		} else {
 			c.use("_toAnyMap")

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -273,6 +273,22 @@ func isStringMapLike(t types.Type) bool {
 	return false
 }
 
+// isStringAnyMapLike reports whether t is or resolves to a map[string]any.
+func isStringAnyMapLike(t types.Type) bool {
+	if isStringAnyMap(t) {
+		return true
+	}
+	if ut, ok := t.(types.UnionType); ok {
+		for _, v := range ut.Variants {
+			if !isStringAnyMap(v) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
 func isMap(t types.Type) bool {
 	_, ok := t.(types.MapType)
 	return ok

--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -129,3 +129,13 @@ Checklist:
 - [ ] Emit warnings for unused variables in generated code.
 - [ ] Expand documentation comments for generated helper functions.
 - [ ] Investigate concurrency patterns for dataset operations.
+- [ ] Improve dataset join heuristics.
+- [ ] Add cross-module constant propagation.
+- [ ] Implement SSA-based optimizations.
+- [ ] Expand integration tests for edge cases.
+- [ ] Provide interactive REPL support for Go backend.
+- [ ] Document compiler internal design.
+- [ ] Add plugin system for code generation hooks.
+- [ ] Support incremental compilation.
+- [ ] Provide AST visualization tooling.
+- [ ] Add runtime tracing for garbage collection.


### PR DESCRIPTION
## Summary
- improve map handling in `compiler/x/go/compiler.go`
- add `isStringAnyMapLike` helper for union-aware checks
- update Go machine README with additional tasks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870f42db340832097798a56fc3855fb