### PR TITLE
Add Rosetta Case-sensitivity task

### DIFF
--- a/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.mochi
+++ b/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.mochi
@@ -1,0 +1,8 @@
+// Mochi version of Rosetta "Case-sensitivity of identifiers" task
+// Demonstrates that identifiers with different case are distinct.
+
+var dog = "Benjamin"
+var Dog = "Samba"
+var DOG = "Bernie"
+
+print("The three dogs are named " + dog + ", " + Dog + " and " + DOG + ".")

--- a/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.out
+++ b/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.out
@@ -1,0 +1,2 @@
+The three dogs are named Benjamin, Samba and Bernie.
+


### PR DESCRIPTION
## Summary
- add Rosetta "Case-sensitivity of identifiers" Mochi example

## Testing
- `go test ./tools/rosetta -tags slow -run 'TestMochiTasks/case-sensitivity-of-identifiers' -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68715a42e9708320a3453ad2a59ab057