### PR TITLE
Add typed group+join support in C# compiler

### DIFF
--- a/compiler/x/cs/runtime.go
+++ b/compiler/x/cs/runtime.go
@@ -312,12 +312,14 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("}")
 			case "_group":
 				c.writeln("public interface _IGroup { System.Collections.IEnumerable Items { get; } }")
-				c.writeln("public class _Group<TKey, TItem> : _IGroup {")
+				c.writeln("public class _Group<TKey, TItem> : _IGroup, IEnumerable<TItem> {")
 				c.indent++
 				c.writeln("public TKey key;")
 				c.writeln("public List<TItem> Items = new List<TItem>();")
 				c.writeln("public _Group(TKey k) { key = k; }")
 				c.writeln("System.Collections.IEnumerable _IGroup.Items => Items;")
+				c.writeln("public IEnumerator<TItem> GetEnumerator() => Items.GetEnumerator();")
+				c.writeln("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => Items.GetEnumerator();")
 				c.indent--
 				c.writeln("}")
 			case "_group_by":

--- a/tests/compiler/cs/typed_join_group.cs.out
+++ b/tests/compiler/cs/typed_join_group.cs.out
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public record struct Customer
+{
+    public int id;
+    public string name;
+}
+
+public record struct Order
+{
+    public int id;
+    public int custId;
+}
+
+public record struct Summary
+{
+    public string name;
+    public int count;
+}
+
+public record struct Key
+{
+    public string name;
+}
+
+class Program
+{
+    static void Main()
+    {
+        List<Customer> customers = new List<Customer> { new Customer { id = 1, name = "Alice" }, new Customer { id = 2, name = "Bob" } };
+        List<Order> orders = new List<Order> { new Order { id = 100, custId = 1 }, new Order { id = 101, custId = 1 }, new Order { id = 102, custId = 2 } };
+        List<Summary> result = new Func<List<Summary>>(() =>
+        {
+            var groups = new Dictionary<string, _Group<Key, Order>>();
+            var order = new List<string>();
+            foreach (var o in orders)
+            {
+                foreach (var c in customers)
+                {
+                    if (!((o.custId == c.id))) continue;
+                    var key = new Key { name = c.name };
+                    var ks = Convert.ToString(key);
+                    if (!groups.TryGetValue(ks, out var g))
+                    {
+                        g = new _Group<Key, Order>(key);
+                        groups[ks] = g;
+                        order.Add(ks);
+                    }
+                    g.Items.Add(o);
+                }
+            }
+            var items = new List<_Group<Key, Order>>();
+            foreach (var ks in order) items.Add(groups[ks]);
+            var _res = new List<Summary>();
+            foreach (var g in items)
+            {
+                _res.Add(new Summary { name = g.key.name, count = Enumerable.Count(g) });
+            }
+            return _res;
+        })();
+        foreach (var r in result)
+        {
+            Console.WriteLine(string.Join(" ", new[] { Convert.ToString(r.name), Convert.ToString(r.count) }));
+        }
+    }
+    public interface _IGroup { System.Collections.IEnumerable Items { get; } }
+    public class _Group<TKey, TItem> : _IGroup, IEnumerable<TItem>
+    {
+        public TKey key;
+        public List<TItem> Items = new List<TItem>();
+        public _Group(TKey k) { key = k; }
+        System.Collections.IEnumerable _IGroup.Items => Items;
+        public IEnumerator<TItem> GetEnumerator() => Items.GetEnumerator();
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => Items.GetEnumerator();
+    }
+
+}

--- a/tests/compiler/cs/typed_join_group.mochi
+++ b/tests/compiler/cs/typed_join_group.mochi
@@ -1,0 +1,26 @@
+type Customer { id: int, name: string }
+
+type Order { id: int, custId: int }
+
+type Summary { name: string, count: int }
+type Key { name: string }
+
+let customers = [
+  Customer { id: 1, name: "Alice" },
+  Customer { id: 2, name: "Bob" }
+]
+
+let orders = [
+  Order { id: 100, custId: 1 },
+  Order { id: 101, custId: 1 },
+  Order { id: 102, custId: 2 }
+]
+
+let result = from o in orders
+             join c in customers on o.custId == c.id
+             group by Key { name: c.name } into g
+             select Summary { name: g.key.name, count: count(g) }
+
+for r in result {
+  print(r.name, r.count)
+}

--- a/tests/compiler/cs/typed_join_group.out
+++ b/tests/compiler/cs/typed_join_group.out
@@ -1,0 +1,2 @@
+Alice 2
+Bob 1


### PR DESCRIPTION
## Summary
- improve `_Group` helper so that groups implement `IEnumerable<T>`
- add typed join+group example for the C# compiler

## Testing
- `go test ./... -tags slow` *(fails: package mochi/archived/... is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_68723e72c9c08320b07272bbc93b1cea