### PR TITLE
Add Rosetta task 143 with VM support

### DIFF
--- a/tests/rosetta/out/Mochi-IR/call-an-object-method.ir
+++ b/tests/rosetta/out/Mochi-IR/call-an-object-method.ir
@@ -1,0 +1,40 @@
+func main (regs=1)
+  // run()
+  Call         r0, run, 
+  Return       r0
+
+  // fun TellSecret(): int {
+func Box.TellSecret (regs=2)
+  // return secret
+  Return       r1
+
+  // fun New(): Box {
+func New (regs=12)
+  // var b = Box{ Contents: "rabbit", secret: 1 }
+  Const        r0, "rabbit"
+  Const        r1, 1
+  Const        r2, "__name"
+  Const        r3, "Box"
+  Const        r4, "Contents"
+  Move         r5, r0
+  Const        r6, "secret"
+  Move         r7, r1
+  MakeClosure  r8, Box.TellSecret, 2, r5
+  // fun TellSecret(): int {
+  Const        r9, "TellSecret"
+  // var b = Box{ Contents: "rabbit", secret: 1 }
+  MakeMap      r10, 4, r2
+  Move         r11, r10
+  // return b
+  Return       r11
+
+  // fun run() {
+func run (regs=5)
+  // var b = New()
+  Call         r0, New, 
+  Move         r1, r0
+  // b.TellSecret()
+  Const        r2, "TellSecret"
+  Index        r3, r1, r2
+  CallV        r4, r3, 0, r0
+  Return       r0

--- a/tests/rosetta/x/Mochi/call-an-object-method.mochi
+++ b/tests/rosetta/x/Mochi/call-an-object-method.mochi
@@ -1,0 +1,20 @@
+// Mochi implementation of Rosetta "Call an object method" task
+// Translated from Go version in tests/rosetta/x/Go/call-an-object-method-3.go
+
+type Box {
+  Contents: string
+  secret: int
+
+  fun TellSecret(): int {
+    return secret
+  }
+}
+
+fun New(): Box {
+  var b = Box{ Contents: "rabbit", secret: 1 }
+  return b
+}
+
+var box = New()
+
+box.TellSecret()


### PR DESCRIPTION
## Summary
- download Go sources for *Call an object method*
- add Mochi translation of the task
- emit struct methods as closures so they can be invoked via field lookup

## Testing
- `go test ./tools/rosetta -tags slow -run TestMochiTasks/call-an-object-method -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687135749ae8832097a99724693d61af