### PR TITLE
Improve C# append inference

### DIFF
--- a/tests/machine/x/cs/append_builtin.cs
+++ b/tests/machine/x/cs/append_builtin.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 class Program {
     static void Main() {
         List<int> a = new List<int> { 1, 2 };
-        Console.WriteLine(JsonSerializer.Serialize(new List<int>(a){3}));
+        Console.WriteLine("[" + string.Join(", ", new List<int>(a){3}) + "]");
     }
 }

--- a/tests/machine/x/cs/cast_string_to_int.cs
+++ b/tests/machine/x/cs/cast_string_to_int.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 class Program {
     static void Main() {
-        Console.WriteLine(_cast<long>("1995"));
+        Console.WriteLine(_cast<int>("1995"));
     }
     static T _cast<T>(dynamic v) {
         if (v is T tv) return tv;

--- a/tests/machine/x/cs/closure.cs
+++ b/tests/machine/x/cs/closure.cs
@@ -1,8 +1,8 @@
 using System;
 
 class Program {
-    static Func<long, long> makeAdder(long n) {
-        return new Func<long, long>((long x) => {
+    static Func<int, int> makeAdder(int n) {
+        return new Func<int, int>((int x) => {
     return (x + n);
 });
     }

--- a/tests/machine/x/cs/fun_call.cs
+++ b/tests/machine/x/cs/fun_call.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static long add(long a, long b) {
+    static int add(int a, int b) {
         return (a + b);
     }
     

--- a/tests/machine/x/cs/fun_expr_in_let.cs
+++ b/tests/machine/x/cs/fun_expr_in_let.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void Main() {
-        Func<int, int> square = new Func<long, long>((long x) => {
+        Func<int, int> square = new Func<int, int>((int x) => {
     return (x * x);
 });
         Console.WriteLine(square(6));

--- a/tests/machine/x/cs/fun_three_args.cs
+++ b/tests/machine/x/cs/fun_three_args.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static long sum3(long a, long b, long c) {
+    static int sum3(int a, int b, int c) {
         return ((a + b) + c);
     }
     

--- a/tests/machine/x/cs/let_and_print.cs
+++ b/tests/machine/x/cs/let_and_print.cs
@@ -3,7 +3,7 @@ using System;
 class Program {
     static void Main() {
         int a = 10;
-        long b = 20;
+        int b = 20;
         Console.WriteLine((a + b));
     }
 }

--- a/tests/machine/x/cs/load_yaml.cs
+++ b/tests/machine/x/cs/load_yaml.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 public record struct Person {
     public string name;
-    public long age;
+    public int age;
     public string email;
 }
 

--- a/tests/machine/x/cs/match_full.cs
+++ b/tests/machine/x/cs/match_full.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static string classify(long n) {
+    static string classify(int n) {
         return new Func<string>(() => {
         var _t = n;
         if (_equal(_t, 0)) return "zero";

--- a/tests/machine/x/cs/nested_function.cs
+++ b/tests/machine/x/cs/nested_function.cs
@@ -1,8 +1,8 @@
 using System;
 
 class Program {
-    static long outer(long x) {
-        long inner(long y) {
+    static int outer(int x) {
+        int inner(int y) {
             return (x + y);
         }
         return inner(5);

--- a/tests/machine/x/cs/partial_application.cs
+++ b/tests/machine/x/cs/partial_application.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static long add(long a, long b) {
+    static int add(int a, int b) {
         return (a + b);
     }
     

--- a/tests/machine/x/cs/pure_fold.cs
+++ b/tests/machine/x/cs/pure_fold.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static long triple(long x) {
+    static int triple(int x) {
         return (x * 3);
     }
     

--- a/tests/machine/x/cs/pure_global_fold.cs
+++ b/tests/machine/x/cs/pure_global_fold.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static long inc(long x) {
+    static int inc(int x) {
         return (x + k);
     }
     

--- a/tests/machine/x/cs/record_assign.cs
+++ b/tests/machine/x/cs/record_assign.cs
@@ -1,7 +1,7 @@
 using System;
 
 public record struct Counter {
-    public long n;
+    public int n;
 }
 
 class Program {

--- a/tests/machine/x/cs/short_circuit.cs
+++ b/tests/machine/x/cs/short_circuit.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static bool boom(long a, long b) {
+    static bool boom(int a, int b) {
         Console.WriteLine("boom");
         return true;
     }

--- a/tests/machine/x/cs/slice.cs
+++ b/tests/machine/x/cs/slice.cs
@@ -8,6 +8,18 @@ class Program {
         Console.WriteLine("[" + string.Join(", ", _sliceList(new List<int> { 1, 2, 3 }, 0, 2)) + "]");
         Console.WriteLine(_sliceString("hello", 1, 4));
     }
+    static string _sliceString(string s, long i, long j) {
+        var start = i;
+        var end = j;
+        var n = s.Length;
+        if (start < 0) start += n;
+        if (end < 0) end += n;
+        if (start < 0) start = 0;
+        if (end > n) end = n;
+        if (end < start) end = start;
+        return s.Substring((int)start, (int)(end - start));
+    }
+    
     static List<dynamic> _sliceList(dynamic l, long i, long j) {
         var list = l as System.Collections.IList;
         if (list == null) return new List<dynamic>();
@@ -22,18 +34,6 @@ class Program {
         var res = new List<dynamic>();
         for (int k = (int)start; k < (int)end; k++) res.Add(list[k]);
         return res;
-    }
-    
-    static string _sliceString(string s, long i, long j) {
-        var start = i;
-        var end = j;
-        var n = s.Length;
-        if (start < 0) start += n;
-        if (end < 0) end += n;
-        if (start < 0) start = 0;
-        if (end > n) end = n;
-        if (end < start) end = start;
-        return s.Substring((int)start, (int)(end - start));
     }
     
 }

--- a/tests/machine/x/cs/tail_recursion.cs
+++ b/tests/machine/x/cs/tail_recursion.cs
@@ -1,7 +1,7 @@
 using System;
 
 class Program {
-    static long sum_rec(long n, long acc) {
+    static int sum_rec(int n, int acc) {
         if (n == 0) {
             return acc;
         }

--- a/tests/machine/x/cs/tree_sum.cs
+++ b/tests/machine/x/cs/tree_sum.cs
@@ -6,13 +6,13 @@ public struct Leaf : Tree {
 }
 public struct Node : Tree {
     public Tree left;
-    public long value;
+    public int value;
     public Tree right;
     public void isTree() {}
 }
 
 class Program {
-    static long sum_tree(Tree t) {
+    static int sum_tree(Tree t) {
         return new Func<dynamic>(() => {
         var _t = t;
         if (_t is Leaf) return 0;

--- a/tests/machine/x/cs/two-sum.cs
+++ b/tests/machine/x/cs/two-sum.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 
 class Program {
-    static List<long> twoSum(List<long> nums, long target) {
+    static List<int> twoSum(List<int> nums, int target) {
         int n = nums.Length;
         for (var i = 0; i < n; i++) {
             for (var j = (i + 1); j < n; j++) {

--- a/tests/machine/x/cs/typed_let.cs
+++ b/tests/machine/x/cs/typed_let.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void Main() {
-        long y = default;
+        int y = default;
         Console.WriteLine(y);
     }
 }

--- a/tests/machine/x/cs/typed_var.cs
+++ b/tests/machine/x/cs/typed_var.cs
@@ -2,7 +2,7 @@ using System;
 
 class Program {
     static void Main() {
-        long x = default;
+        int x = default;
         Console.WriteLine(x);
     }
 }

--- a/tests/machine/x/cs/update_stmt.cs
+++ b/tests/machine/x/cs/update_stmt.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 public record struct Person {
     public string name;
-    public long age;
+    public int age;
     public string status;
 }
 

--- a/tests/machine/x/cs/user_type_literal.cs
+++ b/tests/machine/x/cs/user_type_literal.cs
@@ -2,7 +2,7 @@ using System;
 
 public record struct Person {
     public string name;
-    public long age;
+    public int age;
 }
 
 public record struct Book {

--- a/types/infer.go
+++ b/types/infer.go
@@ -445,6 +445,19 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 				}
 			}
 			return ListType{Elem: AnyType{}}
+		case "append":
+			if len(p.Call.Args) == 2 {
+				t := ExprType(p.Call.Args[0], env)
+				if lt, ok := t.(ListType); ok {
+					elem := lt.Elem
+					argT := ExprType(p.Call.Args[1], env)
+					if !equalTypes(elem, argT) {
+						elem = AnyType{}
+					}
+					return ListType{Elem: elem}
+				}
+			}
+			return ListType{Elem: AnyType{}}
 		case "now":
 			return Int64Type{}
 		case "to_json":


### PR DESCRIPTION
## Summary
- teach the type inference engine about `append`
- regenerate C# machine outputs using the updated compiler

## Testing
- `go test -tags slow ./compiler/x/cs -run TestCompiler -count=1`
- `MOCHI_SKIP_FORMATCS=1 go run -tags slow scripts/compile_cs.go`

------
https://chatgpt.com/codex/tasks/task_e_68715b2da0288320821828603c88f17e