### PR TITLE
Add Zig error handler

### DIFF
--- a/compiler/x/zig/builtins.go
+++ b/compiler/x/zig/builtins.go
@@ -3,6 +3,7 @@
 package zigcode
 
 func (c *Compiler) writeBuiltins() {
+	c.writeErrorHandler()
 	if c.needsAvgInt {
 		c.writeln("fn _avg_int(v: []const i32) i32 {")
 		c.indent++
@@ -116,9 +117,9 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("var res = std.ArrayList(T).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
-		c.writeln("res.appendSlice(v) catch unreachable;")
-		c.writeln("res.append(x) catch unreachable;")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("res.appendSlice(v)" + c.catchHandler() + ";")
+		c.writeln("res.append(x)" + c.catchHandler() + ";")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -154,9 +155,9 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("var res = std.ArrayList(T).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
-		c.writeln("for (a) |it| { res.append(it) catch unreachable; }")
-		c.writeln("for (b) |it| { res.append(it) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("for (a) |it| { res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("for (b) |it| { res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -165,9 +166,9 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("var res = std.ArrayList(T).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
-		c.writeln("for (a) |it| { res.append(it) catch unreachable; }")
-		c.writeln("for (b) |it| { if (!_contains(T, res.items, it)) res.append(it) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("for (a) |it| { res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("for (b) |it| { if (!_contains(T, res.items, it)) res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -176,8 +177,8 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("var res = std.ArrayList(T).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
-		c.writeln("for (a) |it| { if (!_contains(T, b, it)) res.append(it) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("for (a) |it| { if (!_contains(T, b, it)) res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -186,8 +187,8 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("var res = std.ArrayList(T).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
-		c.writeln("for (a) |it| { if (_contains(T, b, it) and !_contains(T, res.items, it)) res.append(it) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("for (a) |it| { if (_contains(T, b, it) and !_contains(T, res.items, it)) res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -197,7 +198,7 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("var buf = std.ArrayList(u8).init(std.heap.page_allocator);")
 		c.writeln("defer buf.deinit();")
-		c.writeln("std.json.stringify(v, .{}, buf.writer()) catch unreachable;")
+		c.writeln("std.json.stringify(v, .{}, buf.writer())" + c.catchHandler() + ";")
 		c.writeln("std.debug.print(\"{s}\\n\", .{buf.items});")
 		c.indent--
 		c.writeln("}")
@@ -209,11 +210,11 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("const alloc = std.heap.page_allocator;")
 		c.writeln("if (path == null or std.mem.eql(u8, path.?, \"-\")) {")
 		c.indent++
-		c.writeln("return std.io.getStdIn().readAllAlloc(alloc, 1 << 20) catch unreachable;")
+		c.writeln("return std.io.getStdIn().readAllAlloc(alloc, 1 << 20)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("} else {")
 		c.indent++
-		c.writeln("return std.fs.cwd().readFileAlloc(alloc, path.?, 1 << 20) catch unreachable;")
+		c.writeln("return std.fs.cwd().readFileAlloc(alloc, path.?, 1 << 20)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.indent--
@@ -223,11 +224,11 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("if (path == null or std.mem.eql(u8, path.?, \"-\")) {")
 		c.indent++
-		c.writeln("std.io.getStdOut().writeAll(data) catch unreachable;")
+		c.writeln("std.io.getStdOut().writeAll(data)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("} else {")
 		c.indent++
-		c.writeln("std.fs.cwd().writeFile(path.?, data) catch unreachable;")
+		c.writeln("std.fs.cwd().writeFile(path.?, data)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.indent--
@@ -250,11 +251,11 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("defer buf.deinit();")
 		c.writeln("if (rows.len == 1) {")
 		c.indent++
-		c.writeln("std.json.stringify(rows[0], .{}, buf.writer()) catch unreachable;")
+		c.writeln("std.json.stringify(rows[0], .{}, buf.writer())" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("} else {")
 		c.indent++
-		c.writeln("std.json.stringify(rows, .{}, buf.writer()) catch unreachable;")
+		c.writeln("std.json.stringify(rows, .{}, buf.writer())" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("_write_output(path, buf.items);")
@@ -269,14 +270,14 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("const alloc = std.heap.page_allocator;")
 		c.writeln("if (std.mem.startsWith(u8, url, \"file://\")) {")
 		c.indent++
-		c.writeln("return std.fs.cwd().readFileAlloc(alloc, url[7..], 1 << 20) catch unreachable;")
+		c.writeln("return std.fs.cwd().readFileAlloc(alloc, url[7..], 1 << 20)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("var child = std.ChildProcess.init(&.{\"curl\", \"-s\", url}, alloc);")
 		c.writeln("child.stdout_behavior = .Pipe;")
-		c.writeln("child.spawn() catch unreachable;")
-		c.writeln("defer { if (child.stdout) |s| { s.close(); } child.wait() catch unreachable; }")
-		c.writeln("return child.stdout.?.readToEndAlloc(alloc, 1 << 20) catch unreachable;")
+		c.writeln("child.spawn()" + c.catchHandler() + ";")
+		c.writeln("defer { if (child.stdout) |s| { s.close(); } child.wait()" + c.catchHandler() + "; }")
+		c.writeln("return child.stdout.?.readToEndAlloc(alloc, 1 << 20)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -334,10 +335,10 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("var i: i32 = s;")
 		c.writeln("while ((st > 0 and i < e) or (st < 0 and i > e)) : (i += st) {")
 		c.indent++
-		c.writeln("res.append(v[@as(usize, @intCast(i))]) catch unreachable;")
+		c.writeln("res.append(v[@as(usize, @intCast(i))])" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -361,10 +362,10 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("var i: i32 = sidx;")
 		c.writeln("while ((stp > 0 and i < eidx) or (stp < 0 and i > eidx)) : (i += stp) {")
 		c.indent++
-		c.writeln("res.append(s[@as(usize, @intCast(i))]) catch unreachable;")
+		c.writeln("res.append(s[@as(usize, @intCast(i))])" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -374,9 +375,9 @@ func (c *Compiler) writeBuiltins() {
 		c.indent++
 		c.writeln("var res = std.ArrayList(T).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
-		c.writeln("for (a) |it| { res.append(it) catch unreachable; }")
-		c.writeln("for (b) |it| { res.append(it) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("for (a) |it| { res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("for (b) |it| { res.append(it)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -384,7 +385,7 @@ func (c *Compiler) writeBuiltins() {
 	if c.needsConcatString {
 		c.writeln("fn _concat_string(a: []const u8, b: []const u8) []const u8 {")
 		c.indent++
-		c.writeln("return std.mem.concat(u8, &[_][]const u8{ a, b }) catch unreachable;")
+		c.writeln("return std.mem.concat(u8, &[_][]const u8{ a, b })" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -395,8 +396,8 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("var res = std.ArrayList([]const u8).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
 		c.writeln("var it = std.mem.split(u8, s, sep);")
-		c.writeln("while (it.next()) |p| { res.append(p) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("while (it.next()) |p| { res.append(p)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -405,7 +406,7 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("fn _join_strings(parts: []const []const u8, sep: []const u8) []const u8 {")
 		c.indent++
 		c.writeln("const alloc = std.heap.page_allocator;")
-		c.writeln("return std.mem.join(u8, sep, parts, alloc) catch unreachable;")
+		c.writeln("return std.mem.join(u8, sep, parts, alloc)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -430,8 +431,8 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("var res = std.ArrayList(K).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
 		c.writeln("var it = m.keyIterator();")
-		c.writeln("while (it.next()) |k_ptr| { res.append(k_ptr.*) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("while (it.next()) |k_ptr| { res.append(k_ptr.*)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -442,8 +443,8 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("var res = std.ArrayList(V).init(std.heap.page_allocator);")
 		c.writeln("defer res.deinit();")
 		c.writeln("var it = m.valueIterator();")
-		c.writeln("while (it.next()) |v_ptr| { res.append(v_ptr.*) catch unreachable; }")
-		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.writeln("while (it.next()) |v_ptr| { res.append(v_ptr.*)" + c.catchHandler() + "; }")
+		c.writeln("return res.toOwnedSlice()" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")
@@ -485,6 +486,18 @@ func (c *Compiler) writeExpectFunc() {
 	c.writeln("fn expect(cond: bool) void {")
 	c.indent++
 	c.writeln("if (!cond) @panic(\"expect failed\");")
+	c.indent--
+	c.writeln("}")
+	c.writeln("")
+}
+
+func (c *Compiler) writeErrorHandler() {
+	if !c.needsErrHandler {
+		return
+	}
+	c.writeln("fn handleError(err: anyerror) noreturn {")
+	c.indent++
+	c.writeln("std.debug.panic(\"{any}\", .{err});")
 	c.indent--
 	c.writeln("}")
 	c.writeln("")

--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -432,6 +432,13 @@ func pascalCase(s string) string {
 	return sanitizeName(strings.Join(parts, ""))
 }
 
+// catchHandler returns the Zig error handling suffix and marks that the
+// generated program needs the runtime error handler.
+func (c *Compiler) catchHandler() string {
+	c.needsErrHandler = true
+	return " catch |err| handleError(err)"
+}
+
 // nameNestedStructs assigns generated names to nested struct types within t.
 // The prefix is used as the base for generated type names. The returned type
 // will have any new struct names registered in the environment.

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -118,7 +118,7 @@ Compiled programs: 100/100
 - [x] Enhance struct type inference for nested map fields.
 - [ ] Support union pattern matching using enums.
 - [ ] Implement iterators for list handling instead of ArrayList allocations.
-- [ ] Replace `catch unreachable` with proper error handling.
+- [x] Replace `catch unreachable` with proper error handling.
 - [ ] Optimize constant folding for arithmetic expressions.
 - [ ] Improve type inference for generic functions.
 - [ ] Handle recursive type definitions.

--- a/tests/machine/x/zig/append_builtin.zig
+++ b/tests/machine/x/zig/append_builtin.zig
@@ -1,10 +1,14 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const a = &[_]i32{
     1,
     2,
 }; // []const i32
 
 pub fn main() void {
-    std.debug.print("{any}\n", .{blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); defer _tmp0.deinit(); _tmp0.appendSlice(a) catch unreachable; _tmp0.append(3) catch unreachable; break :blk0 _tmp0.items; }});
+    std.debug.print("{any}\n", .{blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); defer _tmp0.deinit(); _tmp0.appendSlice(a) catch |err| handleError(err); _tmp0.append(3) catch |err| handleError(err); break :blk0 _tmp0.items; }});
 }

--- a/tests/machine/x/zig/cast_string_to_int.zig
+++ b/tests/machine/x/zig/cast_string_to_int.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 pub fn main() void {
-    std.debug.print("{d}\n", .{std.fmt.parseInt(i32, "1995", 10) catch unreachable});
+    std.debug.print("{d}\n", .{std.fmt.parseInt(i32, "1995", 10) catch |err| handleError(err)});
 }

--- a/tests/machine/x/zig/cross_join.zig
+++ b/tests/machine/x/zig/cross_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const CustomersItem = struct {
     id: i32,
     name: []const u8,
@@ -17,7 +21,7 @@ const customers = &[_]CustomersItem{
     .id = 3,
     .name = "Charlie",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -39,7 +43,7 @@ const orders = &[_]OrdersItem{
     .customerId = 1,
     .total = 300,
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const result = blk0: { var _tmp0 = std.ArrayList(struct {
     orderId: i32,
     orderCustomerId: i32,
@@ -55,7 +59,7 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
     .orderCustomerId = o.customerId,
     .pairedCustomerName = c.name,
     .orderTotal = o.total,
-}) catch unreachable; } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Cross Join: All order-customer pairs ---\n", .{});

--- a/tests/machine/x/zig/cross_join_filter.zig
+++ b/tests/machine/x/zig/cross_join_filter.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const nums = &[_]i32{
     1,
     2,
@@ -18,7 +22,7 @@ const pairs = blk0: { var _tmp0 = std.ArrayList(struct {
 }{
     .n = n,
     .l = l,
-}) catch unreachable; } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Even pairs ---\n", .{});

--- a/tests/machine/x/zig/cross_join_triple.zig
+++ b/tests/machine/x/zig/cross_join_triple.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const nums = &[_]i32{
     1,
     2,
@@ -24,7 +28,7 @@ const combos = blk0: { var _tmp0 = std.ArrayList(struct {
     .n = n,
     .l = l,
     .b = b,
-}) catch unreachable; } } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Cross Join of three lists ---\n", .{});

--- a/tests/machine/x/zig/dataset_sort_take_limit.zig
+++ b/tests/machine/x/zig/dataset_sort_take_limit.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _slice_list(comptime T: type, v: []const T, start: i32, end: i32, step: i32) []T {
     var s = start;
     var e = end;
@@ -16,9 +20,9 @@ fn _slice_list(comptime T: type, v: []const T, start: i32, end: i32, step: i32) 
     defer res.deinit();
     var i: i32 = s;
     while ((st > 0 and i < e) or (st < 0 and i > e)) : (i += st) {
-        res.append(v[@as(usize, @intCast(i))]) catch unreachable;
+        res.append(v[@as(usize, @intCast(i))]) catch |err| handleError(err);
     }
-    return res.toOwnedSlice() catch unreachable;
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 const ProductsItem = struct {
@@ -54,8 +58,8 @@ const products = &[_]ProductsItem{
     .name = "Headphones",
     .price = 200,
 },
-}; // []const ProductsItem
-const expensive = blk0: { var _tmp0 = std.ArrayList(struct { item: ProductsItem, key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp0.append(.{ .item = p, .key = -p.price }) catch unreachable; } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(ProductsItem).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; _tmp2 = _slice_list(ProductsItem, _tmp2, 1, (1 + 3), 1); break :blk0 _tmp2; }; // []const ProductsItem
+}; // []const Productsitem
+const expensive = blk0: { var _tmp0 = std.ArrayList(struct { item: ProductsItem, key: i32 }).init(std.heap.page_allocator); for (products) |p| { _tmp0.append(.{ .item = p, .key = -p.price }) catch |err| handleError(err); } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(ProductsItem).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch |err| handleError(err); } const _tmp2 = _tmp1.toOwnedSlice() catch |err| handleError(err); _tmp2 = _slice_list(ProductsItem, _tmp2, 1, (1 + 3), 1); break :blk0 _tmp2; }; // []const ProductsItem
 
 pub fn main() void {
     std.debug.print("--- Top products (excluding most expensive) ---\n", .{});

--- a/tests/machine/x/zig/dataset_where_filter.zig
+++ b/tests/machine/x/zig/dataset_where_filter.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const PeopleItem = struct {
     name: []const u8,
     age: i32,
@@ -21,7 +25,7 @@ const people = &[_]PeopleItem{
     .name = "Diana",
     .age = 45,
 },
-}; // []const PeopleItem
+}; // []const Peopleitem
 const adults = blk0: { var _tmp0 = std.ArrayList(struct {
     name: []const u8,
     age: i32,
@@ -34,7 +38,7 @@ const adults = blk0: { var _tmp0 = std.ArrayList(struct {
     .name = person.name,
     .age = person.age,
     .is_senior = (person.age >= 60),
-}) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Adults ---\n", .{});

--- a/tests/machine/x/zig/exists_builtin.zig
+++ b/tests/machine/x/zig/exists_builtin.zig
@@ -1,10 +1,14 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const data = &[_]i32{
     1,
     2,
 }; // []const i32
-const flag = (blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (data) |x| { if (!((x == 1))) continue; _tmp0.append(x) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }).len != 0; // bool
+const flag = (blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (data) |x| { if (!((x == 1))) continue; _tmp0.append(x) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }).len != 0; // bool
 
 pub fn main() void {
     std.debug.print("{}\n", .{flag});

--- a/tests/machine/x/zig/for_map_collection.zig
+++ b/tests/machine/x/zig/for_map_collection.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 var m: std.StringHashMap(i32) = undefined; // std.StringHashMap(i32)
 
 pub fn main() void {

--- a/tests/machine/x/zig/group_by.zig
+++ b/tests/machine/x/zig/group_by.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _avg_int(v: []const i32) i32 {
     if (v.len == 0) return 0;
     var sum: i32 = 0;
@@ -51,8 +55,8 @@ const people = &[_]PeopleItem{
     .age = 22,
     .city = "Hanoi",
 },
-}; // []const PeopleItem
-const stats = blk1: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator); var _tmp3 = std.StringHashMap(usize).init(std.heap.page_allocator); for (people) |person| { const _tmp4 = person.city; if (_tmp3.get(_tmp4)) |idx| { _tmp2.items[idx].Items.append(person) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(PeopleItem) }{ .key = _tmp4, .Items = std.ArrayList(PeopleItem).init(std.heap.page_allocator) }; g.Items.append(person) catch unreachable; _tmp2.append(g) catch unreachable; _tmp3.put(_tmp4, _tmp2.items.len - 1) catch unreachable; } } var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator);for (_tmp2.items) |g| { _tmp5.append(g) catch unreachable; } var _tmp6 = std.ArrayList(struct {
+}; // []const Peopleitem
+const stats = blk1: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator); var _tmp3 = std.StringHashMap(usize).init(std.heap.page_allocator); for (people) |person| { const _tmp4 = person.city; if (_tmp3.get(_tmp4)) |idx| { _tmp2.items[idx].Items.append(person) catch |err| handleError(err); } else { var g = struct { key: []const u8, Items: std.ArrayList(PeopleItem) }{ .key = _tmp4, .Items = std.ArrayList(PeopleItem).init(std.heap.page_allocator) }; g.Items.append(person) catch |err| handleError(err); _tmp2.append(g) catch |err| handleError(err); _tmp3.put(_tmp4, _tmp2.items.len - 1) catch |err| handleError(err); } } var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator);for (_tmp2.items) |g| { _tmp5.append(g) catch |err| handleError(err); } var _tmp6 = std.ArrayList(struct {
     city: i32,
     count: i32,
     avg_age: f64,
@@ -63,8 +67,8 @@ const stats = blk1: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items:
 }{
     .city = g.key,
     .count = (g.Items.len),
-    .avg_age = _avg_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |p| { _tmp0.append(p.age) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }),
-}) catch unreachable; } const _tmp6Slice = _tmp6.toOwnedSlice() catch unreachable; break :blk1 _tmp6Slice; }; // []const std.StringHashMap(i32)
+    .avg_age = _avg_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |p| { _tmp0.append(p.age) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }),
+}) catch |err| handleError(err); } const _tmp6Slice = _tmp6.toOwnedSlice() catch |err| handleError(err); break :blk1 _tmp6Slice; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- People grouped by city ---\n", .{});

--- a/tests/machine/x/zig/group_by_conditional_sum.zig
+++ b/tests/machine/x/zig/group_by_conditional_sum.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _sum_int(v: []const i32) i32 {
     var sum: i32 = 0;
     for (v) |it| { sum += it; }
@@ -35,8 +39,8 @@ const items = &[_]ItemsItem{
     .val = 20,
     .flag = true,
 },
-}; // []const ItemsItem
-const result = blk2: { var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator); var _tmp5 = std.StringHashMap(usize).init(std.heap.page_allocator); for (items) |i| { const _tmp6 = i.cat; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(ItemsItem) }{ .key = _tmp6, .Items = std.ArrayList(ItemsItem).init(std.heap.page_allocator) }; g.Items.append(i) catch unreachable; _tmp4.append(g) catch unreachable; _tmp5.put(_tmp6, _tmp4.items.len - 1) catch unreachable; } } var _tmp7 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch unreachable; } var _tmp8 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(ItemsItem) }, key: i32 }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(.{ .item = g, .key = g.key }) catch unreachable; } for (0.._tmp8.items.len) |i| { for (i+1.._tmp8.items.len) |j| { if (_tmp8.items[j].key < _tmp8.items[i].key) { const t = _tmp8.items[i]; _tmp8.items[i] = _tmp8.items[j]; _tmp8.items[j] = t; } } } var _tmp9 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp8.items) |p| { _tmp9.append(p.item) catch unreachable; } var _tmp10 = std.ArrayList(struct {
+}; // []const Itemsitem
+const result = blk2: { var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator); var _tmp5 = std.StringHashMap(usize).init(std.heap.page_allocator); for (items) |i| { const _tmp6 = i.cat; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(i) catch |err| handleError(err); } else { var g = struct { key: []const u8, Items: std.ArrayList(ItemsItem) }{ .key = _tmp6, .Items = std.ArrayList(ItemsItem).init(std.heap.page_allocator) }; g.Items.append(i) catch |err| handleError(err); _tmp4.append(g) catch |err| handleError(err); _tmp5.put(_tmp6, _tmp4.items.len - 1) catch |err| handleError(err); } } var _tmp7 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch |err| handleError(err); } var _tmp8 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(ItemsItem) }, key: i32 }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(.{ .item = g, .key = g.key }) catch |err| handleError(err); } for (0.._tmp8.items.len) |i| { for (i+1.._tmp8.items.len) |j| { if (_tmp8.items[j].key < _tmp8.items[i].key) { const t = _tmp8.items[i]; _tmp8.items[i] = _tmp8.items[j]; _tmp8.items[j] = t; } } } var _tmp9 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp8.items) |p| { _tmp9.append(p.item) catch |err| handleError(err); } var _tmp10 = std.ArrayList(struct {
     cat: i32,
     share: f64,
 }).init(std.heap.page_allocator);for (_tmp9.items) |g| { _tmp10.append(struct {
@@ -44,8 +48,8 @@ const result = blk2: { var _tmp4 = std.ArrayList(struct { key: []const u8, Items
     share: f64,
 }{
     .cat = g.key,
-    .share = (_sum_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp0.append(if (x.flag) (x.val) else (0)) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }) / _sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp2.append(x.val) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk1 _tmp3; })),
-}) catch unreachable; } const _tmp10Slice = _tmp10.toOwnedSlice() catch unreachable; break :blk2 _tmp10Slice; }; // []const std.StringHashMap(i32)
+    .share = (_sum_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp0.append(if (x.flag) (x.val) else (0)) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }) / _sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp2.append(x.val) catch |err| handleError(err); } const _tmp3 = _tmp2.toOwnedSlice() catch |err| handleError(err); break :blk1 _tmp3; })),
+}) catch |err| handleError(err); } const _tmp10Slice = _tmp10.toOwnedSlice() catch |err| handleError(err); break :blk2 _tmp10Slice; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("{any}\n", .{result});

--- a/tests/machine/x/zig/group_by_having.zig
+++ b/tests/machine/x/zig/group_by_having.zig
@@ -1,9 +1,13 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _json(v: anytype) void {
     var buf = std.ArrayList(u8).init(std.heap.page_allocator);
     defer buf.deinit();
-    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.json.stringify(v, .{}, buf.writer()) catch |err| handleError(err);
     std.debug.print("{s}\n", .{buf.items});
 }
 
@@ -48,8 +52,8 @@ const people = &[_]PeopleItem{
     .name = "George",
     .city = "Paris",
 },
-}; // []const PeopleItem
-const big = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator); var _tmp1 = std.StringHashMap(usize).init(std.heap.page_allocator); for (people) |p| { const _tmp2 = p.city; if (_tmp1.get(_tmp2)) |idx| { _tmp0.items[idx].Items.append(p) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(PeopleItem) }{ .key = _tmp2, .Items = std.ArrayList(PeopleItem).init(std.heap.page_allocator) }; g.Items.append(p) catch unreachable; _tmp0.append(g) catch unreachable; _tmp1.put(_tmp2, _tmp0.items.len - 1) catch unreachable; } } var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator);for (_tmp0.items) |g| { if (!(((g.Items.len) >= 4))) continue; _tmp3.append(g) catch unreachable; } var _tmp4 = std.ArrayList(struct {
+}; // []const Peopleitem
+const big = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator); var _tmp1 = std.StringHashMap(usize).init(std.heap.page_allocator); for (people) |p| { const _tmp2 = p.city; if (_tmp1.get(_tmp2)) |idx| { _tmp0.items[idx].Items.append(p) catch |err| handleError(err); } else { var g = struct { key: []const u8, Items: std.ArrayList(PeopleItem) }{ .key = _tmp2, .Items = std.ArrayList(PeopleItem).init(std.heap.page_allocator) }; g.Items.append(p) catch |err| handleError(err); _tmp0.append(g) catch |err| handleError(err); _tmp1.put(_tmp2, _tmp0.items.len - 1) catch |err| handleError(err); } } var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(PeopleItem) }).init(std.heap.page_allocator);for (_tmp0.items) |g| { if (!(((g.Items.len) >= 4))) continue; _tmp3.append(g) catch |err| handleError(err); } var _tmp4 = std.ArrayList(struct {
     city: i32,
     num: i32,
 }).init(std.heap.page_allocator);for (_tmp3.items) |g| { _tmp4.append(struct {
@@ -58,7 +62,7 @@ const big = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items: s
 }{
     .city = g.key,
     .num = (g.Items.len),
-}) catch unreachable; } const _tmp4Slice = _tmp4.toOwnedSlice() catch unreachable; break :blk0 _tmp4Slice; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } const _tmp4Slice = _tmp4.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp4Slice; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     _json(big);

--- a/tests/machine/x/zig/group_by_join.zig
+++ b/tests/machine/x/zig/group_by_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _equal(a: anytype, b: anytype) bool {
     if (@TypeOf(a) != @TypeOf(b)) return false;
     return switch (@typeInfo(@TypeOf(a))) {
@@ -21,7 +25,7 @@ const customers = &[_]CustomersItem{
     .id = 2,
     .name = "Bob",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -39,8 +43,8 @@ const orders = &[_]OrdersItem{
     .id = 102,
     .customerId = 2,
 },
-}; // []const OrdersItem
-const stats = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(OrdersItem) }).init(std.heap.page_allocator); var _tmp1 = std.StringHashMap(usize).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; const _tmp2 = c.name; if (_tmp1.get(_tmp2)) |idx| { _tmp0.items[idx].Items.append(o) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(OrdersItem) }{ .key = _tmp2, .Items = std.ArrayList(OrdersItem).init(std.heap.page_allocator) }; g.Items.append(o) catch unreachable; _tmp0.append(g) catch unreachable; _tmp1.put(_tmp2, _tmp0.items.len - 1) catch unreachable; } } } var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(OrdersItem) }).init(std.heap.page_allocator);for (_tmp0.items) |g| { _tmp3.append(g) catch unreachable; } var _tmp4 = std.ArrayList(struct {
+}; // []const Ordersitem
+const stats = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(OrdersItem) }).init(std.heap.page_allocator); var _tmp1 = std.StringHashMap(usize).init(std.heap.page_allocator); for (orders) |o| { for (customers) |c| { if (!((o.customerId == c.id))) continue; const _tmp2 = c.name; if (_tmp1.get(_tmp2)) |idx| { _tmp0.items[idx].Items.append(o) catch |err| handleError(err); } else { var g = struct { key: []const u8, Items: std.ArrayList(OrdersItem) }{ .key = _tmp2, .Items = std.ArrayList(OrdersItem).init(std.heap.page_allocator) }; g.Items.append(o) catch |err| handleError(err); _tmp0.append(g) catch |err| handleError(err); _tmp1.put(_tmp2, _tmp0.items.len - 1) catch |err| handleError(err); } } } var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(OrdersItem) }).init(std.heap.page_allocator);for (_tmp0.items) |g| { _tmp3.append(g) catch |err| handleError(err); } var _tmp4 = std.ArrayList(struct {
     name: i32,
     count: i32,
 }).init(std.heap.page_allocator);for (_tmp3.items) |g| { _tmp4.append(struct {
@@ -49,7 +53,7 @@ const stats = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items:
 }{
     .name = g.key,
     .count = (g.Items.len),
-}) catch unreachable; } const _tmp4Slice = _tmp4.toOwnedSlice() catch unreachable; break :blk0 _tmp4Slice; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } const _tmp4Slice = _tmp4.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp4Slice; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Orders per customer ---\n", .{});

