### PR TITLE
Improve Scala compiler formatting

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -1061,7 +1061,7 @@ func (c *Compiler) compileExprStmt(s *parser.ExprStmt) error {
 			if err != nil {
 				return err
 			}
-			args[i] = fmt.Sprintf("(%s)", v)
+			args[i] = v
 		}
 		if len(args) == 1 {
 			c.writeln(fmt.Sprintf("println(%s)", args[0]))
@@ -1612,8 +1612,7 @@ func (c *Compiler) compileList(l *parser.ListLiteral, mutable bool) (string, err
 		elems[i] = s
 	}
 
-	typeStr := c.typeOf(elemType)
-	return fmt.Sprintf("%s[%s](%s)", prefix, typeStr, strings.Join(elems, ", ")), nil
+	return fmt.Sprintf("%s(%s)", prefix, strings.Join(elems, ", ")), nil
 }
 
 func (c *Compiler) compileMap(m *parser.MapLiteral, mutable bool) (string, error) {
@@ -1691,12 +1690,10 @@ func (c *Compiler) compileMap(m *parser.MapLiteral, mutable bool) (string, error
 			}
 		}
 	}
-	typeStr := fmt.Sprintf("[%s, %s]", c.typeOf(keyType), c.typeOf(valType))
-
 	if c.inSort {
 		return fmt.Sprintf("(%s)", strings.Join(vals, ", ")), nil
 	}
