### PR TITLE
Add Elixir machine outputs and reserved names update

### DIFF
--- a/compiler/x/ex/compiler.go
+++ b/compiler/x/ex/compiler.go
@@ -31,7 +31,17 @@ type Compiler struct {
 var atomIdent = regexp.MustCompile(`^[a-z_][a-zA-Z0-9_]*$`)
 
 var exReserved = map[string]bool{
-	"end": true,
+	"after":  true,
+	"case":   true,
+	"catch":  true,
+	"do":     true,
+	"else":   true,
+	"end":    true,
+	"fn":     true,
+	"nil":    true,
+	"rescue": true,
+	"try":    true,
+	"when":   true,
 }
 
 func sanitizeName(name string) string {

--- a/tests/machine/x/ex/README.md
+++ b/tests/machine/x/ex/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Elixir source code generated from Mochi programs and the corresponding outputs.
 
-Compiled programs: 100/100
+Compiled programs: 92/100
 
 Checklist:
 
@@ -28,16 +28,16 @@ Checklist:
 - [x] fun_call
 - [x] fun_expr_in_let
 - [x] fun_three_args
-- [x] go_auto
+- [ ] go_auto
 - [x] group_by
 - [x] group_by_conditional_sum
 - [x] group_by_having
 - [x] group_by_join
-- [x] group_by_left_join
+- [ ] group_by_left_join
 - [x] group_by_multi_join
-- [x] group_by_multi_join_sort
-- [x] group_by_sort
-- [x] group_items_iteration
+- [ ] group_by_multi_join_sort
+- [ ] group_by_sort
+- [ ] group_items_iteration
 - [x] if_else
 - [x] if_then_else
 - [x] if_then_else_nested
@@ -56,7 +56,7 @@ Checklist:
 - [x] list_index
 - [x] list_nested_assign
 - [x] list_set_ops
-- [x] load_yaml
+- [ ] load_yaml
 - [x] map_assign
 - [x] map_in_operator
 - [x] map_index
@@ -76,8 +76,8 @@ Checklist:
 - [x] print_hello
 - [x] pure_fold
 - [x] pure_global_fold
-- [x] python_auto
-- [x] python_math
+- [ ] python_auto
+- [ ] python_math
 - [x] query_sum_select
 - [x] record_assign
 - [x] right_join
@@ -108,4 +108,11 @@ Checklist:
 - [x] while_loop
 
 ### Remaining tasks
-None
+- [ ] go_auto
+- [ ] group_by_left_join
+- [ ] group_by_multi_join_sort
+- [ ] group_by_sort
+- [ ] group_items_iteration
+- [ ] load_yaml
+- [ ] python_auto
+- [ ] python_math

--- a/tests/machine/x/ex/go_auto.error
+++ b/tests/machine/x/ex/go_auto.error
@@ -1,0 +1,23 @@
+line 4
+** (SyntaxError) invalid syntax found on /workspace/mochi/tests/machine/x/ex/go_auto.exs:4:25:
+    error: unexpected ( after alias Add. Function names and identifiers in Elixir start with lowercase characters or underscore. For example:
+
+        hello_world()
+        _starting_with_underscore()
+        numb3rs_are_allowed()
+        may_finish_with_question_mark?()
+        may_finish_with_exclamation_mark!()
+
+    Unexpected token: (
+    │
+  4 │ 		IO.inspect(testpkg.Add(2, 3))
+    │                         ^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/go_auto.exs:4:25
+    (elixir 1.18.3) lib/code.ex:1525: Code.require_file/2
+
+defmodule Main do
+	def main do
+		IO.inspect(testpkg.Add(2, 3))
+		IO.inspect(testpkg.Pi)
+		IO.inspect(testpkg.Answer)

--- a/tests/machine/x/ex/group_by_left_join.error
+++ b/tests/machine/x/ex/group_by_left_join.error
@@ -1,0 +1,30 @@
+line 22
+    warning: variable "o" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 22 │          groups = _group_by(rows, fn [c, o] -> c.name end)
+    │                                          ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_left_join.exs:22:42: Main.main/0
+
+    warning: default values for the optional arguments in _query/3 are never used
+    │
+ 97 │   defp _query(src, joins, opts \\ %{}) do
+    │        ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_left_join.exs:97:8: Main (module)
+
+** (KeyError) key :o not found in: [%{id: 1, name: "Alice"}, %{id: 100, customerId: 1}]
+
+If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
+    /workspace/mochi/tests/machine/x/ex/group_by_left_join.exs:24: anonymous fn/2 in Main.main/0
+    (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
+    /workspace/mochi/tests/machine/x/ex/group_by_left_join.exs:24: anonymous fn/1 in Main.main/0
+    (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
+    /workspace/mochi/tests/machine/x/ex/group_by_left_join.exs:24: Main.main/0
+    /workspace/mochi/tests/machine/x/ex/group_by_left_join.exs:213: (file)
+
+           )
+
+         groups = _group_by(rows, fn [c, o] -> c.name end)
+         items = groups
+         Enum.map(items, fn g -> %{name: g.key, count: _count(for r <- g.items, r.o, do: r)} end)

--- a/tests/machine/x/ex/group_by_multi_join_sort.error
+++ b/tests/machine/x/ex/group_by_multi_join_sort.error
@@ -1,0 +1,75 @@
+line 43
+    warning: variable "c" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 43 │                %{items: lineitem, on: fn c, o, l -> l.l_orderkey == o.o_orderkey end},
+    │                                          ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:43:42: Main.main/0
+
+    warning: variable "l" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 44 │                %{items: nation, on: fn c, o, l, n -> n.n_nationkey == c.c_nationkey end}
+    │                                              ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:44:46: Main.main/0
+
+    warning: variable "o" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 44 │                %{items: nation, on: fn c, o, l, n -> n.n_nationkey == c.c_nationkey end}
+    │                                           ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:44:43: Main.main/0
+
+    warning: variable "c" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 48 │                where: fn [c, o, l, n] ->
+    │                           ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:48:27: Main.main/0
+
+    warning: variable "n" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 48 │                where: fn [c, o, l, n] ->
+    │                                    ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:48:36: Main.main/0
+
+    warning: variable "l" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 56 │            _group_by(rows, fn [c, o, l, n] ->
+    │                                      ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:56:38: Main.main/0
+
+    warning: variable "o" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 56 │            _group_by(rows, fn [c, o, l, n] ->
+    │                                   ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:56:35: Main.main/0
+
+     warning: default values for the optional arguments in _query/3 are never used
+     │
+ 147 │   defp _query(src, joins, opts \\ %{}) do
+     │        ~
+     │
+     └─ /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:147:8: Main (module)
+
+** (FunctionClauseError) no function clause matching in anonymous fn/1 in Main.main/0    
+    
+    The following arguments were given to anonymous fn/1 in Main.main/0:
+    
+        # 1
+        [%{c_custkey: 1, c_name: "Alice", c_acctbal: 100, c_nationkey: 1, c_address: "123 St", c_phone: "123-456", c_comment: "Loyal"}]
+    
+    /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:48: anonymous fn/1 in Main.main/0
+    (elixir 1.18.3) lib/enum.ex:4390: Enum.filter_list/2
+    /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:150: Main._query/3
+    /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:39: Main.main/0
+    /workspace/mochi/tests/machine/x/ex/group_by_multi_join_sort.exs:274: (file)
+
+             [
+               %{items: orders, on: fn c, o -> o.o_custkey == c.c_custkey end},
+               %{items: lineitem, on: fn c, o, l -> l.l_orderkey == o.o_orderkey end},
+               %{items: nation, on: fn c, o, l, n -> n.n_nationkey == c.c_nationkey end}
+             ],

--- a/tests/machine/x/ex/group_by_sort.error
+++ b/tests/machine/x/ex/group_by_sort.error
@@ -1,0 +1,28 @@
+line 75
+    warning: default values for the optional arguments in _query/3 are never used
+    │
+ 75 │   defp _query(src, joins, opts \\ %{}) do
+    │        ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/group_by_sort.exs:75:8: Main (module)
+
+** (Protocol.UndefinedError) protocol Enumerable not implemented for type Main.Group (a struct)
+
+Got value:
+
+    %Main.Group{key: "a", items: [%{cat: "a", val: 3}, %{cat: "a", val: 1}]}
+
+    (elixir 1.18.3) lib/enum.ex:1: Enumerable.impl_for!/1
+    (elixir 1.18.3) lib/enum.ex:166: Enumerable.reduce/3
+    (elixir 1.18.3) lib/enum.ex:4515: Enum.map/2
+    /workspace/mochi/tests/machine/x/ex/group_by_sort.exs:13: anonymous fn/1 in Main.main/0
+    (elixir 1.18.3) lib/enum.ex:3363: anonymous fn/2 in Enum.sort_by/3
+    (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
+    (elixir 1.18.3) lib/enum.ex:3363: Enum.sort_by/3
+    /workspace/mochi/tests/machine/x/ex/group_by_sort.exs:13: Main.main/0
+
+  end
+
+  defp _query(src, joins, opts \\ %{}) do
+    where = Map.get(opts, :where)
+    items = Enum.map(src, fn v -> [v] end)

--- a/tests/machine/x/ex/group_items_iteration.error
+++ b/tests/machine/x/ex/group_items_iteration.error
@@ -1,0 +1,23 @@
+line 18
+** (FunctionClauseError) no function clause matching in anonymous fn/2 in Main.main/0    
+    
+    The following arguments were given to anonymous fn/2 in Main.main/0:
+    
+        # 1
+        %{tag: "a", val: 2}
+    
+        # 2
+        {:cont, {1}}
+    
+    /workspace/mochi/tests/machine/x/ex/group_items_iteration.exs:18: anonymous fn/2 in Main.main/0
+    (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
+    /workspace/mochi/tests/machine/x/ex/group_items_iteration.exs:18: anonymous fn/2 in Main.main/0
+    (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
+    /workspace/mochi/tests/machine/x/ex/group_items_iteration.exs:13: Main.main/0
+    /workspace/mochi/tests/machine/x/ex/group_items_iteration.exs:98: (file)
+
+
+        {total} =
+          Enum.reduce(_iter(g.items), {total}, fn x, {total} ->
+            total = total + x.val
+            {:cont, {total}}

--- a/tests/machine/x/ex/load_yaml.error
+++ b/tests/machine/x/ex/load_yaml.error
@@ -1,0 +1,19 @@
+line 14
+    warning: default values for the optional arguments in _load/2 are never used
+    │
+ 14 │   defp _load(path, opts \\ nil) do
+    │        ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/load_yaml.exs:14:8: Main (module)
+
+** (File.Error) could not read file "../interpreter/valid/people.yaml": no such file or directory
+    (elixir 1.18.3) lib/file.ex:385: File.read!/1
+    /workspace/mochi/tests/machine/x/ex/load_yaml.exs:28: Main._load/2
+    /workspace/mochi/tests/machine/x/ex/load_yaml.exs:5: Main.main/0
+    /workspace/mochi/tests/machine/x/ex/load_yaml.exs:90: (file)
+
+  end
+
+  defp _load(path, opts \\ nil) do
+    format = if opts, do: Map.get(opts, "format", "csv"), else: "csv"
+    header = if opts && Map.has_key?(opts, "header"), do: opts["header"], else: true

--- a/tests/machine/x/ex/python_auto.error
+++ b/tests/machine/x/ex/python_auto.error
@@ -1,0 +1,23 @@
+line 4
+    error: undefined variable "math"
+    │
+  4 │     IO.inspect(math.sqrt(16))
+    │                ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_auto.exs:4:16: Main.main/0
+
+    error: undefined variable "math"
+    │
+  5 │     IO.inspect(math.pi)
+    │                ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_auto.exs:5:16: Main.main/0
+
+** (CompileError) /workspace/mochi/tests/machine/x/ex/python_auto.exs: cannot compile module Main (errors have been logged)
+
+
+defmodule Main do
+  def main do
+    IO.inspect(math.sqrt(16))
+    IO.inspect(math.pi)
+  end

--- a/tests/machine/x/ex/python_math.error
+++ b/tests/machine/x/ex/python_math.error
@@ -1,0 +1,58 @@
+line 6
+    error: undefined variable "math"
+    │
+  6 │     area = math.pi * math.pow.(@r, 2)
+    │            ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_math.exs:6:12: Main.main/0
+
+    error: undefined variable "math"
+    │
+  6 │     area = math.pi * math.pow.(@r, 2)
+    │                      ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_math.exs:6:22: Main.main/0
+
+    error: undefined variable "math"
+    │
+  8 │     root = math.sqrt.(49)
+    │            ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_math.exs:8:12: Main.main/0
+
+    error: undefined variable "math"
+    │
+ 10 │     sin45 = math.sin.(math.pi / 4)
+    │             ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_math.exs:10:13: Main.main/0
+
+    error: undefined variable "math"
+    │
+ 10 │     sin45 = math.sin.(math.pi / 4)
+    │                       ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_math.exs:10:23: Main.main/0
+
+    error: undefined variable "math"
+    │
+ 12 │     log_e = math.log.(math.e)
+    │             ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_math.exs:12:13: Main.main/0
+
+    error: undefined variable "math"
+    │
+ 12 │     log_e = math.log.(math.e)
+    │                       ^^^^
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/python_math.exs:12:23: Main.main/0
+
+** (CompileError) /workspace/mochi/tests/machine/x/ex/python_math.exs: cannot compile module Main (errors have been logged)
+
+
+  def main do
+    # area :: float()
+    area = math.pi * math.pow.(@r, 2)
+    # root :: float()
+    root = math.sqrt.(49)

--- a/tests/machine/x/ex/update_stmt.out
+++ b/tests/machine/x/ex/update_stmt.out
@@ -1,0 +1,22 @@
+warning: variable "name" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 19 │         %{name: name, age: age, status: status} = it
+    │                 ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/update_stmt.exs:19:17: Main.main/0
+
+    warning: variable "status" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 19 │         %{name: name, age: age, status: status} = it
+    │                                         ~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/update_stmt.exs:19:41: Main.main/0
+
+    warning: variable "people" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)
+    │
+ 17 │     people =
+    │     ~~~~~~
+    │
+    └─ /workspace/mochi/tests/machine/x/ex/update_stmt.exs:17:5: Main.main/0
+
+ok


### PR DESCRIPTION
## Summary
- extend Elixir reserved keyword list in the compiler
- update generated machine outputs for Elixir
- record failing programs with `.error` logs

## Testing
- `go test ./compiler/x/ex -run TestElixirCompiler_ValidPrograms -tags=slow -v`

------
https://chatgpt.com/codex/tasks/task_e_68725e63ecb88320b1b535fd3d1dad9f