### PR TITLE
Improve FS compiler output

### DIFF
--- a/compiler/x/fs/compiler.go
+++ b/compiler/x/fs/compiler.go
@@ -238,11 +238,13 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 func (c *Compiler) compileLet(l *parser.LetStmt) error {
 	var typ string
 	var err error
+	explicit := false
 	if l.Type != nil {
 		typ, err = c.compileType(l.Type)
 		if err != nil {
 			typ = ""
 		}
+		explicit = true
 	}
 	var val string
 	if l.Value != nil {
@@ -288,11 +290,17 @@ func (c *Compiler) compileLet(l *parser.LetStmt) error {
 		}
 		val = defaultValue(typ)
 	}
-	if typ != "" {
+	if explicit || l.Value == nil {
+		if typ == "" {
+			return fmt.Errorf("let without type at line %d", l.Pos.Line)
+		}
 		c.writeln(fmt.Sprintf("let %s: %s = %s", l.Name, typ, val))
 		c.vars[l.Name] = typ
 	} else {
 		c.writeln(fmt.Sprintf("let %s = %s", l.Name, val))
+		if typ != "" {
+			c.vars[l.Name] = typ
+		}
 	}
 	return nil
 }
@@ -300,11 +308,13 @@ func (c *Compiler) compileLet(l *parser.LetStmt) error {
 func (c *Compiler) compileVar(v *parser.VarStmt) error {
 	var typ string
 	var err error
+	explicit := false
 	if v.Type != nil {
 		typ, err = c.compileType(v.Type)
 		if err != nil {
 			typ = ""
 		}
+		explicit = true
 	}
 	var val string = "0"
 	if v.Value != nil {
@@ -363,11 +373,17 @@ func (c *Compiler) compileVar(v *parser.VarStmt) error {
 	} else if typ != "" {
 		val = defaultValue(typ)
 	}
-	if typ != "" {
+	if explicit || v.Value == nil {
+		if typ == "" {
+			return fmt.Errorf("var without type at line %d", v.Pos.Line)
+		}
 		c.writeln(fmt.Sprintf("let mutable %s: %s = %s", v.Name, typ, val))
 		c.vars[v.Name] = typ
 	} else {
 		c.writeln(fmt.Sprintf("let mutable %s = %s", v.Name, val))
+		if typ != "" {
+			c.vars[v.Name] = typ
+		}
 	}
 	return nil
 }

--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -109,3 +109,4 @@ This directory contains the F# source code and outputs generated from the Mochi 
 
 - Ensure new features continue to compile correctly.
 - Keep generated code in sync with `tests/human/x/fs` when changes occur.
+- Compiler now omits inferred type annotations for variables without explicit types.


### PR DESCRIPTION
## Summary
- tweak F# compiler to omit inferred type annotations
- document change in machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68725af885448320b934ebf130fdc587