### PR TITLE
Enable TPCH q1-q2 for Clojure backend

### DIFF
--- a/compiler/x/clj/tpch_golden_test.go
+++ b/compiler/x/clj/tpch_golden_test.go
@@ -1,0 +1,72 @@
+//go:build slow
+
+package cljcode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	cljcode "mochi/compiler/x/clj"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestCLJCompiler_TPCHQueries(t *testing.T) {
+	if err := cljcode.EnsureClojure(); err != nil {
+		t.Skipf("clojure not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	for i := 1; i <= 2; i++ {
+		base := fmt.Sprintf("q%d", i)
+		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
+		codeWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "clj", base+".clj.out")
+		outWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "clj", base+".out")
+		if _, err := os.Stat(codeWant); err != nil {
+			continue
+		}
+		t.Run(base, func(t *testing.T) {
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := cljcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCode, err := os.ReadFile(codeWant)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s.clj.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.clj")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("clojure", file)
+			cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("clojure run error: %v\n%s", err, out)
+			}
+			gotOut := bytes.TrimSpace(out)
+			wantOut, err := os.ReadFile(outWant)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, gotOut, bytes.TrimSpace(wantOut))
+			}
+		})
+	}
+}

--- a/tests/dataset/tpc-h/compiler/clj/q1.clj.out
+++ b/tests/dataset/tpc-h/compiler/clj/q1.clj.out
@@ -1,0 +1,88 @@
+(ns main)
+
+(defn _avg [v]
+  (let [lst (cond
+              (and (map? v) (contains? v :Items)) (:Items v)
+              (sequential? v) v
+              :else (throw (ex-info "avg() expects list or group" {})))]
+    (if (empty? lst)
+      0
+      (/ (reduce + lst) (double (count lst)))))
+  )
+
+(defn _sum [v]
+  (let [lst (cond
+              (and (map? v) (contains? v :Items)) (:Items v)
+              (sequential? v) v
+              :else (throw (ex-info "sum() expects list or group" {})))]
+    (reduce + 0 lst))
+  )
+
+(defn _equal [a b]
+  (cond
+    (and (sequential? a) (sequential? b))
+      (and (= (count a) (count b)) (every? true? (map _equal a b)))
+    (and (map? a) (map? b))
+      (and (= (count a) (count b))
+           (every? (fn [k] (_equal (get a k) (get b k))) (keys a)))
+    (and (number? a) (number? b))
+      (= (double a) (double b))
+    :else
+      (= a b)))
+
+(defrecord _Group [key Items])
+
+(defn _group_by [src keyfn]
+  (let [groups (transient {})
+        order (transient [])]
+    (doseq [it src]
+      (let [k (keyfn it)
+            ks (str k)
+            g (get groups ks)]
+        (if g
+          (assoc! groups ks (assoc g :Items (conj (:Items g) it)))
+          (do
+            (assoc! groups ks (_Group. k [it]))
+            (conj! order ks))))
+    )
+    (let [g (persistent! groups)
+          o (persistent! order)]
+      (mapv #(get g %) o))))
+
+(defn _escape_json [s]
+  (-> s
+      (clojure.string/replace "\\" "\\\\")
+      (clojure.string/replace "\"" "\\\"")))
+
+(defn _to_json [v]
+  (cond
+    (nil? v) "null"
+    (string? v) (str "\"" (_escape_json v) "\"")
+    (number? v) (str v)
+    (boolean? v) (str v)
+    (sequential? v) (str "[" (clojure.string/join "," (map _to_json v)) "]")
+    (map? v) (str "{" (clojure.string/join "," (map (fn [[k val]]
+                                        (str "\"" (_escape_json (name k)) "\":" (_to_json val))) v)) "}")
+    :else (str "\"" (_escape_json (str v)) "\"")))
+
+(defn _json [v]
+  (println (_to_json v)))
+
+(declare lineitem result)
+
+(defn test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus []
+  (assert (_equal result [{:returnflag "N" :linestatus "O" :sum_qty 53 :sum_base_price 3000 :sum_disc_price (+ 950.0 1800.0) :sum_charge (+ (* 950.0 1.07) (* 1800.0 1.05)) :avg_qty 26.5 :avg_price 1500 :avg_disc 0.07500000000000001 :count_order 2}]) "expect failed")
+)
+
+(defn -main []
+  (def lineitem [{:l_quantity 17 :l_extendedprice 1000.0 :l_discount 0.05 :l_tax 0.07 :l_returnflag "N" :l_linestatus "O" :l_shipdate "1998-08-01"} {:l_quantity 36 :l_extendedprice 2000.0 :l_discount 0.1 :l_tax 0.05 :l_returnflag "N" :l_linestatus "O" :l_shipdate "1998-09-01"} {:l_quantity 25 :l_extendedprice 1500.0 :l_discount 0.0 :l_tax 0.08 :l_returnflag "R" :l_linestatus "F" :l_shipdate "1998-09-03"}]) ;; list of 
+  (def result (let [_src lineitem
+      _filtered (vec (filter (fn [row] (<= (compare (:l_shipdate row) "1998-09-02") 0)) _src))
+      _groups (_group_by _filtered (fn [row] {:returnflag (:l_returnflag row) :linestatus (:l_linestatus row)}))
+      ]
+  (->> _groups (map (fn [g] {:returnflag (:returnflag (:key g)) :linestatus (:linestatus (:key g)) :sum_qty (_sum (vec (->> (for [x (:Items g)] (:l_quantity x))))) :sum_base_price (_sum (vec (->> (for [x (:Items g)] (:l_extendedprice x))))) :sum_disc_price (_sum (vec (->> (for [x (:Items g)] (* (:l_extendedprice x) (- 1 (:l_discount x))))))) :sum_charge (_sum (vec (->> (for [x (:Items g)] (* (* (:l_extendedprice x) (- 1 (:l_discount x))) (+ 1 (:l_tax x))))))) :avg_qty (_avg (vec (->> (for [x (:Items g)] (:l_quantity x))))) :avg_price (_avg (vec (->> (for [x (:Items g)] (:l_extendedprice x))))) :avg_disc (_avg (vec (->> (for [x (:Items g)] (:l_discount x))))) :count_order (count (:Items g))})) vec))) ;; list of 
+  (_json result)
+  (test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus)
+)
+
+(-main)

--- a/tests/dataset/tpc-h/compiler/clj/q1.out
+++ b/tests/dataset/tpc-h/compiler/clj/q1.out
@@ -1,0 +1,1 @@
+[{"avg_price":1500.0,"returnflag":"N","linestatus":"O","avg_qty":26.5,"sum_qty":53,"avg_disc":0.07500000000000001,"sum_disc_price":2750.0,"sum_charge":2906.5,"count_order":2,"sum_base_price":3000.0}]

--- a/tests/dataset/tpc-h/compiler/clj/q2.clj.out
+++ b/tests/dataset/tpc-h/compiler/clj/q2.clj.out
@@ -1,0 +1,62 @@
+(ns main)
+
+(defn _equal [a b]
+  (cond
+    (and (sequential? a) (sequential? b))
+      (and (= (count a) (count b)) (every? true? (map _equal a b)))
+    (and (map? a) (map? b))
+      (and (= (count a) (count b))
+           (every? (fn [k] (_equal (get a k) (get b k))) (keys a)))
+    (and (number? a) (number? b))
+      (= (double a) (double b))
+    :else
+      (= a b)))
+
+(defn _escape_json [s]
+  (-> s
+      (clojure.string/replace "\\" "\\\\")
+      (clojure.string/replace "\"" "\\\"")))
+
+(defn _to_json [v]
+  (cond
+    (nil? v) "null"
+    (string? v) (str "\"" (_escape_json v) "\"")
+    (number? v) (str v)
+    (boolean? v) (str v)
+    (sequential? v) (str "[" (clojure.string/join "," (map _to_json v)) "]")
+    (map? v) (str "{" (clojure.string/join "," (map (fn [[k val]]
+                                        (str "\"" (_escape_json (name k)) "\":" (_to_json val))) v)) "}")
+    :else (str "\"" (_escape_json (str v)) "\"")))
+
+(defn _json [v]
+  (println (_to_json v)))
+
+(defn _sort_key [k]
+  (cond
+    (map? k) (pr-str (into (sorted-map) k))
+    (sequential? k) (vec k)
+    :else k))
+(declare region nation supplier part partsupp europe_nations europe_suppliers target_parts target_partsupp costs min_cost result)
+
+(defn test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part []
+  (assert (_equal result [{:s_acctbal 1000.0 :s_name "BestSupplier" :n_name "FRANCE" :p_partkey 1000 :p_mfgr "M1" :s_address "123 Rue" :s_phone "123" :s_comment "Fast and reliable" :ps_supplycost 10.0}]) "expect failed")
+)
+
+(defn -main []
+  (def region [{:r_regionkey 1 :r_name "EUROPE"} {:r_regionkey 2 :r_name "ASIA"}]) ;; list of 
+  (def nation [{:n_nationkey 10 :n_regionkey 1 :n_name "FRANCE"} {:n_nationkey 20 :n_regionkey 2 :n_name "CHINA"}]) ;; list of 
+  (def supplier [{:s_suppkey 100 :s_name "BestSupplier" :s_address "123 Rue" :s_nationkey 10 :s_phone "123" :s_acctbal 1000.0 :s_comment "Fast and reliable"} {:s_suppkey 200 :s_name "AltSupplier" :s_address "456 Way" :s_nationkey 20 :s_phone "456" :s_acctbal 500.0 :s_comment "Slow"}]) ;; list of 
+  (def part [{:p_partkey 1000 :p_type "LARGE BRASS" :p_size 15 :p_mfgr "M1"} {:p_partkey 2000 :p_type "SMALL COPPER" :p_size 15 :p_mfgr "M2"}]) ;; list of 
+  (def partsupp [{:ps_partkey 1000 :ps_suppkey 100 :ps_supplycost 10.0} {:ps_partkey 1000 :ps_suppkey 200 :ps_supplycost 15.0}]) ;; list of 
+  (def europe_nations (vec (->> (for [r region :when (_equal (:r_name r) "EUROPE") n nation :when (_equal (:n_regionkey n) (:r_regionkey r))] n)))) ;; list of 
+  (def europe_suppliers (vec (->> (for [s supplier n europe_nations :when (_equal (:s_nationkey s) (:n_nationkey n))] {:s s :n n})))) ;; list of 
+  (def target_parts (vec (->> (for [p part :when (and (_equal (:p_size p) 15) (_equal (:p_type p) "LARGE BRASS"))] p)))) ;; list of 
+  (def target_partsupp (vec (->> (for [ps partsupp p target_parts :when (_equal (:ps_partkey ps) (:p_partkey p)) s europe_suppliers :when (_equal (:ps_suppkey ps) (:s_suppkey (:s s)))] {:s_acctbal (:s_acctbal (:s s)) :s_name (:s_name (:s s)) :n_name (:n_name (:n s)) :p_partkey (:p_partkey p) :p_mfgr (:p_mfgr p) :s_address (:s_address (:s s)) :s_phone (:s_phone (:s s)) :s_comment (:s_comment (:s s)) :ps_supplycost (:ps_supplycost ps)})))) ;; list of 
+  (def costs (vec (->> (for [x target_partsupp] (:ps_supplycost x))))) ;; list of float
+  (def min_cost (apply min costs)) ;; float
+  (def result (vec (->> (for [x target_partsupp :when (_equal (:ps_supplycost x) min_cost)] x) (sort-by (fn [x] (_sort_key (- (:s_acctbal x)))))))) ;; list of 
+  (_json result)
+  (test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part)
+)
+
+(-main)

--- a/tests/dataset/tpc-h/compiler/clj/q2.out
+++ b/tests/dataset/tpc-h/compiler/clj/q2.out
@@ -1,0 +1,1 @@
+[{"s_acctbal":1000.0,"n_name":"FRANCE","p_partkey":1000,"p_mfgr":"M1","s_comment":"Fast and reliable","s_name":"BestSupplier","s_address":"123 Rue","ps_supplycost":10.0,"s_phone":"123"}]


### PR DESCRIPTION
## Summary
- generate Clojure code for TPCH q1 and q2
- add golden output for q1 and q2
- test running TPCH queries with the Clojure compiler

## Testing
- `go test -tags slow ./compiler/x/clj -run TestCLJCompiler_TPCHQueries -v`
- `go test -tags slow ./compiler/x/clj -v`

------
https://chatgpt.com/codex/tasks/task_e_68722d24c12883208bf7281764d932eb