--- a/tests/machine/x/zig/group_by_left_join.zig
+++ b/tests/machine/x/zig/group_by_left_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _equal(a: anytype, b: anytype) bool {
     if (@TypeOf(a) != @TypeOf(b)) return false;
     return switch (@typeInfo(@TypeOf(a))) {
@@ -25,7 +29,7 @@ const customers = &[_]CustomersItem{
     .id = 3,
     .name = "Charlie",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -43,8 +47,8 @@ const orders = &[_]OrdersItem{
     .id = 102,
     .customerId = 2,
 },
-}; // []const OrdersItem
-const stats = blk1: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(CustomersItem) }).init(std.heap.page_allocator); var _tmp3 = std.StringHashMap(usize).init(std.heap.page_allocator); for (customers) |c| { for (orders) |o| { if (!((o.customerId == c.id))) continue; const _tmp4 = c.name; if (_tmp3.get(_tmp4)) |idx| { _tmp2.items[idx].Items.append(c) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(CustomersItem) }{ .key = _tmp4, .Items = std.ArrayList(CustomersItem).init(std.heap.page_allocator) }; g.Items.append(c) catch unreachable; _tmp2.append(g) catch unreachable; _tmp3.put(_tmp4, _tmp2.items.len - 1) catch unreachable; } } } var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(CustomersItem) }).init(std.heap.page_allocator);for (_tmp2.items) |g| { _tmp5.append(g) catch unreachable; } var _tmp6 = std.ArrayList(struct {
+}; // []const Ordersitem
+const stats = blk1: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(CustomersItem) }).init(std.heap.page_allocator); var _tmp3 = std.StringHashMap(usize).init(std.heap.page_allocator); for (customers) |c| { for (orders) |o| { if (!((o.customerId == c.id))) continue; const _tmp4 = c.name; if (_tmp3.get(_tmp4)) |idx| { _tmp2.items[idx].Items.append(c) catch |err| handleError(err); } else { var g = struct { key: []const u8, Items: std.ArrayList(CustomersItem) }{ .key = _tmp4, .Items = std.ArrayList(CustomersItem).init(std.heap.page_allocator) }; g.Items.append(c) catch |err| handleError(err); _tmp2.append(g) catch |err| handleError(err); _tmp3.put(_tmp4, _tmp2.items.len - 1) catch |err| handleError(err); } } } var _tmp5 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(CustomersItem) }).init(std.heap.page_allocator);for (_tmp2.items) |g| { _tmp5.append(g) catch |err| handleError(err); } var _tmp6 = std.ArrayList(struct {
     name: i32,
     count: i32,
 }).init(std.heap.page_allocator);for (_tmp5.items) |g| { _tmp6.append(struct {
@@ -52,8 +56,8 @@ const stats = blk1: { var _tmp2 = std.ArrayList(struct { key: []const u8, Items:
     count: i32,
 }{
     .name = g.key,
-    .count = (blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { if (!(r.o)) continue; _tmp0.append(r) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }).len,
-}) catch unreachable; } const _tmp6Slice = _tmp6.toOwnedSlice() catch unreachable; break :blk1 _tmp6Slice; }; // []const i32
+    .count = (blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { if (!(r.o)) continue; _tmp0.append(r) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }).len,
+}) catch |err| handleError(err); } const _tmp6Slice = _tmp6.toOwnedSlice() catch |err| handleError(err); break :blk1 _tmp6Slice; }; // []const i32
 
 pub fn main() void {
     std.debug.print("--- Group Left Join ---\n", .{});

--- a/tests/machine/x/zig/group_by_multi_join.zig
+++ b/tests/machine/x/zig/group_by_multi_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _sum_int(v: []const i32) i32 {
     var sum: i32 = 0;
     for (v) |it| { sum += it; }
@@ -27,7 +31,7 @@ const nations = &[_]NationsItem{
     .id = 2,
     .name = "B",
 },
-}; // []const NationsItem
+}; // []const Nationsitem
 const SuppliersItem = struct {
     id: i32,
     nation: i32,
@@ -41,7 +45,7 @@ const suppliers = &[_]SuppliersItem{
     .id = 2,
     .nation = 2,
 },
-}; // []const SuppliersItem
+}; // []const Suppliersitem
 const PartsuppItem = struct {
     part: i32,
     supplier: i32,
@@ -67,7 +71,7 @@ const partsupp = &[_]PartsuppItem{
     .cost = 5.0,
     .qty = 3,
 },
-}; // []const PartsuppItem
+}; // []const Partsuppitem
 const filtered = blk0: { var _tmp0 = std.ArrayList(struct {
     part: i32,
     value: f64,
@@ -77,8 +81,8 @@ const filtered = blk0: { var _tmp0 = std.ArrayList(struct {
 }{
     .part = ps.part,
     .value = (ps.cost * ps.qty),
-}) catch unreachable; } } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
-const grouped = blk2: { var _tmp4 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator); var _tmp5 = std.AutoHashMap(i32, usize).init(std.heap.page_allocator); for (filtered) |x| { const _tmp6 = x.part; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(x) catch unreachable; } else { var g = struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }{ .key = _tmp6, .Items = std.ArrayList(std.StringHashMap(i32)).init(std.heap.page_allocator) }; g.Items.append(x) catch unreachable; _tmp4.append(g) catch unreachable; _tmp5.put(_tmp6, _tmp4.items.len - 1) catch unreachable; } } var _tmp7 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch unreachable; } var _tmp8 = std.ArrayList(struct {
+}) catch |err| handleError(err); } } } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
+const grouped = blk2: { var _tmp4 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator); var _tmp5 = std.AutoHashMap(i32, usize).init(std.heap.page_allocator); for (filtered) |x| { const _tmp6 = x.part; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(x) catch |err| handleError(err); } else { var g = struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }{ .key = _tmp6, .Items = std.ArrayList(std.StringHashMap(i32)).init(std.heap.page_allocator) }; g.Items.append(x) catch |err| handleError(err); _tmp4.append(g) catch |err| handleError(err); _tmp5.put(_tmp6, _tmp4.items.len - 1) catch |err| handleError(err); } } var _tmp7 = std.ArrayList(struct { key: i32, Items: std.ArrayList(std.StringHashMap(i32)) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch |err| handleError(err); } var _tmp8 = std.ArrayList(struct {
     part: i32,
     total: f64,
 }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(struct {
@@ -86,8 +90,8 @@ const grouped = blk2: { var _tmp4 = std.ArrayList(struct { key: i32, Items: std.
     total: f64,
 }{
     .part = g.key,
-    .total = _sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { _tmp2.append(r.value) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk1 _tmp3; }),
-}) catch unreachable; } const _tmp8Slice = _tmp8.toOwnedSlice() catch unreachable; break :blk2 _tmp8Slice; }; // []const std.StringHashMap(i32)
+    .total = _sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |r| { _tmp2.append(r.value) catch |err| handleError(err); } const _tmp3 = _tmp2.toOwnedSlice() catch |err| handleError(err); break :blk1 _tmp3; }),
+}) catch |err| handleError(err); } const _tmp8Slice = _tmp8.toOwnedSlice() catch |err| handleError(err); break :blk2 _tmp8Slice; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("{any}\n", .{grouped});

