### PR TITLE
Add cap builtin and Rosetta arrays

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -408,6 +408,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: IntType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("cap", FuncType{
+		Params: []Type{ListType{Elem: AnyType{}}},
+		Return: IntType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("append", FuncType{
 		Params: []Type{ListType{Elem: AnyType{}}, AnyType{}},
 		Return: ListType{Elem: AnyType{}},


### PR DESCRIPTION
## Summary
- add `cap` builtin opcode and runtime implementation
- support `cap` in type checker
- include Rosetta Code `Arrays` examples for Mochi and Go

## Testing
- `go test ./tools/rosetta -run TestMochiTasks/arrays -tags slow -count=1`
- `go test ./tools/rosetta -run TestMochiToGo/arrays -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687134217bfc8320ac8a653780c7b0eb