### PR TITLE
Fix numeric casts in Dart compiler

### DIFF
--- a/compiler/x/dart/compiler.go
+++ b/compiler/x/dart/compiler.go
@@ -721,18 +721,10 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 				rr := r
 				if isNumericOp(op.Op) {
 					if !isNumericType(leftType) {
-						cast := "num"
-						if rightType == (types.IntType{}) {
-							cast = "int"
-						}
-						l = fmt.Sprintf("(%s as %s)", l, cast)
+						l = fmt.Sprintf("(%s as num)", l)
 					}
 					if !isNumericType(rightType) {
-						cast := "num"
-						if leftType == (types.IntType{}) {
-							cast = "int"
-						}
-						rr = fmt.Sprintf("(%s as %s)", rr, cast)
+						rr = fmt.Sprintf("(%s as num)", rr)
 					}
 				}
 				res = fmt.Sprintf("%s %s %s", l, op.Op, rr)


### PR DESCRIPTION
## Summary
- adjust Dart code generation for numeric expressions
- avoid int casts when mixing numeric types

## Testing
- `go test ./compiler/x/dart -run TestDartCompiler_TPCHQueries -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6871f4dd2df48320a33b7b0ec5c994ea