--- a/tests/machine/x/zig/group_by_multi_join_sort.zig
+++ b/tests/machine/x/zig/group_by_multi_join_sort.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _sum_int(v: []const i32) i32 {
     var sum: i32 = 0;
     for (v) |it| { sum += it; }
@@ -21,7 +25,7 @@ const NationItem = struct {
 const nation = &[_]NationItem{NationItem{
     .n_nationkey = 1,
     .n_name = "BRAZIL",
-}}; // []const NationItem
+}}; // []const Nationitem
 const CustomerItem = struct {
     c_custkey: i32,
     c_name: []const u8,
@@ -39,7 +43,7 @@ const customer = &[_]CustomerItem{CustomerItem{
     .c_address = "123 St",
     .c_phone = "123-456",
     .c_comment = "Loyal",
-}}; // []const CustomerItem
+}}; // []const Customeritem
 const OrdersItem = struct {
     o_orderkey: i32,
     o_custkey: i32,
@@ -56,7 +60,7 @@ const orders = &[_]OrdersItem{
     .o_custkey = 1,
     .o_orderdate = "1994-01-02",
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const LineitemItem = struct {
     l_orderkey: i32,
     l_returnflag: []const u8,
@@ -76,7 +80,7 @@ const lineitem = &[_]LineitemItem{
     .l_extendedprice = 500.0,
     .l_discount = 0.0,
 },
-}; // []const LineitemItem
+}; // []const Lineitemitem
 const start_date = "1993-10-01"; // []const u8
 const end_date = "1994-01-01"; // []const u8
 const result = blk2: { var _tmp4 = std.ArrayList(struct { key: struct {
@@ -111,7 +115,7 @@ const result = blk2: { var _tmp4 = std.ArrayList(struct { key: struct {
     .c_phone = c.c_phone,
     .c_comment = c.c_comment,
     .n_name = n.n_name,
-}; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(c) catch unreachable; } else { var g = struct { key: struct {
+}; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(c) catch |err| handleError(err); } else { var g = struct { key: struct {
     c_custkey: i32,
     c_name: []const u8,
     c_acctbal: f64,
@@ -119,7 +123,7 @@ const result = blk2: { var _tmp4 = std.ArrayList(struct { key: struct {
     c_phone: []const u8,
     c_comment: []const u8,
     n_name: []const u8,
-}, Items: std.ArrayList(CustomerItem) }{ .key = _tmp6, .Items = std.ArrayList(CustomerItem).init(std.heap.page_allocator) }; g.Items.append(c) catch unreachable; _tmp4.append(g) catch unreachable; _tmp5.put(_tmp6, _tmp4.items.len - 1) catch unreachable; } } } } } var _tmp7 = std.ArrayList(struct { key: struct {
+}, Items: std.ArrayList(CustomerItem) }{ .key = _tmp6, .Items = std.ArrayList(CustomerItem).init(std.heap.page_allocator) }; g.Items.append(c) catch |err| handleError(err); _tmp4.append(g) catch |err| handleError(err); _tmp5.put(_tmp6, _tmp4.items.len - 1) catch |err| handleError(err); } } } } } var _tmp7 = std.ArrayList(struct { key: struct {
     c_custkey: i32,
     c_name: []const u8,
     c_acctbal: f64,
@@ -127,7 +131,7 @@ const result = blk2: { var _tmp4 = std.ArrayList(struct { key: struct {
     c_phone: []const u8,
     c_comment: []const u8,
     n_name: []const u8,
-}, Items: std.ArrayList(CustomerItem) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch unreachable; } var _tmp8 = std.ArrayList(struct { item: struct { key: struct {
+}, Items: std.ArrayList(CustomerItem) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch |err| handleError(err); } var _tmp8 = std.ArrayList(struct { item: struct { key: struct {
     c_custkey: i32,
     c_name: []const u8,
     c_acctbal: f64,
@@ -135,7 +139,7 @@ const result = blk2: { var _tmp4 = std.ArrayList(struct { key: struct {
     c_phone: []const u8,
     c_comment: []const u8,
     n_name: []const u8,
-}, Items: std.ArrayList(CustomerItem) }, key: i32 }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(.{ .item = g, .key = -_sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp2.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk1 _tmp3; }) }) catch unreachable; } for (0.._tmp8.items.len) |i| { for (i+1.._tmp8.items.len) |j| { if (_tmp8.items[j].key < _tmp8.items[i].key) { const t = _tmp8.items[i]; _tmp8.items[i] = _tmp8.items[j]; _tmp8.items[j] = t; } } } var _tmp9 = std.ArrayList(struct { key: struct {
+}, Items: std.ArrayList(CustomerItem) }, key: i32 }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(.{ .item = g, .key = -_sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp2.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch |err| handleError(err); } const _tmp3 = _tmp2.toOwnedSlice() catch |err| handleError(err); break :blk1 _tmp3; }) }) catch |err| handleError(err); } for (0.._tmp8.items.len) |i| { for (i+1.._tmp8.items.len) |j| { if (_tmp8.items[j].key < _tmp8.items[i].key) { const t = _tmp8.items[i]; _tmp8.items[i] = _tmp8.items[j]; _tmp8.items[j] = t; } } } var _tmp9 = std.ArrayList(struct { key: struct {
     c_custkey: i32,
     c_name: []const u8,
     c_acctbal: f64,
@@ -143,7 +147,7 @@ const result = blk2: { var _tmp4 = std.ArrayList(struct { key: struct {
     c_phone: []const u8,
     c_comment: []const u8,
     n_name: []const u8,
-}, Items: std.ArrayList(CustomerItem) }).init(std.heap.page_allocator);for (_tmp8.items) |p| { _tmp9.append(p.item) catch unreachable; } var _tmp10 = std.ArrayList(struct {
+}, Items: std.ArrayList(CustomerItem) }).init(std.heap.page_allocator);for (_tmp8.items) |p| { _tmp9.append(p.item) catch |err| handleError(err); } var _tmp10 = std.ArrayList(struct {
     c_custkey: i32,
     c_name: i32,
     revenue: i32,
@@ -164,13 +168,13 @@ const result = blk2: { var _tmp4 = std.ArrayList(struct { key: struct {
 }{
     .c_custkey = g.key.c_custkey,
     .c_name = g.key.c_name,
-    .revenue = _sum_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp0.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }),
+    .revenue = _sum_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp0.append((x.l.l_extendedprice * ((1 - x.l.l_discount)))) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }),
     .c_acctbal = g.key.c_acctbal,
     .n_name = g.key.n_name,
     .c_address = g.key.c_address,
     .c_phone = g.key.c_phone,
     .c_comment = g.key.c_comment,
-}) catch unreachable; } const _tmp10Slice = _tmp10.toOwnedSlice() catch unreachable; break :blk2 _tmp10Slice; }; // []const i32
+}) catch |err| handleError(err); } const _tmp10Slice = _tmp10.toOwnedSlice() catch |err| handleError(err); break :blk2 _tmp10Slice; }; // []const i32
 
 pub fn main() void {
     std.debug.print("{any}\n", .{result});

--- a/tests/machine/x/zig/group_by_sort.zig
+++ b/tests/machine/x/zig/group_by_sort.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _sum_int(v: []const i32) i32 {
     var sum: i32 = 0;
     for (v) |it| { sum += it; }
@@ -35,8 +39,8 @@ const items = &[_]ItemsItem{
     .cat = "b",
     .val = 2,
 },
-}; // []const ItemsItem
-const grouped = blk2: { var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator); var _tmp5 = std.StringHashMap(usize).init(std.heap.page_allocator); for (items) |i| { const _tmp6 = i.cat; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(i) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(ItemsItem) }{ .key = _tmp6, .Items = std.ArrayList(ItemsItem).init(std.heap.page_allocator) }; g.Items.append(i) catch unreachable; _tmp4.append(g) catch unreachable; _tmp5.put(_tmp6, _tmp4.items.len - 1) catch unreachable; } } var _tmp7 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch unreachable; } var _tmp8 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(ItemsItem) }, key: i32 }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(.{ .item = g, .key = -_sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp2.append(x.val) catch unreachable; } const _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk1 _tmp3; }) }) catch unreachable; } for (0.._tmp8.items.len) |i| { for (i+1.._tmp8.items.len) |j| { if (_tmp8.items[j].key < _tmp8.items[i].key) { const t = _tmp8.items[i]; _tmp8.items[i] = _tmp8.items[j]; _tmp8.items[j] = t; } } } var _tmp9 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp8.items) |p| { _tmp9.append(p.item) catch unreachable; } var _tmp10 = std.ArrayList(struct {
+}; // []const Itemsitem
+const grouped = blk2: { var _tmp4 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator); var _tmp5 = std.StringHashMap(usize).init(std.heap.page_allocator); for (items) |i| { const _tmp6 = i.cat; if (_tmp5.get(_tmp6)) |idx| { _tmp4.items[idx].Items.append(i) catch |err| handleError(err); } else { var g = struct { key: []const u8, Items: std.ArrayList(ItemsItem) }{ .key = _tmp6, .Items = std.ArrayList(ItemsItem).init(std.heap.page_allocator) }; g.Items.append(i) catch |err| handleError(err); _tmp4.append(g) catch |err| handleError(err); _tmp5.put(_tmp6, _tmp4.items.len - 1) catch |err| handleError(err); } } var _tmp7 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp4.items) |g| { _tmp7.append(g) catch |err| handleError(err); } var _tmp8 = std.ArrayList(struct { item: struct { key: []const u8, Items: std.ArrayList(ItemsItem) }, key: i32 }).init(std.heap.page_allocator);for (_tmp7.items) |g| { _tmp8.append(.{ .item = g, .key = -_sum_int(blk1: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp2.append(x.val) catch |err| handleError(err); } const _tmp3 = _tmp2.toOwnedSlice() catch |err| handleError(err); break :blk1 _tmp3; }) }) catch |err| handleError(err); } for (0.._tmp8.items.len) |i| { for (i+1.._tmp8.items.len) |j| { if (_tmp8.items[j].key < _tmp8.items[i].key) { const t = _tmp8.items[i]; _tmp8.items[i] = _tmp8.items[j]; _tmp8.items[j] = t; } } } var _tmp9 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(ItemsItem) }).init(std.heap.page_allocator);for (_tmp8.items) |p| { _tmp9.append(p.item) catch |err| handleError(err); } var _tmp10 = std.ArrayList(struct {
     cat: i32,
     total: f64,
 }).init(std.heap.page_allocator);for (_tmp9.items) |g| { _tmp10.append(struct {
@@ -44,8 +48,8 @@ const grouped = blk2: { var _tmp4 = std.ArrayList(struct { key: []const u8, Item
     total: f64,
 }{
     .cat = g.key,
-    .total = _sum_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp0.append(x.val) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }),
-}) catch unreachable; } const _tmp10Slice = _tmp10.toOwnedSlice() catch unreachable; break :blk2 _tmp10Slice; }; // []const std.StringHashMap(i32)
+    .total = _sum_int(blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp0.append(x.val) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }),
+}) catch |err| handleError(err); } const _tmp10Slice = _tmp10.toOwnedSlice() catch |err| handleError(err); break :blk2 _tmp10Slice; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("{any}\n", .{grouped});