-	return fmt.Sprintf("%s%s(%s)", prefix, typeStr, strings.Join(items, ", ")), nil
+	return fmt.Sprintf("%s(%s)", prefix, strings.Join(items, ", ")), nil
 }
 
 func (c *Compiler) compileStructLit(st *parser.StructLiteral) (string, error) {

--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -102,4 +102,7 @@ The following Mochi programs were compiled to Scala using the automated compiler
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
-\nAll programs compiled successfully.
+All programs compiled successfully.
+
+## Remaining Tasks
+- [ ] Review generated Scala code for idiomatic style

--- a/tests/machine/x/scala/append_builtin.scala
+++ b/tests/machine/x/scala/append_builtin.scala
@@ -1,6 +1,6 @@
 object append_builtin {
-  val a = List[Int](1, 2)
+  val a = List(1, 2)
   def main(args: Array[String]): Unit = {
-    println((a :+ 3))
+    println(a :+ 3)
   }
 }

--- a/tests/machine/x/scala/avg_builtin.scala
+++ b/tests/machine/x/scala/avg_builtin.scala
@@ -1,5 +1,5 @@
 object avg_builtin {
   def main(args: Array[String]): Unit = {
-    println(((List[Int](1, 2, 3)).sum.toDouble / (List[Int](1, 2, 3)).size))
+    println((List(1, 2, 3)).sum.toDouble / (List(1, 2, 3)).size)
   }
 }

--- a/tests/machine/x/scala/basic_compare.scala
+++ b/tests/machine/x/scala/basic_compare.scala
@@ -2,8 +2,8 @@ object basic_compare {
   val a = 10 - 3
   val b = 2 + 2
   def main(args: Array[String]): Unit = {
-    println((a))
-    println((a == 7))
-    println((b < 5))
+    println(a)
+    println(a == 7)
+    println(b < 5)
   }
 }

--- a/tests/machine/x/scala/binary_precedence.scala
+++ b/tests/machine/x/scala/binary_precedence.scala
@@ -1,8 +1,8 @@
 object binary_precedence {
   def main(args: Array[String]): Unit = {
-    println(((1 + 2).asInstanceOf[Int] * 3))
-    println(((1 + 2) * 3))
-    println(((2 * 3).asInstanceOf[Int] + 1))
-    println((2 * (3 + 1)))
+    println((1 + 2).asInstanceOf[Int] * 3)
+    println((1 + 2) * 3)
+    println((2 * 3).asInstanceOf[Int] + 1)
+    println(2 * (3 + 1))
   }
 }

--- a/tests/machine/x/scala/bool_chain.scala
+++ b/tests/machine/x/scala/bool_chain.scala
@@ -1,12 +1,12 @@
 object bool_chain {
   def boom(): Boolean = {
-    println(("boom"))
+    println("boom")
     return true
   }
   
   def main(args: Array[String]): Unit = {
-    println(((1 < 2) && (2 < 3) && (3 < 4)))
-    println(((1 < 2) && (2 > 3) && boom()))
-    println(((1 < 2) && (2 < 3) && (3 > 4) && boom()))
+    println((1 < 2) && (2 < 3) && (3 < 4))
+    println((1 < 2) && (2 > 3) && boom())
+    println((1 < 2) && (2 < 3) && (3 > 4) && boom())
   }
 }

--- a/tests/machine/x/scala/break_continue.scala
+++ b/tests/machine/x/scala/break_continue.scala
@@ -1,5 +1,5 @@
 object break_continue {
-  val numbers = List[Int](1, 2, 3, 4, 5, 6, 7, 8, 9)
+  val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9)
   def main(args: Array[String]): Unit = {
     for(n <- numbers) {
       if ((n % 2).asInstanceOf[Int] == 0) {
@@ -8,7 +8,7 @@ object break_continue {
       if (n > 7) {
         return
       }
-      println(("odd number:") + " " + (n))
+      println("odd number:" + " " + n)
     }
   }
 }

--- a/tests/machine/x/scala/cast_string_to_int.scala
+++ b/tests/machine/x/scala/cast_string_to_int.scala
@@ -1,5 +1,5 @@
 object cast_string_to_int {
   def main(args: Array[String]): Unit = {
-    println(("1995".toInt))
+    println("1995".toInt)
   }
 }

--- a/tests/machine/x/scala/cast_struct.scala
+++ b/tests/machine/x/scala/cast_struct.scala
@@ -3,6 +3,6 @@ case class Todo(var title: String)
 object cast_struct {
   val todo = Todo(title = "hi")
   def main(args: Array[String]): Unit = {
-    println((todo.title))
+    println(todo.title)
   }
 }

--- a/tests/machine/x/scala/closure.scala
+++ b/tests/machine/x/scala/closure.scala
@@ -3,6 +3,6 @@ object closure {
   
   def main(args: Array[String]): Unit = {
     val add10 = makeAdder(10)
-    println((add10(7)))
+    println(add10(7))
   }
 }

--- a/tests/machine/x/scala/count_builtin.scala
+++ b/tests/machine/x/scala/count_builtin.scala
@@ -1,5 +1,5 @@
 object count_builtin {
   def main(args: Array[String]): Unit = {
-    println((List[Int](1, 2, 3).size))
+    println(List(1, 2, 3).size)
   }
 }

--- a/tests/machine/x/scala/cross_join.scala
+++ b/tests/machine/x/scala/cross_join.scala
@@ -3,13 +3,13 @@ object cross_join {
   case class Order(id: Int, customerId: Int, total: Int)
   case class Result(orderId: Int, orderCustomerId: Int, pairedCustomerName: String, orderTotal: Int)
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
-  val orders = List[Order](Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+  val orders = List(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
   val result = for { o <- orders; c <- customers } yield Result(orderId = o.id, orderCustomerId = o.customerId, pairedCustomerName = c.name, orderTotal = o.total)
   def main(args: Array[String]): Unit = {
-    println(("--- Cross Join: All order-customer pairs ---"))
+    println("--- Cross Join: All order-customer pairs ---")
     for(entry <- result) {
-      println(("Order") + " " + (entry.orderId) + " " + ("(customerId:") + " " + (entry.orderCustomerId) + " " + (", total: $") + " " + (entry.orderTotal) + " " + (") paired with") + " " + (entry.pairedCustomerName))
+      println("Order" + " " + entry.orderId + " " + "(customerId:" + " " + entry.orderCustomerId + " " + ", total: $" + " " + entry.orderTotal + " " + ") paired with" + " " + entry.pairedCustomerName)
     }
   }
 }

--- a/tests/machine/x/scala/cross_join_filter.scala
+++ b/tests/machine/x/scala/cross_join_filter.scala
@@ -1,13 +1,13 @@
 object cross_join_filter {
   case class Pair(n: Int, l: String)
 
-  val nums = List[Int](1, 2, 3)
-  val letters = List[String]("A", "B")
+  val nums = List(1, 2, 3)
+  val letters = List("A", "B")
   val pairs = for { n <- nums; l <- letters; if (n % 2).asInstanceOf[Int] == 0 } yield Pair(n = n, l = l)
   def main(args: Array[String]): Unit = {
-    println(("--- Even pairs ---"))
+    println("--- Even pairs ---")
     for(p <- pairs) {
-      println((p.n) + " " + (p.l))
+      println(p.n + " " + p.l)
     }
   }
 }

--- a/tests/machine/x/scala/cross_join_triple.scala
+++ b/tests/machine/x/scala/cross_join_triple.scala
@@ -1,14 +1,14 @@
 object cross_join_triple {
   case class Combo(n: Int, l: String, b: Boolean)
 
-  val nums = List[Int](1, 2)
-  val letters = List[String]("A", "B")
-  val bools = List[Boolean](true, false)
+  val nums = List(1, 2)
+  val letters = List("A", "B")
+  val bools = List(true, false)
   val combos = for { n <- nums; l <- letters; b <- bools } yield Combo(n = n, l = l, b = b)
   def main(args: Array[String]): Unit = {
-    println(("--- Cross Join of three lists ---"))
+    println("--- Cross Join of three lists ---")
     for(c <- combos) {
-      println((c.n) + " " + (c.l) + " " + (c.b))
+      println(c.n + " " + c.l + " " + c.b)
     }
   }
 }

--- a/tests/machine/x/scala/dataset_sort_take_limit.scala
+++ b/tests/machine/x/scala/dataset_sort_take_limit.scala
@@ -1,12 +1,12 @@
 object dataset_sort_take_limit {
   case class Product(name: String, price: Int)
 
-  val products = List[Product](Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
+  val products = List(Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
   val expensive = (for { p <- products } yield p).sortBy(p => -p.price).map(p => p).drop(1).take(3)
   def main(args: Array[String]): Unit = {
-    println(("--- Top products (excluding most expensive) ---"))
+    println("--- Top products (excluding most expensive) ---")
     for(item <- expensive) {
-      println((item.name) + " " + ("costs $") + " " + (item.price))
+      println(item.name + " " + "costs $" + " " + item.price)
     }
   }
 }

--- a/tests/machine/x/scala/dataset_where_filter.scala
+++ b/tests/machine/x/scala/dataset_where_filter.scala
@@ -2,12 +2,12 @@ object dataset_where_filter {
   case class Adult(name: String, age: Int, is_senior: Boolean)
   case class People(name: String, age: Int)
 
-  val people = List[People](People(name = "Alice", age = 30), People(name = "Bob", age = 15), People(name = "Charlie", age = 65), People(name = "Diana", age = 45))
+  val people = List(People(name = "Alice", age = 30), People(name = "Bob", age = 15), People(name = "Charlie", age = 65), People(name = "Diana", age = 45))
   val adults = for { person <- people; if person.age >= 18 } yield Adult(name = person.name, age = person.age, is_senior = person.age >= 60)
   def main(args: Array[String]): Unit = {
-    println(("--- Adults ---"))
+    println("--- Adults ---")
     for(person <- adults) {
-      println((person.name) + " " + ("is") + " " + (person.age) + " " + (if (person.is_senior) " (senior)" else ""))
+      println(person.name + " " + "is" + " " + person.age + " " + if (person.is_senior) " (senior)" else "")
     }
   }
 }

--- a/tests/machine/x/scala/exists_builtin.scala
+++ b/tests/machine/x/scala/exists_builtin.scala
@@ -1,7 +1,7 @@
 object exists_builtin {
-  val data = List[Int](1, 2)
+  val data = List(1, 2)
   val flag = (for { x <- data; if x == 1 } yield x).nonEmpty
   def main(args: Array[String]): Unit = {
-    println((flag))
+    println(flag)
   }
 }

--- a/tests/machine/x/scala/for_list_collection.scala
+++ b/tests/machine/x/scala/for_list_collection.scala
@@ -1,7 +1,7 @@
 object for_list_collection {
   def main(args: Array[String]): Unit = {
-    for(n <- List[Int](1, 2, 3)) {
-      println((n))
+    for(n <- List(1, 2, 3)) {
+      println(n)
     }
   }
 }

--- a/tests/machine/x/scala/for_loop.scala
+++ b/tests/machine/x/scala/for_loop.scala
@@ -1,7 +1,7 @@
 object for_loop {
   def main(args: Array[String]): Unit = {
     for(i <- 1 until 4) {
-      println((i))
+      println(i)
     }
   }
 }

--- a/tests/machine/x/scala/for_map_collection.scala
+++ b/tests/machine/x/scala/for_map_collection.scala
@@ -1,8 +1,8 @@
 object for_map_collection {
   def main(args: Array[String]): Unit = {
-    var m = scala.collection.mutable.Map[String, Int]("a" -> (1), "b" -> (2))
+    var m = scala.collection.mutable.Map("a" -> (1), "b" -> (2))
     for((k, _) <- m) {
-      println((k))
+      println(k)
     }
   }
 }

--- a/tests/machine/x/scala/fun_call.scala
+++ b/tests/machine/x/scala/fun_call.scala
@@ -2,6 +2,6 @@ object fun_call {
   def add(a: Int, b: Int): Int = a + b
   
   def main(args: Array[String]): Unit = {
-    println((add(2, 3)))
+    println(add(2, 3))
   }
 }

--- a/tests/machine/x/scala/fun_expr_in_let.scala
+++ b/tests/machine/x/scala/fun_expr_in_let.scala
@@ -1,6 +1,6 @@
 object fun_expr_in_let {
   val square = (x: Int) => x * x
   def main(args: Array[String]): Unit = {
-    println((square(6)))
+    println(square(6))
   }
 }

--- a/tests/machine/x/scala/fun_three_args.scala
+++ b/tests/machine/x/scala/fun_three_args.scala
@@ -2,6 +2,6 @@ object fun_three_args {
   def sum3(a: Int, b: Int, c: Int): Int = (a + b).asInstanceOf[Int] + c
   
   def main(args: Array[String]): Unit = {
-    println((sum3(1, 2, 3)))
+    println(sum3(1, 2, 3))
   }
 }

--- a/tests/machine/x/scala/go_auto.scala
+++ b/tests/machine/x/scala/go_auto.scala
@@ -6,8 +6,8 @@ object go_auto {
       val Answer: Int = 42
     }
     
-    println((testpkg.Add(2, 3)))
-    println((testpkg.Pi))
-    println((testpkg.Answer))
+    println(testpkg.Add(2, 3))
+    println(testpkg.Pi)
+    println(testpkg.Answer)
   }
 }

--- a/tests/machine/x/scala/group_by.scala
+++ b/tests/machine/x/scala/group_by.scala
@@ -4,12 +4,12 @@ object group_by {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val people = List[People](People(name = "Alice", age = 30, city = "Paris"), People(name = "Bob", age = 15, city = "Hanoi"), People(name = "Charlie", age = 65, city = "Paris"), People(name = "Diana", age = 45, city = "Hanoi"), People(name = "Eve", age = 70, city = "Paris"), People(name = "Frank", age = 22, city = "Hanoi"))
+  val people = List(People(name = "Alice", age = 30, city = "Paris"), People(name = "Bob", age = 15, city = "Hanoi"), People(name = "Charlie", age = 65, city = "Paris"), People(name = "Diana", age = 45, city = "Hanoi"), People(name = "Eve", age = 70, city = "Paris"), People(name = "Frank", age = 22, city = "Hanoi"))
   val stats = ((for { person <- people } yield (person.city, person)).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).map{ g => Stat(city = g.key, count = (g).size, avg_age = (for { p <- g } yield p.age).sum.toDouble / (for { p <- g } yield p.age).size) }.toList
   def main(args: Array[String]): Unit = {
-    println(("--- People grouped by city ---"))
+    println("--- People grouped by city ---")
     for(s <- stats) {
-      println((s.city) + " " + (": count =") + " " + (s.count) + " " + (", avg_age =") + " " + (s.avg_age))
+      println(s.city + " " + ": count =" + " " + s.count + " " + ", avg_age =" + " " + s.avg_age)
     }
   }
 }

--- a/tests/machine/x/scala/group_by_conditional_sum.scala
+++ b/tests/machine/x/scala/group_by_conditional_sum.scala
@@ -4,9 +4,9 @@ object group_by_conditional_sum {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val items = List[Item](Item(cat = "a", `val` = 10, flag = true), Item(cat = "a", `val` = 5, flag = false), Item(cat = "b", `val` = 20, flag = true))
+  val items = List(Item(cat = "a", `val` = 10, flag = true), Item(cat = "a", `val` = 5, flag = false), Item(cat = "b", `val` = 20, flag = true))
   val result = (((for { i <- items } yield (i.cat, i)).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).sortBy(g => g.key)).map{ g => Result(cat = g.key, share = (for { x <- g } yield if (x.flag) x.`val` else 0).sum / (for { x <- g } yield x.`val`).sum) }.toList
   def main(args: Array[String]): Unit = {
-    println((result))
+    println(result)
   }
 }

--- a/tests/machine/x/scala/group_by_having.scala
+++ b/tests/machine/x/scala/group_by_having.scala
@@ -4,8 +4,8 @@ object group_by_having {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val people = List[People](People(name = "Alice", city = "Paris"), People(name = "Bob", city = "Hanoi"), People(name = "Charlie", city = "Paris"), People(name = "Diana", city = "Hanoi"), People(name = "Eve", city = "Paris"), People(name = "Frank", city = "Hanoi"), People(name = "George", city = "Paris"))
-  val big = (((for { p <- people } yield (p.city, p)).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).filter{ g => (g).size >= 4 }).map{ g => Map[String, Any]("city" -> (g.key), "num" -> ((g).size)) }.toList
+  val people = List(People(name = "Alice", city = "Paris"), People(name = "Bob", city = "Hanoi"), People(name = "Charlie", city = "Paris"), People(name = "Diana", city = "Hanoi"), People(name = "Eve", city = "Paris"), People(name = "Frank", city = "Hanoi"), People(name = "George", city = "Paris"))
+  val big = (((for { p <- people } yield (p.city, p)).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).filter{ g => (g).size >= 4 }).map{ g => Map("city" -> (g.key), "num" -> ((g).size)) }.toList
   def main(args: Array[String]): Unit = {
     println(scala.util.parsing.json.JSONObject(big).toString())
   }

--- a/tests/machine/x/scala/group_by_join.scala
+++ b/tests/machine/x/scala/group_by_join.scala
@@ -6,13 +6,13 @@ object group_by_join {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
-  val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
+  val orders = List(Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))
   val stats = ((for { o <- orders; c <- customers; if o.customerId == (c.id).asInstanceOf[Int] } yield (c.name, Stat(o = o, c = c))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).map{ g => Stat1(name = g.key, count = (g).size) }.toList
   def main(args: Array[String]): Unit = {
-    println(("--- Orders per customer ---"))
+    println("--- Orders per customer ---")
     for(s <- stats) {
-      println((s.name) + " " + ("orders:") + " " + (s.count))
+      println(s.name + " " + "orders:" + " " + s.count)
     }
   }
 }

--- a/tests/machine/x/scala/group_by_left_join.scala
+++ b/tests/machine/x/scala/group_by_left_join.scala
@@ -6,13 +6,13 @@ object group_by_left_join {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
-  val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+  val orders = List(Order(id = 100, customerId = 1), Order(id = 101, customerId = 1), Order(id = 102, customerId = 2))
   val stats = ((for { c <- customers; o = orders.find(o => (o.customerId).asInstanceOf[Int] == c.id) } yield (c.name, Stat(c = c, o = o))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).map{ g => Stat1(name = g.key, count = (for { r <- g; if r.o.nonEmpty } yield r).size) }.toList
   def main(args: Array[String]): Unit = {
-    println(("--- Group Left Join ---"))
+    println("--- Group Left Join ---")
     for(s <- stats) {
-      println((s.name) + " " + ("orders:") + " " + (s.count))
+      println(s.name + " " + "orders:" + " " + s.count)
     }
   }
 }

--- a/tests/machine/x/scala/group_by_multi_join.scala
+++ b/tests/machine/x/scala/group_by_multi_join.scala
@@ -7,12 +7,12 @@ object group_by_multi_join {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val nations = List[Nation](Nation(id = 1, name = "A"), Nation(id = 2, name = "B"))
-  val suppliers = List[Supplier](Supplier(id = 1, nation = 1), Supplier(id = 2, nation = 2))
-  val partsupp = List[Partsupp](Partsupp(part = 100, supplier = 1, cost = 10, qty = 2), Partsupp(part = 100, supplier = 2, cost = 20, qty = 1), Partsupp(part = 200, supplier = 1, cost = 5, qty = 3))
+  val nations = List(Nation(id = 1, name = "A"), Nation(id = 2, name = "B"))
+  val suppliers = List(Supplier(id = 1, nation = 1), Supplier(id = 2, nation = 2))
+  val partsupp = List(Partsupp(part = 100, supplier = 1, cost = 10, qty = 2), Partsupp(part = 100, supplier = 2, cost = 20, qty = 1), Partsupp(part = 200, supplier = 1, cost = 5, qty = 3))
   val filtered = for { ps <- partsupp; s <- suppliers; if (s.id).asInstanceOf[Int] == ps.supplier; n <- nations; if (n.id).asInstanceOf[Int] == s.nation; if n.name == "A" } yield Filtered(part = ps.part, value = ps.cost * ps.qty)
   val grouped = ((for { x <- filtered } yield (x.part, x)).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).map{ g => Grouped(part = g.key, total = (for { r <- g } yield r.value).sum) }.toList
   def main(args: Array[String]): Unit = {
-    println((grouped))
+    println(grouped)
   }
 }

--- a/tests/machine/x/scala/group_by_multi_join_sort.scala
+++ b/tests/machine/x/scala/group_by_multi_join_sort.scala
@@ -9,14 +9,14 @@ object group_by_multi_join_sort {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val nation = List[Nation](Nation(n_nationkey = 1, n_name = "BRAZIL"))
-  val customer = List[Customer](Customer(c_custkey = 1, c_name = "Alice", c_acctbal = 100, c_nationkey = 1, c_address = "123 St", c_phone = "123-456", c_comment = "Loyal"))
-  val orders = List[Order](Order(o_orderkey = 1000, o_custkey = 1, o_orderdate = "1993-10-15"), Order(o_orderkey = 2000, o_custkey = 1, o_orderdate = "1994-01-02"))
-  val lineitem = List[Lineitem](Lineitem(l_orderkey = 1000, l_returnflag = "R", l_extendedprice = 1000, l_discount = 0.1), Lineitem(l_orderkey = 2000, l_returnflag = "N", l_extendedprice = 500, l_discount = 0))
+  val nation = List(Nation(n_nationkey = 1, n_name = "BRAZIL"))
+  val customer = List(Customer(c_custkey = 1, c_name = "Alice", c_acctbal = 100, c_nationkey = 1, c_address = "123 St", c_phone = "123-456", c_comment = "Loyal"))
+  val orders = List(Order(o_orderkey = 1000, o_custkey = 1, o_orderdate = "1993-10-15"), Order(o_orderkey = 2000, o_custkey = 1, o_orderdate = "1994-01-02"))
+  val lineitem = List(Lineitem(l_orderkey = 1000, l_returnflag = "R", l_extendedprice = 1000, l_discount = 0.1), Lineitem(l_orderkey = 2000, l_returnflag = "N", l_extendedprice = 500, l_discount = 0))
   val start_date = "1993-10-01"
   val end_date = "1994-01-01"
   val result = (((for { c <- customer; o <- orders; if (o.o_custkey).asInstanceOf[Int] == c.c_custkey; l <- lineitem; if (l.l_orderkey).asInstanceOf[Int] == o.o_orderkey; n <- nation; if (n.n_nationkey).asInstanceOf[Int] == c.c_nationkey; if o.o_orderdate >= start_date && o.o_orderdate < end_date && l.l_returnflag == "R" } yield (Result(c_custkey = c.c_custkey, c_name = c.c_name, c_acctbal = c.c_acctbal, c_address = c.c_address, c_phone = c.c_phone, c_comment = c.c_comment, n_name = n.n_name), Result1(c = c, o = o, l = l, n = n))).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g } yield x.l.l_extendedprice * (1 - x.l.l_discount)).sum)).map{ g => Result2(c_custkey = g.key.c_custkey, c_name = g.key.c_name, revenue = (for { x <- g } yield x.l.l_extendedprice * (1 - x.l.l_discount)).sum, c_acctbal = g.key.c_acctbal, n_name = g.key.n_name, c_address = g.key.c_address, c_phone = g.key.c_phone, c_comment = g.key.c_comment) }.toList
   def main(args: Array[String]): Unit = {
-    println((result))
+    println(result)
   }
 }

--- a/tests/machine/x/scala/group_by_sort.scala
+++ b/tests/machine/x/scala/group_by_sort.scala
@@ -4,9 +4,9 @@ object group_by_sort {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val items = List[Item](Item(cat = "a", `val` = 3), Item(cat = "a", `val` = 1), Item(cat = "b", `val` = 5), Item(cat = "b", `val` = 2))
+  val items = List(Item(cat = "a", `val` = 3), Item(cat = "a", `val` = 1), Item(cat = "b", `val` = 5), Item(cat = "b", `val` = 2))
   val grouped = (((for { i <- items } yield (i.cat, i)).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).sortBy(g => -(for { x <- g } yield x.`val`).sum)).map{ g => Grouped(cat = g.key, total = (for { x <- g } yield x.`val`).sum) }.toList
   def main(args: Array[String]): Unit = {
-    println((grouped))
+    println(grouped)
   }
 }

--- a/tests/machine/x/scala/group_items_iteration.scala
+++ b/tests/machine/x/scala/group_items_iteration.scala
@@ -4,10 +4,10 @@ object group_items_iteration {
 
   case class _Group[K,T](key: K, items: List[T]) extends Iterable[T] { def iterator: Iterator[T] = items.iterator }
 
-  val data = List[Data](Data(tag = "a", `val` = 1), Data(tag = "a", `val` = 2), Data(tag = "b", `val` = 3))
+  val data = List(Data(tag = "a", `val` = 1), Data(tag = "a", `val` = 2), Data(tag = "b", `val` = 3))
   val groups = ((for { d <- data } yield (d.tag, d)).groupBy(_._1).map{ case(k,list) => _Group(k, list.map(_._2)) }.toList).map{ g => g }.toList
   def main(args: Array[String]): Unit = {
-    var tmp = scala.collection.mutable.ArrayBuffer[Any]()
+    var tmp = scala.collection.mutable.ArrayBuffer()
     for(g <- groups) {
       var total = 0
       for(x <- g.items) {
@@ -16,6 +16,6 @@ object group_items_iteration {
       tmp = tmp :+ Auto1(tag = g.key, total = total)
     }
     val result = (for { r <- tmp } yield r).sortBy(r => r.tag).map(r => r)
-    println((result))
+    println(result)
   }
 }

--- a/tests/machine/x/scala/if_else.scala
+++ b/tests/machine/x/scala/if_else.scala
@@ -2,9 +2,9 @@ object if_else {
   val x = 5
   def main(args: Array[String]): Unit = {
     if (x > 3) {
-      println(("big"))
+      println("big")
     } else {
-      println(("small"))
+      println("small")
     }
   }
 }

--- a/tests/machine/x/scala/if_then_else.scala
+++ b/tests/machine/x/scala/if_then_else.scala
@@ -2,6 +2,6 @@ object if_then_else {
   val x = 12
   val msg = if (x > 10) "yes" else "no"
   def main(args: Array[String]): Unit = {
-    println((msg))
+    println(msg)
   }
 }

--- a/tests/machine/x/scala/if_then_else_nested.scala
+++ b/tests/machine/x/scala/if_then_else_nested.scala
@@ -2,6 +2,6 @@ object if_then_else_nested {
   val x = 8
   val msg = if (x > 10) "big" else if (x > 5) "medium" else "small"
   def main(args: Array[String]): Unit = {
-    println((msg))
+    println(msg)
   }
 }

--- a/tests/machine/x/scala/in_operator.scala
+++ b/tests/machine/x/scala/in_operator.scala
@@ -1,7 +1,7 @@
 object in_operator {
-  val xs = List[Int](1, 2, 3)
+  val xs = List(1, 2, 3)
   def main(args: Array[String]): Unit = {
-    println((xs.contains(2)))
-    println((!(xs.contains(5))))
+    println(xs.contains(2))
+    println(!(xs.contains(5)))
   }
 }

--- a/tests/machine/x/scala/in_operator_extended.scala
+++ b/tests/machine/x/scala/in_operator_extended.scala
@@ -1,16 +1,16 @@
 object in_operator_extended {
   case class M(a: Int)
 
-  val xs = List[Int](1, 2, 3)
+  val xs = List(1, 2, 3)
   val ys = for { x <- xs; if (x % 2).asInstanceOf[Int] == 1 } yield x
   def main(args: Array[String]): Unit = {
-    println((ys.contains(1)))
-    println((ys.contains(2)))
-    val m = Map[String, Int]("a" -> (1))
-    println((m.contains("a")))
-    println((m.contains("b")))
+    println(ys.contains(1))
+    println(ys.contains(2))
+    val m = Map("a" -> (1))
+    println(m.contains("a"))
+    println(m.contains("b"))
     val s = "hello"
-    println((s.contains("ell")))
-    println((s.contains("foo")))
+    println(s.contains("ell"))
+    println(s.contains("foo"))
   }
 }

--- a/tests/machine/x/scala/inner_join.scala
+++ b/tests/machine/x/scala/inner_join.scala
@@ -3,13 +3,13 @@ object inner_join {
   case class Order(id: Int, customerId: Int, total: Int)
   case class Result(orderId: Int, customerName: String, total: Int)
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
-  val orders = List[Order](Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 4, total = 80))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+  val orders = List(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 4, total = 80))
   val result = for { o <- orders; c <- customers; if o.customerId == (c.id).asInstanceOf[Int] } yield Result(orderId = o.id, customerName = c.name, total = o.total)
   def main(args: Array[String]): Unit = {
-    println(("--- Orders with customer info ---"))
+    println("--- Orders with customer info ---")
     for(entry <- result) {
-      println(("Order") + " " + (entry.orderId) + " " + ("by") + " " + (entry.customerName) + " " + ("- $") + " " + (entry.total))
+      println("Order" + " " + entry.orderId + " " + "by" + " " + entry.customerName + " " + "- $" + " " + entry.total)
     }
   }
 }

--- a/tests/machine/x/scala/join_multi.scala
+++ b/tests/machine/x/scala/join_multi.scala
@@ -4,14 +4,14 @@ object join_multi {
   case class Order(id: Int, customerId: Int)
   case class Result(name: String, sku: String)
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
-  val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 2))
-  val items = List[Item](Item(orderId = 100, sku = "a"), Item(orderId = 101, sku = "b"))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
+  val orders = List(Order(id = 100, customerId = 1), Order(id = 101, customerId = 2))
+  val items = List(Item(orderId = 100, sku = "a"), Item(orderId = 101, sku = "b"))
   val result = for { o <- orders; c <- customers; if o.customerId == (c.id).asInstanceOf[Int]; i <- items; if o.id == (i.orderId).asInstanceOf[Int] } yield Result(name = c.name, sku = i.sku)
   def main(args: Array[String]): Unit = {
-    println(("--- Multi Join ---"))
+    println("--- Multi Join ---")
     for(r <- result) {
-      println((r.name) + " " + ("bought item") + " " + (r.sku))
+      println(r.name + " " + "bought item" + " " + r.sku)
     }
   }
 }

--- a/tests/machine/x/scala/json_builtin.scala
+++ b/tests/machine/x/scala/json_builtin.scala
@@ -1,7 +1,7 @@
 object json_builtin {
   case class M(a: Int, b: Int)
 
-  val m = Map[String, Int]("a" -> (1), "b" -> (2))
+  val m = Map("a" -> (1), "b" -> (2))
   def main(args: Array[String]): Unit = {
     println(scala.util.parsing.json.JSONObject(m).toString())
   }

--- a/tests/machine/x/scala/left_join.scala
+++ b/tests/machine/x/scala/left_join.scala
@@ -4,13 +4,13 @@ object left_join {
   case class Result(orderId: Int, customer: Option[Customer], total: Int)
   case class Result1(orderId: Int, customer: Customer, total: Int)
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
-  val orders = List[Order](Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 3, total = 80))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
+  val orders = List(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 3, total = 80))
   val result = for { o <- orders; c = customers.find(c => o.customerId == (c.id).asInstanceOf[Int]) } yield Result(orderId = o.id, customer = c, total = o.total)
   def main(args: Array[String]): Unit = {
-    println(("--- Left Join ---"))
+    println("--- Left Join ---")
     for(entry <- result) {
-      println(("Order") + " " + (entry.orderId) + " " + ("customer") + " " + (entry.customer) + " " + ("total") + " " + (entry.total))
+      println("Order" + " " + entry.orderId + " " + "customer" + " " + entry.customer + " " + "total" + " " + entry.total)
     }
   }
 }

--- a/tests/machine/x/scala/left_join_multi.scala
+++ b/tests/machine/x/scala/left_join_multi.scala
@@ -5,14 +5,14 @@ object left_join_multi {
   case class Result(orderId: Int, name: String, item: Option[Item])
   case class Result1(orderId: Int, name: String, item: Item)
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
-  val orders = List[Order](Order(id = 100, customerId = 1), Order(id = 101, customerId = 2))
-  val items = List[Item](Item(orderId = 100, sku = "a"))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"))
+  val orders = List(Order(id = 100, customerId = 1), Order(id = 101, customerId = 2))
+  val items = List(Item(orderId = 100, sku = "a"))
   val result = for { o <- orders; c <- customers; if o.customerId == (c.id).asInstanceOf[Int]; i = items.find(i => o.id == (i.orderId).asInstanceOf[Int]) } yield Result(orderId = o.id, name = c.name, item = i)
   def main(args: Array[String]): Unit = {
-    println(("--- Left Join Multi ---"))
+    println("--- Left Join Multi ---")
     for(r <- result) {
-      println((r.orderId) + " " + (r.name) + " " + (r.item))
+      println(r.orderId + " " + r.name + " " + r.item)
     }
   }
 }

--- a/tests/machine/x/scala/len_builtin.scala
+++ b/tests/machine/x/scala/len_builtin.scala
@@ -1,5 +1,5 @@
 object len_builtin {
   def main(args: Array[String]): Unit = {
-    println((List[Int](1, 2, 3).length))
+    println(List(1, 2, 3).length)
   }
 }

--- a/tests/machine/x/scala/len_map.scala
+++ b/tests/machine/x/scala/len_map.scala
@@ -1,5 +1,5 @@
 object len_map {
   def main(args: Array[String]): Unit = {
-    println((Map[String, Int]("a" -> (1), "b" -> (2)).size))
+    println(Map("a" -> (1), "b" -> (2)).size)
   }
 }

--- a/tests/machine/x/scala/len_string.scala
+++ b/tests/machine/x/scala/len_string.scala
@@ -1,5 +1,5 @@
 object len_string {
   def main(args: Array[String]): Unit = {
-    println(("mochi".length))
+    println("mochi".length)
   }
 }

--- a/tests/machine/x/scala/let_and_print.scala
+++ b/tests/machine/x/scala/let_and_print.scala
@@ -2,6 +2,6 @@ object let_and_print {
   val a = 10
   val b: Int = 20
   def main(args: Array[String]): Unit = {
-    println((a + b))
+    println(a + b)
   }
 }

--- a/tests/machine/x/scala/list_assign.scala
+++ b/tests/machine/x/scala/list_assign.scala
@@ -1,7 +1,7 @@
 object list_assign {
   def main(args: Array[String]): Unit = {
-    var nums = scala.collection.mutable.ArrayBuffer[Int](1, 2)
+    var nums = scala.collection.mutable.ArrayBuffer(1, 2)
     nums(1) = 3
-    println((nums(1)))
+    println(nums(1))
   }
 }

--- a/tests/machine/x/scala/list_index.scala
+++ b/tests/machine/x/scala/list_index.scala
@@ -1,6 +1,6 @@
 object list_index {
-  val xs = List[Int](10, 20, 30)
+  val xs = List(10, 20, 30)
   def main(args: Array[String]): Unit = {
-    println((xs(1)))
+    println(xs(1))
   }
 }

--- a/tests/machine/x/scala/list_nested_assign.scala
+++ b/tests/machine/x/scala/list_nested_assign.scala
@@ -1,8 +1,8 @@
 object list_nested_assign {
   def main(args: Array[String]): Unit = {
-    var matrix = scala.collection.mutable.ArrayBuffer[List[Int]](List[Int](1, 2), List[Int](3, 4))
+    var matrix = scala.collection.mutable.ArrayBuffer(List(1, 2), List(3, 4))
     val _tmp0 = matrix(1).updated(0, 5)
     matrix = matrix.updated(1, _tmp0)
-    println((matrix(1)(0)))
+    println(matrix(1)(0))
   }
 }

--- a/tests/machine/x/scala/list_set_ops.scala
+++ b/tests/machine/x/scala/list_set_ops.scala
@@ -1,8 +1,8 @@
 object list_set_ops {
   def main(args: Array[String]): Unit = {
-    println((((List[Int](1, 2)) ++ (List[Int](2, 3))).distinct))
-    println((((List[Int](1, 2, 3)).toSet diff (List[Int](2)).toSet).toList))
-    println((((List[Int](1, 2, 3)).toSet intersect (List[Int](2, 4)).toSet).toList))
-    println(((List[Int](1, 2) ++ List[Int](2, 3)).length))
+    println(((List(1, 2)) ++ (List(2, 3))).distinct)
+    println(((List(1, 2, 3)).toSet diff (List(2)).toSet).toList)
+    println(((List(1, 2, 3)).toSet intersect (List(2, 4)).toSet).toList)
+    println((List(1, 2) ++ List(2, 3)).length)
   }
 }

--- a/tests/machine/x/scala/load_yaml.scala
+++ b/tests/machine/x/scala/load_yaml.scala
@@ -23,7 +23,7 @@ object load_yaml {
   val adults = for { p <- people; if p.age >= 18 } yield Adult(name = p.name, email = p.email)
   def main(args: Array[String]): Unit = {
     for(a <- adults) {
-      println((a.name) + " " + (a.email))
+      println(a.name + " " + a.email)
     }
   }
 }

--- a/tests/machine/x/scala/map_assign.scala
+++ b/tests/machine/x/scala/map_assign.scala
@@ -1,7 +1,7 @@
 object map_assign {
   def main(args: Array[String]): Unit = {
-    var scores = scala.collection.mutable.Map[String, Int]("alice" -> (1))
+    var scores = scala.collection.mutable.Map("alice" -> (1))
     scores("bob") = 2
-    println((scores("bob")))
+    println(scores("bob"))
   }
 }

--- a/tests/machine/x/scala/map_in_operator.scala
+++ b/tests/machine/x/scala/map_in_operator.scala
@@ -1,7 +1,7 @@
 object map_in_operator {
-  val m = Map[Int, String](1 -> ("a"), 2 -> ("b"))
+  val m = Map(1 -> ("a"), 2 -> ("b"))
   def main(args: Array[String]): Unit = {
-    println((m.contains(1)))
-    println((m.contains(3)))
+    println(m.contains(1))
+    println(m.contains(3))
   }
 }

--- a/tests/machine/x/scala/map_index.scala
+++ b/tests/machine/x/scala/map_index.scala
@@ -1,6 +1,6 @@
 object map_index {
-  val m = Map[String, Int]("a" -> (1), "b" -> (2))
+  val m = Map("a" -> (1), "b" -> (2))
   def main(args: Array[String]): Unit = {
-    println((m("b")))
+    println(m("b"))
   }
 }

--- a/tests/machine/x/scala/map_int_key.scala
+++ b/tests/machine/x/scala/map_int_key.scala
@@ -1,6 +1,6 @@
 object map_int_key {
-  val m = Map[Int, String](1 -> ("a"), 2 -> ("b"))
+  val m = Map(1 -> ("a"), 2 -> ("b"))
   def main(args: Array[String]): Unit = {
-    println((m(1)))
+    println(m(1))
   }
 }

--- a/tests/machine/x/scala/map_literal_dynamic.scala
+++ b/tests/machine/x/scala/map_literal_dynamic.scala
@@ -2,7 +2,7 @@ object map_literal_dynamic {
   def main(args: Array[String]): Unit = {
     var x = 3
     var y = 4
-    var m = scala.collection.mutable.Map[String, Int]("a" -> (x), "b" -> (y))
-    println((m("a")) + " " + (m("b")))
+    var m = scala.collection.mutable.Map("a" -> (x), "b" -> (y))
+    println(m("a") + " " + m("b"))
   }
 }

--- a/tests/machine/x/scala/map_membership.scala
+++ b/tests/machine/x/scala/map_membership.scala
@@ -1,7 +1,7 @@
 object map_membership {
-  val m = Map[String, Int]("a" -> (1), "b" -> (2))
+  val m = Map("a" -> (1), "b" -> (2))
   def main(args: Array[String]): Unit = {
-    println((m.contains("a")))
-    println((m.contains("c")))
+    println(m.contains("a"))
+    println(m.contains("c"))
   }
 }

--- a/tests/machine/x/scala/map_nested_assign.scala
+++ b/tests/machine/x/scala/map_nested_assign.scala
@@ -1,8 +1,8 @@
 object map_nested_assign {
   def main(args: Array[String]): Unit = {
-    var data = scala.collection.mutable.Map[String, Map[String, Int]]("outer" -> (Map[String, Int]("inner" -> (1))))
+    var data = scala.collection.mutable.Map("outer" -> (Map("inner" -> (1))))
     val _tmp0 = data("outer").updated("inner", 2)
     data = data.updated("outer", _tmp0)
-    println((data("outer")("inner")))
+    println(data("outer")("inner"))
   }
 }

--- a/tests/machine/x/scala/match_expr.scala
+++ b/tests/machine/x/scala/match_expr.scala
@@ -7,6 +7,6 @@ object match_expr {
     case _ => "unknown"
   }
   def main(args: Array[String]): Unit = {
-    println((label))
+    println(label)
   }
 }

--- a/tests/machine/x/scala/match_full.scala
+++ b/tests/machine/x/scala/match_full.scala
@@ -13,7 +13,7 @@ object match_full {
   }
   
   def main(args: Array[String]): Unit = {
-    println((label))
+    println(label)
     val day = "sun"
     val mood = day match {
       case "mon" => "tired"
@@ -21,14 +21,14 @@ object match_full {
       case "sun" => "relaxed"
       case _ => "normal"
     }
-    println((mood))
+    println(mood)
     val ok = true
     val status = ok match {
       case true => "confirmed"
       case false => "denied"
     }
-    println((status))
-    println((classify(0)))
-    println((classify(5)))
+    println(status)
+    println(classify(0))
+    println(classify(5))
   }
 }

--- a/tests/machine/x/scala/math_ops.scala
+++ b/tests/machine/x/scala/math_ops.scala
@@ -1,7 +1,7 @@
 object math_ops {
   def main(args: Array[String]): Unit = {
-    println((6 * 7))
-    println((7 / 2))
-    println((7 % 2))
+    println(6 * 7)
+    println(7 / 2)
+    println(7 % 2)
   }
 }

--- a/tests/machine/x/scala/membership.scala
+++ b/tests/machine/x/scala/membership.scala
@@ -1,7 +1,7 @@
 object membership {
-  val nums = List[Int](1, 2, 3)
+  val nums = List(1, 2, 3)
   def main(args: Array[String]): Unit = {
-    println((nums.contains(2)))
-    println((nums.contains(4)))
+    println(nums.contains(2))
+    println(nums.contains(4))
   }
 }

--- a/tests/machine/x/scala/min_max_builtin.scala
+++ b/tests/machine/x/scala/min_max_builtin.scala
@@ -1,7 +1,7 @@
 object min_max_builtin {
-  val nums = List[Int](3, 1, 4)
+  val nums = List(3, 1, 4)
   def main(args: Array[String]): Unit = {
-    println((nums.min))
-    println((nums.max))
+    println(nums.min)
+    println(nums.max)
   }
 }

--- a/tests/machine/x/scala/nested_function.scala
+++ b/tests/machine/x/scala/nested_function.scala
@@ -5,6 +5,6 @@ object nested_function {
   }
   
   def main(args: Array[String]): Unit = {
-    println((outer(3)))
+    println(outer(3))
   }
 }

