### PR TITLE
Improve Python compiler type inference

### DIFF
--- a/compiler/x/python/infer.go
+++ b/compiler/x/python/infer.go
@@ -45,5 +45,26 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 }
 
 func resultType(op string, left, right types.Type) types.Type {
-	return types.ResultType(op, left, right)
+        return types.ResultType(op, left, right)
+}
+
+// inferFunReturnType returns the unified type of all return statements in body.
+// If return statements have differing types it falls back to AnyType. When no
+// explicit return is present it yields VoidType.
+func (c *Compiler) inferFunReturnType(body []*parser.Statement) types.Type {
+        var ret types.Type
+        for _, st := range body {
+                if st.Return != nil {
+                        t := c.inferExprType(st.Return.Value)
+                        if ret == nil {
+                                ret = t
+                        } else if !equalTypes(ret, t) {
+                                return types.AnyType{}
+                        }
+                }
+        }
+        if ret == nil {
+                return types.VoidType{}
+        }
+        return ret
 }

--- a/compiler/x/python/statements.go
+++ b/compiler/x/python/statements.go
@@ -968,15 +968,18 @@ func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 		}
 		paramTypes[i] = typ
 	}
-	retType := "None"
-	if ft.Return != nil {
-		retType = pyType(c.namedType(ft.Return))
-	} else if fun.Return != nil {
-		retType = pyType(c.namedType(c.resolveTypeRef(fun.Return)))
-	}
-	if c.typeHints && needsTyping(retType) {
-		needTyping = true
-	}
+       var retT types.Type = types.VoidType{}
+       if ft.Return != nil {
+               retT = ft.Return
+       } else if fun.Return != nil {
+               retT = c.resolveTypeRef(fun.Return)
+       } else if c.env != nil {
+               retT = c.inferFunReturnType(fun.Body)
+       }
+       retType := pyType(c.namedType(retT))
+       if c.typeHints && needsTyping(retType) {
+               needTyping = true
+       }
 	if c.typeHints {
 		c.buf.WriteString(") -> " + retType + ":\n")
 	} else {
@@ -1138,15 +1141,18 @@ func (c *Compiler) compileMethod(structName string, env *types.Env, fun *parser.
 		}
 		paramTypes[i] = typ
 	}
-	retType := "None"
-	if ft.Return != nil {
-		retType = pyType(c.namedType(ft.Return))
-	} else if fun.Return != nil {
-		retType = pyType(c.namedType(c.resolveTypeRef(fun.Return)))
-	}
-	if c.typeHints && needsTyping(retType) {
-		needTyping = true
-	}
+       var retT types.Type = types.VoidType{}
+       if ft.Return != nil {
+               retT = ft.Return
+       } else if fun.Return != nil {
+               retT = c.resolveTypeRef(fun.Return)
+       } else if c.env != nil {
+               retT = c.inferFunReturnType(fun.Body)
+       }
+       retType := pyType(c.namedType(retT))
+       if c.typeHints && needsTyping(retType) {
+               needTyping = true
+       }
 	if c.typeHints {
 		c.buf.WriteString(") -> " + retType + ":\n")
 	} else {

--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -111,6 +111,7 @@ Compiled programs: 100/100 successful.
 - [ ] Support optional type annotations
 - [ ] Integrate with Python packaging tools
 - [x] Generate docstrings for compiled functions
+- [x] Implement return type inference for functions
 - [ ] Optimize stream handling performance
 - [ ] Expand test coverage for edge cases
 - [ ] Reduce external module dependencies


### PR DESCRIPTION
## Summary
- enhance Python compiler with function return type inference
- use inferred return types when generating functions and methods
- document completed work in machine README

## Testing
- `go test ./compiler/x/python -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6871c0509dc08320b509eb49f2a01323