### PR TITLE
Improve Clojure compiler extern handling

### DIFF
--- a/compiler/x/clj/helpers.go
+++ b/compiler/x/clj/helpers.go
@@ -458,3 +458,14 @@ func joinEqParts(e *parser.Expr) (*parser.Expr, *parser.Expr, bool) {
 	}
 	return left, right, true
 }
+
+// identNameSimple returns the identifier name if p is a simple identifier with no postfix operations.
+func identNameSimple(p *parser.Primary) string {
+	if p == nil {
+		return ""
+	}
+	if p.Selector != nil && len(p.Selector.Tail) == 0 {
+		return p.Selector.Root
+	}
+	return ""
+}

--- a/tests/machine/x/clj/README.md
+++ b/tests/machine/x/clj/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Clojure code generated from the Mochi programs in `tests/vm/valid` using the Clojure compiler. Each program was compiled and executed. Successful runs produced an `.out` file while failures produced an `.error` file.
 
-Compiled programs: 97/100 successful.
+Compiled programs: 98/100 successful.
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -74,7 +74,7 @@ Compiled programs: 97/100 successful.
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
 - [x] python_auto.mochi
-- [ ] python_math.mochi
+- [x] python_math.mochi
 - [x] query_sum_select.mochi
 - [x] record_assign.mochi
 - [x] right_join.mochi
@@ -105,7 +105,7 @@ Compiled programs: 97/100 successful.
 - [x] while_loop.mochi
 
 ## Status
-3 programs failed.
+2 programs failed.
 
 ## Remaining tasks
 - [ ] Fix failing examples

--- a/tests/machine/x/clj/load_yaml.error
+++ b/tests/machine/x/clj/load_yaml.error
@@ -3,4 +3,4 @@ Execution error (FileNotFoundException) at java.io.FileInputStream/open0 (FileIn
 /workspace/mochi/tests/machine/x/interpreter/valid/people.yaml (No such file or directory)
 
 Full report at:
-/tmp/clojure-14042751378679712154.edn
+/tmp/clojure-9610542794357024463.edn

--- a/tests/machine/x/clj/outer_join.error
+++ b/tests/machine/x/clj/outer_join.error
@@ -3,4 +3,4 @@ Execution error (ArityException) at main/-query$fn (outer_join.clj:96).
 Wrong number of args (3) passed to: main/-main/fn--709
 
 Full report at:
-/tmp/clojure-5176762423752956687.edn
+/tmp/clojure-9348128618022823193.edn

--- a/tests/machine/x/clj/python_math.clj
+++ b/tests/machine/x/clj/python_math.clj
@@ -1,0 +1,17 @@
+(ns main)
+
+(declare r area root sin45 log_e)
+
+(defn -main []
+  (def r 3.0) ;; float
+  (def area (* Math/PI (Math/pow r 2.0))) ;; float
+  (def root (Math/sqrt 49.0)) ;; float
+  (def sin45 (Math/sin (/ Math/PI 4.0))) ;; float
+  (def log_e (Math/log Math/E)) ;; float
+  (println "Circle area with r =" r "=>" area)
+  (println "Square root of 49:" root)
+  (println "sin(π/4):" sin45)
+  (println "log(e):" log_e)
+)
+
+(-main)

--- a/tests/machine/x/clj/python_math.error
+++ b/tests/machine/x/clj/python_math.error
@@ -1,1 +1,0 @@
-unsupported statement

--- a/tests/machine/x/clj/python_math.out
+++ b/tests/machine/x/clj/python_math.out
@@ -1,0 +1,4 @@
+Circle area with r = 3.0 => 28.274333882308138
+Square root of 49: 7.0
+sin(π/4): 0.7071067811865475
+log(e): 1.0


### PR DESCRIPTION
## Summary
- support extern declarations in the Clojure compiler
- auto-map extern math functions to Java `Math` APIs
- regenerate Clojure machine translations
  - `python_math` now compiles and runs
- update machine README for Clojure

## Testing
- `go test -tags slow ./compiler/x/clj -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6872547a8a208320ba8a20b4ad935d6f