### PR TITLE
Update TS compiler for typed globals

### DIFF
--- a/compiler/x/ts/helpers.go
+++ b/compiler/x/ts/helpers.go
@@ -265,7 +265,12 @@ func tsType(t types.Type) string {
 		}
 		return elem + "[]"
 	case types.MapType:
-		return "{ [key: " + tsType(tt.Key) + "]: " + tsType(tt.Value) + " }"
+		key := tsType(tt.Key)
+		val := tsType(tt.Value)
+		if key == "string" && val == "any" {
+			return "Record<string, any>"
+		}
+		return "{ [key: " + key + "]: " + val + " }"
 	case types.StructType:
 		name := sanitizeName(tt.Name)
 		if name != "" {


### PR DESCRIPTION
## Summary
- improve TypeScript codegen to reuse checked types for globals
- map `map[string]any` to `Record<string, any>`

## Testing
- `go test -tags slow ./compiler/x/ts -run ^TestTSCompiler_TPCHQueries/q1$ -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6871f607823c8320a95f5f77c86b8c8a