--- a/tests/machine/x/scala/order_by_map.scala
+++ b/tests/machine/x/scala/order_by_map.scala
@@ -1,9 +1,9 @@
 object order_by_map {
   case class Data(a: Int, b: Int)
 
-  val data = List[Data](Data(a = 1, b = 2), Data(a = 1, b = 1), Data(a = 0, b = 5))
+  val data = List(Data(a = 1, b = 2), Data(a = 1, b = 1), Data(a = 0, b = 5))
   val sorted = (for { x <- data } yield x).sortBy(x => Data(a = x.a, b = x.b)).map(x => x)
   def main(args: Array[String]): Unit = {
-    println((sorted))
+    println(sorted)
   }
 }

--- a/tests/machine/x/scala/outer_join.scala
+++ b/tests/machine/x/scala/outer_join.scala
@@ -10,20 +10,20 @@ object outer_join {
 
   def _right_join[A,B](a: List[A], b: List[B])(cond: (A,B) => Boolean): List[(Option[A], B)] = for(y <- b) yield (a.find(x => cond(x,y)), y)
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"), Customer(id = 4, name = "Diana"))
-  val orders = List[Order](Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 5, total = 80))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"), Customer(id = 4, name = "Diana"))
+  val orders = List(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 5, total = 80))
   val result = for { _pair0 <- _outer_join(orders, customers)((o,c) => o.customerId == (c.id).asInstanceOf[Int]); o = _pair0._1; c = _pair0._2 } yield Result(order = o, customer = c)
   def main(args: Array[String]): Unit = {
-    println(("--- Outer Join using syntax ---"))
+    println("--- Outer Join using syntax ---")
     for(row <- result) {
       if (row.order != null) {
         if (row.customer != null) {
-          println(("Order") + " " + (row.order.id) + " " + ("by") + " " + (row.customer.name) + " " + ("- $") + " " + (row.order.total))
+          println("Order" + " " + row.order.id + " " + "by" + " " + row.customer.name + " " + "- $" + " " + row.order.total)
         } else {
-          println(("Order") + " " + (row.order.id) + " " + ("by") + " " + ("Unknown") + " " + ("- $") + " " + (row.order.total))
+          println("Order" + " " + row.order.id + " " + "by" + " " + "Unknown" + " " + "- $" + " " + row.order.total)
         }
       } else {
-        println(("Customer") + " " + (row.customer.name) + " " + ("has no orders"))
+        println("Customer" + " " + row.customer.name + " " + "has no orders")
       }
     }
   }

