### PR TITLE
Improve Rust compiler output

### DIFF
--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -3320,6 +3320,15 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 	}
 	switch call.Func {
 	case "print":
+		if len(call.Args) == 1 {
+			a := call.Args[0]
+			if a != nil && a.Binary != nil && len(a.Binary.Right) == 0 {
+				u := a.Binary.Left
+				if u != nil && len(u.Ops) == 0 && u.Value != nil && len(u.Value.Ops) == 0 && u.Value.Target != nil && u.Value.Target.Lit != nil && u.Value.Target.Lit.Str != nil {
+					return fmt.Sprintf("println!(%q)", *u.Value.Target.Lit.Str), nil
+				}
+			}
+		}
 		fmtParts := make([]string, len(args))
 		for i, a := range call.Args {
 			if c.env != nil {

--- a/tests/machine/x/rust/bool_chain.rs
+++ b/tests/machine/x/rust/bool_chain.rs
@@ -1,6 +1,6 @@
 fn main() {
     fn boom() -> bool {
-        println!("{}", "boom");
+        println!("boom");
         return true;
     }
     println!("{}", (1 < 2) && (2 < 3) && (3 < 4));

--- a/tests/machine/x/rust/cross_join.rs
+++ b/tests/machine/x/rust/cross_join.rs
@@ -23,7 +23,7 @@ fn main() {
     let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }, Customer { id: 3, name: "Charlie" }];
     let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 2, total: 125 }, Order { id: 102, customerId: 1, total: 300 }];
     let result = { let mut tmp1 = Vec::new();for o in &orders { for c in &customers { tmp1.push(Result { orderId: o.id, orderCustomerId: o.customerId, pairedCustomerName: c.name, orderTotal: o.total }); } } tmp1 };
-    println!("{}", "--- Cross Join: All order-customer pairs ---");
+    println!("--- Cross Join: All order-customer pairs ---");
     for entry in result {
         println!("{} {} {} {} {} {} {} {}", "Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName);
     }

--- a/tests/machine/x/rust/cross_join_filter.rs
+++ b/tests/machine/x/rust/cross_join_filter.rs
@@ -8,7 +8,7 @@ fn main() {
     let nums = vec![1, 2, 3];
     let letters = vec!["A", "B"];
     let pairs = { let mut tmp1 = Vec::new();for &n in &nums { for &l in &letters { if !(n % 2 == 0) { continue; } tmp1.push(Result { n: n, l: l }); } } tmp1 };
-    println!("{}", "--- Even pairs ---");
+    println!("--- Even pairs ---");
     for p in pairs {
         println!("{} {}", p.n, p.l);
     }

--- a/tests/machine/x/rust/cross_join_triple.rs
+++ b/tests/machine/x/rust/cross_join_triple.rs
@@ -10,7 +10,7 @@ fn main() {
     let letters = vec!["A", "B"];
     let bools = vec![true, false];
     let combos = { let mut tmp1 = Vec::new();for &n in &nums { for &l in &letters { for &b in &bools { tmp1.push(Result { n: n, l: l, b: b }); } } } tmp1 };
-    println!("{}", "--- Cross Join of three lists ---");
+    println!("--- Cross Join of three lists ---");
     for c in combos {
         println!("{} {} {}", c.n, c.l, c.b);
     }

--- a/tests/machine/x/rust/dataset_sort_take_limit.rs
+++ b/tests/machine/x/rust/dataset_sort_take_limit.rs
@@ -7,7 +7,7 @@ struct Product {
 fn main() {
     let products = vec![Product { name: "Laptop", price: 1500 }, Product { name: "Smartphone", price: 900 }, Product { name: "Tablet", price: 600 }, Product { name: "Monitor", price: 300 }, Product { name: "Keyboard", price: 100 }, Product { name: "Mouse", price: 50 }, Product { name: "Headphones", price: 200 }];
     let expensive = { let mut tmp1 = Vec::new();for p in &products { let tmp2 = p.clone(); let tmp3 = -p.price; tmp1.push((tmp3, tmp2)); } tmp1.sort_by(|a,b| a.0.partial_cmp(&b.0).unwrap()); let mut tmp4 = Vec::new(); for p in tmp1 { tmp4.push(p.1); } let tmp4 = tmp4[1 as usize..(1 + 3) as usize].to_vec(); tmp4 };
-    println!("{}", "--- Top products (excluding most expensive) ---");
+    println!("--- Top products (excluding most expensive) ---");
     for item in expensive {
         println!("{} {} {}", item.name, "costs $", item.price);
     }

--- a/tests/machine/x/rust/dataset_where_filter.rs
+++ b/tests/machine/x/rust/dataset_where_filter.rs
@@ -14,7 +14,7 @@ struct Result {
 fn main() {
     let people = vec![People { name: "Alice", age: 30 }, People { name: "Bob", age: 15 }, People { name: "Charlie", age: 65 }, People { name: "Diana", age: 45 }];
     let adults = { let mut tmp1 = Vec::new();for person in &people { if !(person.age >= 18) { continue; } tmp1.push(Result { name: person.name, age: person.age, is_senior: person.age >= 60 }); } tmp1 };
-    println!("{}", "--- Adults ---");
+    println!("--- Adults ---");
     for person in adults {
         println!("{} {} {} {}", person.name, "is", person.age, if person.is_senior { " (senior)" } else { "" });
     }

--- a/tests/machine/x/rust/group_by.rs
+++ b/tests/machine/x/rust/group_by.rs
@@ -26,7 +26,7 @@ fn avg(v: &[i32]) -> f64 {
 fn main() {
     let people = vec![People { name: "Alice", age: 30, city: "Paris" }, People { name: "Bob", age: 15, city: "Hanoi" }, People { name: "Charlie", age: 65, city: "Paris" }, People { name: "Diana", age: 45, city: "Hanoi" }, People { name: "Eve", age: 70, city: "Paris" }, People { name: "Frank", age: 22, city: "Hanoi" }];
     let stats = { let mut tmp1 = std::collections::HashMap::new();for person in &people { let key = person.city; tmp1.entry(key).or_insert_with(Vec::new).push(person.clone()); } let mut tmp2 = Vec::<Group>::new(); for (k,v) in tmp1 { tmp2.push(Group { key: k, items: v }); } let mut result = Vec::new(); for g in tmp2 { result.push(Result { city: g.key, count: g.clone().items.len() as i32, avg_age: avg(&{ let mut tmp3 = Vec::new();for p in &g.clone().items { tmp3.push(p.age); } tmp3 }) }); } result };
-    println!("{}", "--- People grouped by city ---");
+    println!("--- People grouped by city ---");
     for s in stats {
         println!("{} {} {} {} {}", s.city, ": count =", s.count, ", avg_age =", s.avg_age);
     }

--- a/tests/machine/x/rust/group_by_join.rs
+++ b/tests/machine/x/rust/group_by_join.rs
@@ -32,7 +32,7 @@ fn main() {
     let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }];
     let orders = vec![Order { id: 100, customerId: 1 }, Order { id: 101, customerId: 1 }, Order { id: 102, customerId: 2 }];
     let stats = { let mut tmp1 = std::collections::HashMap::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } let key = c.name; tmp1.entry(key).or_insert_with(Vec::new).push(Item {o: o.clone(), c: c.clone() }); } } let mut tmp2 = Vec::<Group>::new(); for (k,v) in tmp1 { tmp2.push(Group { key: k, items: v }); } let mut result = Vec::new(); for g in tmp2 { result.push(Result { name: g.key, count: g.clone().items.len() as i32 }); } result };
-    println!("{}", "--- Orders per customer ---");
+    println!("--- Orders per customer ---");
     for s in stats {
         println!("{} {} {}", s.name, "orders:", s.count);
     }

--- a/tests/machine/x/rust/group_by_left_join.rs
+++ b/tests/machine/x/rust/group_by_left_join.rs
@@ -32,7 +32,7 @@ fn main() {
     let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }, Customer { id: 3, name: "Charlie" }];
     let orders = vec![Order { id: 100, customerId: 1 }, Order { id: 101, customerId: 1 }, Order { id: 102, customerId: 2 }];
     let stats = { let mut tmp1 = std::collections::HashMap::new();for c in &customers { let mut tmp3 = false; for o in &orders { if !(o.customerId == c.id) { continue; } tmp3 = true; let key = c.name; tmp1.entry(key).or_insert_with(Vec::new).push(Item {c: c.clone(), o: o.clone() }); } if !tmp3 { let o: Order = Default::default(); let key = c.name; tmp1.entry(key).or_insert_with(Vec::new).push(Item {c: c.clone(), o: o.clone() }); } } let mut tmp2 = Vec::<Group>::new(); for (k,v) in tmp1 { tmp2.push(Group { key: k, items: v }); } let mut result = Vec::new(); for g in tmp2 { result.push(Result { name: g.key, count: { let mut tmp4 = Vec::new();for r in &g.clone().items { if !(r.o != Default::default()) { continue; } tmp4.push(r.clone()); } tmp4 }.len() as i32 }); } result };
-    println!("{}", "--- Group Left Join ---");
+    println!("--- Group Left Join ---");
     for s in stats {
         println!("{} {} {}", s.name, "orders:", s.count);
     }

--- a/tests/machine/x/rust/if_else.rs
+++ b/tests/machine/x/rust/if_else.rs
@@ -1,8 +1,8 @@
 fn main() {
     let x = 5;
     if x > 3 {
-        println!("{}", "big");
+        println!("big");
     } else {
-        println!("{}", "small");
+        println!("small");
     }
 }

--- a/tests/machine/x/rust/inner_join.rs
+++ b/tests/machine/x/rust/inner_join.rs
@@ -22,7 +22,7 @@ fn main() {
     let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }, Customer { id: 3, name: "Charlie" }];
     let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 2, total: 125 }, Order { id: 102, customerId: 1, total: 300 }, Order { id: 103, customerId: 4, total: 80 }];
     let result = { let mut tmp1 = Vec::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } tmp1.push(Result { orderId: o.id, customerName: c.name, total: o.total }); } } tmp1 };
