### PR TITLE
Add typed join helper for Python backend

### DIFF
--- a/compiler/x/python/README.md
+++ b/compiler/x/python/README.md
@@ -54,6 +54,7 @@ var helperMap = map[string]string{
     "_group_by":   helperGroupBy,
     "_count":      helperCount,
     "_avg":        helperAvg,
+    "_join":       helperJoin,
     "_union_all":  helperUnionAll,
     "_union":      helperUnion,
     "_except":     helperExcept,


### PR DESCRIPTION
## Summary
- provide `_join` helper for Python target
- expose `_join` via `helperMap`
- document `_join` runtime helper

## Testing
- `go test ./compiler/x/python -run ^$ -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68723e6e2dac832094a3cf9750f00682