### PR TITLE
Add namespace customization for C# compiler

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -34,6 +34,7 @@ type Compiler struct {
 	structHint   string
 	extraStructs []types.StructType
 	structCount  int
+	Namespace    string
 }
 
 // New creates a new C# compiler.
@@ -51,6 +52,7 @@ func New(env *types.Env) *Compiler {
 		structHint:   "",
 		extraStructs: nil,
 		structCount:  0,
+		Namespace:    "",
 	}
 }
 
@@ -87,8 +89,12 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		c.writeln("using System.Data;")
 	}
 	c.writeln("")
-	if prog.Package != "" {
-		c.writeln("namespace " + sanitizeName(prog.Package) + " {")
+	ns := c.Namespace
+	if ns == "" {
+		ns = prog.Package
+	}
+	if ns != "" {
+		c.writeln("namespace " + sanitizeName(ns) + " {")
 		c.indent++
 	}
 	// Compile Mochi package imports
@@ -223,7 +229,11 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	c.indent--
 	c.writeln("}")
-	if prog.Package != "" {
+	ns = c.Namespace
+	if ns == "" {
+		ns = prog.Package
+	}
+	if ns != "" {
 		c.indent--
 		c.writeln("}")
 	}

--- a/scripts/compile_cs.go
+++ b/scripts/compile_cs.go
@@ -40,7 +40,11 @@ func main() {
 			os.Remove(csPath)
 			continue
 		}
-		code, err := cscode.New(env).Compile(prog)
+		comp := cscode.New(env)
+		if ns := os.Getenv("CS_NAMESPACE"); ns != "" {
+			comp.Namespace = ns
+		}
+		code, err := comp.Compile(prog)
 		if err != nil {
 			os.WriteFile(errPath, []byte(err.Error()), 0644)
 			os.Remove(csPath)

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -4,6 +4,8 @@ This directory holds C# source generated from the Mochi programs in `tests/vm/va
 
 Compiled programs: 100/100
 
+The namespace of generated files can be customized by setting the `CS_NAMESPACE` environment variable when running `scripts/compile_cs.go`.
+
 Checklist:
 
 - [x] append_builtin
@@ -131,7 +133,7 @@ Checklist:
 - [ ] Provide integration with build systems (MSBuild, etc.)
 - [ ] Document runtime API usage with examples
 - [ ] Add cross-platform path handling
-- [ ] Support customizing generated namespaces
+- [x] Support customizing generated namespaces
 - [ ] Provide interactive REPL for generated code
 - [ ] Integrate static analysis for generated projects
 - [ ] Support generics in query comprehensions


### PR DESCRIPTION
## Summary
- allow specifying a custom namespace for the C# compiler
- expose namespace override via `CS_NAMESPACE` in `scripts/compile_cs.go`
- document namespace customization and mark task complete in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68710744d35083208d5f4311e93dabbb