--- a/tests/machine/x/scala/partial_application.scala
+++ b/tests/machine/x/scala/partial_application.scala
@@ -3,6 +3,6 @@ object partial_application {
   
   def main(args: Array[String]): Unit = {
     val add5 = (p0: Int) => add(5, p0)
-    println((add5(3)))
+    println(add5(3))
   }
 }

--- a/tests/machine/x/scala/print_hello.scala
+++ b/tests/machine/x/scala/print_hello.scala
@@ -1,5 +1,5 @@
 object print_hello {
   def main(args: Array[String]): Unit = {
-    println(("hello"))
+    println("hello")
   }
 }

--- a/tests/machine/x/scala/pure_fold.scala
+++ b/tests/machine/x/scala/pure_fold.scala
@@ -2,6 +2,6 @@ object pure_fold {
   def triple(x: Int): Int = x * 3
   
   def main(args: Array[String]): Unit = {
-    println((triple(1 + 2)))
+    println(triple(1 + 2))
   }
 }

--- a/tests/machine/x/scala/pure_global_fold.scala
+++ b/tests/machine/x/scala/pure_global_fold.scala
@@ -3,6 +3,6 @@ object pure_global_fold {
   def inc(x: Int): Int = x + k
   
   def main(args: Array[String]): Unit = {
-    println((inc(3)))
+    println(inc(3))
   }
 }

