### PR TITLE
Improve Zig compiler output

### DIFF
--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -130,3 +130,13 @@ Compiled programs: 100/100
 - [ ] Add support for customizing allocator.
 - [ ] Introduce command line options for optimization levels.
 - [ ] Provide examples demonstrating interop with C libraries.
+- [ ] Support customizable import paths.
+- [ ] Generate documentation comments for emitted functions.
+- [ ] Optionally disable runtime helpers for smaller binaries.
+- [ ] Unroll small-range loops for performance.
+- [ ] Capture closures across multiple modules.
+- [ ] Provide a linter for generated Zig code.
+- [ ] Add cross-platform build script for automated tests.
+- [ ] Auto-generate tests from `test` blocks in Mochi sources.
+- [ ] Cache compiled modules to speed up repeated builds.
+- [ ] Explore asynchronous IO support in generated code.


### PR DESCRIPTION
## Summary
- add `writelnType` helper that appends inferred type comments
- use `writelnType` for let/var declarations in Zig compiler
- expand Zig machine README with additional TODO items

## Testing
- `go test ./compiler/x/zig -tags slow -run TestZigCompiler_ValidPrograms -count=1 -timeout=30s` *(fails: zig compiler missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870fd926fb483208e6b4e756a1e532b