### PR TITLE
Improve C backend JSON output

### DIFF
--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -139,3 +139,13 @@ Checklist:
 - [ ] Allow inline assembly blocks
 - [ ] Support 64-bit integer types
 - [ ] Generate debug symbols for gdb
+- [ ] Improve constant folding for arithmetic expressions
+- [ ] Add support for struct method receivers
+- [ ] Implement union type pattern matching
+- [ ] Generate C99 designated initializers
+- [ ] Support builtin regex operations
+- [ ] Provide configuration for custom allocators
+- [ ] Implement dead code elimination pass
+- [ ] Add benchmarking harness for generated C
+- [ ] Support optional parameters in functions
+- [ ] Document runtime error handling conventions


### PR DESCRIPTION
## Summary
- enhance C compiler JSON generation for lists of structs
- restore machine README and list remaining tasks

## Testing
- `go test -tags slow ./compiler/x/c -run TestCCompiler_ValidPrograms/print_hello`
- `go test -tags slow ./compiler/x/c -run TestCCompiler_ValidPrograms/python_math`


------
https://chatgpt.com/codex/tasks/task_e_6870fc3ab0b88320ad41a12761212953