### PR TITLE
Implement join key type checks in C backend

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -3023,6 +3023,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 			if !ok {
 				return "0"
 			}
+			if _, _, ok := c.eqJoinKeys(j.On, q.Var, j.Var); !ok {
+				return "0"
+			}
 			on := c.compileExpr(j.On)
 			left := false
 			if j.Side != nil && *j.Side == "left" {


### PR DESCRIPTION
## Summary
- add `eqJoinKeys` helper to verify join equality types
- abort code generation if join keys have mismatched types

## Testing
- `go test -tags=slow ./compiler/x/c -run TestCCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68723e6ee224832082e57ef89d6093b9