--- a/tests/machine/x/scala/python_auto.scala
+++ b/tests/machine/x/scala/python_auto.scala
@@ -1,6 +1,6 @@
 object python_auto {
   def main(args: Array[String]): Unit = {
-    println((scala.math.sqrt(16)))
-    println((scala.math.Pi))
+    println(scala.math.sqrt(16))
+    println(scala.math.Pi)
   }
 }

--- a/tests/machine/x/scala/python_math.scala
+++ b/tests/machine/x/scala/python_math.scala
@@ -5,9 +5,9 @@ object python_math {
     val root = scala.math.sqrt(49)
     val sin45 = scala.math.sin(scala.math.Pi / 4)
     val log_e = scala.math.log(scala.math.E)
-    println(("Circle area with r =") + " " + (r) + " " + ("=>") + " " + (area))
-    println(("Square root of 49:") + " " + (root))
-    println(("sin(π/4):") + " " + (sin45))
-    println(("log(e):") + " " + (log_e))
+    println("Circle area with r =" + " " + r + " " + "=>" + " " + area)
+    println("Square root of 49:" + " " + root)
+    println("sin(π/4):" + " " + sin45)
+    println("log(e):" + " " + log_e)
   }
 }

--- a/tests/machine/x/scala/query_sum_select.scala
+++ b/tests/machine/x/scala/query_sum_select.scala
@@ -1,7 +1,7 @@
 object query_sum_select {
-  val nums = List[Int](1, 2, 3)
+  val nums = List(1, 2, 3)
   val result = (for { n <- nums; if n > 1 } yield n).sum
   def main(args: Array[String]): Unit = {
-    println((result))
+    println(result)
   }
 }

