### PR TITLE
Improve C backend list handling

### DIFF
--- a/compiler/x/c/helpers.go
+++ b/compiler/x/c/helpers.go
@@ -159,6 +159,15 @@ func isListFloatType(t types.Type) bool {
 	return false
 }
 
+func isListBoolType(t types.Type) bool {
+	if lt, ok := t.(types.ListType); ok {
+		if _, ok2 := lt.Elem.(types.BoolType); ok2 {
+			return true
+		}
+	}
+	return false
+}
+
 func isStringType(t types.Type) bool {
 	_, ok := t.(types.StringType)
 	return ok


### PR DESCRIPTION
## Summary
- expand C helper functions with `isListBoolType`
- treat `len` selector on constant lists with compile-time length
- index bool lists as arrays instead of struct data

## Testing
- `go test ./... -run TestDummy -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6871f0db1430832090e6cb81e7eb3e1b