### PR TITLE
Improve Kotlin codegen

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -2171,8 +2171,10 @@ var kotlinKeywords = map[string]bool{
 	"when":   true,
 }
 
+var identRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 func escapeIdent(name string) string {
-	if kotlinKeywords[name] {
+	if kotlinKeywords[name] || !identRE.MatchString(name) {
 		return "`" + name + "`"
 	}
 	return name

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -32,3 +32,4 @@ Successful programs have matching `.kt` and `.out` files.
 - Provide better support for the Python `math` helpers and other foreign
   imports.
 - Finish compiling the remaining programs listed above.
+- Escape Kotlin keywords such as `val` when used as record fields.


### PR DESCRIPTION
## Summary
- handle keyword field names in Kotlin compiler
- note Kotlin keyword escaping in machine README

## Testing
- `go test ./compiler/x/kotlin -tags slow -run TestKotlinPrograms/append_builtin -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68725f20f8c48320aba49fd3fb005ff3