### PR TITLE
Add TPCH Zig golden tests

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -2307,6 +2307,20 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr, asReturn bool) (string, e
 			}
 			return operand{expr: cmp}, nil
 		}
+		if (opName == "<" || opName == "<=" || opName == ">" || opName == ">=") && (left.isStr || right.isStr) {
+			var cmp string
+			switch opName {
+			case "<":
+				cmp = fmt.Sprintf("std.mem.order(u8, %s, %s) == .lt", left.expr, right.expr)
+			case "<=":
+				cmp = fmt.Sprintf("std.mem.order(u8, %s, %s) != .gt", left.expr, right.expr)
+			case ">":
+				cmp = fmt.Sprintf("std.mem.order(u8, %s, %s) == .gt", left.expr, right.expr)
+			case ">=":
+				cmp = fmt.Sprintf("std.mem.order(u8, %s, %s) != .lt", left.expr, right.expr)
+			}
+			return operand{expr: cmp}, nil
+		}
 		if opName == "in" {
 			if right.isMap {
 				expr = fmt.Sprintf("%s.contains(%s)", right.expr, left.expr)

--- a/compiler/x/zig/tpch_golden_test.go
+++ b/compiler/x/zig/tpch_golden_test.go
@@ -1,0 +1,101 @@
+//go:build slow
+
+package zigcode_test
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"mochi/compiler/x/testutil"
+	zigcode "mochi/compiler/x/zig"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func shouldUpdate() bool {
+	f := flag.Lookup("update")
+	return f != nil && f.Value.String() == "true"
+}
+
+// TestZigCompiler_TPCH_Golden compiles TPCH queries q1 and q2
+// and compares the generated Zig code with golden files.
+func TestZigCompiler_TPCH_Golden(t *testing.T) {
+	zigc, err := zigcode.EnsureZig()
+	if err != nil {
+		t.Skipf("zig not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 2; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-h", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := zigcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			code = bytes.TrimSpace(code)
+			wantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "zig", q+".zig.out")
+			if shouldUpdate() {
+				if err := os.WriteFile(wantPath, append(code, '\n'), 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			} else {
+				want, err := os.ReadFile(wantPath)
+				if err != nil {
+					t.Fatalf("read golden: %v", err)
+				}
+				if !bytes.Equal(code, bytes.TrimSpace(want)) {
+					t.Errorf("generated code mismatch for %s.zig.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, code, bytes.TrimSpace(want))
+				}
+			}
+
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.zig")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			exe := filepath.Join(tmp, "main")
+			if out, err := exec.Command(zigc, "build-exe", file, "-O", "ReleaseSafe", "-femit-bin="+exe).CombinedOutput(); err != nil {
+				t.Fatalf("zig build error: %v\n%s", err, out)
+			}
+			out, err := exec.Command(exe).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run error: %v\n%s", err, out)
+			}
+			compiled := bytes.TrimSpace(out)
+
+			p, err := vm.Compile(prog, env)
+			if err != nil {
+				t.Fatalf("vm compile error: %v", err)
+			}
+			var buf bytes.Buffer
+			m := vm.New(p, &buf)
+			if err := m.Run(); err != nil {
+				if ve, ok := err.(*vm.VMError); ok {
+					t.Fatalf("vm run error:\n%s", ve.Format(p))
+				}
+				t.Fatalf("vm run error: %v", err)
+			}
+			vmOut := bytes.TrimSpace(buf.Bytes())
+			if !bytes.Equal(compiled, vmOut) {
+				t.Errorf("output mismatch for %s\n\n-- zig --\n%s\n\n-- vm --\n%s\n", q, compiled, vmOut)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add golden test for Zig TPCH queries
- support string comparison using `std.mem.order`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68722d4791f883208b2631ceb0bc6291