### PR TITLE
Improve C# compiler handling of int type

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -2969,7 +2969,7 @@ func csType(t *parser.TypeRef) string {
 	if t.Simple != nil {
 		switch *t.Simple {
 		case "int":
-			return "long"
+			return "int"
 		case "float":
 			return "double"
 		case "string":
@@ -3219,7 +3219,7 @@ func listElemType(e *parser.Expr) string {
 	lit := pv.Target.Lit
 	switch {
 	case lit.Int != nil:
-		return "long"
+		return "int"
 	case lit.Float != nil:
 		return "double"
 	case lit.Str != nil:

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -130,3 +130,13 @@ Checklist:
 - [ ] Add support for .NET interactive notebooks
 - [ ] Provide integration with build systems (MSBuild, etc.)
 - [ ] Document runtime API usage with examples
+- [ ] Add cross-platform path handling
+- [ ] Support customizing generated namespaces
+- [ ] Provide interactive REPL for generated code
+- [ ] Integrate static analysis for generated projects
+- [ ] Support generics in query comprehensions
+- [ ] Improve CLI output colorization
+- [ ] Offer VS Code extension integration
+- [ ] Publish Docker image for compiled apps
+- [ ] Add integration tests for runtime helpers
+- [ ] Package compiled code as a NuGet library


### PR DESCRIPTION
## Summary
- update cs compiler to emit `int` instead of `long` for Mochi `int`
- adjust list element inference accordingly
- extend machine output README with additional tasks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870f47f8c9c832080261c4b12695e67