### PR TITLE
Add v0.10.24 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # 📦 CHANGELOG.md
+## [0.10.24] – 2025-07-12T16:18:37+07:00
+
+### Added
+
+* Numerous new Rosetta Code tasks including Barnsley fern and Benford's law
+* TPC-H query 1 tests with updated dataset outputs
+* Bool list arrays and list length helpers in the C backend
+* JSON helper for TypeScript and typed grouping for C#
+
+### Changed
+
+* TypeScript compiler checks globals, preserves doc comments and uses interface-based structs
+* Scala compiler improves group and join generation with option types
+* Kotlin, Java and Go compilers refine join handling and map indexing
+* Python, C++ and Rust compilers enhance type inference and formatting
+
+### Fixed
+
+* Fortran query line continuations and circular prime example
+* Java map assignment bugs and TypeScript map loop issues
+* Dart numeric casts and C++ aggregate inference
+
 ## [0.10.23] – 2025-07-11T15:23:14+07:00
 
 ### Added

--- a/releases/v0.10.24.md
+++ b/releases/v0.10.24.md
@@ -1,0 +1,30 @@
+# Jul 2025 (v0.10.24)
+
+Released on Sat Jul 12 16:18:37 2025 +0700.
+
+Mochi v0.10.24 expands dataset coverage with TPC‑H examples, adds many new Rosetta Code translations and refines compilers across the board. The C runtime gains array helpers while the virtual machine improves bigint support.
+
+## Examples
+
+- Dozens of new Rosetta Code tasks including Barnsley fern, Benford's law and Bresenham line
+- Added TPC‑H query 1 tests and updated dataset outputs
+- Refreshed Python, Go and Fortran examples
+
+## Compilers
+
+- C backend introduces bool list arrays, list length helpers and outer/right join support
+- TypeScript compiler checks global types, preserves doc comments and uses interface-based structs
+- Scala compiler improves group and join generation with safe division and option types
+- Kotlin, Java and C# compilers refine builtin imports and typed grouping
+- Python, C++, Rust and Go compilers enhance type inference and printing helpers
+
+## Runtime
+
+- Virtual machine handles bigint division and updated TPC‑H IR
+- Printing helpers support lists of structs with array-based lists
+- Memory usage reduced for aggregates and list operations
+
+## Documentation
+
+- Machine READMEs updated with remaining tasks and runtime notes
+- Clarified helper removal and marked async support complete


### PR DESCRIPTION
## Summary
- document v0.10.24 in CHANGELOG
- add release notes for v0.10.24

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68722c6cce5c8320bf2db42e39f7aa64