### PR TITLE
Improve Zig struct inference

### DIFF
--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -467,6 +467,19 @@ func (c *Compiler) structTypeFromExpr(e *parser.Expr) (types.Type, bool) {
 		return nil, false
 	}
 	u := e.Binary.Left
+	if len(u.Value.Ops) > 0 {
+		if cast := u.Value.Ops[len(u.Value.Ops)-1].Cast; cast != nil {
+			t := c.resolveTypeRef(cast.Type)
+			if _, ok := t.(types.StructType); ok {
+				return t, true
+			}
+			if lt, ok := t.(types.ListType); ok {
+				if _, ok2 := lt.Elem.(types.StructType); ok2 {
+					return lt, true
+				}
+			}
+		}
+	}
 	if ml := u.Value.Target.Map; ml != nil {
 		st, ok := c.structTypeFromMapLiteral(ml, "")
 		if ok {

--- a/compiler/x/zig/infer.go
+++ b/compiler/x/zig/infer.go
@@ -12,6 +12,15 @@ func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
 	if e == nil {
 		return types.AnyType{}
 	}
+	// Handle casts early so that type assertions propagate.
+	if len(e.Binary.Right) == 0 {
+		u := e.Binary.Left
+		if len(u.Value.Ops) > 0 {
+			if cast := u.Value.Ops[len(u.Value.Ops)-1].Cast; cast != nil {
+				return c.resolveTypeRef(cast.Type)
+			}
+		}
+	}
 	// Handle simple literals directly for better inference.
 	if len(e.Binary.Right) == 0 {
 		u := e.Binary.Left

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -113,6 +113,7 @@ Compiled programs: 100/100
 - [ ] Improve idiomatic mappings for Zig built-ins.
 - [x] Generate named structs from constant map literals for readability.
 - [x] Improve struct inference when map literals match existing definitions.
+- [x] Enhance struct type inference for cast expressions.
 - [ ] Support union pattern matching using enums.
 - [ ] Implement iterators for list handling instead of ArrayList allocations.
 - [ ] Replace `catch unreachable` with proper error handling.


### PR DESCRIPTION
## Summary
- improve Zig compiler's type inference to detect types on cast expressions
- detect struct types from casts in `structTypeFromExpr`
- document progress in zig machine README

## Testing
- `go test -tags slow ./compiler/x/zig -run TestZigCompiler_ValidPrograms -count=1` *(fails: installing Zig)*

------
https://chatgpt.com/codex/tasks/task_e_6871bb808f8c83209bd75249b915ebc5