### PR TITLE
Improve Zig compiler struct inference

### DIFF
--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -111,7 +111,7 @@ Compiled programs: 100/100
 - [ ] Keep generated outputs in sync with compiler improvements.
 - [ ] Add more idiomatic mappings for built-in functions (e.g. string concatenation).
 - [ ] Improve idiomatic mappings for Zig built-ins.
-- [ ] Generate named structs from constant map literals for readability.
+ - [x] Generate named structs from constant map literals for readability.
 - [ ] Support union pattern matching using enums.
 - [ ] Implement iterators for list handling instead of ArrayList allocations.
 - [ ] Replace `catch unreachable` with proper error handling.


### PR DESCRIPTION
## Summary
- enhance struct detection for map literals and lists
- infer named struct types when matching existing definitions
- update Zig machine output tasks checklist

## Testing
- `go test ./compiler/x/zig -tags slow -run TestZigCompiler_ValidPrograms/print_hello -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68715da7b6408320b62f75114cb39f7a