### PR TITLE
Extend Kotlin TPCH tests

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -213,9 +213,8 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.inferred = make(map[string]types.StructType)
 	c.mapNodes = make(map[*parser.MapLiteral]string)
 
-	// Structural inference currently generates data classes which
-	// cause type mismatches for untyped query results. Skip for now.
-	//c.discoverStructs(prog)
+       // Structural inference infers struct types from map literals.
+       c.discoverStructs(prog)
 
 	// handle builtin imports
 	for _, s := range prog.Statements {
@@ -1190,10 +1189,12 @@ func (c *Compiler) builtinCall(call *parser.CallExpr, args []string) (string, bo
 			c.use("toDouble")
 			return fmt.Sprintf("%s.map{ toDouble(it) }.average()", args[0]), true
 		}
-	case "sum":
-		if len(args) == 1 {
-			return fmt.Sprintf("%s.sum()", args[0]), true
-		}
+       case "sum":
+               if len(args) == 1 {
+                        c.use("sum")
+                        c.use("toInt")
+                        return fmt.Sprintf("sum(%s)", args[0]), true
+               }
 	case "max":
 		if len(args) == 1 {
 			return fmt.Sprintf("%s.maxOrNull() ?: 0", args[0]), true

--- a/compiler/x/kotlin/tpch_test.go
+++ b/compiler/x/kotlin/tpch_test.go
@@ -64,7 +64,7 @@ func TestKotlinCompiler_TPCH(t *testing.T) {
 	if _, err := exec.LookPath("kotlinc"); err != nil {
 		t.Skip("kotlinc not installed")
 	}
-	for _, base := range []string{"q1"} {
-		t.Run(base, func(t *testing.T) { runTPCHQuery(t, base) })
-	}
+       for _, base := range []string{"q1", "q2"} {
+               t.Run(base, func(t *testing.T) { runTPCHQuery(t, base) })
+       }
 }


### PR DESCRIPTION
## Summary
- enable structural inference in Kotlin compiler
- ensure `sum` builtin pulls in required helpers
- run Kotlin tpch tests for queries q1 and q2

## Testing
- `go test -tags slow ./compiler/x/kotlin -run TestKotlinCompiler_TPCH/q1 -count=1` *(fails: unresolved reference errors)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68722d31aeb883209e08e1d32bdafa5b