### PR TITLE
Enhance C# compiler builtins

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -2808,8 +2808,14 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if _, ok := t.(types.StringType); ok {
 			return fmt.Sprintf("%s.Length", args[0]), nil
 		}
-		c.useLinq = true
-		return fmt.Sprintf("Enumerable.Count(%s)", args[0]), nil
+		switch t.(type) {
+		case types.ListType, types.MapType:
+			c.useLinq = true
+			return fmt.Sprintf("%s.Count()", args[0]), nil
+		default:
+			c.useLinq = true
+			return fmt.Sprintf("Enumerable.Count(%s)", args[0]), nil
+		}
 	case "append":
 		if len(args) != 2 {
 			return "", fmt.Errorf("append expects 2 args")
@@ -2853,8 +2859,7 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		t := c.inferExprType(call.Args[0])
 		if lt, ok := t.(types.ListType); ok && isNumeric(lt.Elem) {
 			c.useLinq = true
-			v := c.newVar()
-			return fmt.Sprintf("Enumerable.Average(%s.Select(%s=>Convert.ToDouble(%s)))", args[0], v, v), nil
+			return fmt.Sprintf("Enumerable.Average(%s)", args[0]), nil
 		}
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", args[0]), nil
@@ -2865,8 +2870,7 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		t := c.inferExprType(call.Args[0])
 		if lt, ok := t.(types.ListType); ok && isNumeric(lt.Elem) {
 			c.useLinq = true
-			v := c.newVar()
-			return fmt.Sprintf("Enumerable.Sum(%s.Select(%s=>Convert.ToDouble(%s)))", args[0], v, v), nil
+			return fmt.Sprintf("Enumerable.Sum(%s)", args[0]), nil
 		}
 		c.use("_sum")
 		return fmt.Sprintf("_sum(%s)", args[0]), nil

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -1,0 +1,16 @@
+# C# Machine Output
+
+This directory contains C# source generated from the Mochi programs in `tests/vm/valid`.
+Each program has a `.cs` file along with the expected output `.out` if compilation
+and execution succeeded. If a program failed to compile or run, an `.error` file
+is present instead.
+
+Compiled programs: 96/100
+
+Failing programs:
+- cast_string_to_int.mochi
+- cross_join.mochi
+- dataset_sort_take_limit.mochi
+- dataset_where_filter.mochi
+
+The remaining programs compile and run successfully under `dotnet`.

--- a/tests/machine/x/cs/avg_builtin.cs
+++ b/tests/machine/x/cs/avg_builtin.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program {
-    static void Main() {
-        Console.WriteLine(Enumerable.Average(new List<int> { 1, 2, 3 }.Select(_tmp0=>Convert.ToDouble(_tmp0))));
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(Enumerable.Average(new List<int> { 1, 2, 3 }));
     }
 }

--- a/tests/machine/x/cs/cast_string_to_int.error
+++ b/tests/machine/x/cs/cast_string_to_int.error
@@ -1,0 +1,2 @@
+line: 0
+error: exit status 134

--- a/tests/machine/x/cs/count_builtin.cs
+++ b/tests/machine/x/cs/count_builtin.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-class Program {
-    static void Main() {
-        Console.WriteLine(Enumerable.Count(new List<int> { 1, 2, 3 }));
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new List<int> { 1, 2, 3 }.Count());
     }
 }

--- a/tests/machine/x/cs/cross_join.error
+++ b/tests/machine/x/cs/cross_join.error
@@ -1,0 +1,2 @@
+line: 0
+error: exit status 1

--- a/tests/machine/x/cs/dataset_sort_take_limit.error
+++ b/tests/machine/x/cs/dataset_sort_take_limit.error
@@ -1,0 +1,2 @@
+line: 0
+error: exit status 1

--- a/tests/machine/x/cs/dataset_where_filter.error
+++ b/tests/machine/x/cs/dataset_where_filter.error
@@ -1,0 +1,2 @@
+line: 0
+error: exit status 1


### PR DESCRIPTION
## Summary
- improve builtin handling in the C# compiler
- update generated C# for `avg_builtin` and `count_builtin`
- document machine output status for C# programs
- keep `.error` files for failing programs

## Testing
- `PATTERN="tests/vm/valid/avg_builtin.mochi" go run -tags slow scripts/compile_cs.go`
- `PATTERN="tests/vm/valid/count_builtin.mochi" go run -tags slow scripts/compile_cs.go`


------
https://chatgpt.com/codex/tasks/task_e_687249b2b54083209c812f67c349bbfd