### PR TITLE
Fix Pascal formatter

### DIFF
--- a/compiler/x/pascal/tools.go
+++ b/compiler/x/pascal/tools.go
@@ -88,69 +88,17 @@ func EnsurePtop() error {
 // FormatPas runs ptop to pretty-print Pascal code if available.
 // Keywords keep their original casing and indentation is set to two spaces.
 func FormatPas(src []byte) []byte {
-	path, err := exec.LookPath("ptop")
-	if err != nil {
-		src = bytes.ReplaceAll(src, []byte("\t"), []byte("  "))
-		lines := bytes.Split(src, []byte("\n"))
-		for i, ln := range lines {
-			lines[i] = bytes.TrimRight(ln, " \t")
-		}
-		src = bytes.Join(lines, []byte("\n"))
-		if len(src) > 0 && src[len(src)-1] != '\n' {
-			src = append(src, '\n')
-		}
-		return src
-	}
-
-	inFile, err := os.CreateTemp("", "src-*.pas")
-	if err != nil {
-		return src
-	}
-	defer os.Remove(inFile.Name())
-	if _, err := inFile.Write(src); err != nil {
-		inFile.Close()
-		return src
-	}
-	inFile.Close()
-	outFile := inFile.Name() + ".out"
-	defer os.Remove(outFile)
-
-	cfgFile, err := os.CreateTemp("", "ptop-*.cfg")
-	if err == nil {
-		cfgFile.Close()
-		_ = exec.Command(path, "-g", cfgFile.Name()).Run()
-		if data, err := os.ReadFile(cfgFile.Name()); err == nil {
-			data = bytes.ReplaceAll(data, []byte(",capital"), nil)
-			data = bytes.ReplaceAll(data, []byte("=capital"), []byte("="))
-			_ = os.WriteFile(cfgFile.Name(), data, 0644)
-		}
-		defer os.Remove(cfgFile.Name())
-	}
-
-	args := []string{"-i", "2"}
-	if cfgFile != nil {
-		args = append(args, "-c", cfgFile.Name())
-	}
-	args = append(args, inFile.Name(), outFile)
-	if err := exec.Command(path, args...).Run(); err != nil {
-		data, _ := os.ReadFile(inFile.Name())
-		if len(data) > 0 && data[len(data)-1] != '\n' {
-			data = append(data, '\n')
-		}
-		return data
-	}
-	out, err := os.ReadFile(outFile)
-	if err != nil {
-		return src
-	}
-	out = bytes.TrimLeft(out, "\n")
-	lines := bytes.Split(out, []byte("\n"))
+	// ptop formatting sometimes mangles generic declarations, so we
+	// perform a minimal formatting pass ourselves instead of invoking
+	// the external tool.
+	src = bytes.ReplaceAll(src, []byte("\t"), []byte("  "))
+	lines := bytes.Split(src, []byte("\n"))
 	for i, ln := range lines {
 		lines[i] = bytes.TrimRight(ln, " \t")
 	}
-	out = bytes.Join(lines, []byte("\n"))
-	if len(out) > 0 && out[len(out)-1] != '\n' {
-		out = append(out, '\n')
+	src = bytes.Join(lines, []byte("\n"))
+	if len(src) > 0 && src[len(src)-1] != '\n' {
+		src = append(src, '\n')
 	}
-	return out
+	return src
 }


### PR DESCRIPTION
## Summary
- simplify Pascal code formatter

## Testing
- `go test -tags slow ./compiler/x/pascal -run Test`

------
https://chatgpt.com/codex/tasks/task_e_687269b44410832095ffd4143b469922