### PR TITLE
Improve Rust compiler index handling

### DIFF
--- a/tests/machine/x/rust/avg_builtin.rs
+++ b/tests/machine/x/rust/avg_builtin.rs
@@ -1,6 +1,6 @@
-fn avg(v: &[i32]) -> f64 {
-    let sum: i32 = v.iter().sum();
-    sum as f64 / v.len() as f64
+fn avg<T>(v: &[T]) -> f64 where T: Into<f64> + Copy {
+    let sum: f64 = v.iter().map(|&x| x.into()).sum();
+    sum / v.len() as f64
 }
 
 fn main() {

--- a/tests/machine/x/rust/group_by.rs
+++ b/tests/machine/x/rust/group_by.rs
@@ -18,9 +18,9 @@ struct Result {
     avg_age: f64,
 }
 
-fn avg(v: &[i32]) -> f64 {
-    let sum: i32 = v.iter().sum();
-    sum as f64 / v.len() as f64
+fn avg<T>(v: &[T]) -> f64 where T: Into<f64> + Copy {
+    let sum: f64 = v.iter().map(|&x| x.into()).sum();
+    sum / v.len() as f64
 }
 
 fn main() {

--- a/tests/machine/x/rust/list_assign.rs
+++ b/tests/machine/x/rust/list_assign.rs
@@ -1,5 +1,5 @@
 fn main() {
     let mut nums = vec![1, 2];
-    nums[1 as usize] = 3;
-    println!("{}", nums[1 as usize]);
+    nums[1] = 3;
+    println!("{}", nums[1]);
 }

--- a/tests/machine/x/rust/list_index.rs
+++ b/tests/machine/x/rust/list_index.rs
@@ -1,4 +1,4 @@
 fn main() {
     let xs = vec![10, 20, 30];
-    println!("{}", xs[1 as usize]);
+    println!("{}", xs[1]);
 }

--- a/tests/machine/x/rust/list_nested_assign.rs
+++ b/tests/machine/x/rust/list_nested_assign.rs
@@ -1,5 +1,5 @@
 fn main() {
     let mut matrix = vec![vec![1, 2], vec![3, 4]];
-    matrix[1 as usize][0 as usize] = 5;
-    println!("{}", matrix[1 as usize][0 as usize]);
+    matrix[1][0] = 5;
+    println!("{}", matrix[1][0]);
 }

--- a/tests/machine/x/rust/min_max_builtin.rs
+++ b/tests/machine/x/rust/min_max_builtin.rs
@@ -1,9 +1,9 @@
-fn min(v: &[i32]) -> i32 {
-    *v.iter().min().unwrap()
+fn min<T: PartialOrd + Copy>(v: &[T]) -> T {
+    *v.iter().min_by(|a,b| a.partial_cmp(b).unwrap()).unwrap()
 }
 
-fn max(v: &[i32]) -> i32 {
-    *v.iter().max().unwrap()
+fn max<T: PartialOrd + Copy>(v: &[T]) -> T {
+    *v.iter().max_by(|a,b| a.partial_cmp(b).unwrap()).unwrap()
 }
 
 fn main() {

--- a/tests/machine/x/rust/slice.rs
+++ b/tests/machine/x/rust/slice.rs
@@ -1,5 +1,5 @@
 fn main() {
-    println!("{:?}", vec![1, 2, 3][1 as usize..3 as usize].to_vec());
-    println!("{:?}", vec![1, 2, 3][0 as usize..2 as usize].to_vec());
-    println!("{}", &"hello"[1 as usize..4 as usize]);
+    println!("{:?}", vec![1, 2, 3][1..3].to_vec());
+    println!("{:?}", vec![1, 2, 3][0..2].to_vec());
+    println!("{}", &"hello"[1..4]);
 }

--- a/tests/machine/x/rust/string_index.rs
+++ b/tests/machine/x/rust/string_index.rs
@@ -1,4 +1,4 @@
 fn main() {
     let s = "mochi";
-    println!("{}", s.chars().nth(1 as usize).unwrap());
+    println!("{}", s.chars().nth(1).unwrap());
 }

--- a/tests/machine/x/rust/substring_builtin.rs
+++ b/tests/machine/x/rust/substring_builtin.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("{}", &"mochi"[1 as usize..4 as usize]);
+    println!("{}", &"mochi"[1..4]);
 }

--- a/tests/machine/x/rust/two-sum.rs
+++ b/tests/machine/x/rust/two-sum.rs
@@ -11,6 +11,6 @@ fn main() {
         return vec![-1, -1];
     }
     let result = twoSum(vec![2, 7, 11, 15], 9);
-    println!("{}", result[0 as usize]);
-    println!("{}", result[1 as usize]);
+    println!("{}", result[0]);
+    println!("{}", result[1]);
 }


### PR DESCRIPTION
## Summary
- refine rust compiler with `isIntLiteral` helper and cleaner index conversions
- regenerate Rust machine outputs using new compiler logic

## Testing
- `go test ./compiler/x/rust -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687264c585bc832094d77b4a1004b1f6