### PR TITLE
Add list slice support for COBOL compiler

### DIFF
--- a/tests/machine/x/cobol/README.md
+++ b/tests/machine/x/cobol/README.md
@@ -1,4 +1,4 @@
-# Mochi to COBOL Machine Translations (60/97 compiled)
+# Mochi to COBOL Machine Translations (61/97 compiled)
 
 Generated using `go run -tags slow scripts/compile_cobol.go`.
 
@@ -77,7 +77,7 @@ Generated using `go run -tags slow scripts/compile_cobol.go`.
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
-- [ ] slice.mochi
+ - [x] slice.mochi
 - [ ] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi

--- a/tests/machine/x/cobol/slice.cob
+++ b/tests/machine/x/cobol/slice.cob
@@ -1,0 +1,10 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. SLICE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 TMP PIC 9(9) VALUE 0.
+       PROCEDURE DIVISION.
+       DISPLAY 2 3
+       DISPLAY 1 2
+       DISPLAY "hello"((1 + 1):(4 - 1))
+       STOP RUN.

--- a/tests/machine/x/cobol/slice.error
+++ b/tests/machine/x/cobol/slice.error
@@ -1,1 +1,0 @@
-unsupported expression at line 1


### PR DESCRIPTION
## Summary
- handle list slice literals in print statements
- fold list slices during expression compilation
- expose helper `listSliceLiteralExpr`
- regenerate slice test output
- update COBOL machine translation checklist

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68710745dac083208cf1c1503f8c2fd5