### PR TITLE
Add Mochi implementation for Rosetta check file task

### DIFF
--- a/tests/rosetta/x/Mochi/check-that-file-exists.mochi
+++ b/tests/rosetta/x/Mochi/check-that-file-exists.mochi
@@ -1,0 +1,26 @@
+// Mochi translation of Rosetta "Check that file exists" task
+// Since Mochi currently lacks standard filesystem APIs, we simulate a minimal
+// filesystem containing only a few example paths.
+
+// fs maps paths to a boolean indicating whether the entry is a directory.
+fun printStat(fs: map<string, bool>, path: string) {
+  if path in fs {
+    if fs[path] {
+      print(path + " is a directory")
+    } else {
+      print(path + " is a file")
+    }
+  } else {
+    print("stat " + path + ": no such file or directory")
+  }
+}
+
+fun main() {
+  var fs: map<string, bool> = {}
+  fs["docs"] = true
+  for p in ["input.txt", "/input.txt", "docs", "/docs"] {
+    printStat(fs, p)
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/check-that-file-exists.out
+++ b/tests/rosetta/x/Mochi/check-that-file-exists.out
@@ -1,0 +1,4 @@
+stat input.txt: no such file or directory
+stat /input.txt: no such file or directory
+docs is a directory
+stat /docs: no such file or directory


### PR DESCRIPTION
## Summary
- add Mochi version of `Check-that-file-exists`
- include expected output

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/check-that-file-exists.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6871c1e9a33c832097f616b25dc398c8