### PR TITLE
Improve C++ compiler vector inference

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -3183,6 +3183,30 @@ func (c *Compiler) extractVectorElemType(expr string) string {
 		if idx := strings.Index(texpr, "{"); idx != -1 {
 			texpr = texpr[:idx]
 		}
+		if strings.HasSuffix(texpr, "[0]") {
+			base := strings.TrimSuffix(texpr, "[0]")
+			if t := c.elemType[base]; t != "" {
+				return t
+			}
+			if t := c.varStruct[base]; t != "" {
+				return t
+			}
+		}
+		if strings.HasPrefix(texpr, "std::declval<") && strings.Contains(texpr, ">().") {
+			tmp := strings.TrimPrefix(texpr, "std::declval<")
+			parts := strings.SplitN(tmp, ">().", 2)
+			if len(parts) == 2 {
+				structName := parts[0]
+				field := parts[1]
+				if info, ok := c.structByName[structName]; ok {
+					for i, f := range info.Fields {
+						if f == field {
+							return info.Types[i]
+						}
+					}
+				}
+			}
+		}
 		if texpr == "true" || texpr == "false" {
 			return "bool"
 		}

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -114,7 +114,7 @@ Compiled programs: 100/100
 - [ ] Support concurrency primitives
 - [ ] Provide wrappers for standard libraries
 - [ ] Implement generics for map keys
-- [ ] Enhance vector element type inference
+ - [x] Enhance vector element type inference
 - [ ] Add command line interface for the compiler
 - [ ] Integrate CMake build generation
 - [ ] Support user defined modules


### PR DESCRIPTION
## Summary
- enhance vector element inference in C++ backend
- mark task done in C++ machine README

## Testing
- `go test -tags=slow ./compiler/x/cpp -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6871c0228a8c832092a5c1ce75bdc3d6