### PR TITLE
Add Erlang TPCH q1-q2 support

### DIFF
--- a/compiler/x/erlang/tpch_golden_test.go
+++ b/compiler/x/erlang/tpch_golden_test.go
@@ -1,0 +1,90 @@
+//go:build slow
+
+package erlang_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	erlang "mochi/compiler/x/erlang"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestErlangCompiler_TPCHQueries(t *testing.T) {
+	if _, err := exec.LookPath("escript"); err != nil {
+		t.Skip("escript not installed")
+	}
+	root := repoRoot(t)
+	for i := 1; i <= 2; i++ {
+		base := fmt.Sprintf("q%d", i)
+		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
+		codeWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "erlang", base+".erl.out")
+		outWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "erlang", base+".out")
+		if _, err := os.Stat(codeWant); err != nil {
+			continue
+		}
+		t.Run(base, func(t *testing.T) {
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := erlang.New(src).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCode, err := os.ReadFile(codeWant)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s.erl.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.erl")
+			if err := os.WriteFile(file, code, 0755); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			out, err := exec.Command("escript", file).CombinedOutput()
+			if err != nil {
+				t.Fatalf("escript error: %v\n%s", err, out)
+			}
+			gotOut := bytes.TrimSpace(out)
+			wantOut, err := os.ReadFile(outWant)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, gotOut, bytes.TrimSpace(wantOut))
+			}
+		})
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}

--- a/tests/dataset/tpc-h/compiler/erlang/q1.erl.out
+++ b/tests/dataset/tpc-h/compiler/erlang/q1.erl.out
@@ -1,96 +1,28 @@
 #!/usr/bin/env escript
--module(main).
--export([main/1, test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0]).
-
-test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() ->
-	mochi_expect((Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => ((950 * 1.07) + (1800 * 1.05)), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}])).
+% q1.erl - generated from q1.mochi
 
 main(_) ->
-	Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
-	Result = [#{returnflag => maps:get(returnflag, maps:get(key, G)), linestatus => maps:get(linestatus, maps:get(key, G)), sum_qty => mochi_sum([maps:get(l_quantity, X) || X <- G]), sum_base_price => mochi_sum([maps:get(l_extendedprice, X) || X <- G]), sum_disc_price => mochi_sum([(maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) || X <- G]), sum_charge => mochi_sum([((maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) * (1 + maps:get(l_tax, X))) || X <- G]), avg_qty => mochi_avg([maps:get(l_quantity, X) || X <- G]), avg_price => mochi_avg([maps:get(l_extendedprice, X) || X <- G]), avg_disc => mochi_avg([maps:get(l_discount, X) || X <- G]), count_order => mochi_count(G)} || G <- mochi_group_by([Row || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")], fun(Row) -> #{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)} end)],
-	mochi_json(Result)
-,
-	mochi_run_test("Q1 aggregates revenue and quantity by returnflag + linestatus", fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0).
+    Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
+    Result = [#{returnflag => maps:get(returnflag, Key0), linestatus => maps:get(linestatus, Key0), sum_qty => lists:sum([maps:get(l_quantity, X) || X <- Val0]), sum_base_price => lists:sum([maps:get(l_extendedprice, X) || X <- Val0]), sum_disc_price => lists:sum([(maps:get(l_extendedprice, X) * ((1 - maps:get(l_discount, X)))) || X <- Val0]), sum_charge => lists:sum([((maps:get(l_extendedprice, X) * ((1 - maps:get(l_discount, X)))) * ((1 + maps:get(l_tax, X)))) || X <- Val0]), avg_qty => (lists:sum([maps:get(l_quantity, X) || X <- Val0]) / length([maps:get(l_quantity, X) || X <- Val0])), avg_price => (lists:sum([maps:get(l_extendedprice, X) || X <- Val0]) / length([maps:get(l_extendedprice, X) || X <- Val0])), avg_disc => (lists:sum([maps:get(l_discount, X) || X <- Val0]) / length([maps:get(l_discount, X) || X <- Val0])), count_order => length(Val0)} || {Key0, Val0} <- maps:to_list(lists:foldl(fun({Key0, Val0}, Acc0) -> L = maps:get(Key0, Acc0, []), maps:put(Key0, [Val0 | L], Acc0) end, #{}, [{#{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)}, Row} || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")]))],
+    mochi_json(Result),
+    (case (Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => (((950 * 1.07)) + ((1800 * 1.05))), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}]) of true -> ok; _ -> erlang:error(test_failed) end).
 
