### PR TITLE
Add Brazilian numbers Rosetta example

### DIFF
--- a/tests/rosetta/out/Go/brazilian-numbers-1.out
+++ b/tests/rosetta/out/Go/brazilian-numbers-1.out
@@ -1,0 +1,10 @@
+First 20 Brazilian numbers:
+7 8 10 12 13 14 15 16 18 20 21 22 24 26 27 28 30 31 32 33 
+
+First 20 odd Brazilian numbers:
+7 13 15 21 27 31 33 35 39 43 45 51 55 57 63 65 69 73 75 77 
+
+First 20 prime Brazilian numbers:
+7 13 31 43 73 127 157 211 241 307 421 463 601 757 1093 1123 1483 1723 2551 2801 
+
+The 100,000th Brazilian number: 110468

--- a/tests/rosetta/out/Go/brazilian-numbers-2.out
+++ b/tests/rosetta/out/Go/brazilian-numbers-2.out
@@ -1,0 +1,36 @@
+Sieving took 6728.5681 ms
+
+Checking first few prime numbers of sequential ones:
+ones checked found
+   3   32540  3923
+   5     182    44
+   7      32     9
+  11       8     1
+  13       6     3
+  17       4     1
+  19       4     1
+Adding Brazilian primes to the sieve took 22.7249 ms
+
+The first 20 Brazilian numbers are:
+7 8 10 12 13 14 15 16 18 20 21 22 24 26 27 28 30 31 32 33 
+
+The first 20 odd Brazilian numbers are:
+7 13 15 21 27 31 33 35 39 43 45 51 55 57 63 65 69 73 75 77 
+
+The first 20 prime Brazilian numbers are:
+7 13 31 43 73 127 157 211 241 307 421 463 601 757 1093 1123 1483 1723 2551 2801 
+
+Required output took 0.0626 ms
+
+Decade count of Brazilian numbers:
+             10th is 20               time:   0.0663 ms
+            100th is 132              time:   0.0698 ms
+          1,000th is 1,191            time:   0.0736 ms
+         10,000th is 11,364           time:   0.0871 ms
+        100,000th is 110,468          time:   0.1858 ms
+      1,000,000th is 1,084,566        time:   1.1680 ms
+     10,000,000th is 10,708,453       time:  33.6940 ms
+    100,000,000th is 106,091,516      time: 199.0773 ms
+  1,000,000,000th is 1,053,421,821    time: 1203.5074 ms
+
+Total elapsed was 7959.3938 ms

--- a/tests/rosetta/x/Mochi/brazilian-numbers.mochi
+++ b/tests/rosetta/x/Mochi/brazilian-numbers.mochi
@@ -1,0 +1,98 @@
+// Mochi implementation of Rosetta "Brazilian numbers" task
+// Translated from Go version in tests/rosetta/x/Go/brazilian-numbers-1.go
+
+fun sameDigits(n: int, b: int): bool {
+  var f = n % b
+  n = (n / b) as int
+  while n > 0 {
+    if n % b != f {
+      return false
+    }
+    n = (n / b) as int
+  }
+  return true
+}
+
+fun isBrazilian(n: int): bool {
+  if n < 7 {
+    return false
+  }
+  if n % 2 == 0 && n >= 8 {
+    return true
+  }
+  var b = 2
+  while b < n - 1 {
+    if sameDigits(n, b) {
+      return true
+    }
+    b = b + 1
+  }
+  return false
+}
+
+fun isPrime(n: int): bool {
+  if n < 2 {
+    return false
+  }
+  if n % 2 == 0 {
+    return n == 2
+  }
+  if n % 3 == 0 {
+    return n == 3
+  }
+  var d = 5
+  while d * d <= n {
+    if n % d == 0 {
+      return false
+    }
+    d = d + 2
+    if n % d == 0 {
+      return false
+    }
+    d = d + 4
+  }
+  return true
+}
+
+fun main() {
+  var kinds = [" ", " odd ", " prime "]
+  for kind in kinds {
+    print("First 20" + kind + "Brazilian numbers:")
+    var c = 0
+    var n = 7
+    while true {
+      if isBrazilian(n) {
+        print(str(n) + " ")
+        c = c + 1
+        if c == 20 {
+          print("\n")
+          break
+        }
+      }
+      if kind == " " {
+        n = n + 1
+      } else if kind == " odd " {
+        n = n + 2
+      } else { // prime
+        while true {
+          n = n + 2
+          if isPrime(n) {
+            break
+          }
+        }
+      }
+    }
+  }
+
+  var n = 7
+  var c = 0
+  while c < 100000 {
+    if isBrazilian(n) {
+      c = c + 1
+    }
+    n = n + 1
+  }
+  print("The 100,000th Brazilian number: " + str(n - 1))
+}
+
+main()

--- a/tests/rosetta/x/Mochi/brazilian-numbers.out
+++ b/tests/rosetta/x/Mochi/brazilian-numbers.out
@@ -1,0 +1,10 @@
+First 20 Brazilian numbers:
+7 8 10 12 13 14 15 16 18 20 21 22 24 26 27 28 30 31 32 33
+
+First 20 odd Brazilian numbers:
+7 13 15 21 27 31 33 35 39 43 45 51 55 57 63 65 69 73 75 77
+
+First 20 prime Brazilian numbers:
+7 13 31 43 73 127 157 211 241 307 421 463 601 757 1093 1123 1483 1723 2551 2801
+
+The 100,000th Brazilian number: 110468


### PR DESCRIPTION
## Summary
- add Go outputs for Brazilian numbers reference
- implement Brazilian numbers in Mochi
- add matching golden output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68710c21be7c8320be66bbca98ab048a