### PR TITLE
Improve Go compiler variable naming

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -39,6 +39,7 @@ type Compiler struct {
 	externObjects map[string]bool
 
 	tempVarCount int
+	varCounts    map[string]int
 
 	returnType types.Type
 
@@ -68,6 +69,7 @@ func New(env *types.Env) *Compiler {
 		tsAuto:          map[string]bool{},
 		externObjects:   map[string]bool{},
 		tempVarCount:    0,
+		varCounts:       map[string]int{},
 		anonStructCount: 0,
 	}
 }

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -436,14 +436,13 @@ func (c *Compiler) eqJoinKeys(e *parser.Expr, leftVar, rightVar string) (string,
 }
 
 func (c *Compiler) newVar() string {
-	name := fmt.Sprintf("tmp%d", c.tempVarCount)
-	c.tempVarCount++
-	return name
+	return c.newNamedVar("tmp")
 }
 
 func (c *Compiler) newNamedVar(prefix string) string {
-	name := fmt.Sprintf("%s%d", prefix, c.tempVarCount)
-	c.tempVarCount++
+	count := c.varCounts[prefix]
+	name := fmt.Sprintf("%s%d", prefix, count)
+	c.varCounts[prefix] = count + 1
 	return name
 }
 

--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -114,7 +114,7 @@ Checklist:
 - [x] Simplify struct initialization when field order matches.
 - [ ] Improve error messages for type mismatches.
 - [ ] Implement streaming I/O support in the runtime.
-- [ ] Refine variable naming in generated code.
+ - [x] Refine variable naming in generated code.
 - [ ] Add support for map literals with computed keys.
 - [ ] Generate comments from Mochi docs in output.
 - [ ] Investigate build-time caching to speed up tests.


### PR DESCRIPTION
## Summary
- tweak Go compiler to generate better temp variable names
- record completion of variable naming task

## Testing
- `go test -run TestGoCompiler_ValidPrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687244bbcd388320a9ed40716cc54652