-mochi_count(X) when is_list(X) -> length(X);
-mochi_count(X) when is_map(X), maps:is_key('Items', X) -> length(maps:get('Items', X));
-mochi_count(X) when is_map(X) -> maps:size(X);
-mochi_count(X) when is_binary(X) -> byte_size(X);
-mochi_count(_) -> erlang:error(badarg).
+mochi_escape_json([]) -> [];
+mochi_escape_json([H|T]) ->
+    E = case H of
+        $\ -> "\\";
+        $" -> "\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
 
-mochi_avg([]) -> 0;
-mochi_avg(M) when is_map(M), maps:is_key('Items', M) -> mochi_avg(maps:get('Items', M));
-mochi_avg(L) when is_list(L) ->
-	Sum = lists:foldl(fun(X, Acc) ->
-		case X of
-			I when is_integer(I) -> Acc + I;
-			F when is_float(F) -> Acc + F;
-			_ -> erlang:error(badarg) end
-		end, 0, L),
-		Sum / length(L);
-	mochi_avg(_) -> erlang:error(badarg).
+mochi_to_json(true) -> "true";
+mochi_to_json(false) -> "false";
+mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
+mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
+mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
+mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
+mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
 
-mochi_sum([]) -> 0;
-mochi_sum(M) when is_map(M), maps:is_key('Items', M) -> mochi_sum(maps:get('Items', M));
-mochi_sum(L) when is_list(L) ->
-	lists:foldl(fun(X, Acc) ->
-		case X of
-			I when is_integer(I) -> Acc + I;
-			F when is_float(F) -> Acc + F;
-			_ -> erlang:error(badarg) end
-		end, 0, L);
-	mochi_sum(_) -> erlang:error(badarg).
-
-
-mochi_group_by(Src, KeyFun) ->
-	{Groups, Order} = lists:foldl(fun(It, {G,O}) ->
-		Key = KeyFun(It),
-		KS = lists:flatten(io_lib:format("~p", [Key])),
-		case maps:get(KS, G, undefined) of
-			undefined ->
-				Group = #{key => Key, 'Items' => [It]},
-				{maps:put(KS, Group, G), O ++ [KS]};
-			Group0 ->
-				Items = maps:get('Items', Group0) ++ [It],
-				Group1 = maps:put('Items', Items, Group0),
-				{maps:put(KS, Group1, G), O}
-			end
-		end, {#{}, []}, Src),
-		[ maps:get(K, Groups) || K <- Order ].
-	
-	mochi_escape_json([]) -> [];
-	mochi_escape_json([H|T]) ->
-		E = case H of
-			$\\ -> "\\\\";
-			$" -> "\\"";
-			_ -> [H]
-		end,
-		E ++ mochi_escape_json(T).
-	
-	mochi_to_json(true) -> "true";
-	mochi_to_json(false) -> "false";
-	mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
-	mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
-	mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
-	mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
-	mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}";
-	
-	mochi_json(V) -> io:format("~s~n", [mochi_to_json(V)]).
-	
-	mochi_expect(true) -> ok;
-	mochi_expect(_) -> erlang:error(expect_failed).
-	
-	mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
-	mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
-	mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
-	
-	mochi_run_test(Name, Fun) ->
-		mochi_test_start(Name),
-		Start = erlang:monotonic_time(millisecond),
-		try Fun() of _ ->
-			Duration = erlang:monotonic_time(millisecond) - Start,
-			mochi_test_pass(Duration)
-		catch C:R ->
-			Duration = erlang:monotonic_time(millisecond) - Start,
-			mochi_test_fail({C,R}, Duration)
-		end.
+mochi_json(V) -> io:format("~s
+", [mochi_to_json(V)]).

--- a/tests/dataset/tpc-h/compiler/erlang/q1.out
+++ b/tests/dataset/tpc-h/compiler/erlang/q1.out
@@ -1,1 +1,1 @@
-[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]
+[{"returnflag":"N","linestatus":"O","sum_qty":53,"sum_base_price":3000,"sum_disc_price":2750.0,"sum_charge":2906.5,"avg_qty":26.5,"avg_price":1.5e3,"avg_disc":0.07500000000000001,"count_order":2}]

--- a/tests/dataset/tpc-h/compiler/erlang/q2.erl.out
+++ b/tests/dataset/tpc-h/compiler/erlang/q2.erl.out
@@ -1,0 +1,38 @@
+#!/usr/bin/env escript
+% q2.erl - generated from q2.mochi
+
+main(_) ->
+    Region = [#{r_regionkey => 1, r_name => "EUROPE"}, #{r_regionkey => 2, r_name => "ASIA"}],
+    Nation = [#{n_nationkey => 10, n_regionkey => 1, n_name => "FRANCE"}, #{n_nationkey => 20, n_regionkey => 2, n_name => "CHINA"}],
+    Supplier = [#{s_suppkey => 100, s_name => "BestSupplier", s_address => "123 Rue", s_nationkey => 10, s_phone => "123", s_acctbal => 1000, s_comment => "Fast and reliable"}, #{s_suppkey => 200, s_name => "AltSupplier", s_address => "456 Way", s_nationkey => 20, s_phone => "456", s_acctbal => 500, s_comment => "Slow"}],
+    Part = [#{p_partkey => 1000, p_type => "LARGE BRASS", p_size => 15, p_mfgr => "M1"}, #{p_partkey => 2000, p_type => "SMALL COPPER", p_size => 15, p_mfgr => "M2"}],
+    Partsupp = [#{ps_partkey => 1000, ps_suppkey => 100, ps_supplycost => 10}, #{ps_partkey => 1000, ps_suppkey => 200, ps_supplycost => 15}],
+    Europe_nations = [N || R <- Region, N <- Nation, (maps:get(n_regionkey, N) == maps:get(r_regionkey, R)), (maps:get(r_name, R) == "EUROPE")],
+    Europe_suppliers = [#{s => S, n => N} || S <- Supplier, N <- Europe_nations, (maps:get(s_nationkey, S) == maps:get(n_nationkey, N))],
+    Target_parts = [P || P <- Part, (((maps:get(p_size, P) == 15) andalso maps:get(p_type, P)) == "LARGE BRASS")],
+    Target_partsupp = [#{s_acctbal => maps:get(s_acctbal, maps:get(s, S)), s_name => maps:get(s_name, maps:get(s, S)), n_name => maps:get(n_name, maps:get(n, S)), p_partkey => maps:get(p_partkey, P), p_mfgr => maps:get(p_mfgr, P), s_address => maps:get(s_address, maps:get(s, S)), s_phone => maps:get(s_phone, maps:get(s, S)), s_comment => maps:get(s_comment, maps:get(s, S)), ps_supplycost => maps:get(ps_supplycost, Ps)} || Ps <- Partsupp, P <- Target_parts, S <- Europe_suppliers, (maps:get(ps_partkey, Ps) == maps:get(p_partkey, P)), (maps:get(ps_suppkey, Ps) == maps:get(s_suppkey, maps:get(s, S)))],
+    Costs = [maps:get(ps_supplycost, X) || X <- Target_partsupp],
+    Min_cost = lists:min(Costs),
+    Result = [V || {_, V} <- lists:keysort(1, [{-maps:get(s_acctbal, X), X} || X <- Target_partsupp, (maps:get(ps_supplycost, X) == Min_cost)])],
+    mochi_json(Result),
+    (case (Result == [#{s_acctbal => 1000, s_name => "BestSupplier", n_name => "FRANCE", p_partkey => 1000, p_mfgr => "M1", s_address => "123 Rue", s_phone => "123", s_comment => "Fast and reliable", ps_supplycost => 10}]) of true -> ok; _ -> erlang:error(test_failed) end).
+
+mochi_escape_json([]) -> [];
+mochi_escape_json([H|T]) ->
+    E = case H of
+        $\ -> "\\";
+        $" -> "\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
+
+mochi_to_json(true) -> "true";
+mochi_to_json(false) -> "false";
+mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
+mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
+mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
+mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
+mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
+
+mochi_json(V) -> io:format("~s
+", [mochi_to_json(V)]).

--- a/tests/dataset/tpc-h/compiler/erlang/q2.out
+++ b/tests/dataset/tpc-h/compiler/erlang/q2.out
@@ -1,0 +1,1 @@
+[{"n_name":"FRANCE","s_name":"BestSupplier","s_address":"123\Rue","s_phone":"123","s_acctbal":1000,"s_comment":"Fast\and\reliable","p_partkey":1000,"p_mfgr":"M1","ps_supplycost":10}]


### PR DESCRIPTION
## Summary
- implement Erlang TPCH golden tests
- add generated code and output for queries q1 and q2

## Testing
- `go test ./compiler/x/erlang -tags slow -run TestErlangCompiler_TPCHQueries -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68722d2a280483208a3cd40946e3ee62