### PR TITLE
Improve C++ type inference

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -3081,6 +3081,17 @@ func (c *Compiler) inferType(expr string) string {
 			}
 			return "int"
 		}
+		if trimmed == "true" || trimmed == "false" {
+			return "bool"
+		}
+		if !strings.ContainsAny(trimmed, "{}?:") {
+			if strings.Contains(trimmed, "==") || strings.Contains(trimmed, "!=") ||
+				strings.Contains(trimmed, "<=") || strings.Contains(trimmed, ">=") ||
+				strings.Contains(trimmed, " && ") || strings.Contains(trimmed, " || ") ||
+				strings.HasPrefix(trimmed, "!") || strings.Contains(trimmed, " < ") || strings.Contains(trimmed, " > ") {
+				return "bool"
+			}
+		}
 	}
 	return ""
 }

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -114,7 +114,8 @@ Compiled programs: 100/100
 - [ ] Support concurrency primitives
 - [ ] Provide wrappers for standard libraries
 - [ ] Implement generics for map keys
- - [x] Enhance vector element type inference
+- [x] Enhance vector element type inference
+- [x] Improve boolean expression type inference
 - [ ] Add command line interface for the compiler
 - [ ] Integrate CMake build generation
 - [ ] Support user defined modules

--- a/tests/machine/x/cpp/basic_compare.cpp
+++ b/tests/machine/x/cpp/basic_compare.cpp
@@ -4,7 +4,7 @@ int main() {
   auto a = (10 - 3);
   auto b = (2 + 2);
   std::cout << a << std::endl;
-  std::cout << std::boolalpha << (a == 7) << std::endl;
-  std::cout << std::boolalpha << (b < 5) << std::endl;
+  std::cout << ((a == 7) ? "true" : "false") << std::endl;
+  std::cout << ((b < 5) ? "true" : "false") << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/bool_chain.cpp
+++ b/tests/machine/x/cpp/bool_chain.cpp
@@ -7,11 +7,12 @@ bool boom() {
 }
 
 int main() {
-  std::cout << std::boolalpha << ((((1 < 2)) && ((2 < 3))) && ((3 < 4)))
+  std::cout << (((((1 < 2)) && ((2 < 3))) && ((3 < 4))) ? "true" : "false")
             << std::endl;
-  std::cout << std::boolalpha << ((((1 < 2)) && ((2 > 3))) && boom())
+  std::cout << (((((1 < 2)) && ((2 > 3))) && boom()) ? "true" : "false")
             << std::endl;
-  std::cout << std::boolalpha
-            << (((((1 < 2)) && ((2 < 3))) && ((3 > 4))) && boom()) << std::endl;
+  std::cout << ((((((1 < 2)) && ((2 < 3))) && ((3 > 4))) && boom()) ? "true"
+                                                                    : "false")
+            << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/cross_join_triple.cpp
+++ b/tests/machine/x/cpp/cross_join_triple.cpp
@@ -15,7 +15,7 @@ int main() {
   std::vector<int> nums = std::vector<int>{1, 2};
   std::vector<std::string> letters =
       std::vector<std::string>{std::string("A"), std::string("B")};
-  std::vector<bool> bools = std::vector<decltype(true)>{true, false};
+  std::vector<bool> bools = std::vector<bool>{true, false};
   auto combos = ([&]() {
     std::vector<Combo> __items;
     for (auto n : nums) {

--- a/tests/machine/x/cpp/map_in_operator.cpp
+++ b/tests/machine/x/cpp/map_in_operator.cpp
@@ -5,7 +5,7 @@
 int main() {
   auto m = std::unordered_map<int, std::string>{{1, std::string("a")},
                                                 {2, std::string("b")}};
-  std::cout << std::boolalpha << (m.count(1) > 0) << std::endl;
-  std::cout << std::boolalpha << (m.count(3) > 0) << std::endl;
+  std::cout << ((m.count(1) > 0) ? "true" : "false") << std::endl;
+  std::cout << ((m.count(3) > 0) ? "true" : "false") << std::endl;
   return 0;
 }

--- a/tests/machine/x/cpp/short_circuit.cpp
+++ b/tests/machine/x/cpp/short_circuit.cpp
@@ -7,7 +7,7 @@ bool boom(int a, int b) {
 }
 
 int main() {
-  std::cout << std::boolalpha << (false && boom(1, 2)) << std::endl;
-  std::cout << std::boolalpha << (true || boom(1, 2)) << std::endl;
+  std::cout << ((false && boom(1, 2)) ? "true" : "false") << std::endl;
+  std::cout << ((true || boom(1, 2)) ? "true" : "false") << std::endl;
   return 0;
 }


### PR DESCRIPTION
## Summary
- refine boolean type inference in C++ compiler
- update generated C++ test outputs
- document completed tasks for the C++ backend

## Testing
- `go test -tags slow ./compiler/x/cpp -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6871c1c0a30083208355b832e302e0c7