### PR TITLE
Improve Scala compiler

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -3,7 +3,7 @@
 This directory contains Scala code generated from the Mochi programs in `tests/vm/valid` using the Scala compiler. Each source file was compiled with `scalac` and executed with `scala`. Successful runs produced an `.out` file while failures produced an `.error` file.
 
 Compiled programs: 100
-Executed successfully: 92
+Executed successfully: 93
 
 ## Program checklist
 - [x] append_builtin.mochi
@@ -162,3 +162,4 @@ Executed successfully: 92
 - [ ] Implement plugin architecture for optimizations.
 - [ ] Explore macros for compile-time checks.
 
+- [ ] Fix outer join and group_by translations.

--- a/tests/machine/x/scala/dataset_sort_take_limit.scala
+++ b/tests/machine/x/scala/dataset_sort_take_limit.scala
@@ -2,7 +2,7 @@ object dataset_sort_take_limit {
   case class Product(name: String, price: Int)
 
   val products = List[Product](Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
-  val expensive = (for { p <- products } yield p).sortBy(p => -p.price).drop(1).take(3)
+  val expensive = (for { p <- products } yield p).sortBy(p => -p.price).map(p => p).drop(1).take(3)
   def main(args: Array[String]): Unit = {
     println(("--- Top products (excluding most expensive) ---"))
     for(item <- expensive) {

--- a/tests/machine/x/scala/group_by.scala
+++ b/tests/machine/x/scala/group_by.scala
@@ -1,9 +1,10 @@
 object group_by {
   case class People(name: String, age: Int, city: String)
-  case class Stat(city: String, count: Int, avg_age: Double)
+  case class Stat(person: People)
+  case class Stat1(city: String, count: Int, avg_age: Double)
 
   val people = List[People](People(name = "Alice", age = 30, city = "Paris"), People(name = "Bob", age = 15, city = "Hanoi"), People(name = "Charlie", age = 65, city = "Paris"), People(name = "Diana", age = 45, city = "Hanoi"), People(name = "Eve", age = 70, city = "Paris"), People(name = "Frank", age = 22, city = "Hanoi"))
-  val stats = ((for { person <- people } yield (person.city, (person))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Stat(city = g._1, count = (g._2).size, avg_age = (for { p <- g._2 } yield p.age).sum.toDouble / (for { p <- g._2 } yield p.age).size) } }.toList
+  val stats = ((for { person <- people } yield (person.city, Stat(person = person))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Stat1(city = g.key, count = (g._2).size, avg_age = (for { p <- g._2 } yield p.age).sum.toDouble / (for { p <- g._2 } yield p.age).size) } }.toList
   def main(args: Array[String]): Unit = {
     println(("--- People grouped by city ---"))
     for(s <- stats) {

--- a/tests/machine/x/scala/group_by_conditional_sum.scala
+++ b/tests/machine/x/scala/group_by_conditional_sum.scala
@@ -1,6 +1,7 @@
 object group_by_conditional_sum {
   case class Item(cat: String, `val`: Int, flag: Boolean)
-  case class Result(cat: String, share: Double)
+  case class Result(i: Item)
+  case class Result1(cat: String, share: Double)
 
   def _truthy(v: Any): Boolean = v match {
     case null => false
@@ -16,7 +17,7 @@ object group_by_conditional_sum {
   }
 
   val items = List[Item](Item(cat = "a", `val` = 10, flag = true), Item(cat = "a", `val` = 5, flag = false), Item(cat = "b", `val` = 20, flag = true))
-  val result = (((for { i <- items } yield (i.cat, (i))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).sortBy(g => g._1)).map{ case(gKey,gItems) => { val g = (gKey, gItems); Result(cat = g._1, share = (for { x <- g._2 } yield if (_truthy(x.flag)) x.`val` else 0).sum / (for { x <- g._2 } yield x.`val`).sum) } }.toList
+  val result = (((for { i <- items } yield (i.cat, Result(i = i))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).sortBy(g => g.key)).map{ case(gKey,gItems) => { val g = (gKey, gItems); Result1(cat = g.key, share = (for { x <- g._2 } yield if (_truthy(x.flag)) x.`val` else 0).sum / (for { x <- g._2 } yield x.`val`).sum) } }.toList
   def main(args: Array[String]): Unit = {
     println((result))
   }

--- a/tests/machine/x/scala/group_by_having.scala
+++ b/tests/machine/x/scala/group_by_having.scala
@@ -1,9 +1,10 @@
 object group_by_having {
-  case class Big(city: String, num: Int)
+  case class Big(p: People)
+  case class Big1(city: String, num: Int)
   case class People(name: String, city: String)
 
   val people = List[People](People(name = "Alice", city = "Paris"), People(name = "Bob", city = "Hanoi"), People(name = "Charlie", city = "Paris"), People(name = "Diana", city = "Hanoi"), People(name = "Eve", city = "Paris"), People(name = "Frank", city = "Hanoi"), People(name = "George", city = "Paris"))
-  val big = (((for { p <- people } yield (p.city, (p))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).filter{ case(gKey,gItems) => { val g = (gKey, gItems); (g._2).size >= 4 } }).map{ case(gKey,gItems) => { val g = (gKey, gItems); Map[String, Any]("city" -> (g._1), "num" -> ((g._2).size)) } }.toList
+  val big = (((for { p <- people } yield (p.city, Big(p = p))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).filter{ case(gKey,gItems) => { val g = (gKey, gItems); (g._2).size >= 4 } }).map{ case(gKey,gItems) => { val g = (gKey, gItems); Map[String, Any]("city" -> (g.key), "num" -> ((g._2).size)) } }.toList
   def main(args: Array[String]): Unit = {
     println(scala.util.parsing.json.JSONObject(big).toString())
   }

--- a/tests/machine/x/scala/group_by_join.scala
+++ b/tests/machine/x/scala/group_by_join.scala
@@ -1,11 +1,12 @@
 object group_by_join {
   case class Customer(id: Int, name: String)
   case class Order(id: Int, customerId: Int)
-  case class Stat(name: String, count: Int)
+  case class Stat(o: Order, c: Customer)
+  case class Stat1(name: String, count: Int)
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
   val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))
-  val stats = ((for { o <- orders; c <- customers; if o.customerId == (c.id).asInstanceOf[Int] } yield (c.name, (o, c))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Stat(name = g._1, count = (g._2).size) } }.toList
+  val stats = ((for { o <- orders; c <- customers; if o.customerId == (c.id).asInstanceOf[Int] } yield (c.name, Stat(o = o, c = c))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Stat1(name = g.key, count = (g._2).size) } }.toList
   def main(args: Array[String]): Unit = {
     println(("--- Orders per customer ---"))
     for(s <- stats) {

--- a/tests/machine/x/scala/group_by_left_join.scala
+++ b/tests/machine/x/scala/group_by_left_join.scala
@@ -1,11 +1,25 @@
 object group_by_left_join {
   case class Customer(id: Int, name: String)
   case class Order(id: Int, customerId: Int)
-  case class Stat(name: String, count: Int)
+  case class Stat(c: Customer, o: Option[Order])
+  case class Stat1(name: String, count: Int)
+
+  def _truthy(v: Any): Boolean = v match {
+    case null => false
+    case b: Boolean => b
+    case i: Int => i != 0
+    case l: Long => l != 0L
+    case d: Double => d != 0.0
+    case s: String => s.nonEmpty
+    case m: scala.collection.Map[_, _] => m.nonEmpty
+    case it: Iterable[_] => it.nonEmpty
+    case opt: Option[_] => opt.nonEmpty
+    case _ => true
+  }
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
   val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))
-  val stats = ((for { c <- customers; o = orders.find(o => (o.customerId).asInstanceOf[Int] == c.id) } yield (c.name, (c, o))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Stat(name = g._1, count = (for { r <- g._2; if r.o } yield r).size) } }.toList
+  val stats = ((for { c <- customers; o = orders.find(o => (o.customerId).asInstanceOf[Int] == c.id) } yield (c.name, Stat(c = c, o = o))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Stat1(name = g.key, count = (for { r <- g._2; if _truthy(r.o) } yield r).size) } }.toList
   def main(args: Array[String]): Unit = {
     println(("--- Group Left Join ---"))
     for(s <- stats) {

--- a/tests/machine/x/scala/group_by_multi_join.scala
+++ b/tests/machine/x/scala/group_by_multi_join.scala
@@ -1,6 +1,7 @@
 object group_by_multi_join {
   case class Filtered(part: Int, value: Double)
-  case class Grouped(part: Int, total: Int)
+  case class Grouped(x: Filtered)
+  case class Grouped1(part: Int, total: Int)
   case class Nation(id: Int, name: String)
   case class Partsupp(part: Int, supplier: Int, cost: Double, qty: Int)
   case class Supplier(id: Int, nation: Int)
@@ -9,7 +10,7 @@ object group_by_multi_join {
   val suppliers = List[Supplier](Supplier(id = 1, nation = 1), Supplier(id = 2, nation = 2))
   val partsupp = List[Partsupp](Partsupp(part = 100, supplier = 1, cost = 10, qty = 2), Partsupp(part = 100, supplier = 2, cost = 20, qty = 1), Partsupp(part = 200, supplier = 1, cost = 5, qty = 3))
   val filtered = for { ps <- partsupp; s <- suppliers; if (s.id).asInstanceOf[Int] == ps.supplier; n <- nations; if (n.id).asInstanceOf[Int] == s.nation; if n.name == "A" } yield Filtered(part = ps.part, value = ps.cost * ps.qty)
-  val grouped = ((for { x <- filtered } yield (x.part, (x))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Grouped(part = g._1, total = (for { r <- g._2 } yield r.value).sum) } }.toList
+  val grouped = ((for { x <- filtered } yield (x.part, Grouped(x = x))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); Grouped1(part = g.key, total = (for { r <- g._2 } yield r.value).sum) } }.toList
   def main(args: Array[String]): Unit = {
     println((grouped))
   }

--- a/tests/machine/x/scala/group_by_multi_join_sort.scala
+++ b/tests/machine/x/scala/group_by_multi_join_sort.scala
@@ -4,7 +4,8 @@ object group_by_multi_join_sort {
   case class Nation(n_nationkey: Int, n_name: String)
   case class Order(o_orderkey: Int, o_custkey: Int, o_orderdate: String)
   case class Result(c_custkey: Int, c_name: String, c_acctbal: Double, c_address: String, c_phone: String, c_comment: String, n_name: String)
-  case class Result1(c_custkey: Int, c_name: String, revenue: Int, c_acctbal: Double, n_name: String, c_address: String, c_phone: String, c_comment: String)
+  case class Result1(c: Customer, o: Order, l: Lineitem, n: Nation)
+  case class Result2(c_custkey: Int, c_name: String, revenue: Int, c_acctbal: Double, n_name: String, c_address: String, c_phone: String, c_comment: String)
 
   val nation = List[Nation](Nation(n_nationkey = 1, n_name = "BRAZIL"))
   val customer = List[Customer](Customer(c_custkey = 1, c_name = "Alice", c_acctbal = 100, c_nationkey = 1, c_address = "123 St", c_phone = "123-456", c_comment = "Loyal"))
@@ -12,7 +13,7 @@ object group_by_multi_join_sort {
   val lineitem = List[Lineitem](Lineitem(l_orderkey = 1000, l_returnflag = "R", l_extendedprice = 1000, l_discount = 0.1), Lineitem(l_orderkey = 2000, l_returnflag = "N", l_extendedprice = 500, l_discount = 0))
   val start_date = "1993-10-01"
   val end_date = "1994-01-01"
-  val result = (((for { c <- customer; o <- orders; if (o.o_custkey).asInstanceOf[Int] == c.c_custkey; l <- lineitem; if (l.l_orderkey).asInstanceOf[Int] == o.o_orderkey; n <- nation; if (n.n_nationkey).asInstanceOf[Int] == c.c_nationkey; if o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag == "R" } yield (Result(c_custkey = c.c_custkey, c_name = c.c_name, c_acctbal = c.c_acctbal, c_address = c.c_address, c_phone = c.c_phone, c_comment = c.c_comment, n_name = n.n_name), (c, o, l, n))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g._2 } yield (x.l.l_extendedprice).asInstanceOf[Int] * ((1 - (x.l.l_discount).asInstanceOf[Int])).asInstanceOf[Int]).sum)).map{ case(gKey,gItems) => { val g = (gKey, gItems); Result1(c_custkey = g.key.c_custkey, c_name = g.key.c_name, revenue = (for { x <- g._2 } yield (x.l.l_extendedprice).asInstanceOf[Int] * ((1 - (x.l.l_discount).asInstanceOf[Int])).asInstanceOf[Int]).sum, c_acctbal = g.key.c_acctbal, n_name = g.key.n_name, c_address = g.key.c_address, c_phone = g.key.c_phone, c_comment = g.key.c_comment) } }.toList
+  val result = (((for { c <- customer; o <- orders; if (o.o_custkey).asInstanceOf[Int] == c.c_custkey; l <- lineitem; if (l.l_orderkey).asInstanceOf[Int] == o.o_orderkey; n <- nation; if (n.n_nationkey).asInstanceOf[Int] == c.c_nationkey; if o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag == "R" } yield (Result(c_custkey = c.c_custkey, c_name = c.c_name, c_acctbal = c.c_acctbal, c_address = c.c_address, c_phone = c.c_phone, c_comment = c.c_comment, n_name = n.n_name), Result1(c = c, o = o, l = l, n = n))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g._2 } yield (x.l.l_extendedprice).asInstanceOf[Int] * ((1 - (x.l.l_discount).asInstanceOf[Int])).asInstanceOf[Int]).sum)).map{ case(gKey,gItems) => { val g = (gKey, gItems); Result2(c_custkey = g.key.c_custkey, c_name = g.key.c_name, revenue = (for { x <- g._2 } yield (x.l.l_extendedprice).asInstanceOf[Int] * ((1 - (x.l.l_discount).asInstanceOf[Int])).asInstanceOf[Int]).sum, c_acctbal = g.key.c_acctbal, n_name = g.key.n_name, c_address = g.key.c_address, c_phone = g.key.c_phone, c_comment = g.key.c_comment) } }.toList
   def main(args: Array[String]): Unit = {
     println((result))
   }

--- a/tests/machine/x/scala/group_by_sort.scala
+++ b/tests/machine/x/scala/group_by_sort.scala
@@ -1,9 +1,10 @@
 object group_by_sort {
-  case class Grouped(cat: String, total: Int)
+  case class Grouped(i: Item)
+  case class Grouped1(cat: String, total: Int)
   case class Item(cat: String, `val`: Int)
 
   val items = List[Item](Item(cat = "a", `val` = 3), Item(cat = "a", `val` = 1), Item(cat = "b", `val` = 5), Item(cat = "b", `val` = 2))
-  val grouped = (((for { i <- items } yield (i.cat, (i))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g._2 } yield x.`val`).sum)).map{ case(gKey,gItems) => { val g = (gKey, gItems); Grouped(cat = g._1, total = (for { x <- g._2 } yield x.`val`).sum) } }.toList
+  val grouped = (((for { i <- items } yield (i.cat, Grouped(i = i))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g._2 } yield x.`val`).sum)).map{ case(gKey,gItems) => { val g = (gKey, gItems); Grouped1(cat = g.key, total = (for { x <- g._2 } yield x.`val`).sum) } }.toList
   def main(args: Array[String]): Unit = {
     println((grouped))
   }

--- a/tests/machine/x/scala/group_items_iteration.scala
+++ b/tests/machine/x/scala/group_items_iteration.scala
@@ -1,19 +1,20 @@
 object group_items_iteration {
   case class Auto1(tag: String, total: Int)
   case class Data(tag: String, `val`: Int)
+  case class Group(d: Data)
 
   val data = List[Data](Data(tag = "a", `val` = 1), Data(tag = "a", `val` = 2), Data(tag = "b", `val` = 3))
-  val groups = ((for { d <- data } yield (d.tag, (d))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); g._2 } }.toList
+  val groups = ((for { d <- data } yield (d.tag, Group(d = d))).groupBy(_._1).map{ case(k,list) => (k, list.map(_._2)) }.toList).map{ case(gKey,gItems) => { val g = (gKey, gItems); g._2 } }.toList
   def main(args: Array[String]): Unit = {
     var tmp = scala.collection.mutable.ArrayBuffer[Any]()
     for(g <- groups) {
       var total = 0
-      for(x <- g._2) {
+      for(x <- g.items) {
         total += x.`val`
       }
-      tmp = tmp :+ Auto1(tag = g._1, total = total)
+      tmp = tmp :+ Auto1(tag = g.key, total = total)
     }
-    val result = (for { r <- tmp } yield r).sortBy(r => r.tag)
+    val result = (for { r <- tmp } yield r).sortBy(r => r.tag).map(r => r)
     println((result))
   }
 }

--- a/tests/machine/x/scala/left_join.scala
+++ b/tests/machine/x/scala/left_join.scala
@@ -1,7 +1,7 @@
 object left_join {
   case class Customer(id: Int, name: String)
   case class Order(id: Int, customerId: Int, total: Int)
-  case class Result(orderId: Int, customer: Any, total: Int)
+  case class Result(orderId: Int, customer: Option[Customer], total: Int)
   case class Result1(orderId: Int, customer: Customer, total: Int)
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))

--- a/tests/machine/x/scala/left_join_multi.scala
+++ b/tests/machine/x/scala/left_join_multi.scala
@@ -2,7 +2,7 @@ object left_join_multi {
   case class Customer(id: Int, name: String)
   case class Item(orderId: Int, sku: String)
   case class Order(id: Int, customerId: Int)
-  case class Result(orderId: Int, name: String, item: Any)
+  case class Result(orderId: Int, name: String, item: Option[Item])
   case class Result1(orderId: Int, name: String, item: Item)
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))

--- a/tests/machine/x/scala/order_by_map.scala
+++ b/tests/machine/x/scala/order_by_map.scala
@@ -2,7 +2,7 @@ object order_by_map {
   case class Data(a: Int, b: Int)
 
   val data = List[Data](Data(a = 1, b = 2), Data(a = 1, b = 1), Data(a = 0, b = 5))
-  val sorted = (for { x <- data } yield x).sortBy(x => Data(a = x.a, b = x.b))
+  val sorted = (for { x <- data } yield x).sortBy(x => Data(a = x.a, b = x.b)).map(x => x)
   def main(args: Array[String]): Unit = {
     println((sorted))
   }

--- a/tests/machine/x/scala/outer_join.scala
+++ b/tests/machine/x/scala/outer_join.scala
@@ -1,8 +1,10 @@
 object outer_join {
   case class Customer(id: Int, name: String)
   case class Order(id: Int, customerId: Int, total: Int)
-  case class Result(order: Order, customer: Any)
+  case class Result(order: Option[Order], customer: Option[Customer])
   case class Result1(order: Order, customer: Customer)
+
+  def _outer_join[A,B](a: List[A], b: List[B])(cond: (A,B) => Boolean): List[(Option[A], Option[B])] = { val left = _left_join(a,b)(cond).map{ case(x,y) => (Some(x), y) }; val right = _right_join(a,b)(cond).collect{ case(None, r) => (None, Some(r)) }; left ++ right }
 
   def _truthy(v: Any): Boolean = v match {
     case null => false
@@ -19,7 +21,7 @@ object outer_join {
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"), Customer(id = 4, name = "Diana"))
   val orders = List[Order](Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 5, total = 80))
-  val result = for { o <- orders; c = customers.find(c => o.customerId == (c.id).asInstanceOf[Int]) } yield Result(order = o, customer = c)
+  val result = for { _pair0 <- _outer_join(orders, customers)((o,c) => o.customerId == (c.id).asInstanceOf[Int]); o = _pair0._1; c = _pair0._2 } yield Result(order = o, customer = c)
   def main(args: Array[String]): Unit = {
     println(("--- Outer Join using syntax ---"))
     for(row <- result) {

--- a/tests/machine/x/scala/right_join.scala
+++ b/tests/machine/x/scala/right_join.scala
@@ -1,7 +1,7 @@
 object right_join {
   case class Customer(id: Int, name: String)
   case class Order(id: Int, customerId: Int, total: Int)
-  case class Result(customerName: String, order: Any)
+  case class Result(customerName: String, order: Option[Order])
   case class Result1(customerName: String, order: Order)
 
   def _truthy(v: Any): Boolean = v match {

--- a/tests/machine/x/scala/save_jsonl_stdout.out
+++ b/tests/machine/x/scala/save_jsonl_stdout.out
@@ -1,0 +1,2 @@
+{"name" : "Alice", "age" : 30}
+{"name" : "Bob", "age" : 25}

--- a/tests/machine/x/scala/save_jsonl_stdout.scala
+++ b/tests/machine/x/scala/save_jsonl_stdout.scala
@@ -4,10 +4,10 @@ object save_jsonl_stdout {
   def _save_jsonl(rows: Iterable[Any], path: String): Unit = {
     def toMap(v: Any): Map[String,Any] = v match {
       case m: Map[_, _] => m.asInstanceOf[Map[String,Any]]
-      case p: Product => p.getClass.getDeclaredFields.map(_.getName).zip(p.productIterator).toMap.asInstanceOf[Map[String,Any]]
+      case p: Product => p.getClass.getDeclaredFields.map(_.getName).zip(p.productIterator.toList).toMap.asInstanceOf[Map[String,Any]]
       case x => Map("value" -> x)
     }
-    val out = if(path == "-") Console.out else new java.io.PrintWriter(path)
+    val out: java.io.PrintWriter = if(path == "-") new java.io.PrintWriter(System.out) else new java.io.PrintWriter(path)
     rows.foreach(r => out.println(scala.util.parsing.json.JSONObject(toMap(r)).toString()))
     out.flush()
     if(out ne Console.out) out.close()


### PR DESCRIPTION
## Summary
- update `_save_jsonl` helper for scala
- support `Option` types in scala compiler
- improve selector handling
- better truthiness checks in query compiler
- regenerate Scala machine translations
- update Scala machine README and output

## Testing
- `go run -tags slow scripts/compile_scala.go`
- `scalac two-sum.scala && scala two_sum > /tmp/twosum.out`


------
https://chatgpt.com/codex/tasks/task_e_68718d0daea883209dccc467bd0d5dcb