### PR TITLE
Add note on TPC-H support for Elixir backend

### DIFF
--- a/compiler/x/ex/README.md
+++ b/compiler/x/ex/README.md
@@ -12,4 +12,11 @@ The Elixir backend compiles Mochi programs to Elixir source code. It is used whe
 
 ## TPC-H Progress
 
-Queries `q1` and `q2` from the TPC-H suite compile and execute successfully. The generated Elixir code lives under `tests/dataset/tpc-h/compiler/ex`.
+Queries `q1` and `q2` from the TPC-H suite compile and execute successfully.
+The generated Elixir code lives under `tests/dataset/tpc-h/compiler/ex`.
+
+You can re-generate the golden files and verify execution with:
+
+```bash
+go test ./compiler/x/ex -run TestExCompiler_TPCHQueries -tags=slow -v
+```

--- a/compiler/x/ex/README.md
+++ b/compiler/x/ex/README.md
@@ -1,0 +1,15 @@
+# Elixir Backend
+
+The Elixir backend compiles Mochi programs to Elixir source code. It is used when targeting the BEAM runtime or for quick experimentation with Elixir tooling.
+
+## Files
+
+- `compiler.go` – walks the AST and emits Elixir source
+- `expr.go` – expression helpers
+- `runtime.go` – helper functions injected into generated code
+- `tools.go` – ensures the `elixir` binary is available during tests
+- `compiler_test.go` and `tpch_golden_test.go` – golden tests verifying generated programs run correctly
+
+## TPC-H Progress
+
+Queries `q1` and `q2` from the TPC-H suite compile and execute successfully. The generated Elixir code lives under `tests/dataset/tpc-h/compiler/ex`.


### PR DESCRIPTION
## Summary
- document Elixir backend
- mention that TPC-H queries `q1` and `q2` compile and run successfully

## Testing
- `go test ./compiler/x/ex -run TestExCompiler_TPCHQueries -tags=slow -v`

------
https://chatgpt.com/codex/tasks/task_e_68722d28ac308320b062fd6107d55163