### PR TITLE
Update Kotlin backend and compilation status

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -1197,11 +1197,11 @@ func (c *Compiler) builtinCall(call *parser.CallExpr, args []string) (string, bo
 		}
 	case "max":
 		if len(args) == 1 {
-			return fmt.Sprintf("%s.maxOrNull() ?: 0", args[0]), true
+			return fmt.Sprintf("%s.max() ?: 0", args[0]), true
 		}
 	case "min":
 		if len(args) == 1 {
-			return fmt.Sprintf("%s.minOrNull() ?: 0", args[0]), true
+			return fmt.Sprintf("%s.min() ?: 0", args[0]), true
 		}
 	case "values":
 		if len(args) == 1 {
@@ -2256,7 +2256,9 @@ func (c *Compiler) builtinImport(im *parser.ImportStmt) (bool, error) {
 			c.writeln("const val pi: Double = kotlin.math.PI")
 			c.writeln("const val e: Double = kotlin.math.E")
 			c.writeln("fun sqrt(x: Double): Double = kotlin.math.sqrt(x)")
-			c.writeln("fun pow(x: Double, y: Double): Double = kotlin.math.pow(x, y)")
+			// Kotlin 1.3 does not provide a top-level pow function.
+			// Use java.lang.Math.pow for portability.
+			c.writeln("fun pow(x: Double, y: Double): Double = Math.pow(x, y)")
 			c.writeln("fun sin(x: Double): Double = kotlin.math.sin(x)")
 			c.writeln("fun log(x: Double): Double = kotlin.math.ln(x)")
 			c.indent--

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -1,0 +1,34 @@
+# Kotlin Machine Outputs
+
+This directory contains Kotlin source files generated from the Mochi programs in
+`tests/vm/valid`. They are produced by the Kotlin backend in
+`compiler/x/kotlin` and compiled using `kotlinc`.
+
+## Compilation status
+
+As of this commit the test suite compiles and runs most example programs. The
+following 13 programs currently fail to compile and have corresponding `.error`
+files:
+
+- group_by_conditional_sum
+- group_by_join
+- group_by_left_join
+- group_by_multi_join_sort
+- group_by_sort
+- group_items_iteration
+- in_operator_extended
+- order_by_map
+- outer_join
+- query_sum_select
+- right_join
+- sort_stable
+- tree_sum
+
+Successful programs have matching `.kt` and `.out` files.
+
+## TODO
+
+- Implement dataset join and group-by operations in the Kotlin backend.
+- Provide better support for the Python `math` helpers and other foreign
+  imports.
+- Finish compiling the remaining programs listed above.

--- a/tests/machine/x/kotlin/group_by_conditional_sum.error
+++ b/tests/machine/x/kotlin/group_by_conditional_sum.error
@@ -1,0 +1,27 @@
+line 41:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/group_by_conditional_sum.kt:41:37: error: expecting property name or receiver type
+        __res.add(if (x.flag) x.val else 0)
+                                    ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_conditional_sum.kt:41:41: error: expecting ','
+        __res.add(if (x.flag) x.val else 0)
+                                        ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_conditional_sum.kt:47:24: error: expecting property name or receiver type
+        __res.add(x.val)
+                       ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_conditional_sum.kt:47:25: error: expecting ')'
+        __res.add(x.val)
+                        ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_conditional_sum.kt:38:47: error: type mismatch: inferred type is Int but Double was expected
+        __res.add(Result(cat = g.key, share = sum(run {
+                                              ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_conditional_sum.kt:41:19: error: 'if' must have both main and 'else' branches if used as an expression
+        __res.add(if (x.flag) x.val else 0)
+                  ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_conditional_sum.kt:53:17: error: unresolved reference: key
+}.sortedBy { it.key as Comparable<Any> }
+                ^
+
+ 40:     for (x in g) {
+ 41:         __res.add(if (x.flag) x.val else 0)
+ 42:     }

--- a/tests/machine/x/kotlin/group_by_join.error
+++ b/tests/machine/x/kotlin/group_by_join.error
@@ -1,0 +1,9 @@
+line 25:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/group_by_join.kt:25:25: error: type mismatch: inferred type is MutableMap<Any?, Any?> but MutableMap<String, Any?> was expected
+                __g.add(mutableMapOf("o" to o, "c" to c) as MutableMap<Any?, Any?>)
+                        ^
+
+ 24:                 }
+ 25:                 __g.add(mutableMapOf("o" to o, "c" to c) as MutableMap<Any?, Any?>)
+ 26:             }

--- a/tests/machine/x/kotlin/group_by_left_join.error
+++ b/tests/machine/x/kotlin/group_by_left_join.error
@@ -1,0 +1,9 @@
+line 34:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/group_by_left_join.kt:34:25: error: type mismatch: inferred type is MutableMap<Any?, Any?> but MutableMap<String, Any?> was expected
+                __g.add(mutableMapOf("c" to c, "o" to o) as MutableMap<Any?, Any?>)
+                        ^
+
+ 33:                 }
+ 34:                 __g.add(mutableMapOf("c" to c, "o" to o) as MutableMap<Any?, Any?>)
+ 35:             }

--- a/tests/machine/x/kotlin/group_by_multi_join_sort.error
+++ b/tests/machine/x/kotlin/group_by_multi_join_sort.error
@@ -1,0 +1,67 @@
+line 46:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:46:33: error: type expected
+    val __groups = mutableMapOf<, Group<, MutableMap<String, Any?>>>()
+                                ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:46:41: error: type expected
+    val __groups = mutableMapOf<, Group<, MutableMap<String, Any?>>>()
+                                        ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:47:33: error: type expected
+    val __order = mutableListOf<>()
+                                ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:63:45: error: type mismatch: inferred type is MutableMap<Any?, Any?> but MutableMap<String, Any?> was expected
+                                    __g.add(mutableMapOf("c" to c, "o" to o, "l" to l, "n" to n) as MutableMap<Any?, Any?>)
+                                            ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:78:29: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<String, Any?>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                            ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:78:65: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<String, Any?>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:78:86: error: none of the following functions can be called with the arguments supplied: 
+public final operator fun times(other: Byte): Double defined in kotlin.Double
+public final operator fun times(other: Double): Double defined in kotlin.Double
+public final operator fun times(other: Float): Double defined in kotlin.Double
+public final operator fun times(other: Int): Double defined in kotlin.Double
+public final operator fun times(other: Long): Double defined in kotlin.Double
+public final operator fun times(other: Short): Double defined in kotlin.Double
+        __res.add((toDouble((x as MutableMap<String, Any?>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                     ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:78:108: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<String, Any?>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                           ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:78:144: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<String, Any?>)["l"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["l"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                                                               ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:86:15: error: for-loop range must have an 'iterator()' method
+    for (x in it) {
+              ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:87:29: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<String, Any?>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                            ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:87:66: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<String, Any?>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                 ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:87:87: error: none of the following functions can be called with the arguments supplied: 
+public final operator fun times(other: Byte): Double defined in kotlin.Double
+public final operator fun times(other: Double): Double defined in kotlin.Double
+public final operator fun times(other: Float): Double defined in kotlin.Double
+public final operator fun times(other: Int): Double defined in kotlin.Double
+public final operator fun times(other: Long): Double defined in kotlin.Double
+public final operator fun times(other: Short): Double defined in kotlin.Double
+        __res.add((toDouble((x as MutableMap<String, Any?>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                      ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:87:109: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, Any?>.get(key: String): Any? defined in kotlin.collections
+        __res.add((toDouble((x as MutableMap<String, Any?>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                            ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_multi_join_sort.kt:87:146: error: no get method providing array access
+        __res.add((toDouble((x as MutableMap<String, Any?>)["it"]["l_extendedprice"]) * toDouble((1 - toInt((x as MutableMap<String, Any?>)["it"]["l_discount"]))) as MutableMap<String, Any?>))
+                                                                                                                                                 ^
+
+ 45: val result = run {
+ 46:     val __groups = mutableMapOf<, Group<, MutableMap<String, Any?>>>()
+ 47:     val __order = mutableListOf<>()

--- a/tests/machine/x/kotlin/group_by_sort.error
+++ b/tests/machine/x/kotlin/group_by_sort.error
@@ -1,0 +1,21 @@
+line 41:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/group_by_sort.kt:41:24: error: expecting property name or receiver type
+        __res.add(x.val)
+                       ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_sort.kt:41:25: error: expecting ')'
+        __res.add(x.val)
+                        ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_sort.kt:50:24: error: expecting property name or receiver type
+        __res.add(x.val)
+                       ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_sort.kt:50:25: error: expecting ')'
+        __res.add(x.val)
+                        ^
+/workspace/mochi/tests/machine/x/kotlin/group_by_sort.kt:49:15: error: for-loop range must have an 'iterator()' method
+    for (x in it) {
+              ^
+
+ 40:     for (x in g) {
+ 41:         __res.add(x.val)
+ 42:     }

--- a/tests/machine/x/kotlin/group_items_iteration.error
+++ b/tests/machine/x/kotlin/group_items_iteration.error
@@ -1,0 +1,11 @@
+line 35:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/group_items_iteration.kt:35:11: error: type inference failed: Not enough information to infer parameter T in inline fun <T> mutableListOf(): MutableList<T>
+Please specify it explicitly.
+
+var tmp = mutableListOf()
+          ^
+
+ 34: 
+ 35: var tmp = mutableListOf()
+ 36: 

--- a/tests/machine/x/kotlin/in_operator_extended.error
+++ b/tests/machine/x/kotlin/in_operator_extended.error
@@ -1,0 +1,126 @@
+line 22:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/in_operator_extended.kt:22:17: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@SinceKotlin @InlineOnly public inline operator fun <T : Any, R : Iterable<String>> ???.contains(element: String?): Boolean where R : ClosedRange<String> defined in kotlin.ranges
+public operator fun <@OnlyInputTypes T> Array<out String>.contains(element: String): Boolean defined in kotlin.collections
+public operator fun BooleanArray.contains(element: Boolean): Boolean defined in kotlin.collections
+public operator fun ByteArray.contains(element: Byte): Boolean defined in kotlin.collections
+public operator fun CharArray.contains(element: Char): Boolean defined in kotlin.collections
+public operator fun CharSequence.contains(char: Char, ignoreCase: Boolean = ...): Boolean defined in kotlin.text
+public operator fun CharSequence.contains(other: CharSequence, ignoreCase: Boolean = ...): Boolean defined in kotlin.text
+@InlineOnly public inline operator fun CharSequence.contains(regex: Regex): Boolean defined in kotlin.text
+public operator fun DoubleArray.contains(element: Double): Boolean defined in kotlin.collections
+public operator fun FloatArray.contains(element: Float): Boolean defined in kotlin.collections
+public operator fun IntArray.contains(element: Int): Boolean defined in kotlin.collections
+public operator fun LongArray.contains(element: Long): Boolean defined in kotlin.collections
+public operator fun ShortArray.contains(element: Short): Boolean defined in kotlin.collections
+public operator fun <@OnlyInputTypes T> Iterable<String>.contains(element: String): Boolean defined in kotlin.collections
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, ???>.contains(key: String): Boolean defined in kotlin.collections
+@SinceKotlin @InlineOnly public inline operator fun CharRange.contains(element: Char?): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Byte>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Byte>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Byte>.contains(value: Int): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Byte>.contains(value: Long): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Byte>.contains(value: Short): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Byte): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Double>.contains(value: Float): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Int): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Long): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Short): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Byte): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Float>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Int): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Long): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Short): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Int>.contains(value: Byte): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Int>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Int>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Int>.contains(value: Long): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Int>.contains(value: Short): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Long>.contains(value: Byte): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Long>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Long>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Long>.contains(value: Int): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Long>.contains(value: Short): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Short>.contains(value: Byte): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Short>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Short>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Short>.contains(value: Int): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Short>.contains(value: Long): Boolean defined in kotlin.ranges
+@SinceKotlin @InlineOnly public inline operator fun IntRange.contains(element: Int?): Boolean defined in kotlin.ranges
+@SinceKotlin @InlineOnly public inline operator fun LongRange.contains(element: Long?): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun UIntRange.contains(value: UByte): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes @InlineOnly public inline operator fun UIntRange.contains(element: UInt?): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun UIntRange.contains(value: ULong): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun UIntRange.contains(value: UShort): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun ULongRange.contains(value: UByte): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun ULongRange.contains(value: UInt): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes @InlineOnly public inline operator fun ULongRange.contains(element: ULong?): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun ULongRange.contains(value: UShort): Boolean defined in kotlin.ranges
+public operator fun <@OnlyInputTypes T> Sequence<String>.contains(element: String): Boolean defined in kotlin.sequences
+    println("a" in m)
+                ^
+/workspace/mochi/tests/machine/x/kotlin/in_operator_extended.kt:23:17: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@SinceKotlin @InlineOnly public inline operator fun <T : Any, R : Iterable<String>> ???.contains(element: String?): Boolean where R : ClosedRange<String> defined in kotlin.ranges
+public operator fun <@OnlyInputTypes T> Array<out String>.contains(element: String): Boolean defined in kotlin.collections
+public operator fun BooleanArray.contains(element: Boolean): Boolean defined in kotlin.collections
+public operator fun ByteArray.contains(element: Byte): Boolean defined in kotlin.collections
+public operator fun CharArray.contains(element: Char): Boolean defined in kotlin.collections
+public operator fun CharSequence.contains(char: Char, ignoreCase: Boolean = ...): Boolean defined in kotlin.text
+public operator fun CharSequence.contains(other: CharSequence, ignoreCase: Boolean = ...): Boolean defined in kotlin.text
+@InlineOnly public inline operator fun CharSequence.contains(regex: Regex): Boolean defined in kotlin.text
+public operator fun DoubleArray.contains(element: Double): Boolean defined in kotlin.collections
+public operator fun FloatArray.contains(element: Float): Boolean defined in kotlin.collections
+public operator fun IntArray.contains(element: Int): Boolean defined in kotlin.collections
+public operator fun LongArray.contains(element: Long): Boolean defined in kotlin.collections
+public operator fun ShortArray.contains(element: Short): Boolean defined in kotlin.collections
+public operator fun <@OnlyInputTypes T> Iterable<String>.contains(element: String): Boolean defined in kotlin.collections
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out String, ???>.contains(key: String): Boolean defined in kotlin.collections
+@SinceKotlin @InlineOnly public inline operator fun CharRange.contains(element: Char?): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Byte>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Byte>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Byte>.contains(value: Int): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Byte>.contains(value: Long): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Byte>.contains(value: Short): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Byte): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Double>.contains(value: Float): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Int): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Long): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Double>.contains(value: Short): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Byte): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Float>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Int): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Long): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Float>.contains(value: Short): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Int>.contains(value: Byte): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Int>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Int>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Int>.contains(value: Long): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Int>.contains(value: Short): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Long>.contains(value: Byte): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Long>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Long>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Long>.contains(value: Int): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Long>.contains(value: Short): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Short>.contains(value: Byte): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Short>.contains(value: Double): Boolean defined in kotlin.ranges
+@Deprecated @JvmName public operator fun ClosedRange<Short>.contains(value: Float): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Short>.contains(value: Int): Boolean defined in kotlin.ranges
+@JvmName public operator fun ClosedRange<Short>.contains(value: Long): Boolean defined in kotlin.ranges
+@SinceKotlin @InlineOnly public inline operator fun IntRange.contains(element: Int?): Boolean defined in kotlin.ranges
+@SinceKotlin @InlineOnly public inline operator fun LongRange.contains(element: Long?): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun UIntRange.contains(value: UByte): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes @InlineOnly public inline operator fun UIntRange.contains(element: UInt?): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun UIntRange.contains(value: ULong): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun UIntRange.contains(value: UShort): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun ULongRange.contains(value: UByte): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun ULongRange.contains(value: UInt): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes @InlineOnly public inline operator fun ULongRange.contains(element: ULong?): Boolean defined in kotlin.ranges
+@SinceKotlin @ExperimentalUnsignedTypes public operator fun ULongRange.contains(value: UShort): Boolean defined in kotlin.ranges
+public operator fun <@OnlyInputTypes T> Sequence<String>.contains(element: String): Boolean defined in kotlin.sequences
+    println("b" in m)
+                ^
+
+ 21:     println(2 in ys)
+ 22:     println("a" in m)
+ 23:     println("b" in m)

--- a/tests/machine/x/kotlin/order_by_map.error
+++ b/tests/machine/x/kotlin/order_by_map.error
@@ -1,0 +1,11 @@
+line 0:
+Exception in thread "main" java.lang.ExceptionInInitializerError
+Caused by: java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class java.lang.Comparable (java.util.LinkedHashMap and java.lang.Comparable are in module java.base of loader 'bootstrap')
+	at Order_by_mapKt$$special$$inlined$sortedBy$1.compare(Comparisons.kt:320)
+	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
+	at java.base/java.util.TimSort.sort(TimSort.java:220)
+	at java.base/java.util.Arrays.sort(Arrays.java:1234)
+	at kotlin.collections.ArraysKt___ArraysJvmKt.sortWith(_ArraysJvm.kt:1862)
+	at kotlin.collections.CollectionsKt___CollectionsKt.sortedWith(_Collections.kt:947)
+	at Order_by_mapKt.<clinit>(order_by_map.kt:17)
+

--- a/tests/machine/x/kotlin/outer_join.error
+++ b/tests/machine/x/kotlin/outer_join.error
@@ -1,0 +1,24 @@
+line 49:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/outer_join.kt:49:51: error: unresolved reference: id
+                println(listOf("Order", row.order.id, "by", row.customer.name, "- $", row.order.total).joinToString(" "))
+                                                  ^
+/workspace/mochi/tests/machine/x/kotlin/outer_join.kt:49:74: error: unresolved reference: name
+                println(listOf("Order", row.order.id, "by", row.customer.name, "- $", row.order.total).joinToString(" "))
+                                                                         ^
+/workspace/mochi/tests/machine/x/kotlin/outer_join.kt:49:97: error: unresolved reference: total
+                println(listOf("Order", row.order.id, "by", row.customer.name, "- $", row.order.total).joinToString(" "))
+                                                                                                ^
+/workspace/mochi/tests/machine/x/kotlin/outer_join.kt:52:51: error: unresolved reference: id
+                println(listOf("Order", row.order.id, "by", "Unknown", "- $", row.order.total).joinToString(" "))
+                                                  ^
+/workspace/mochi/tests/machine/x/kotlin/outer_join.kt:52:89: error: unresolved reference: total
+                println(listOf("Order", row.order.id, "by", "Unknown", "- $", row.order.total).joinToString(" "))
+                                                                                        ^
+/workspace/mochi/tests/machine/x/kotlin/outer_join.kt:56:53: error: unresolved reference: name
+            println(listOf("Customer", row.customer.name, "has no orders").joinToString(" "))
+                                                    ^
+
+ 48:             if (toBool(row.customer)) {
+ 49:                 println(listOf("Order", row.order.id, "by", row.customer.name, "- $", row.order.total).joinToString(" "))
+ 50:             }

--- a/tests/machine/x/kotlin/query_sum_select.error
+++ b/tests/machine/x/kotlin/query_sum_select.error
@@ -1,0 +1,9 @@
+line 20:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/query_sum_select.kt:20:27: error: type mismatch: inferred type is Int but List<Any?> was expected
+            __res.add(sum(n))
+                          ^
+
+ 19:         if (n > 1) {
+ 20:             __res.add(sum(n))
+ 21:         }

--- a/tests/machine/x/kotlin/right_join.error
+++ b/tests/machine/x/kotlin/right_join.error
@@ -1,0 +1,12 @@
+line 40:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/right_join.kt:40:85: error: unresolved reference: id
+            println(listOf("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total).joinToString(" "))
+                                                                                    ^
+/workspace/mochi/tests/machine/x/kotlin/right_join.kt:40:108: error: unresolved reference: total
+            println(listOf("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total).joinToString(" "))
+                                                                                                           ^
+
+ 39:         if (toBool(entry.order)) {
+ 40:             println(listOf("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total).joinToString(" "))
+ 41:         }

--- a/tests/machine/x/kotlin/sort_stable.error
+++ b/tests/machine/x/kotlin/sort_stable.error
@@ -1,0 +1,9 @@
+line 11:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/sort_stable.kt:11:17: error: unresolved reference: n
+}.sortedBy { it.n as Comparable<Any> }
+                ^
+
+ 10:     __res
+ 11: }.sortedBy { it.n as Comparable<Any> }
+ 12: 

--- a/tests/machine/x/kotlin/tree_sum.error
+++ b/tests/machine/x/kotlin/tree_sum.error
@@ -1,0 +1,27 @@
+line 23:
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/machine/x/kotlin/tree_sum.kt:23:5: error: 'when' expression must be exhaustive, add necessary 'is Node' branch or 'else' branch instead
+    when (__t) {
+    ^
+/workspace/mochi/tests/machine/x/kotlin/tree_sum.kt:25:14: error: unresolved reference: left
+        Node(left, value, right) -> toInt(sum_tree(left) + toInt(value)) + sum_tree(right)
+             ^
+/workspace/mochi/tests/machine/x/kotlin/tree_sum.kt:25:20: error: unresolved reference: value
+        Node(left, value, right) -> toInt(sum_tree(left) + toInt(value)) + sum_tree(right)
+                   ^
+/workspace/mochi/tests/machine/x/kotlin/tree_sum.kt:25:27: error: unresolved reference: right
+        Node(left, value, right) -> toInt(sum_tree(left) + toInt(value)) + sum_tree(right)
+                          ^
+/workspace/mochi/tests/machine/x/kotlin/tree_sum.kt:25:52: error: unresolved reference: left
+        Node(left, value, right) -> toInt(sum_tree(left) + toInt(value)) + sum_tree(right)
+                                                   ^
+/workspace/mochi/tests/machine/x/kotlin/tree_sum.kt:25:66: error: unresolved reference: value
+        Node(left, value, right) -> toInt(sum_tree(left) + toInt(value)) + sum_tree(right)
+                                                                 ^
+/workspace/mochi/tests/machine/x/kotlin/tree_sum.kt:25:85: error: unresolved reference: right
+        Node(left, value, right) -> toInt(sum_tree(left) + toInt(value)) + sum_tree(right)
+                                                                                    ^
+
+ 22:     val __t = t
+ 23:     when (__t) {
+ 24:         Leaf -> 0


### PR DESCRIPTION
## Summary
- fix pow helper for Kotlin `python_auto` import
- fall back to `min()` and `max()` for older Kotlin
- add Kotlin machine output README with failing programs
- store `.error` logs for programs that fail to compile

## Testing
- `go test ./compiler/x/kotlin -tags slow -run TestKotlinPrograms/python_auto -count=1`
- `go test ./compiler/x/kotlin -tags slow -run TestKotlinPrograms/min_max_builtin -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687249d3dd748320bfb9dd475509c731