### PR TITLE
Add rosetta outputs for arithmetic-geometric mean task

### DIFF
--- a/tests/rosetta/out/Go/arithmetic-geometric-mean-calculate-pi.error
+++ b/tests/rosetta/out/Go/arithmetic-geometric-mean-calculate-pi.error
@@ -1,0 +1,4 @@
+run error: exit status 1
+# command-line-arguments
+../../tests/rosetta/out/Go/arithmetic-geometric-mean-calculate-pi.go:58:6: main redeclared in this block
+	../../tests/rosetta/out/Go/arithmetic-geometric-mean-calculate-pi.go:54:6: other declaration of main

--- a/tests/rosetta/out/Go/arithmetic-geometric-mean-calculate-pi.go
+++ b/tests/rosetta/out/Go/arithmetic-geometric-mean-calculate-pi.go
@@ -1,0 +1,60 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+)
+
+// line 4
+func abs(x float64) float64 {
+	if x < 0.0 {
+		return -x
+	}
+	return x
+}
+
+// line 9
+func sqrtApprox(x float64) float64 {
+	var guess float64 = x
+	var i int = 0
+	for {
+		if !(i < 20) {
+			break
+		}
+		guess = ((guess + (x / guess)) / 2.0)
+		i = (i + 1)
+	}
+	return guess
+}
+
+// line 19
+func agmPi() float64 {
+	var a float64 = 1.0
+	var g float64 = (1.0 / sqrtApprox(2.0))
+	var sum float64 = 0.0
+	var pow float64 = 2.0
+	for {
+		if !(abs((a - g)) > 0.000000000000001) {
+			break
+		}
+		var t float64 = ((a + g) / 2.0)
+		var u float64 = sqrtApprox((a * g))
+		a = t
+		g = u
+		pow = (pow * 2.0)
+		var diff float64 = ((a * a) - (g * g))
+		sum = (sum + (diff * pow))
+	}
+	var pi float64 = (((4.0 * a) * a) / (1.0 - sum))
+	return pi
+}
+
+// line 37
+func main() {
+	fmt.Println(fmt.Sprint(agmPi()))
+}
+
+func main() {
+	main()
+}

--- a/tests/rosetta/out/Mochi-IR/arithmetic-geometric-mean-calculate-pi.ir
+++ b/tests/rosetta/out/Mochi-IR/arithmetic-geometric-mean-calculate-pi.ir
@@ -1,0 +1,119 @@
+func main (regs=1)
+  // main()
+  Call         r0, main, 
+  Return       r0
+
+  // fun abs(x: float): float {
+func abs (regs=4)
+  // if x < 0.0 { return -x }
+  Const        r1, 0.0
+  LessFloat    r2, r0, r1
+  JumpIfFalse  r2, L0
+  Neg          r3, r0
+  Return       r3
+L0:
+  // return x
+  Return       r0
+
+  // fun sqrtApprox(x: float): float {
+func sqrtApprox (regs=12)
+  // var guess = x
+  Move         r1, r0
+  // var i = 0
+  Const        r2, 0
+  Move         r3, r2
+L1:
+  // while i < 20 {
+  Const        r4, 20
+  LessInt      r5, r3, r4
+  JumpIfFalse  r5, L0
+  // guess = (guess + x / guess) / 2.0
+  Div          r6, r0, r1
+  Add          r7, r1, r6
+  Const        r8, 2.0
+  DivFloat     r9, r7, r8
+  Move         r1, r9
+  // i = i + 1
+  Const        r10, 1
+  AddInt       r11, r3, r10
+  Move         r3, r11
+  // while i < 20 {
+  Jump         L1
+L0:
+  // return guess
+  Return       r1
+
+  // fun agmPi(): float {
+func agmPi (regs=35)
+  // var a = 1.0
+  Const        r0, 1.0
+  Move         r1, r0
+  // var g = 1.0 / sqrtApprox(2.0)
+  Const        r0, 1.0
+  Const        r3, 2.0
+  Move         r2, r3
+  Call         r4, sqrtApprox, r2
+  DivFloat     r5, r0, r4
+  Move         r6, r5
+  // var sum = 0.0
+  Const        r7, 0.0
+  Move         r8, r7
+  // var pow = 2.0
+  Const        r3, 2.0
+  Move         r9, r3
+L1:
+  // while abs(a - g) > 0.000000000000001 {
+  SubFloat     r11, r1, r6
+  Move         r10, r11
+  Call         r12, abs, r10
+  Const        r13, 0.000000000000001
+  LessFloat    r14, r13, r12
+  JumpIfFalse  r14, L0
+  // var t = (a + g) / 2.0
+  AddFloat     r15, r1, r6
+  Const        r3, 2.0
+  DivFloat     r16, r15, r3
+  Move         r17, r16
+  // var u = sqrtApprox(a * g)
+  MulFloat     r19, r1, r6
+  Move         r18, r19
+  Call         r20, sqrtApprox, r18
+  Move         r21, r20
+  // a = t
+  Move         r1, r17
+  // g = u
+  Move         r6, r21
+  // pow = pow * 2.0
+  Const        r3, 2.0
+  MulFloat     r22, r9, r3
+  Move         r9, r22
+  // var diff = a * a - g * g
+  MulFloat     r23, r1, r1
+  Mul          r24, r6, r6
+  SubFloat     r25, r23, r24
+  Move         r26, r25
+  // sum = sum + diff * pow
+  MulFloat     r27, r26, r9
+  AddFloat     r28, r8, r27
+  Move         r8, r28
+  // while abs(a - g) > 0.000000000000001 {
+  Jump         L1
+L0:
+  // var pi = 4.0 * a * a / (1.0 - sum)
+  Const        r29, 4.0
+  MulFloat     r30, r29, r1
+  MulFloat     r31, r30, r1
+  Const        r0, 1.0
+  SubFloat     r32, r0, r8
+  DivFloat     r33, r31, r32
+  Move         r34, r33
+  // return pi
+  Return       r34
+
+  // fun main() {
+func main (regs=2)
+  // print(str(agmPi()))
+  Call         r0, agmPi, 
+  Str          r1, r0
+  Print        r1
+  Return       r0


### PR DESCRIPTION
## Summary
- add Go output for `arithmetic-geometric-mean-calculate-pi`
- add associated error file
- add generated Mochi IR

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks/arithmetic-geometric-mean-calculate-pi -v`
- `go test ./tools/rosetta -tags slow -run TestMochiIR/arithmetic-geometric-mean-calculate-pi -update -v`

------
https://chatgpt.com/codex/tasks/task_e_68713a5694808320882fc80ab362b234