### PR TITLE
Add stack-based int list creation in C backend

### DIFF
--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -106,3 +106,7 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## TODO
+
+- [ ] Replace remaining dynamic `list_int_create` usages with stack arrays.

--- a/tests/machine/x/c/group_by_multi_join.c
+++ b/tests/machine/x/c/group_by_multi_join.c
@@ -213,7 +213,8 @@ int main() {
   tmp4.len = tmp5;
   list_FilteredItem filtered = tmp4;
   list_FilteredItem tmp9 = list_FilteredItem_create(filtered.len);
-  list_int tmp10 = list_int_create(filtered.len);
+  int tmp10_data[filtered.len];
+  list_int tmp10 = {0, tmp10_data};
   int tmp11 = 0;
   for (int i12 = 0; i12 < filtered.len; i12++) {
     FilteredItem x = filtered.data[i12];


### PR DESCRIPTION
## Summary
- support allocating int lists on the stack instead of calling `list_int_create`
- regenerate C output for `group_by_multi_join`
- track remaining work in the C machine README

## Testing
- `go test -tags slow ./compiler/x/c -run TestCCompiler_ValidPrograms/group_by -count=1`
- `go test -tags slow ./compiler/x/c -run TestCCompiler_ValidPrograms/append_builtin -count=1`
- `go test -tags slow ./compiler/x/c -run TestCCompiler_ValidPrograms/group_by_conditional_sum -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68722cd7450c83209349a808e6083152