### PR TITLE
Improve C backend float constants

### DIFF
--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -106,3 +106,17 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+
+## Remaining tasks
+- [ ] group_by_join
+- [ ] group_by_left_join
+- [ ] group_by_multi_join
+- [ ] group_by_multi_join_sort
+- [ ] group_items_iteration
+- [ ] left_join
+- [ ] left_join_multi
+- [ ] load_yaml
+- [ ] order_by_map
+- [ ] python_math (rounding difference)
+- [ ] save_jsonl_stdout

--- a/tests/machine/x/c/python_math.c
+++ b/tests/machine/x/c/python_math.c
@@ -8,22 +8,22 @@ extern double math_pow(double x, double y);
 extern double math_sin(double x);
 extern double math_log(double x);
 
-static double r = 3;
+static double r = 3.0;
 
 int main() {
-  int area = 3.141592653589793 * (r * r);
+  double area = 3.141592653589793 * (r * r);
   double root = 7;
   double sin45 = __builtin_sin(3.141592653589793 / 4.0);
   double log_e = __builtin_log(2.718281828459045);
   printf("%s ", "Circle area with r =");
-  printf("%d ", r);
+  printf("%.17g ", r);
   printf("%s ", "=>");
-  printf("%d\n", area);
+  printf("%.17g\n", area);
   printf("%s ", "Square root of 49:");
-  printf("%.16g\n", root);
+  printf("%.17g\n", root);
   printf("%s ", "sin(π/4):");
-  printf("%.16g\n", sin45);
+  printf("%.17g\n", sin45);
   printf("%s ", "log(e):");
-  printf("%.16g\n", log_e);
+  printf("%.17g\n", log_e);
   return 0;
 }

--- a/tests/machine/x/c/python_math.error
+++ b/tests/machine/x/c/python_math.error
@@ -1,9 +1,9 @@
 line: 0
 error: output mismatch
 -- got --
-Circle area with r = -2133086880 => 28
+Circle area with r = 3 => 28.274333882308138
 Square root of 49: 7
-sin(π/4): 0.7071067811865475
+sin(π/4): 0.70710678118654746
 log(e): 1
 -- want --
 Circle area with r = 3 => 28.274333882308138


### PR DESCRIPTION
## Summary
- improve type inference for constant globals
- keep trailing decimal when emitting float constants
- print floats with more precision
- update machine output for python_math
- document remaining compilation tasks for C backend

## Testing
- `go test -tags slow ./compiler/x/c -run TestCCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68724e0ba09c8320be1b2251f421a8e9