### PR TITLE
Update Scheme backend dataset helpers

### DIFF
--- a/compiler/x/scheme/compiler.go
+++ b/compiler/x/scheme/compiler.go
@@ -14,7 +14,7 @@ import (
 	"mochi/types"
 )
 
-const datasetHelpers = `(import (srfi 95) (chibi json) (chibi io) (chibi) (chibi string))
+const datasetHelpers = `(import (srfi 1) (srfi 95) (chibi json) (chibi io) (chibi process) (chibi fmt) (chibi) (chibi string))
 
 (define (_to_string v)
   (call-with-output-string (lambda (p) (write v p))))

--- a/tests/machine/x/scheme/README.md
+++ b/tests/machine/x/scheme/README.md
@@ -117,3 +117,13 @@ This directory contains Scheme code generated from the Mochi programs in `tests/
 - [ ] Add generic type parameter compilation
 - [ ] Extend dataset query language with window functions
 - [ ] Improve error messages for invalid constructs
+- [ ] Reduce startup time for the compiler tests
+- [ ] Provide better integration with package managers
+- [ ] Add support for tail-position detection
+- [ ] Generate documentation comments from Mochi sources
+- [ ] Support interactive debugging hooks
+- [ ] Improve constant folding optimizations
+- [ ] Better detection of dead code during compilation
+- [ ] Implement lazy evaluation primitives
+- [ ] Add code coverage instrumentation
+- [ ] Provide tooling for dependency visualization


### PR DESCRIPTION
## Summary
- broaden imports for Scheme dataset helpers to avoid runtime warnings
- expand scheme machine README task list

## Testing
- `gofmt -w compiler/x/scheme/compiler.go`
- `go test -run TestVMValidPrograms -tags slow -count=1` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687104001d4483209a118c831c0d9f67