-    println!("{}", "--- Orders with customer info ---");
+    println!("--- Orders with customer info ---");
     for entry in result {
         println!("{} {} {} {} {} {}", "Order", entry.orderId, "by", entry.customerName, "- $", entry.total);
     }

--- a/tests/machine/x/rust/join_multi.rs
+++ b/tests/machine/x/rust/join_multi.rs
@@ -27,7 +27,7 @@ fn main() {
     let orders = vec![Order { id: 100, customerId: 1 }, Order { id: 101, customerId: 2 }];
     let items = vec![Item { orderId: 100, sku: "a" }, Item { orderId: 101, sku: "b" }];
     let result = { let mut tmp1 = Vec::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } for i in &items { if !(o.id == i.orderId) { continue; } tmp1.push(Result { name: c.name, sku: i.sku }); } } } tmp1 };
-    println!("{}", "--- Multi Join ---");
+    println!("--- Multi Join ---");
     for r in result {
         println!("{} {} {}", r.name, "bought item", r.sku);
     }

--- a/tests/machine/x/rust/left_join.rs
+++ b/tests/machine/x/rust/left_join.rs
@@ -22,7 +22,7 @@ fn main() {
     let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }];
     let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 3, total: 80 }];
     let result = { let mut tmp1 = Vec::new();for o in &orders { let mut _matched = false; for c in &customers { if !(o.customerId == c.id) { continue; } _matched = true; tmp1.push(Result { orderId: o.id, customer: c.clone(), total: o.total }); } if !_matched { let c: Customer = Default::default(); tmp1.push(Result { orderId: o.id, customer: c.clone(), total: o.total }); } } tmp1 };
