### PR TITLE
Improve Zig struct inference

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -430,6 +430,7 @@ func (c *Compiler) compileGlobalDecls(prog *parser.Program) error {
 				} else if s.Let.Value != nil {
 					typ = c.inferExprType(s.Let.Value)
 					if st, ok := c.structTypeFromExpr(s.Let.Value); ok {
+						st = c.nameNestedStructs(pascalCase(name), st)
 						switch tt := st.(type) {
 						case types.StructType:
 							if tt.Name == "" {
@@ -1968,6 +1969,7 @@ func (c *Compiler) compileVar(st *parser.VarStmt, inFun bool) error {
 			} else {
 				typ = c.inferExprType(st.Value)
 				if stype, ok := c.structTypeFromExpr(st.Value); ok {
+					stype = c.nameNestedStructs(pascalCase(name), stype)
 					switch tt := stype.(type) {
 					case types.StructType:
 						if tt.Name == "" {

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -115,6 +115,7 @@ Compiled programs: 100/100
 - [x] Improve struct inference when map literals match existing definitions.
 - [x] Enhance struct type inference for cast expressions.
 - [x] Enhance struct type inference for list literals with uniform fields.
+- [x] Enhance struct type inference for nested map fields.
 - [ ] Support union pattern matching using enums.
 - [ ] Implement iterators for list handling instead of ArrayList allocations.
 - [ ] Replace `catch unreachable` with proper error handling.


### PR DESCRIPTION
## Summary
- enhance Zig compiler type inference for nested structs
- document nested struct inference support in Zig README

## Testing
- `go test ./compiler/x/zig -tags slow` *(fails: package constraints)*
- `go test $(go list ./... | grep -v archived)` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871c09a50c8832081b0fcb87fc3d818