### PR TITLE
Improve Python compiler docstrings

### DIFF
--- a/compiler/x/python/statements.go
+++ b/compiler/x/python/statements.go
@@ -1005,7 +1005,20 @@ func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 	origEnv := c.env
 	c.env = child
 	c.indent++
-	c.writeln(fmt.Sprintf("\"\"\"%s.\"\"\"", name))
+	paramDocs := make([]string, len(fun.Params))
+	for i, p := range fun.Params {
+		desc := sanitizeName(p.Name)
+		if paramTypes[i] != nil && c.typeHints {
+			typStr := pyType(c.namedType(paramTypes[i]))
+			desc += ": " + typStr
+		}
+		paramDocs[i] = desc
+	}
+	sigDoc := fmt.Sprintf("%s(%s)", name, strings.Join(paramDocs, ", "))
+	if retType != "None" {
+		sigDoc += " -> " + retType
+	}
+	c.writeln(fmt.Sprintf("\"\"\"%s\"\"\"", sigDoc))
 	for _, n := range nonlocals {
 		c.writeln("nonlocal " + n)
 	}

--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -110,7 +110,7 @@ Compiled programs: 100/100 successful.
 - [ ] Improve error reporting for runtime failures
 - [ ] Support optional type annotations
 - [ ] Integrate with Python packaging tools
-- [ ] Generate docstrings for compiled functions
+- [x] Generate docstrings for compiled functions
 - [ ] Optimize stream handling performance
 - [ ] Expand test coverage for edge cases
 - [ ] Reduce external module dependencies
@@ -125,3 +125,14 @@ Compiled programs: 100/100 successful.
 - [ ] Add plugin architecture for new targets
 - [ ] Provide integration tests with dataset examples
 - [ ] Document embedding compiled code in larger projects
+- [ ] Implement static analysis for unreachable code
+- [ ] Support generator functions
+- [ ] Provide configuration file for compiler options
+- [ ] Optimize recursive function handling
+- [ ] Generate type stub files
+- [ ] Integrate with virtual environments
+- [ ] Provide interactive REPL for compiled code
+- [ ] Add runtime checks for invariants
+- [ ] Support advanced slicing operations
+- [ ] Document integration with Jupyter notebooks
+- [ ] Add pattern matching support


### PR DESCRIPTION
## Summary
- emit better docstrings in Python functions with parameter and return type information
- mark docstring task as completed and add additional TODO items

## Testing
- `go test ./compiler/x/python -tags slow -run TestPyCompiler_SubsetPrograms -count=1` *(fails: python run errors and golden mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6870fbd8fabc8320b115a8b9bf2a653d