-    println!("{}", "--- Left Join ---");
+    println!("--- Left Join ---");
     for entry in result {
         println!("{} {} {} {:?} {} {}", "Order", entry.orderId, "customer", entry.customer, "total", entry.total);
     }

--- a/tests/machine/x/rust/left_join_multi.rs
+++ b/tests/machine/x/rust/left_join_multi.rs
@@ -28,7 +28,7 @@ fn main() {
     let orders = vec![Order { id: 100, customerId: 1 }, Order { id: 101, customerId: 2 }];
     let items = vec![Item { orderId: 100, sku: "a" }];
     let result = { let mut tmp1 = Vec::new();for o in &orders { for c in &customers { if !(o.customerId == c.id) { continue; } let mut _matched = false; for i in &items { if !(o.id == i.orderId) { continue; } _matched = true; tmp1.push(Result { orderId: o.id, name: c.name, item: i.clone() }); } if !_matched { let i: Item = Default::default(); tmp1.push(Result { orderId: o.id, name: c.name, item: i.clone() }); } } } tmp1 };
-    println!("{}", "--- Left Join Multi ---");
+    println!("--- Left Join Multi ---");
     for r in result {
         println!("{} {} {:?}", r.orderId, r.name, r.item);
     }

--- a/tests/machine/x/rust/outer_join.rs
+++ b/tests/machine/x/rust/outer_join.rs
@@ -21,7 +21,7 @@ fn main() {
     let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }, Customer { id: 3, name: "Charlie" }, Customer { id: 4, name: "Diana" }];
     let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 2, total: 125 }, Order { id: 102, customerId: 1, total: 300 }, Order { id: 103, customerId: 5, total: 80 }];
     let result = { let mut tmp1 = Vec::new();for o in &orders { let mut _matched = false; for c in &customers { if !(o.customerId == c.id) { continue; } _matched = true; tmp1.push(Result { order: o.clone(), customer: c.clone() }); } if !_matched { let c: Customer = Default::default(); tmp1.push(Result { order: o.clone(), customer: c.clone() }); } } for c in &customers { let mut _matched = false; for o in &orders { if o.customerId == c.id { _matched = true; break; } } if !_matched { let o: Order = Default::default(); tmp1.push(Result { order: o.clone(), customer: c.clone() }); } } tmp1 };
