### PR TITLE
Add Mochi solution for Rosetta task 150

### DIFF
--- a/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.mochi
+++ b/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.mochi
@@ -1,8 +1,47 @@
-// Mochi version of Rosetta "Case-sensitivity of identifiers" task
-// Demonstrates that identifiers with different case are distinct.
+// Mochi implementation of Rosetta "Case sensitivity of identifiers" task
 
-var dog = "Benjamin"
-var Dog = "Samba"
-var DOG = "Bernie"
+fun main() {
+  // variables belonging to the package
+  var pkg_dog = "Salt"
+  var Dog = "Pepper"
+  var pkg_DOG = "Mustard"
 
-print("The three dogs are named " + dog + ", " + Dog + " and " + DOG + ".")
+  fun packageSees(d1: string, d2: string, d3: string): map<string, bool> {
+    print("Package sees: " + d1 + " " + d2 + " " + d3)
+    return {"pkg_dog": true, "Dog": true, "pkg_DOG": true}
+  }
+
+  // three dogs from the package
+  var d = packageSees(pkg_dog, Dog, pkg_DOG)
+  print("There are " + str(len(d)) + " dogs.\n")
+
+  // declare a new variable in main
+  var dog = "Benjamin"
+  d = packageSees(pkg_dog, Dog, pkg_DOG)
+  print("Main sees:   " + dog + " " + Dog + " " + pkg_DOG)
+  d["dog"] = true
+  d["Dog"] = true
+  d["pkg_DOG"] = true
+  print("There are " + str(len(d)) + " dogs.\n")
+
+  // change the exported Dog variable
+  Dog = "Samba"
+  d = packageSees(pkg_dog, Dog, pkg_DOG)
+  print("Main sees:   " + dog + " " + Dog + " " + pkg_DOG)
+  d["dog"] = true
+  d["Dog"] = true
+  d["pkg_DOG"] = true
+  print("There are " + str(len(d)) + " dogs.\n")
+
+  // shadow the package DOG variable with a new one
+  var DOG = "Bernie"
+  d = packageSees(pkg_dog, Dog, pkg_DOG)
+  print("Main sees:   " + dog + " " + Dog + " " + DOG)
+  d["dog"] = true
+  d["Dog"] = true
+  d["pkg_DOG"] = true
+  d["DOG"] = true
+  print("There are " + str(len(d)) + " dogs.")
+}
+
+main()

--- a/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.out
+++ b/tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.out
@@ -1,2 +1,14 @@
-The three dogs are named Benjamin, Samba and Bernie.
+Package sees: Salt Pepper Mustard
+There are 3 dogs.
 
+Package sees: Salt Pepper Mustard
+Main sees:   Benjamin Pepper Mustard
+There are 4 dogs.
+
+Package sees: Salt Samba Mustard
+Main sees:   Benjamin Samba Mustard
+There are 4 dogs.
+
+Package sees: Salt Samba Mustard
+Main sees:   Benjamin Samba Bernie
+There are 5 dogs.


### PR DESCRIPTION
## Summary
- add Mochi implementation for "Case sensitivity of identifiers"
- include expected output for the new task

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.mochi`
- `diff -u /tmp/out.txt tests/rosetta/x/Mochi/case-sensitivity-of-identifiers.out`
- `go test ./tools/rosetta -run TestMochiTasks -tags slow` *(fails: interrupted after several minutes)*

------
https://chatgpt.com/codex/tasks/task_e_68718d2ea2948320bc1b700f5f0c364b