--- a/tests/machine/x/zig/group_items_iteration.zig
+++ b/tests/machine/x/zig/group_items_iteration.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _equal(a: anytype, b: anytype) bool {
     if (@TypeOf(a) != @TypeOf(b)) return false;
     return switch (@typeInfo(@TypeOf(a))) {
@@ -25,10 +29,10 @@ const data = &[_]DataItem{
     .tag = "b",
     .val = 3,
 },
-}; // []const DataItem
-const groups = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(DataItem) }).init(std.heap.page_allocator); var _tmp1 = std.StringHashMap(usize).init(std.heap.page_allocator); for (data) |d| { const _tmp2 = d.tag; if (_tmp1.get(_tmp2)) |idx| { _tmp0.items[idx].Items.append(d) catch unreachable; } else { var g = struct { key: []const u8, Items: std.ArrayList(DataItem) }{ .key = _tmp2, .Items = std.ArrayList(DataItem).init(std.heap.page_allocator) }; g.Items.append(d) catch unreachable; _tmp0.append(g) catch unreachable; _tmp1.put(_tmp2, _tmp0.items.len - 1) catch unreachable; } } var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(DataItem) }).init(std.heap.page_allocator);for (_tmp0.items) |g| { _tmp3.append(g) catch unreachable; } var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp3.items) |g| { _tmp4.append(g) catch unreachable; } const _tmp4Slice = _tmp4.toOwnedSlice() catch unreachable; break :blk0 _tmp4Slice; }; // []const i32
+}; // []const Dataitem
+const groups = blk0: { var _tmp0 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(DataItem) }).init(std.heap.page_allocator); var _tmp1 = std.StringHashMap(usize).init(std.heap.page_allocator); for (data) |d| { const _tmp2 = d.tag; if (_tmp1.get(_tmp2)) |idx| { _tmp0.items[idx].Items.append(d) catch |err| handleError(err); } else { var g = struct { key: []const u8, Items: std.ArrayList(DataItem) }{ .key = _tmp2, .Items = std.ArrayList(DataItem).init(std.heap.page_allocator) }; g.Items.append(d) catch |err| handleError(err); _tmp0.append(g) catch |err| handleError(err); _tmp1.put(_tmp2, _tmp0.items.len - 1) catch |err| handleError(err); } } var _tmp3 = std.ArrayList(struct { key: []const u8, Items: std.ArrayList(DataItem) }).init(std.heap.page_allocator);for (_tmp0.items) |g| { _tmp3.append(g) catch |err| handleError(err); } var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp3.items) |g| { _tmp4.append(g) catch |err| handleError(err); } const _tmp4Slice = _tmp4.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp4Slice; }; // []const i32
 var tmp = &[]i32{}; // []const i32
