### PR TITLE
Add Rosetta example: call-a-foreign-language-function

### DIFF
--- a/tests/rosetta/x/Mochi/call-a-foreign-language-function.mochi
+++ b/tests/rosetta/x/Mochi/call-a-foreign-language-function.mochi
@@ -1,4 +1,12 @@
-fun strdup(s: string): string { return s + "" }
+
+// Mochi implementation of Rosetta "Call a foreign language function" task
+// Translated from tests/rosetta/x/Go/call-a-foreign-language-function.go
+// The Go version duplicates a string using the C library function strdup.
+// Here we implement the same behavior directly without FFI.
+fun strdup(s: string): string {
+  // return a new copy of the string
+  return s + ""
+}
 
 fun main() {
   let go1 = "hello C"


### PR DESCRIPTION
## Summary
- improve `call-a-foreign-language-function.mochi` with explanatory comments
- mimic the Go example's logic without FFI

## Testing
- `go test ./tools/rosetta -run TestMochiTasks/call-a-foreign-language-function$ -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687156550c00832091729f56aea3462c