### PR TITLE
Add typed join group support in Erlang compiler

### DIFF
--- a/compiler/x/erlang/compiler.go
+++ b/compiler/x/erlang/compiler.go
@@ -831,16 +831,22 @@ func (c *Compiler) compileQuery(q *parser.QueryExpr) (string, error) {
 			keyExpr = "{" + strings.Join(keyParts, ", ") + "}"
 		}
 
-		vars := []string{capitalize(q.Var)}
+		vars := []string{q.Var}
 		for _, fr := range q.Froms {
-			vars = append(vars, capitalize(fr.Var))
+			vars = append(vars, fr.Var)
 		}
 		for _, j := range q.Joins {
-			vars = append(vars, capitalize(j.Var))
+			vars = append(vars, j.Var)
 		}
-		elemMap := strings.Join(vars, ", ")
-		if len(vars) > 1 {
-			elemMap = "{" + elemMap + "}"
+		parts := make([]string, len(vars))
+		for i, v := range vars {
+			parts[i] = fmt.Sprintf("%s => %s", v, capitalize(v))
+		}
+		elemMap := ""
+		if len(parts) == 1 {
+			elemMap = capitalize(vars[0])
+		} else {
+			elemMap = "#{" + strings.Join(parts, ", ") + "}"
 		}
 
 		pairList := "[{" + keyExpr + ", " + elemMap + "} || " + strings.Join(gens, ", ")


### PR DESCRIPTION
## Summary
- generate group-by items as maps when joining
- ensure Erlang query compilation handles field access in grouped joins

## Testing
- `go test ./compiler/x/erlang -run TestCompilePrograms -tags slow -count=1`
- `go test ./compiler/x/erlang -run TPCH -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68723e7c38248320aea250be4c31efd8