### PR TITLE
Add avg helper to Ruby backend

### DIFF
--- a/compiler/x/rb/compiler.go
+++ b/compiler/x/rb/compiler.go
@@ -1969,7 +1969,8 @@ func (c *Compiler) compileBuiltinCall(name string, args []string, origArgs []*pa
 		if len(args) != 1 {
 			return "", true, fmt.Errorf("avg expects 1 arg")
 		}
-		return fmt.Sprintf("((%[1]s).length > 0 ? (%[1]s).sum(0.0) / (%[1]s).length : 0)", args[0]), true, nil
+		c.use("_avg")
+		return fmt.Sprintf("_avg(%s)", args[0]), true, nil
 	case "sum":
 		if len(args) != 1 {
 			return "", true, fmt.Errorf("sum expects 1 arg")

--- a/compiler/x/rb/runtime.go
+++ b/compiler/x/rb/runtime.go
@@ -194,6 +194,19 @@ end`
   s
 end`
 
+	helperAvg = `def _avg(v)
+  list = nil
+  if defined?(MGroup) && v.is_a?(MGroup)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.sum(0.0) / list.length
+end`
+
 	helperMin = `def _min(v)
   list = nil
   if v.respond_to?(:Items)
@@ -450,6 +463,7 @@ var helperMap = map[string]string{
 	"_max":         helperMax,
 	"_first":       helperFirst,
 	"_sum":         helperSum,
+	"_avg":         helperAvg,
 	"_eval":        helperEval,
 	"_group":       helperGroup,
 	"_group_by":    helperGroupBy,

--- a/tests/dataset/tpc-h/compiler/rb/q1.rb.out
+++ b/tests/dataset/tpc-h/compiler/rb/q1.rb.out
@@ -1,5 +1,17 @@
 require 'ostruct'
 
+def _avg(v)
+  list = nil
+  if defined?(MGroup) && v.is_a?(MGroup)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.sum(0.0) / list.length
+end
 class MGroup
   include Enumerable
   attr_accessor :key, :Items
@@ -189,7 +201,7 @@ $result = (begin
 	_items0 = _groups
 	_res = []
 	for g in _items0
-		_res << OpenStruct.new(returnflag: g.key.returnflag, linestatus: g.key.linestatus, sum_qty: _sum(((g)).map { |x| x.l_quantity }), sum_base_price: _sum(((g)).map { |x| x.l_extendedprice }), sum_disc_price: _sum(((g)).map { |x| (x.l_extendedprice * ((1 - x.l_discount))) }), sum_charge: _sum(((g)).map { |x| ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))) }), avg_qty: ((((g)).map { |x| x.l_quantity }).length > 0 ? (((g)).map { |x| x.l_quantity }).sum(0.0) / (((g)).map { |x| x.l_quantity }).length : 0), avg_price: ((((g)).map { |x| x.l_extendedprice }).length > 0 ? (((g)).map { |x| x.l_extendedprice }).sum(0.0) / (((g)).map { |x| x.l_extendedprice }).length : 0), avg_disc: ((((g)).map { |x| x.l_discount }).length > 0 ? (((g)).map { |x| x.l_discount }).sum(0.0) / (((g)).map { |x| x.l_discount }).length : 0), count_order: (g).length)
+		_res << OpenStruct.new(returnflag: g.key.returnflag, linestatus: g.key.linestatus, sum_qty: _sum(((g)).map { |x| x.l_quantity }), sum_base_price: _sum(((g)).map { |x| x.l_extendedprice }), sum_disc_price: _sum(((g)).map { |x| (x.l_extendedprice * ((1 - x.l_discount))) }), sum_charge: _sum(((g)).map { |x| ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))) }), avg_qty: _avg(((g)).map { |x| x.l_quantity }), avg_price: _avg(((g)).map { |x| x.l_extendedprice }), avg_disc: _avg(((g)).map { |x| x.l_discount }), count_order: (g).length)
 	end
 	_res
 end)


### PR DESCRIPTION
## Summary
- enhance Ruby compiler runtime with `_avg` helper
- use `_avg` for averaging
- update TPCH q1 golden code

## Testing
- `go test -tags slow ./compiler/x/rb -run TPCH -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68722d4b24fc83209b006c948bb58e82