### PR TITLE
Fix Rosetta Caesar cipher tests

### DIFF
--- a/tests/rosetta/x/Mochi/caesar-cipher-1.mochi
+++ b/tests/rosetta/x/Mochi/caesar-cipher-1.mochi
@@ -1,3 +1,14 @@
+fun indexOf(s: string, ch: string): int {
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i+1) == ch {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
 fun ord(ch: string): int {
   let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   let lower = "abcdefghijklmnopqrstuvwxyz"

--- a/tests/rosetta/x/Mochi/caesar-cipher-2.mochi
+++ b/tests/rosetta/x/Mochi/caesar-cipher-2.mochi
@@ -1,3 +1,14 @@
+fun indexOf(s: string, ch: string): int {
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i+1) == ch {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
 fun ord(ch: string): int {
   let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   let lower = "abcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
## Summary
- add missing `indexOf` helper to Caesar cipher Mochi samples
- ensure Rosetta Caesar cipher tests run successfully

## Testing
- `go test ./tools/rosetta -tags=slow -run MochiTasks/caesar-cipher-1 -count=1`
- `go test ./tools/rosetta -tags=slow -run MochiTasks/caesar-cipher-2 -count=1`
- `go test ./... --count=1`


------
https://chatgpt.com/codex/tasks/task_e_687156200fa08320a8f15bb512ea5c9f