-    println!("{}", "--- Outer Join using syntax ---");
+    println!("--- Outer Join using syntax ---");
     for row in result {
         if row.order != Order::default() {
             if row.customer != Customer::default() {

--- a/tests/machine/x/rust/print_hello.rs
+++ b/tests/machine/x/rust/print_hello.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("{}", "hello");
+    println!("hello");
 }

--- a/tests/machine/x/rust/right_join.rs
+++ b/tests/machine/x/rust/right_join.rs
@@ -21,7 +21,7 @@ fn main() {
     let customers = vec![Customer { id: 1, name: "Alice" }, Customer { id: 2, name: "Bob" }, Customer { id: 3, name: "Charlie" }, Customer { id: 4, name: "Diana" }];
     let orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 2, total: 125 }, Order { id: 102, customerId: 1, total: 300 }];
     let result = { let mut tmp1 = Vec::new();for o in &orders { let mut _matched = false; for c in &customers { if !(o.customerId == c.id) { continue; } _matched = true; tmp1.push(Result { customerName: c.name, order: o.clone() }); } if !_matched { let c: Customer = Default::default(); tmp1.push(Result { customerName: c.name, order: o.clone() }); } } tmp1 };
-    println!("{}", "--- Right Join using syntax ---");
+    println!("--- Right Join using syntax ---");
     for entry in result {
         if entry.order != Order::default() {
             println!("{} {} {} {} {} {}", "Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total);

--- a/tests/machine/x/rust/short_circuit.rs
+++ b/tests/machine/x/rust/short_circuit.rs
@@ -1,6 +1,6 @@
 fn main() {
     fn boom(a: i32, b: i32) -> bool {
-        println!("{}", "boom");
+        println!("boom");
         return true;
     }
     println!("{}", false && boom(1, 2));

--- a/tests/machine/x/rust/test_block.rs
+++ b/tests/machine/x/rust/test_block.rs
@@ -1,5 +1,5 @@
 fn main() {
     let x = 1 + 2;
     assert!(x == 3);
-    println!("{}", "ok");
+    println!("ok");
 }

--- a/tests/machine/x/rust/update_stmt.rs
+++ b/tests/machine/x/rust/update_stmt.rs
@@ -21,5 +21,5 @@ fn main() {
     }
     let people = tmp3;
     assert!(people == vec![Person { name: "Alice", age: 17, status: "minor" }, Person { name: "Bob", age: 26, status: "adult" }, Person { name: "Charlie", age: 19, status: "adult" }, Person { name: "Diana", age: 16, status: "minor" }]);
-    println!("{}", "ok");
+    println!("ok");
 }


### PR DESCRIPTION
## Summary
- tweak Rust compiler to print simple string literals without format placeholders
- regenerate machine Rust sources

## Testing
- `go test -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68715b38854c8320855125435fd36480