### PR TITLE
Add union type support for Dart compiler

### DIFF
--- a/tests/machine/x/dart/README.md
+++ b/tests/machine/x/dart/README.md
@@ -111,7 +111,7 @@ Checklist:
 
 - [ ] Support slices and range expressions
 - [ ] Implement pattern matching translation
-- [ ] Generate struct type definitions
+- [x] Generate struct type definitions
 - [ ] Improve query optimization
 - [ ] Add asynchronous I/O support
 - [ ] Enhance error reporting in generated code

--- a/tests/machine/x/dart/tree_sum.dart
+++ b/tests/machine/x/dart/tree_sum.dart
@@ -1,16 +1,26 @@
+abstract class Tree {}
+class Leaf extends Tree {
+  Leaf();
+}
+class Node extends Tree {
+  dynamic left;
+  int value;
+  dynamic right;
+  Node(this.left, this.value, this.right);
+}
+
 int sum_tree(Tree t) {
   return (() {
-    var _t = t;
-    if (_t is Leaf) {
-      return 0;
-    } else if (_t is Node) {
-      var left = (_t as Node).left;
-      var value = (_t as Node).value;
-      var right = (_t as Node).right;
-      return (sum_tree(left) + (value as int) as int) + sum_tree(right);
-    }
-    return null;
-  })();
+  var _t = t;
+  if (_t is Leaf) {
+    return 0;
+  } else if (_t is Node) {
+    var left = (_t as Node).left;
+    var value = (_t as Node).value;
+    var right = (_t as Node).right;
+    return (sum_tree(left) + (value as num) as num) + sum_tree(right);
+  }  return null;
+})();
 }
 
 var t = Node(Leaf(), 1, Node(Leaf(), 2, Leaf()));

--- a/tests/machine/x/dart/tree_sum.error
+++ b/tests/machine/x/dart/tree_sum.error
@@ -1,3 +1,0 @@
-line 1: exit status 254
-int sum_tree(Tree t) {
-  return (() {


### PR DESCRIPTION
## Summary
- extend Dart compiler with union type generation
- regenerate `tree_sum.dart` using new union support
- update Dart machine README checklist
- remove obsolete error file

## Testing
- `go test ./compiler/x/dart -run TestDartCompiler_ValidPrograms -tags slow -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687244c5deec832098e920b345e4641d