-const result = blk1: { var _tmp5 = std.ArrayList(struct { item: i32, key: i32 }).init(std.heap.page_allocator); for (tmp) |r| { _tmp5.append(.{ .item = r, .key = r.tag }) catch unreachable; } for (0.._tmp5.items.len) |i| { for (i+1.._tmp5.items.len) |j| { if (_tmp5.items[j].key < _tmp5.items[i].key) { const t = _tmp5.items[i]; _tmp5.items[i] = _tmp5.items[j]; _tmp5.items[j] = t; } } } var _tmp6 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp5.items) |p| { _tmp6.append(p.item) catch unreachable; } const _tmp7 = _tmp6.toOwnedSlice() catch unreachable; break :blk1 _tmp7; }; // []const i32
+const result = blk1: { var _tmp5 = std.ArrayList(struct { item: i32, key: i32 }).init(std.heap.page_allocator); for (tmp) |r| { _tmp5.append(.{ .item = r, .key = r.tag }) catch |err| handleError(err); } for (0.._tmp5.items.len) |i| { for (i+1.._tmp5.items.len) |j| { if (_tmp5.items[j].key < _tmp5.items[i].key) { const t = _tmp5.items[i]; _tmp5.items[i] = _tmp5.items[j]; _tmp5.items[j] = t; } } } var _tmp6 = std.ArrayList(i32).init(std.heap.page_allocator);for (_tmp5.items) |p| { _tmp6.append(p.item) catch |err| handleError(err); } const _tmp7 = _tmp6.toOwnedSlice() catch |err| handleError(err); break :blk1 _tmp7; }; // []const i32
 
 pub fn main() void {
     for (groups) |g| {
@@ -36,13 +40,13 @@ pub fn main() void {
         for (g.items) |x| {
             total = (total + x.val);
         }
-        tmp = blk2: { var _tmp8 = std.ArrayList(i32).init(std.heap.page_allocator); defer _tmp8.deinit(); _tmp8.appendSlice(tmp) catch unreachable; _tmp8.append(struct {
+        tmp = blk2: { var _tmp8 = std.ArrayList(i32).init(std.heap.page_allocator); defer _tmp8.deinit(); _tmp8.appendSlice(tmp) catch |err| handleError(err); _tmp8.append(struct {
     tag: []const u8,
     total: i32,
 }{
     .tag = g.key,
     .total = total,
-}) catch unreachable; break :blk2 _tmp8.items; };
+}) catch |err| handleError(err); break :blk2 _tmp8.items; };
     }
     std.debug.print("{any}\n", .{result});
 }

--- a/tests/machine/x/zig/in_operator_extended.zig
+++ b/tests/machine/x/zig/in_operator_extended.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _contains_list_int(v: []const i32, item: i32) bool {
     for (v) |it| { if (it == item) return true; }
     return false;
@@ -10,7 +14,7 @@ const xs = &[_]i32{
     2,
     3,
 }; // []const i32
-const ys = blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (xs) |x| { if (!((@mod(x, 2) == 1))) continue; _tmp0.append(x) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const i32
+const ys = blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (xs) |x| { if (!((@mod(x, 2) == 1))) continue; _tmp0.append(x) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const i32
 const M = struct { a: i32, };
 const m = M{ .a = 1 }; // M
 const s = "hello"; // []const u8

--- a/tests/machine/x/zig/inner_join.zig
+++ b/tests/machine/x/zig/inner_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const CustomersItem = struct {
     id: i32,
     name: []const u8,
@@ -17,7 +21,7 @@ const customers = &[_]CustomersItem{
     .id = 3,
     .name = "Charlie",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -44,7 +48,7 @@ const orders = &[_]OrdersItem{
     .customerId = 4,
     .total = 80,
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const result = blk0: { var _tmp0 = std.ArrayList(struct {
     orderId: i32,
     customerName: []const u8,
@@ -57,7 +61,7 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
     .orderId = o.id,
     .customerName = c.name,
     .total = o.total,
-}) catch unreachable; } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Orders with customer info ---\n", .{});

--- a/tests/machine/x/zig/join_multi.zig
+++ b/tests/machine/x/zig/join_multi.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const CustomersItem = struct {
     id: i32,
     name: []const u8,
@@ -13,7 +17,7 @@ const customers = &[_]CustomersItem{
     .id = 2,
     .name = "Bob",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -27,7 +31,7 @@ const orders = &[_]OrdersItem{
     .id = 101,
     .customerId = 2,
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const ItemsItem = struct {
     orderId: i32,
     sku: []const u8,
@@ -41,7 +45,7 @@ const items = &[_]ItemsItem{
     .orderId = 101,
     .sku = "b",
 },
-}; // []const ItemsItem
+}; // []const Itemsitem
 const result = blk0: { var _tmp0 = std.ArrayList(struct {
     name: []const u8,
     sku: []const u8,
@@ -51,7 +55,7 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
 }{
     .name = c.name,
     .sku = i.sku,
-}) catch unreachable; } } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap([]const u8)
+}) catch |err| handleError(err); } } } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap([]const u8)
 
 pub fn main() void {
     std.debug.print("--- Multi Join ---\n", .{});

--- a/tests/machine/x/zig/json_builtin.zig
+++ b/tests/machine/x/zig/json_builtin.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 fn _json(v: anytype) void {
     var buf = std.ArrayList(u8).init(std.heap.page_allocator);
     defer buf.deinit();
-    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.json.stringify(v, .{}, buf.writer()) catch |err| handleError(err);
     std.debug.print("{s}\n", .{buf.items});
 }
 

--- a/tests/machine/x/zig/left_join.zig
+++ b/tests/machine/x/zig/left_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const CustomersItem = struct {
     id: i32,
     name: []const u8,
@@ -13,7 +17,7 @@ const customers = &[_]CustomersItem{
     .id = 2,
     .name = "Bob",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -30,7 +34,7 @@ const orders = &[_]OrdersItem{
     .customerId = 3,
     .total = 80,
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const result = blk0: { var _tmp0 = std.ArrayList(struct {
     orderId: i32,
     customer: CustomersItem,
@@ -43,7 +47,7 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
     .orderId = o.id,
     .customer = c,
     .total = o.total,
-}) catch unreachable; } if (!matched) { const c: ?CustomersItem = null; _tmp0.append(struct {
+}) catch |err| handleError(err); } if (!matched) { const c: ?CustomersItem = null; _tmp0.append(struct {
     orderId: i32,
     customer: CustomersItem,
     total: i32,
@@ -51,7 +55,7 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
     .orderId = o.id,
     .customer = c,
     .total = o.total,
-}) catch unreachable; } } const res = _tmp0.toOwnedSlice() catch unreachable; break :blk0 res; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } const res = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 res; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Left Join ---\n", .{});

--- a/tests/machine/x/zig/left_join_multi.zig
+++ b/tests/machine/x/zig/left_join_multi.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const CustomersItem = struct {
     id: i32,
     name: []const u8,
@@ -13,7 +17,7 @@ const customers = &[_]CustomersItem{
     .id = 2,
     .name = "Bob",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -27,7 +31,7 @@ const orders = &[_]OrdersItem{
     .id = 101,
     .customerId = 2,
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const ItemsItem = struct {
     orderId: i32,
     sku: []const u8,
@@ -35,7 +39,7 @@ const ItemsItem = struct {
 const items = &[_]ItemsItem{ItemsItem{
     .orderId = 100,
     .sku = "a",
-}}; // []const ItemsItem
+}}; // []const Itemsitem
 const result = blk0: { var _tmp0 = std.ArrayList(struct {
     orderId: i32,
     name: []const u8,
@@ -48,7 +52,7 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
     .orderId = o.id,
     .name = c.name,
     .item = i,
-}) catch unreachable; } } } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Left Join Multi ---\n", .{});

--- a/tests/machine/x/zig/list_set_ops.zig
+++ b/tests/machine/x/zig/list_set_ops.zig
@@ -8,31 +8,31 @@ fn _contains(comptime T: type, v: []const T, item: T) bool {
 fn _union_all(comptime T: type, a: []const T, b: []const T) []T {
     var res = std.ArrayList(T).init(std.heap.page_allocator);
     defer res.deinit();
-    for (a) |it| { res.append(it) catch unreachable; }
-    for (b) |it| { res.append(it) catch unreachable; }
-    return res.toOwnedSlice() catch unreachable;
+    for (a) |it| { res.append(it) catch |err| handleError(err); }
+    for (b) |it| { res.append(it) catch |err| handleError(err); }
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 fn _union(comptime T: type, a: []const T, b: []const T) []T {
     var res = std.ArrayList(T).init(std.heap.page_allocator);
     defer res.deinit();
-    for (a) |it| { res.append(it) catch unreachable; }
-    for (b) |it| { if (!_contains(T, res.items, it)) res.append(it) catch unreachable; }
-    return res.toOwnedSlice() catch unreachable;
+    for (a) |it| { res.append(it) catch |err| handleError(err); }
+    for (b) |it| { if (!_contains(T, res.items, it)) res.append(it) catch |err| handleError(err); }
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 fn _except(comptime T: type, a: []const T, b: []const T) []T {
     var res = std.ArrayList(T).init(std.heap.page_allocator);
     defer res.deinit();
-    for (a) |it| { if (!_contains(T, b, it)) res.append(it) catch unreachable; }
-    return res.toOwnedSlice() catch unreachable;
+    for (a) |it| { if (!_contains(T, b, it)) res.append(it) catch |err| handleError(err); }
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 fn _intersect(comptime T: type, a: []const T, b: []const T) []T {
     var res = std.ArrayList(T).init(std.heap.page_allocator);
     defer res.deinit();
-    for (a) |it| { if (_contains(T, b, it) and !_contains(T, res.items, it)) res.append(it) catch unreachable; }
-    return res.toOwnedSlice() catch unreachable;
+    for (a) |it| { if (_contains(T, b, it) and !_contains(T, res.items, it)) res.append(it) catch |err| handleError(err); }
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 pub fn main() void {

--- a/tests/machine/x/zig/load_yaml.zig
+++ b/tests/machine/x/zig/load_yaml.zig
@@ -1,19 +1,23 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _read_input(path: ?[]const u8) []const u8 {
     const alloc = std.heap.page_allocator;
     if (path == null or std.mem.eql(u8, path.?, "-")) {
-        return std.io.getStdIn().readAllAlloc(alloc, 1 << 20) catch unreachable;
+        return std.io.getStdIn().readAllAlloc(alloc, 1 << 20) catch |err| handleError(err);
     } else {
-        return std.fs.cwd().readFileAlloc(alloc, path.?, 1 << 20) catch unreachable;
+        return std.fs.cwd().readFileAlloc(alloc, path.?, 1 << 20) catch |err| handleError(err);
     }
 }
 
 fn _write_output(path: ?[]const u8, data: []const u8) void {
     if (path == null or std.mem.eql(u8, path.?, "-")) {
-        std.io.getStdOut().writeAll(data) catch unreachable;
+        std.io.getStdOut().writeAll(data) catch |err| handleError(err);
     } else {
-        std.fs.cwd().writeFile(path.?, data) catch unreachable;
+        std.fs.cwd().writeFile(path.?, data) catch |err| handleError(err);
     }
 }
 
@@ -38,7 +42,7 @@ const adults = blk0: { var _tmp0 = std.ArrayList(struct {
 }{
     .name = p.name,
     .email = p.email,
-}) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // []const std.StringHashMap([]const u8)
+}) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // []const std.StringHashMap([]const u8)
 
 pub fn main() void {
     for (adults) |a| {

--- a/tests/machine/x/zig/map_assign.zig
+++ b/tests/machine/x/zig/map_assign.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 var scores: std.StringHashMap(i32) = undefined; // std.StringHashMap(i32)
 
 pub fn main() void {
-    _ = scores.put("bob", 2) catch unreachable;
+    _ = scores.put("bob", 2) catch |err| handleError(err);
     std.debug.print("{d}\n", .{scores["bob"]});
 }

--- a/tests/machine/x/zig/map_in_operator.zig
+++ b/tests/machine/x/zig/map_in_operator.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 
-const m = (blk0: { var _map0 = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); _map0.put(1, "a") catch unreachable; _map0.put(2, "b") catch unreachable; break :blk0 _map0; }); // std.AutoHashMap(i32, []const u8)
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
+const m = (blk0: { var _map0 = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); _map0.put(1, "a") catch |err| handleError(err); _map0.put(2, "b") catch |err| handleError(err); break :blk0 _map0; }); // std.AutoHashMap(i32, []const u8)
 
 pub fn main() void {
     std.debug.print("{}\n", .{m.contains(1)});

--- a/tests/machine/x/zig/map_int_key.zig
+++ b/tests/machine/x/zig/map_int_key.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 
-const m = (blk0: { var _map0 = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); _map0.put(1, "a") catch unreachable; _map0.put(2, "b") catch unreachable; break :blk0 _map0; }); // std.AutoHashMap(i32, []const u8)
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
+const m = (blk0: { var _map0 = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); _map0.put(1, "a") catch |err| handleError(err); _map0.put(2, "b") catch |err| handleError(err); break :blk0 _map0; }); // std.AutoHashMap(i32, []const u8)
 
 pub fn main() void {
     std.debug.print("{s}\n", .{m[1]});

--- a/tests/machine/x/zig/map_literal_dynamic.zig
+++ b/tests/machine/x/zig/map_literal_dynamic.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 var x = 3; // i32
 var y = 4; // i32
 var m: std.StringHashMap(i32) = undefined; // std.StringHashMap(i32)

--- a/tests/machine/x/zig/map_nested_assign.zig
+++ b/tests/machine/x/zig/map_nested_assign.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 var data: std.StringHashMap(struct { inner: i32, }) = undefined; // std.StringHashMap(struct { inner: i32, })
 
 pub fn main() void {

--- a/tests/machine/x/zig/order_by_map.zig
+++ b/tests/machine/x/zig/order_by_map.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const DataItem = struct {
     a: i32,
     b: i32,
@@ -17,14 +21,14 @@ const data = &[_]DataItem{
     .a = 0,
     .b = 5,
 },
-}; // []const DataItem
+}; // []const Dataitem
 const sorted = blk0: { var _tmp0 = std.ArrayList(struct { item: DataItem, key: struct {
     a: i32,
     b: i32,
-} }).init(std.heap.page_allocator); for (data) |x| { _tmp0.append(.{ .item = x, .key = DataItem{
+} }).init(std.heap.page_allocator); for (data) |x| { _tmp0.append(.{ .item = x, .key = Dataitem{
     .a = x.a,
     .b = x.b,
-} }) catch unreachable; } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(DataItem).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk0 _tmp2; }; // []const DataItem
+} }) catch |err| handleError(err); } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(DataItem).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch |err| handleError(err); } const _tmp2 = _tmp1.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp2; }; // []const DataItem
 
 pub fn main() void {
     std.debug.print("{any}\n", .{sorted});

--- a/tests/machine/x/zig/outer_join.zig
+++ b/tests/machine/x/zig/outer_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const CustomersItem = struct {
     id: i32,
     name: []const u8,
@@ -21,7 +25,7 @@ const customers = &[_]CustomersItem{
     .id = 4,
     .name = "Diana",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -48,7 +52,7 @@ const orders = &[_]OrdersItem{
     .customerId = 5,
     .total = 80,
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const result = blk0: { var _tmp0 = std.ArrayList(struct {
     order: OrdersItem,
     customer: CustomersItem,
@@ -58,13 +62,13 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
 }{
     .order = o,
     .customer = c,
-}) catch unreachable; } for (customers, 0..) |j, ji| { if (!_tmp1.contains(ji)) { const o: ?OrdersItem = null; c = j; _tmp0.append(struct {
+}) catch |err| handleError(err); } for (customers, 0..) |j, ji| { if (!_tmp1.contains(ji)) { const o: ?OrdersItem = null; c = j; _tmp0.append(struct {
     order: OrdersItem,
     customer: CustomersItem,
 }{
     .order = o,
     .customer = c,
-}) catch unreachable; } } const res = _tmp0.toOwnedSlice() catch unreachable; break :blk0 res; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } const res = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 res; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Outer Join using syntax ---\n", .{});

--- a/tests/machine/x/zig/query_sum_select.zig
+++ b/tests/machine/x/zig/query_sum_select.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 fn _sum_int(v: []const i32) i32 {
     var sum: i32 = 0;
     for (v) |it| { sum += it; }
@@ -11,7 +15,7 @@ const nums = &[_]i32{
     2,
     3,
 }; // []const i32
-const result = blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (nums) |n| { if (!((n > 1))) continue; _tmp0.append(_sum_int(n)) catch unreachable; } const _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk0 _tmp1; }; // f64
+const result = blk0: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (nums) |n| { if (!((n > 1))) continue; _tmp0.append(_sum_int(n)) catch |err| handleError(err); } const _tmp1 = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp1; }; // f64
 
 pub fn main() void {
     std.debug.print("{any}\n", .{result});

--- a/tests/machine/x/zig/right_join.zig
+++ b/tests/machine/x/zig/right_join.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const CustomersItem = struct {
     id: i32,
     name: []const u8,
@@ -21,7 +25,7 @@ const customers = &[_]CustomersItem{
     .id = 4,
     .name = "Diana",
 },
-}; // []const CustomersItem
+}; // []const Customersitem
 const OrdersItem = struct {
     id: i32,
     customerId: i32,
@@ -43,7 +47,7 @@ const orders = &[_]OrdersItem{
     .customerId = 1,
     .total = 300,
 },
-}; // []const OrdersItem
+}; // []const Ordersitem
 const result = blk0: { var _tmp0 = std.ArrayList(struct {
     customerName: []const u8,
     order: OrdersItem,
@@ -53,13 +57,13 @@ const result = blk0: { var _tmp0 = std.ArrayList(struct {
 }{
     .customerName = c.name,
     .order = o,
-}) catch unreachable; } if (!matched) { const c: ?CustomersItem = null; _tmp0.append(struct {
+}) catch |err| handleError(err); } if (!matched) { const c: ?CustomersItem = null; _tmp0.append(struct {
     customerName: []const u8,
     order: OrdersItem,
 }{
     .customerName = c.name,
     .order = o,
-}) catch unreachable; } } const res = _tmp0.toOwnedSlice() catch unreachable; break :blk0 res; }; // []const std.StringHashMap(i32)
+}) catch |err| handleError(err); } } const res = _tmp0.toOwnedSlice() catch |err| handleError(err); break :blk0 res; }; // []const std.StringHashMap(i32)
 
 pub fn main() void {
     std.debug.print("--- Right Join using syntax ---\n", .{});

--- a/tests/machine/x/zig/save_jsonl_stdout.zig
+++ b/tests/machine/x/zig/save_jsonl_stdout.zig
@@ -3,17 +3,17 @@ const std = @import("std");
 fn _read_input(path: ?[]const u8) []const u8 {
     const alloc = std.heap.page_allocator;
     if (path == null or std.mem.eql(u8, path.?, "-")) {
-        return std.io.getStdIn().readAllAlloc(alloc, 1 << 20) catch unreachable;
+        return std.io.getStdIn().readAllAlloc(alloc, 1 << 20) catch |err| handleError(err);
     } else {
-        return std.fs.cwd().readFileAlloc(alloc, path.?, 1 << 20) catch unreachable;
+        return std.fs.cwd().readFileAlloc(alloc, path.?, 1 << 20) catch |err| handleError(err);
     }
 }
 
 fn _write_output(path: ?[]const u8, data: []const u8) void {
     if (path == null or std.mem.eql(u8, path.?, "-")) {
-        std.io.getStdOut().writeAll(data) catch unreachable;
+        std.io.getStdOut().writeAll(data) catch |err| handleError(err);
     } else {
-        std.fs.cwd().writeFile(path.?, data) catch unreachable;
+        std.fs.cwd().writeFile(path.?, data) catch |err| handleError(err);
     }
 }
 
@@ -21,9 +21,9 @@ fn _save_json(rows: anytype, path: ?[]const u8) void {
     var buf = std.ArrayList(u8).init(std.heap.page_allocator);
     defer buf.deinit();
     if (rows.len == 1) {
-        std.json.stringify(rows[0], .{}, buf.writer()) catch unreachable;
+        std.json.stringify(rows[0], .{}, buf.writer()) catch |err| handleError(err);
     } else {
-        std.json.stringify(rows, .{}, buf.writer()) catch unreachable;
+        std.json.stringify(rows, .{}, buf.writer()) catch |err| handleError(err);
     }
     _write_output(path, buf.items);
 }
@@ -41,7 +41,7 @@ const people = &[_]PeopleItem{
     .name = "Bob",
     .age = 25,
 },
-}; // []const PeopleItem
+}; // []const Peopleitem
 
 pub fn main() void {
     _save_json(people, "-");

--- a/tests/machine/x/zig/slice.zig
+++ b/tests/machine/x/zig/slice.zig
@@ -16,9 +16,9 @@ fn _slice_list(comptime T: type, v: []const T, start: i32, end: i32, step: i32) 
     defer res.deinit();
     var i: i32 = s;
     while ((st > 0 and i < e) or (st < 0 and i > e)) : (i += st) {
-        res.append(v[@as(usize, @intCast(i))]) catch unreachable;
+        res.append(v[@as(usize, @intCast(i))]) catch |err| handleError(err);
     }
-    return res.toOwnedSlice() catch unreachable;
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 fn _slice_string(s: []const u8, start: i32, end: i32, step: i32) []const u8 {
@@ -37,9 +37,9 @@ fn _slice_string(s: []const u8, start: i32, end: i32, step: i32) []const u8 {
     defer res.deinit();
     var i: i32 = sidx;
     while ((stp > 0 and i < eidx) or (stp < 0 and i > eidx)) : (i += stp) {
-        res.append(s[@as(usize, @intCast(i))]) catch unreachable;
+        res.append(s[@as(usize, @intCast(i))]) catch |err| handleError(err);
     }
-    return res.toOwnedSlice() catch unreachable;
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 pub fn main() void {

--- a/tests/machine/x/zig/sort_stable.zig
+++ b/tests/machine/x/zig/sort_stable.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
 const ItemsItem = struct {
     n: i32,
     v: []const u8,
@@ -17,8 +21,8 @@ const items = &[_]ItemsItem{
     .n = 2,
     .v = "c",
 },
-}; // []const ItemsItem
-const result = blk0: { var _tmp0 = std.ArrayList(struct { item: u8, key: i32 }).init(std.heap.page_allocator); for (items) |i| { _tmp0.append(.{ .item = i.v, .key = i.n }) catch unreachable; } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(u8).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch unreachable; } const _tmp2 = _tmp1.toOwnedSlice() catch unreachable; break :blk0 _tmp2; }; // []const []const u8
+}; // []const Itemsitem
+const result = blk0: { var _tmp0 = std.ArrayList(struct { item: u8, key: i32 }).init(std.heap.page_allocator); for (items) |i| { _tmp0.append(.{ .item = i.v, .key = i.n }) catch |err| handleError(err); } for (0.._tmp0.items.len) |i| { for (i+1.._tmp0.items.len) |j| { if (_tmp0.items[j].key < _tmp0.items[i].key) { const t = _tmp0.items[i]; _tmp0.items[i] = _tmp0.items[j]; _tmp0.items[j] = t; } } } var _tmp1 = std.ArrayList(u8).init(std.heap.page_allocator);for (_tmp0.items) |p| { _tmp1.append(p.item) catch |err| handleError(err); } const _tmp2 = _tmp1.toOwnedSlice() catch |err| handleError(err); break :blk0 _tmp2; }; // []const []const u8
 
 pub fn main() void {
     std.debug.print("{any}\n", .{result});

--- a/tests/machine/x/zig/string_prefix_slice.zig
+++ b/tests/machine/x/zig/string_prefix_slice.zig
@@ -16,9 +16,9 @@ fn _slice_string(s: []const u8, start: i32, end: i32, step: i32) []const u8 {
     defer res.deinit();
     var i: i32 = sidx;
     while ((stp > 0 and i < eidx) or (stp < 0 and i > eidx)) : (i += stp) {
-        res.append(s[@as(usize, @intCast(i))]) catch unreachable;
+        res.append(s[@as(usize, @intCast(i))]) catch |err| handleError(err);
     }
-    return res.toOwnedSlice() catch unreachable;
+    return res.toOwnedSlice() catch |err| handleError(err);
 }
 
 const prefix = "fore"; // []const u8


### PR DESCRIPTION
## Summary
- add catchHandler to mark need for runtime error handling
- emit handleError helper and use it everywhere
- regenerate Zig machine outputs with error handling
- mark README task as complete

## Testing
- `go test -tags slow ./compiler/x/zig -run TestCompileSmall -count=1`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6871ed54bb508320a460b515d133e15b