### PR TITLE
Update Scala compiler helpers

### DIFF
--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -3,7 +3,7 @@
 This directory contains Scala code generated from the Mochi programs in `tests/vm/valid` using the Scala compiler. Each source file was compiled with `scalac` and executed with `scala`. Successful runs produced an `.out` file while failures produced an `.error` file.
 
 Compiled programs: 100
-Executed successfully: 100
+Executed successfully: 85
 
 ## Program checklist
 - [x] append_builtin.mochi

--- a/tests/machine/x/scala/group_by.scala
+++ b/tests/machine/x/scala/group_by.scala
@@ -3,7 +3,7 @@ object group_by {
   case class Stat(person: People)
   case class Stat1(city: String, count: Int, avg_age: Double)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val people = List[People](People(name = "Alice", age = 30, city = "Paris"), People(name = "Bob", age = 15, city = "Hanoi"), People(name = "Charlie", age = 65, city = "Paris"), People(name = "Diana", age = 45, city = "Hanoi"), People(name = "Eve", age = 70, city = "Paris"), People(name = "Frank", age = 22, city = "Hanoi"))
   val stats = ((for { person <- people } yield (person.city, Stat(person = person))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).map{ g => Stat1(city = g.key, count = (g).size, avg_age = (for { p <- g } yield p.age).sum.toDouble / (for { p <- g } yield p.age).size) }.toList

--- a/tests/machine/x/scala/group_by_conditional_sum.scala
+++ b/tests/machine/x/scala/group_by_conditional_sum.scala
@@ -3,7 +3,7 @@ object group_by_conditional_sum {
   case class Result(i: Item)
   case class Result1(cat: String, share: Double)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val items = List[Item](Item(cat = "a", `val` = 10, flag = true), Item(cat = "a", `val` = 5, flag = false), Item(cat = "b", `val` = 20, flag = true))
   val result = (((for { i <- items } yield (i.cat, Result(i = i))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).sortBy(g => g.key)).map{ g => Result1(cat = g.key, share = (for { x <- g } yield if (x.flag != null) x.`val` else 0).sum / (for { x <- g } yield x.`val`).sum) }.toList

--- a/tests/machine/x/scala/group_by_having.scala
+++ b/tests/machine/x/scala/group_by_having.scala
@@ -3,7 +3,7 @@ object group_by_having {
   case class Big1(city: String, num: Int)
   case class People(name: String, city: String)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val people = List[People](People(name = "Alice", city = "Paris"), People(name = "Bob", city = "Hanoi"), People(name = "Charlie", city = "Paris"), People(name = "Diana", city = "Hanoi"), People(name = "Eve", city = "Paris"), People(name = "Frank", city = "Hanoi"), People(name = "George", city = "Paris"))
   val big = (((for { p <- people } yield (p.city, Big(p = p))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).filter{ g => (g).size >= 4 }).map{ g => Map[String, Any]("city" -> (g.key), "num" -> ((g).size)) }.toList

--- a/tests/machine/x/scala/group_by_join.scala
+++ b/tests/machine/x/scala/group_by_join.scala
@@ -4,7 +4,7 @@ object group_by_join {
   case class Stat(o: Order, c: Customer)
   case class Stat1(name: String, count: Int)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
   val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))

--- a/tests/machine/x/scala/group_by_left_join.scala
+++ b/tests/machine/x/scala/group_by_left_join.scala
@@ -4,7 +4,7 @@ object group_by_left_join {
   case class Stat(c: Customer, o: Option[Order])
   case class Stat1(name: String, count: Int)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
   val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))

--- a/tests/machine/x/scala/group_by_multi_join.scala
+++ b/tests/machine/x/scala/group_by_multi_join.scala
@@ -6,7 +6,7 @@ object group_by_multi_join {
   case class Partsupp(part: Int, supplier: Int, cost: Double, qty: Int)
   case class Supplier(id: Int, nation: Int)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val nations = List[Nation](Nation(id = 1, name = "A"), Nation(id = 2, name = "B"))
   val suppliers = List[Supplier](Supplier(id = 1, nation = 1), Supplier(id = 2, nation = 2))

--- a/tests/machine/x/scala/group_by_multi_join_sort.scala
+++ b/tests/machine/x/scala/group_by_multi_join_sort.scala
@@ -7,7 +7,7 @@ object group_by_multi_join_sort {
   case class Result1(c: Customer, o: Order, l: Lineitem, n: Nation)
   case class Result2(c_custkey: Int, c_name: String, revenue: Int, c_acctbal: Double, n_name: String, c_address: String, c_phone: String, c_comment: String)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val nation = List[Nation](Nation(n_nationkey = 1, n_name = "BRAZIL"))
   val customer = List[Customer](Customer(c_custkey = 1, c_name = "Alice", c_acctbal = 100, c_nationkey = 1, c_address = "123 St", c_phone = "123-456", c_comment = "Loyal"))

--- a/tests/machine/x/scala/group_by_sort.scala
+++ b/tests/machine/x/scala/group_by_sort.scala
@@ -3,7 +3,7 @@ object group_by_sort {
   case class Grouped1(cat: String, total: Int)
   case class Item(cat: String, `val`: Int)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val items = List[Item](Item(cat = "a", `val` = 3), Item(cat = "a", `val` = 1), Item(cat = "b", `val` = 5), Item(cat = "b", `val` = 2))
   val grouped = (((for { i <- items } yield (i.cat, Grouped(i = i))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g } yield x.`val`).sum)).map{ g => Grouped1(cat = g.key, total = (for { x <- g } yield x.`val`).sum) }.toList

--- a/tests/machine/x/scala/group_items_iteration.scala
+++ b/tests/machine/x/scala/group_items_iteration.scala
@@ -3,7 +3,7 @@ object group_items_iteration {
   case class Data(tag: String, `val`: Int)
   case class Group(d: Data)
 
-  case class _Group[K,T](key: K, items: List[T])
+  case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
   val data = List[Data](Data(tag = "a", `val` = 1), Data(tag = "a", `val` = 2), Data(tag = "b", `val` = 3))
   val groups = ((for { d <- data } yield (d.tag, Group(d = d))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).map{ g => g }.toList

--- a/tests/machine/x/scala/outer_join.scala
+++ b/tests/machine/x/scala/outer_join.scala
@@ -4,7 +4,11 @@ object outer_join {
   case class Result(order: Option[Order], customer: Option[Customer])
   case class Result1(order: Order, customer: Customer)
 
+  def _left_join[A,B](a: List[A], b: List[B])(cond: (A,B) => Boolean): List[(A, Option[B])] = for(x <- a) yield (x, b.find(y => cond(x,y)))
+
   def _outer_join[A,B](a: List[A], b: List[B])(cond: (A,B) => Boolean): List[(Option[A], Option[B])] = { val left = _left_join(a,b)(cond).map{ case(x,y) => (Some(x), y) }; val right = _right_join(a,b)(cond).collect{ case(None, r) => (None, Some(r)) }; left ++ right }
+
+  def _right_join[A,B](a: List[A], b: List[B])(cond: (A,B) => Boolean): List[(Option[A], B)] = for(y <- b) yield (a.find(x => cond(x,y)), y)
 
   val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"), Customer(id = 4, name = "Diana"))
   val orders = List[Order](Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 5, total = 80))


### PR DESCRIPTION
## Summary
- update Scala compiler helpers to include join dependencies
- emit `_Group` as an iterable so group results work
- update machine generated Scala code and README statistics

## Testing
- `go run -tags=slow scripts/compile_scala.go` *(fails: scalac errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_6871f5a262e8832093bb3a4a94200c4e