### PR TITLE
Improve Clojure machine runtime

### DIFF
--- a/compiler/x/clj/runtime.go
+++ b/compiler/x/clj/runtime.go
@@ -28,10 +28,16 @@ const (
 `
 
 	helperRelPath = `(defn _rel_path [p]
-  (let [base (.getParent (java.io.File. *file*))]
-    (-> (java.nio.file.Paths/get base (into-array String [p]))
-        .normalize
-        .toString)))`
+  (let [start (.getParentFile (java.io.File. *file*))]
+    (loop [dir start i 0]
+      (let [candidate (-> (java.nio.file.Paths/get (.getPath dir)
+                                              (into-array String [p]))
+                          .normalize
+                          .toString)]
+        (cond
+          (.exists (java.io.File. candidate)) candidate
+          (< i 5) (recur (.getParentFile dir) (inc i))
+          :else candidate))))`
 
 	helperCount = `(defn _count [v]
   (cond

--- a/tests/machine/x/clj/README.md
+++ b/tests/machine/x/clj/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Clojure code generated from the Mochi programs in `tests/vm/valid` using the Clojure compiler. Each program was compiled and executed. Successful runs produced an `.out` file while failures produced an `.error` file.
 
-Compiled programs: 98/100 successful.
+Compiled programs: 99/100 successful.
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -53,7 +53,7 @@ Compiled programs: 98/100 successful.
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
 - [x] list_set_ops.mochi
-- [ ] load_yaml.mochi
+- [x] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi
@@ -105,7 +105,7 @@ Compiled programs: 98/100 successful.
 - [x] while_loop.mochi
 
 ## Status
-2 programs failed.
+1 program failed.
 
 ## Remaining tasks
 - [ ] Fix failing examples

--- a/tests/machine/x/clj/load_yaml.clj
+++ b/tests/machine/x/clj/load_yaml.clj
@@ -1,10 +1,16 @@
 (ns main)
 
 (defn _rel_path [p]
-  (let [base (.getParent (java.io.File. *file*))]
-    (-> (java.nio.file.Paths/get base (into-array String [p]))
-        .normalize
-        .toString)))
+  (let [start (.getParentFile (java.io.File. *file*))]
+    (loop [dir start i 0]
+      (let [candidate (-> (java.nio.file.Paths/get (.getPath dir)
+                                              (into-array String [p]))
+                          .normalize
+                          .toString)]
+        (cond
+          (.exists (java.io.File. candidate)) candidate
+          (< i 5) (recur (.getParentFile dir) (inc i))
+          :else candidate))))
 (defn _parse_csv [text header delim]
   (let [lines (->> (clojure.string/split-lines text)
                    (remove clojure.string/blank?))


### PR DESCRIPTION
## Summary
- enhance `_rel_path` helper to search parent directories
- regenerate `load_yaml.clj`
- mark `load_yaml.mochi` as passing in README (99/100 successful)

## Testing
- `go test ./...` *(fails: main redeclared in scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6872671795888320b2ee5c9f1a574d94