### PR TITLE
Fix Java compiler map nested assignments

### DIFF
--- a/compiler/x/java/compiler.go
+++ b/compiler/x/java/compiler.go
@@ -1736,8 +1736,13 @@ func (c *Compiler) compileAssign(a *parser.AssignStmt) error {
 			}
 		} else {
 			if strings.HasPrefix(typ, "Map<") {
-				target = fmt.Sprintf("((Map)%s.get(%s))", target, ix)
-				typ = mapValueType(typ)
+				vt := mapValueType(typ)
+				cast := "Map"
+				if vt != "Object" {
+					cast = vt
+				}
+				target = fmt.Sprintf("((%s)%s.get(%s))", cast, target, ix)
+				typ = vt
 			} else if strings.HasPrefix(typ, "List<") {
 				target = fmt.Sprintf("((List)%s.get(%s))", target, ix)
 				typ = listElemType(typ)
@@ -1745,8 +1750,13 @@ func (c *Compiler) compileAssign(a *parser.AssignStmt) error {
 				target = fmt.Sprintf("%s.%s", target, field)
 				typ = c.fieldType(typ, field)
 			} else {
-				target = fmt.Sprintf("((Map)%s.get(%s))", target, ix)
-				typ = mapValueType(typ)
+				vt := mapValueType(typ)
+				cast := "Map"
+				if vt != "Object" {
+					cast = vt
+				}
+				target = fmt.Sprintf("((%s)%s.get(%s))", cast, target, ix)
+				typ = vt
 			}
 		}
 	}
@@ -2209,8 +2219,13 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					}
 				} else {
 					if strings.HasPrefix(typ, "Map<") {
-						val = fmt.Sprintf("((Map)%s.get(%s))", val, idx)
-						typ = mapValueType(typ)
+						vt := mapValueType(typ)
+						cast := "Map"
+						if vt != "Object" {
+							cast = vt
+						}
+						val = fmt.Sprintf("((%s)%s.get(%s))", cast, val, idx)
+						typ = vt
 					} else if strings.HasPrefix(typ, "List<") {
 						val = fmt.Sprintf("((List)%s.get(%s))", val, idx)
 						typ = listElemType(typ)
@@ -2219,11 +2234,22 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 							val = fmt.Sprintf("%s.%s", val, field)
 							typ = c.fieldType(typ, field)
 						} else {
-							val = fmt.Sprintf("((Map)%s).get(%s)", val, idx)
-							typ = mapValueType(typ)
+							vt := mapValueType(typ)
+							cast := "Map"
+							if vt != "Object" {
+								cast = vt
+							}
+							val = fmt.Sprintf("((%s)%s).get(%s)", cast, val, idx)
+							typ = vt
 						}
 					} else {
-						val = fmt.Sprintf("((Map)%s.get(%s))", val, idx)
+						vt := mapValueType(typ)
+						cast := "Map"
+						if vt != "Object" {
+							cast = vt
+						}
+						val = fmt.Sprintf("((%s)%s.get(%s))", cast, val, idx)
+						typ = vt
 					}
 				}
 			}

--- a/tests/machine/x/java/map_nested_assign.java
+++ b/tests/machine/x/java/map_nested_assign.java
@@ -39,7 +39,7 @@ public class MapNestedAssign {
     }
     public static void main(String[] args) {
     Map<String,Inner> data = mapOfEntries(entry("outer", new Inner(1)));
-    ((Map)data.get("outer")).inner = 2;
-    System.out.println(((Map)data.get("outer")).inner);
+    ((Inner)data.get("outer")).inner = 2;
+    System.out.println(((Inner)data.get("outer")).inner);
     }
 }

--- a/tests/machine/x/java/user_type_literal.java
+++ b/tests/machine/x/java/user_type_literal.java
@@ -1,21 +1,5 @@
 import java.util.*;
 
-class Book {
-    String title;
-    Person author;
-    Book(String title, Person author) {
-        this.title = title;
-        this.author = author;
-    }
-    @Override public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Book other)) return false;
-        return Objects.equals(this.title, other.title) && Objects.equals(this.author, other.author);
-    }
-    @Override public int hashCode() {
-        return Objects.hash(title, author);
-    }
-}
 class Person {
     String name;
     int age;
@@ -30,6 +14,22 @@ class Person {
     }
     @Override public int hashCode() {
         return Objects.hash(name, age);
+    }
+}
+class Book {
+    String title;
+    Person author;
+    Book(String title, Person author) {
+        this.title = title;
+        this.author = author;
+    }
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Book other)) return false;
+        return Objects.equals(this.title, other.title) && Objects.equals(this.author, other.author);
+    }
+    @Override public int hashCode() {
+        return Objects.hash(title, author);
     }
 }
 public class UserTypeLiteral {


### PR DESCRIPTION
## Summary
- improve Java compiler's handling of nested map assignments
- regenerate Java outputs for `map_nested_assign.mochi` and `user_type_literal.mochi`

## Testing
- `go test ./compiler/x/java -tags slow -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6871ec94a1508320a6c502fdd71b683d