### PR TITLE
Add logging option to Python compiler

### DIFF
--- a/compiler/x/python/README.md
+++ b/compiler/x/python/README.md
@@ -12,6 +12,8 @@ The Python backend translates Mochi programs into standard Python source code. I
 - `runtime.go` – stringified runtime helpers injected into generated programs
 - `tools.go` – ensures `python3` is available for benchmarks and tests
 - Struct methods defined inside `type` blocks are emitted as Python class methods
+- `SetTypeHints` toggles optional type annotations
+- `SetLogger` enables logging of compiler phases
 
 ## Runtime Helpers
 

--- a/compiler/x/python/statements.go
+++ b/compiler/x/python/statements.go
@@ -667,13 +667,15 @@ func (c *Compiler) compileStructType(st types.StructType) error {
 	if needTyping && c.typeHints {
 		c.imports["typing"] = "typing"
 	}
+	c.logf("finished type %s", name)
 	return nil
 }
 
 func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
+	name := sanitizeName(t.Name)
+	c.logf("compile type %s", name)
 	c.imports["dataclasses"] = "dataclasses"
 	needTyping := false
-	name := sanitizeName(t.Name)
 	if len(t.Variants) > 0 {
 		c.writeln(fmt.Sprintf("class %s:", name))
 		c.indent++
@@ -945,6 +947,7 @@ func (c *Compiler) compileUpdate(u *parser.UpdateStmt) error {
 }
 func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 	name := sanitizeName(fun.Name)
+	c.logf("compile function %s", name)
 	needTyping := false
 	c.writeIndent()
 	c.buf.WriteString("def " + name + "(")
@@ -1053,6 +1056,7 @@ func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 	if needTyping && c.typeHints {
 		c.imports["typing"] = "typing"
 	}
+	c.logf("finished function %s", name)
 	return nil
 }
 

--- a/tests/machine/x/python/README.md
+++ b/tests/machine/x/python/README.md
@@ -120,7 +120,7 @@ Compiled programs: 100/100 successful.
 - [ ] Provide CLI for custom output directory
 - [ ] Implement caching for compiled modules
 - [ ] Support incremental compilation
-- [ ] Add logging for compiler phases
+- [x] Add logging for compiler phases
 - [ ] Enhance error messages with line numbers
 - [ ] Provide option to suppress runtime imports
 - [ ] Add plugin architecture for new targets


### PR DESCRIPTION
## Summary
- add `SetLogger` to `pycode.Compiler` for optional logging
- log compilation steps in the Python backend
- document the new helper in the Python backend README
- check off logging task in Python machine README

## Testing
- `go build -tags slow ./compiler/x/python`

------
https://chatgpt.com/codex/tasks/task_e_687244be25a08320935db9c60919a689