### PR TITLE
Enable Clojure compiler to run TPCH q1

### DIFF
--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -893,8 +893,12 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 		return fmt.Sprintf("(%s %s %s)", opName, left, right), leftType
 	case "%":
 		return fmt.Sprintf("(%s %s %s)", opName, left, right), leftType
-	case "==", "!=":
-		return fmt.Sprintf("(%s %s %s)", opName, left, right), types.BoolType{}
+	case "==":
+		c.use("_equal")
+		return fmt.Sprintf("(_equal %s %s)", left, right), types.BoolType{}
+	case "!=":
+		c.use("_equal")
+		return fmt.Sprintf("(not (_equal %s %s))", left, right), types.BoolType{}
 	case "<", "<=", ">", ">=":
 		// Compare strings using (compare) if either static types or
 		// heuristics indicate string values. Map fields are typed as

--- a/compiler/x/clj/runtime.go
+++ b/compiler/x/clj/runtime.go
@@ -84,6 +84,19 @@ const (
 	helperGroup = `(defrecord _Group [key Items])
 `
 
+	helperEqual = `(defn _equal [a b]
+  (cond
+    (and (sequential? a) (sequential? b))
+      (and (= (count a) (count b)) (every? true? (map _equal a b)))
+    (and (map? a) (map? b))
+      (and (= (count a) (count b))
+           (every? (fn [k] (_equal (get a k) (get b k))) (keys a)))
+    (and (number? a) (number? b))
+      (= (double a) (double b))
+    :else
+      (= a b)))
+`
+
 	helperGroupBy = `(defn _group_by [src keyfn]
   (let [groups (transient {})
         order (transient [])]
@@ -96,9 +109,10 @@ const (
           (do
             (assoc! groups ks (_Group. k [it]))
             (conj! order ks))))
+    )
     (let [g (persistent! groups)
           o (persistent! order)]
-      (mapv #(get g %) o))) )
+      (mapv #(get g %) o))))
 `
 
 	helperParseCSV = `(defn _parse_csv [text header delim]
@@ -381,6 +395,7 @@ var helperMap = map[string]string{
 	"_sum":              helperSum,
 	"_min":              helperMin,
 	"_max":              helperMax,
+	"_equal":            helperEqual,
 	"_Group":            helperGroup,
 	"_group_by":         helperGroupBy,
 	"_parse_csv":        helperParseCSV,
@@ -414,6 +429,7 @@ var helperOrder = []string{
 	"_sum",
 	"_min",
 	"_max",
+	"_equal",
 	"_Group",
 	"_group_by",
 	"_parse_csv",


### PR DESCRIPTION
## Summary
- implement `_equal` helper for numeric-aware equality in Clojure runtime
- fix `_group_by` helper to persist transients after the loop
- use `_equal` for `==`/`!=` comparisons

## Testing
- `go test ./compiler/x/clj -run TestCompileValidPrograms -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6871f4f0b20c8320bb8c8318363e8103