### PR TITLE
Add Prolog FFI support

### DIFF
--- a/tests/machine/x/pl/README.md
+++ b/tests/machine/x/pl/README.md
@@ -4,7 +4,7 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 
 ## Summary
 
- - 97/97 programs compiled and ran successfully.
+ - 100/100 programs compiled (execution requires `swipl`).
 
 ### Checklist
 - [x] append_builtin
@@ -28,6 +28,7 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 - [x] fun_call
 - [x] fun_expr_in_let
 - [x] fun_three_args
+- [x] go_auto
 - [x] group_by_multi_join_sort
 - [x] if_else
 - [x] if_then_else
@@ -61,6 +62,8 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 - [x] print_hello
 - [x] pure_fold
 - [x] pure_global_fold
+- [x] python_auto
+- [x] python_math
 - [x] record_assign
 - [x] short_circuit
 - [x] slice
@@ -118,3 +121,13 @@ This directory contains Prolog code generated from the Mochi programs in `tests/
 - [ ] Handle records with optional fields
 - [ ] Support lazy evaluation features
 - [ ] Document known limitations in compiler
+- [ ] Improve pattern matching translation
+- [ ] Better list comprehension support
+- [ ] Implement dictionary update syntax
+- [ ] Support Prolog modules for packages
+- [ ] Generate comments from Mochi source
+- [ ] Implement property-based tests
+- [ ] Optimize query compilation
+- [ ] Support multi-file compilation
+- [ ] Add linter for generated Prolog
+- [ ] Improve variable naming heuristics

--- a/tests/machine/x/pl/go_auto.pl
+++ b/tests/machine/x/pl/go_auto.pl
@@ -1,0 +1,18 @@
+:- style_check(-singleton).
+testpkg_add(A, B, R) :- R is A + B.
+testpkg_pi(P) :- P is 3.14.
+testpkg_answer(A) :- A is 42.
+
+:- initialization(main, main).
+main :-
+    testpkg_add(2, 3, _V0),
+    _V1 is _V0,
+    write(_V1),
+    nl,
+    testpkg_pi(_V2),
+    write(_V2),
+    nl,
+    testpkg_answer(_V3),
+    write(_V3),
+    nl,
+    true.

--- a/tests/machine/x/pl/python_auto.pl
+++ b/tests/machine/x/pl/python_auto.pl
@@ -1,0 +1,18 @@
+:- style_check(-singleton).
+math_pi(P) :- P is 3.141592653589793.
+math_e(E) :- E is 2.718281828459045.
+math_sqrt(X, R) :- R is sqrt(X).
+math_pow(X, Y, R) :- R is X ** Y.
+math_sin(X, R) :- R is sin(X).
+math_log(X, R) :- R is log(X).
+
+:- initialization(main, main).
+main :-
+    math_sqrt(16, _V0),
+    _V1 is _V0,
+    write(_V1),
+    nl,
+    math_pi(_V2),
+    write(_V2),
+    nl,
+    true.

--- a/tests/machine/x/pl/python_math.pl
+++ b/tests/machine/x/pl/python_math.pl
@@ -1,0 +1,44 @@
+:- style_check(-singleton).
+math_pi(P) :- P is 3.141592653589793.
+math_e(E) :- E is 2.718281828459045.
+math_sqrt(X, R) :- R is sqrt(X).
+math_pow(X, Y, R) :- R is X ** Y.
+math_sin(X, R) :- R is sin(X).
+math_log(X, R) :- R is log(X).
+
+:- initialization(main, main).
+main :-
+    R is 3,
+    math_pi(_V0),
+    math_pow(R, 2, _V1),
+    Area is (_V0 * _V1),
+    math_sqrt(49, _V2),
+    Root is _V2,
+    math_pi(_V3),
+    math_sin((_V3 / 4), _V4),
+    Sin45 is _V4,
+    math_e(_V5),
+    math_log(_V5, _V6),
+    Log_e is _V6,
+    write("Circle area with r ="),
+    write(' '),
+    write(R),
+    write(' '),
+    ("=>" -> _V7 = true ; _V7 = false),
+    write(_V7),
+    write(' '),
+    write(Area),
+    nl,
+    write("Square root of 49:"),
+    write(' '),
+    write(Root),
+    nl,
+    write("sin(π/4):"),
+    write(' '),
+    write(Sin45),
+    nl,
+    write("log(e):"),
+    write(' '),
+    write(Log_e),
+    nl,
+    true.


### PR DESCRIPTION
## Summary
- support FFI imports in Prolog compiler
- generate built‑ins for Go `testpkg` and Python `math`
- compile new programs using updated compiler
- update Prolog machine README with new programs and tasks

## Testing
- `go test ./compiler/x/pl -run TestPrologCompiler/go_auto -tags slow` *(fails: exec: "swipl" not found)*
- `go test ./compiler/x/pl -run TestPrologCompiler/python_auto -tags slow` *(fails: exec: "swipl" not found)*
- `go test ./compiler/x/pl -run TestPrologCompiler/python_math -tags slow` *(fails: exec: "swipl" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e7b030a08320a5b12f52345438f7