### PR TITLE
Improve Zig struct inference from list literals

### DIFF
--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -114,6 +114,7 @@ Compiled programs: 100/100
 - [x] Generate named structs from constant map literals for readability.
 - [x] Improve struct inference when map literals match existing definitions.
 - [x] Enhance struct type inference for cast expressions.
+- [x] Enhance struct type inference for list literals with uniform fields.
 - [ ] Support union pattern matching using enums.
 - [ ] Implement iterators for list handling instead of ArrayList allocations.
 - [ ] Replace `catch unreachable` with proper error handling.


### PR DESCRIPTION
## Summary
- refine `structTypeFromExpr` for Zig backend to check all elements of list literals and infer structs when fields are uniform
- document this new capability in the Zig machine README

## Testing
- `go test -tags slow ./tests/vm -run TestVM_ValidPrograms -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6871beea8a448320a0e7b168d7f94b96