### PR TITLE
Improve Zig join builtin

### DIFF
--- a/compiler/x/zig/builtins.go
+++ b/compiler/x/zig/builtins.go
@@ -404,15 +404,8 @@ func (c *Compiler) writeBuiltins() {
 	if c.needsJoinString {
 		c.writeln("fn _join_strings(parts: []const []const u8, sep: []const u8) []const u8 {")
 		c.indent++
-		c.writeln("var res = std.ArrayList(u8).init(std.heap.page_allocator);")
-		c.writeln("defer res.deinit();")
-		c.writeln("for (parts, 0..) |it, i| {")
-		c.indent++
-		c.writeln("if (i > 0) res.appendSlice(sep) catch unreachable;")
-		c.writeln("res.appendSlice(it) catch unreachable;")
-		c.indent--
-		c.writeln("}")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("const alloc = std.heap.page_allocator;")
+		c.writeln("return std.mem.join(u8, sep, parts, alloc) catch unreachable;")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")


### PR DESCRIPTION
## Summary
- implement `_join_strings` using `std.mem.join` for idiomatic Zig

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68710780a6cc8320ae78cea58ef84b2a