### PR TITLE
Add Mochi version for call-a-function variant 4

### DIFF
--- a/tests/rosetta/x/Mochi/call-a-function-4.mochi
+++ b/tests/rosetta/x/Mochi/call-a-function-4.mochi
@@ -1,6 +1,16 @@
-// Placeholder for gif.Encode example; Mochi has no GIF library.
+// Simple stand-in for the Go example calling gif.Encode.
+// The real Go code writes a GIF image to an io.Writer but
+// produces no visible output.  Here we implement a dummy
+// function so the example is runnable without external
+// libraries while matching the behaviour (no output).
+
+fun gifEncode(dest: any, img: any, opts: map<string,int>) {
+  // real encoding would happen here
+  let _ = opts["NumColors"]  // access to mimic usage
+}
+
 fun main() {
-  // Would call gif.Encode here
+  gifEncode(nil, nil, {"NumColors": 16})
 }
 
 main()


### PR DESCRIPTION
## Summary
- implement a runnable example for `call-a-function` variant 4

## Testing
- `go test ./tools/rosetta -run TestMochiTasks/call-a-function-5 -tags=slow -v`
- `go test ./tools/rosetta -run TestMochiTasks/call-a-function-6 -tags=slow -v`
- `go test ./tools/rosetta -run TestMochiTasks/call-a-function-11 -tags=slow -v`
- `go test ./tools/rosetta -run TestMochiTasks/call-a-function-12 -tags=slow -v`


------
https://chatgpt.com/codex/tasks/task_e_6871567220c483209fbe34d8f762e963