--- a/tests/machine/x/scala/record_assign.scala
+++ b/tests/machine/x/scala/record_assign.scala
@@ -8,6 +8,6 @@ object record_assign {
   def main(args: Array[String]): Unit = {
     var c = Counter(n = 0)
     inc(c)
-    println((c.n))
+    println(c.n)
   }
 }

--- a/tests/machine/x/scala/right_join.scala
+++ b/tests/machine/x/scala/right_join.scala
@@ -4,16 +4,16 @@ object right_join {
   case class Result(customerName: String, order: Option[Order])
   case class Result1(customerName: String, order: Order)
 
-  val customers = List[Customer](Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"), Customer(id = 4, name = "Diana"))
-  val orders = List[Order](Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
+  val customers = List(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"), Customer(id = 4, name = "Diana"))
+  val orders = List(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
   val result = for { c <- customers; o = orders.find(o => (o.customerId).asInstanceOf[Int] == c.id) } yield Result(customerName = c.name, order = o)
   def main(args: Array[String]): Unit = {
-    println(("--- Right Join using syntax ---"))
+    println("--- Right Join using syntax ---")
     for(entry <- result) {
       if (entry.order != null) {
-        println(("Customer") + " " + (entry.customerName) + " " + ("has order") + " " + (entry.order.id) + " " + ("- $") + " " + (entry.order.total))
+        println("Customer" + " " + entry.customerName + " " + "has order" + " " + entry.order.id + " " + "- $" + " " + entry.order.total)
       } else {
-        println(("Customer") + " " + (entry.customerName) + " " + ("has no orders"))
+        println("Customer" + " " + entry.customerName + " " + "has no orders")
       }
     }
   }

--- a/tests/machine/x/scala/save_jsonl_stdout.scala
+++ b/tests/machine/x/scala/save_jsonl_stdout.scala
@@ -13,7 +13,7 @@ object save_jsonl_stdout {
     if(out ne Console.out) out.close()
   }
 
-  val people = List[People](People(name = "Alice", age = 30), People(name = "Bob", age = 25))
+  val people = List(People(name = "Alice", age = 30), People(name = "Bob", age = 25))
   def main(args: Array[String]): Unit = {
     _save_jsonl(people, "-")
   }

--- a/tests/machine/x/scala/short_circuit.scala
+++ b/tests/machine/x/scala/short_circuit.scala
@@ -1,11 +1,11 @@
 object short_circuit {
   def boom(a: Int, b: Int): Boolean = {
-    println(("boom"))
+    println("boom")
     return true
   }
   
   def main(args: Array[String]): Unit = {
-    println((false && boom(1, 2)))
-    println((true || boom(1, 2)))
+    println(false && boom(1, 2))
+    println(true || boom(1, 2))
   }
 }

--- a/tests/machine/x/scala/slice.scala
+++ b/tests/machine/x/scala/slice.scala
@@ -1,7 +1,7 @@
 object slice {
   def main(args: Array[String]): Unit = {
-    println((List[Int](1, 2, 3).slice(1, 3)))
-    println((List[Int](1, 2, 3).slice(0, 2)))
-    println(("hello".substring(1, 4)))
+    println(List(1, 2, 3).slice(1, 3))
+    println(List(1, 2, 3).slice(0, 2))
+    println("hello".substring(1, 4))
   }
 }

--- a/tests/machine/x/scala/sort_stable.scala
+++ b/tests/machine/x/scala/sort_stable.scala
@@ -1,9 +1,9 @@
 object sort_stable {
   case class Item(n: Int, v: String)
 
-  val items = List[Item](Item(n = 1, v = "a"), Item(n = 1, v = "b"), Item(n = 2, v = "c"))
+  val items = List(Item(n = 1, v = "a"), Item(n = 1, v = "b"), Item(n = 2, v = "c"))
   val result = (for { i <- items } yield i).sortBy(i => i.n).map(i => i.v)
   def main(args: Array[String]): Unit = {
-    println((result))
+    println(result)
   }
 }

--- a/tests/machine/x/scala/str_builtin.scala
+++ b/tests/machine/x/scala/str_builtin.scala
@@ -1,5 +1,5 @@
 object str_builtin {
   def main(args: Array[String]): Unit = {
-    println((123.toString))
+    println(123.toString)
   }
 }

--- a/tests/machine/x/scala/string_compare.scala
+++ b/tests/machine/x/scala/string_compare.scala
@@ -1,8 +1,8 @@
 object string_compare {
   def main(args: Array[String]): Unit = {
-    println(("a" < "b"))
-    println(("a" <= "a"))
-    println(("b" > "a"))
-    println(("b" >= "b"))
+    println("a" < "b")
+    println("a" <= "a")
+    println("b" > "a")
+    println("b" >= "b")
   }
 }

--- a/tests/machine/x/scala/string_concat.scala
+++ b/tests/machine/x/scala/string_concat.scala
@@ -1,5 +1,5 @@
 object string_concat {
   def main(args: Array[String]): Unit = {
-    println(("hello " + "world"))
+    println("hello " + "world")
   }
 }

--- a/tests/machine/x/scala/string_contains.scala
+++ b/tests/machine/x/scala/string_contains.scala
@@ -1,7 +1,7 @@
 object string_contains {
   val s = "catch"
   def main(args: Array[String]): Unit = {
-    println((s.contains("cat")))
-    println((s.contains("dog")))
+    println(s.contains("cat"))
+    println(s.contains("dog"))
   }
 }

--- a/tests/machine/x/scala/string_in_operator.scala
+++ b/tests/machine/x/scala/string_in_operator.scala
@@ -1,7 +1,7 @@
 object string_in_operator {
   val s = "catch"
   def main(args: Array[String]): Unit = {
-    println((s.contains("cat")))
-    println((s.contains("dog")))
+    println(s.contains("cat"))
+    println(s.contains("dog"))
   }
 }

--- a/tests/machine/x/scala/string_index.scala
+++ b/tests/machine/x/scala/string_index.scala
@@ -1,6 +1,6 @@
 object string_index {
   val s = "mochi"
   def main(args: Array[String]): Unit = {
-    println((s.charAt(1)))
+    println(s.charAt(1))
   }
 }

--- a/tests/machine/x/scala/string_prefix_slice.scala
+++ b/tests/machine/x/scala/string_prefix_slice.scala
@@ -2,8 +2,8 @@ object string_prefix_slice {
   val prefix = "fore"
   val s1 = "forest"
   def main(args: Array[String]): Unit = {
-    println((s1.substring(0, prefix.length) == prefix))
+    println(s1.substring(0, prefix.length) == prefix)
     val s2 = "desert"
-    println((s2.substring(0, prefix.length) == prefix))
+    println(s2.substring(0, prefix.length) == prefix)
   }
 }

--- a/tests/machine/x/scala/substring_builtin.scala
+++ b/tests/machine/x/scala/substring_builtin.scala
@@ -1,5 +1,5 @@
 object substring_builtin {
   def main(args: Array[String]): Unit = {
-    println(("mochi".substring(1, 4)))
+    println("mochi".substring(1, 4))
   }
 }

--- a/tests/machine/x/scala/sum_builtin.scala
+++ b/tests/machine/x/scala/sum_builtin.scala
@@ -1,5 +1,5 @@
 object sum_builtin {
   def main(args: Array[String]): Unit = {
-    println((List[Int](1, 2, 3).sum))
+    println(List(1, 2, 3).sum)
   }
 }

--- a/tests/machine/x/scala/tail_recursion.scala
+++ b/tests/machine/x/scala/tail_recursion.scala
@@ -7,6 +7,6 @@ object tail_recursion {
   }
   
   def main(args: Array[String]): Unit = {
-    println((sum_rec(10, 0)))
+    println(sum_rec(10, 0))
   }
 }

--- a/tests/machine/x/scala/test_block.scala
+++ b/tests/machine/x/scala/test_block.scala
@@ -2,6 +2,6 @@ object test_block {
   def main(args: Array[String]): Unit = {
     val x = 1 + 2
     assert(x == 3)
-    println(("ok"))
+    println("ok")
   }
 }

--- a/tests/machine/x/scala/tree_sum.scala
+++ b/tests/machine/x/scala/tree_sum.scala
@@ -10,6 +10,6 @@ object tree_sum {
   
   def main(args: Array[String]): Unit = {
     val t = Node(left = Leaf, value = 1, right = Node(left = Leaf, value = 2, right = Leaf))
-    println((sum_tree(t)))
+    println(sum_tree(t))
   }
 }

--- a/tests/machine/x/scala/two-sum.scala
+++ b/tests/machine/x/scala/two-sum.scala
@@ -4,16 +4,16 @@ object two_sum {
     for(i <- 0 until n) {
       for(j <- i + 1 until n) {
         if ((nums(i) + nums(j)).asInstanceOf[Int] == target) {
-          return List[Int](i, j)
+          return List(i, j)
         }
       }
     }
-    return List[Int](-1, -1)
+    return List(-1, -1)
   }
   
   def main(args: Array[String]): Unit = {
-    val result = twoSum(List[Int](2, 7, 11, 15), 9)
-    println((result(0)))
-    println((result(1)))
+    val result = twoSum(List(2, 7, 11, 15), 9)
+    println(result(0))
+    println(result(1))
   }
 }

--- a/tests/machine/x/scala/typed_let.scala
+++ b/tests/machine/x/scala/typed_let.scala
@@ -1,6 +1,6 @@
 object typed_let {
   val y: Int = 0
   def main(args: Array[String]): Unit = {
-    println((y))
+    println(y)
   }
 }

--- a/tests/machine/x/scala/typed_var.scala
+++ b/tests/machine/x/scala/typed_var.scala
@@ -1,6 +1,6 @@
 object typed_var {
   def main(args: Array[String]): Unit = {
     var x: Int = 0
-    println((x))
+    println(x)
   }
 }

--- a/tests/machine/x/scala/unary_neg.scala
+++ b/tests/machine/x/scala/unary_neg.scala
@@ -1,6 +1,6 @@
 object unary_neg {
   def main(args: Array[String]): Unit = {
-    println((-3))
-    println((5 + (-2)))
+    println(-3)
+    println(5 + (-2))
   }
 }

--- a/tests/machine/x/scala/update_stmt.scala
+++ b/tests/machine/x/scala/update_stmt.scala
@@ -1,7 +1,7 @@
 case class Person(var name: String, var age: Int, var status: String)
 
 object update_stmt {
-  var people: scala.collection.mutable.ArrayBuffer[Person] = scala.collection.mutable.ArrayBuffer[Person](Person(name = "Alice", age = 17, status = "minor"), Person(name = "Bob", age = 25, status = "unknown"), Person(name = "Charlie", age = 18, status = "unknown"), Person(name = "Diana", age = 16, status = "minor"))
+  var people: scala.collection.mutable.ArrayBuffer[Person] = scala.collection.mutable.ArrayBuffer(Person(name = "Alice", age = 17, status = "minor"), Person(name = "Bob", age = 25, status = "unknown"), Person(name = "Charlie", age = 18, status = "unknown"), Person(name = "Diana", age = 16, status = "minor"))
   def main(args: Array[String]): Unit = {
     for(_i0 <- 0 until people.length) {
       var _it1 = people(_i0)
@@ -15,7 +15,7 @@ object update_stmt {
       _it1 = Person(name = name, age = age, status = status)
       people = people.updated(_i0, _it1)
     }
-    assert(people == List[Person](Person(name = "Alice", age = 17, status = "minor"), Person(name = "Bob", age = 26, status = "adult"), Person(name = "Charlie", age = 19, status = "adult"), Person(name = "Diana", age = 16, status = "minor")))
-    println(("ok"))
+    assert(people == List(Person(name = "Alice", age = 17, status = "minor"), Person(name = "Bob", age = 26, status = "adult"), Person(name = "Charlie", age = 19, status = "adult"), Person(name = "Diana", age = 16, status = "minor")))
+    println("ok")
   }
 }

--- a/tests/machine/x/scala/user_type_literal.scala
+++ b/tests/machine/x/scala/user_type_literal.scala
@@ -5,6 +5,6 @@ case class Book(var title: String, var author: Person)
 object user_type_literal {
   val book = Book(title = "Go", author = Person(name = "Bob", age = 42))
   def main(args: Array[String]): Unit = {
-    println((book.author.name))
+    println(book.author.name)
   }
 }

--- a/tests/machine/x/scala/values_builtin.scala
+++ b/tests/machine/x/scala/values_builtin.scala
@@ -1,6 +1,6 @@
 object values_builtin {
-  val m = Map[String, Int]("a" -> (1), "b" -> (2), "c" -> (3))
+  val m = Map("a" -> (1), "b" -> (2), "c" -> (3))
   def main(args: Array[String]): Unit = {
-    println((m.values.toList))
+    println(m.values.toList)
   }
 }

--- a/tests/machine/x/scala/var_assignment.scala
+++ b/tests/machine/x/scala/var_assignment.scala
@@ -2,6 +2,6 @@ object var_assignment {
   def main(args: Array[String]): Unit = {
     var x = 1
     x = 2
-    println((x))
+    println(x)
   }
 }

--- a/tests/machine/x/scala/while_loop.scala
+++ b/tests/machine/x/scala/while_loop.scala
@@ -2,7 +2,7 @@ object while_loop {
   def main(args: Array[String]): Unit = {
     var i = 0
     while (i < 3) {
-      println((i))
+      println(i)
       i += 1
     }
   }


### PR DESCRIPTION
## Summary
- tweak Scala compiler to avoid wrapping print args in parentheses and drop generic types on list/map literals
- regenerate Scala machine outputs with new formatting
- document remaining task in Scala machine README

## Testing
- `go test -tags slow ./compiler/x/scala`


------
https://chatgpt.com/codex/tasks/task_e_687264f070ac8320926dd54f5c5d1c5c