### PR TITLE
Add Mochi solution for Rosetta Chat server task

### DIFF
--- a/tests/rosetta/x/Mochi/chat-server.mochi
+++ b/tests/rosetta/x/Mochi/chat-server.mochi
@@ -1,0 +1,45 @@
+// Mochi implementation of Rosetta "Chat server" task
+// This is a simplified simulation of a chat server using in-memory lists.
+
+fun removeName(names: list<string>, name: string): list<string> {
+  var out: list<string> = []
+  for n in names {
+    if n != name {
+      out = append(out, n)
+    }
+  }
+  return out
+}
+
+fun main() {
+  var clients: list<string> = []
+
+  fun broadcast(msg: string) {
+    // In a real chat server this would send to all connected clients.
+    print(msg)
+  }
+
+  fun add(name: string) {
+    clients = append(clients, name)
+    broadcast("+++ \"" + name + "\" connected +++\n")
+  }
+
+  fun send(name: string, msg: string) {
+    broadcast(name + "> " + msg + "\n")
+  }
+
+  fun remove(name: string) {
+    clients = removeName(clients, name)
+    broadcast("--- \"" + name + "\" disconnected ---\n")
+  }
+
+  add("Alice")
+  add("Bob")
+  send("Alice", "Hello Bob!")
+  send("Bob", "Hi Alice!")
+  remove("Bob")
+  remove("Alice")
+  broadcast("Server stopping!\n")
+}
+
+main()

--- a/tests/rosetta/x/Mochi/chat-server.out
+++ b/tests/rosetta/x/Mochi/chat-server.out
@@ -1,0 +1,7 @@
++++ "Alice" connected +++
++++ "Bob" connected +++
+Alice> Hello Bob!
+Bob> Hi Alice!
+--- "Bob" disconnected ---
+--- "Alice" disconnected ---
+Server stopping!


### PR DESCRIPTION
## Summary
- add Rosetta `chat-server` implementation in Mochi
- provide expected output for Mochi implementation

## Testing
- `go test -tags slow -run TestMochiTasks -count=1 -timeout 60s` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68718d8e53f483208dba6ed1d6d97791