### PR TITLE
Improve Rust compiler error messages

### DIFF
--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -1696,13 +1696,13 @@ func (c *Compiler) compileMatchPattern(e *parser.Expr) (string, error) {
 			call := u.Value.Target.Call
 			if info, ok := c.variantInfo[call.Func]; ok {
 				if len(call.Args) != len(info.Order) {
-					return "", fmt.Errorf("pattern arg mismatch")
+					return "", fmt.Errorf("pattern arg mismatch at line %d", call.Pos.Line)
 				}
 				parts := make([]string, len(call.Args))
 				for i, a := range call.Args {
 					id, ok := c.simpleIdent(a)
 					if !ok {
-						return "", fmt.Errorf("complex pattern not supported")
+						return "", fmt.Errorf("complex pattern not supported at line %d", a.Pos.Line)
 					}
 					parts[i] = fmt.Sprintf("%s: %s", info.Order[i], id)
 				}

--- a/tests/machine/x/rust/avg_builtin.rs
+++ b/tests/machine/x/rust/avg_builtin.rs
@@ -1,6 +1,6 @@
-fn avg(v: &[i32]) -> f64 {
-    let sum: i32 = v.iter().sum();
-    sum as f64 / v.len() as f64
+fn avg<T>(v: &[T]) -> f64 where T: Into<f64> + Copy {
+    let sum: f64 = v.iter().map(|&x| x.into()).sum();
+    sum / v.len() as f64
 }
 
 fn main() {

--- a/tests/machine/x/rust/group_by.rs
+++ b/tests/machine/x/rust/group_by.rs
@@ -18,9 +18,9 @@ struct Result {
     avg_age: f64,
 }
 
-fn avg(v: &[i32]) -> f64 {
-    let sum: i32 = v.iter().sum();
-    sum as f64 / v.len() as f64
+fn avg<T>(v: &[T]) -> f64 where T: Into<f64> + Copy {
+    let sum: f64 = v.iter().map(|&x| x.into()).sum();
+    sum / v.len() as f64
 }
 
 fn main() {

--- a/tests/machine/x/rust/min_max_builtin.rs
+++ b/tests/machine/x/rust/min_max_builtin.rs
@@ -1,9 +1,9 @@
-fn min(v: &[i32]) -> i32 {
-    *v.iter().min().unwrap()
+fn min<T: PartialOrd + Copy>(v: &[T]) -> T {
+    *v.iter().min_by(|a,b| a.partial_cmp(b).unwrap()).unwrap()
 }
 
-fn max(v: &[i32]) -> i32 {
-    *v.iter().max().unwrap()
+fn max<T: PartialOrd + Copy>(v: &[T]) -> T {
+    *v.iter().max_by(|a,b| a.partial_cmp(b).unwrap()).unwrap()
 }
 
 fn main() {


### PR DESCRIPTION
## Summary
- enhance pattern match errors in Rust compiler
- regenerate Rust machine outputs with generic helpers

## Testing
- `go test ./compiler/x/rust -run TestCompilePrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687244dd4c0c8320875c5a1bbc6f7b7b