### PR TITLE
Add doc comment support to TS compiler

### DIFF
--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -502,8 +502,13 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 }
 
 func (c *Compiler) compileLet(s *parser.LetStmt) error {
-	name := sanitizeName(s.Name)
-	value := "undefined"
+        name := sanitizeName(s.Name)
+        if s.Doc != "" {
+                for _, ln := range strings.Split(s.Doc, "\n") {
+                        c.writeln("// " + ln)
+                }
+        }
+        value := "undefined"
 	if s.Value != nil {
 		v, err := c.compileExpr(s.Value)
 		if err != nil {
@@ -541,8 +546,13 @@ func (c *Compiler) compileLet(s *parser.LetStmt) error {
 }
 
 func (c *Compiler) compileVar(s *parser.VarStmt) error {
-	name := sanitizeName(s.Name)
-	value := "undefined"
+        name := sanitizeName(s.Name)
+        if s.Doc != "" {
+                for _, ln := range strings.Split(s.Doc, "\n") {
+                        c.writeln("// " + ln)
+                }
+        }
+        value := "undefined"
 	if s.Value != nil {
 		if ml := s.Value.Binary.Left.Value.Target.Map; ml != nil && len(ml.Items) == 0 {
 			if c.env != nil {
@@ -972,7 +982,12 @@ func (c *Compiler) compileAgentOn(agentName string, env *types.Env, h *parser.On
 }
 
 func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
-	name := sanitizeName(t.Name)
+        name := sanitizeName(t.Name)
+        if t.Doc != "" {
+                for _, ln := range strings.Split(t.Doc, "\n") {
+                        c.writeln("// " + ln)
+                }
+        }
 
 	if len(t.Variants) > 0 {
 		var variants []string
@@ -1200,13 +1215,18 @@ func (c *Compiler) compileFor(stmt *parser.ForStmt) error {
 }
 
 func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
-	name := sanitizeName(fun.Name)
-	c.writeIndent()
-	if c.asyncFuncs[name] {
-		c.buf.WriteString("async function " + name + "(")
-	} else {
-		c.buf.WriteString("function " + name + "(")
-	}
+        name := sanitizeName(fun.Name)
+        if fun.Doc != "" {
+                for _, ln := range strings.Split(fun.Doc, "\n") {
+                        c.writeln("// " + ln)
+                }
+        }
+        c.writeIndent()
+        if c.asyncFuncs[name] {
+                c.buf.WriteString("async function " + name + "(")
+        } else {
+                c.buf.WriteString("function " + name + "(")
+        }
 	var ft types.FuncType
 	if c.env != nil {
 		if t, err := c.env.GetVar(fun.Name); err == nil {

--- a/tests/machine/x/ts/README.md
+++ b/tests/machine/x/ts/README.md
@@ -114,7 +114,7 @@ Compiled: 100/100 programs
 - [x] Use template strings for string concatenation
 - [x] Leverage built-in array helpers instead of manual loops
 - [x] Add async function support for I/O operations
-- [ ] Preserve comments from source Mochi code
+- [x] Preserve comments from source Mochi code
 - [ ] Generate discriminated union helpers
 - [ ] Optimize query translations to use map/reduce
 - [ ] Support optional chaining and nullish coalescing

--- a/tests/machine/x/typescript/README.md
+++ b/tests/machine/x/typescript/README.md
@@ -115,7 +115,7 @@ Compiled: 100/100 programs
 - [x] Use template strings for string concatenation
 - [x] Leverage built-in array helpers instead of manual loops
 - [x] Add async function support for I/O operations
-- [ ] Preserve comments from source Mochi code
+- [x] Preserve comments from source Mochi code
 - [ ] Generate discriminated union helpers
 - [ ] Optimize query translations to use map/reduce
 - [ ] Support optional chaining and nullish coalescing


### PR DESCRIPTION
## Summary
- support emitting comments on functions, variables and type declarations for TypeScript compiler
- regenerate machine README and mark comment preservation complete

## Testing
- `go test ./compiler/x/ts -run TestGenerateMachineOutput -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6871be94f7588320a03b590473514779