### PR TITLE
Improve Racket compiler output

### DIFF
--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -319,8 +319,13 @@ func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 				expr = fmt.Sprintf("(not (equal? %s %s))", l, r)
 			}
 		case "<", "<=", ">", ">=":
-			strOp := map[string]string{"<": "string<?", "<=": "string<=?", ">": "string>?", ">=": "string>=?"}[op.op]
-			expr = fmt.Sprintf("(cond [(string? %s) (%s %s %s)] [(string? %s) (%s %s %s)] [else (%s %s %s)])", l, strOp, l, r, r, strOp, l, r, op.op, l, r)
+			if ls || rs {
+				strOp := map[string]string{"<": "string<?", "<=": "string<=?", ">": "string>?", ">=": "string>=?"}[op.op]
+				expr = fmt.Sprintf("(%s %s %s)", strOp, l, r)
+				outStr = false
+			} else {
+				expr = fmt.Sprintf("(%s %s %s)", op.op, l, r)
+			}
 		case "&&":
 			expr = fmt.Sprintf("(and %s %s)", l, r)
 		case "||":

--- a/tests/machine/x/racket/README.md
+++ b/tests/machine/x/racket/README.md
@@ -111,4 +111,3 @@ Compiled programs: 100/100
 
 - Ensure new features continue to compile correctly.
 - Keep generated code in sync with `tests/human/x/racket`.
-

--- a/tests/machine/x/racket/if_then_else.rkt
+++ b/tests/machine/x/racket/if_then_else.rkt
@@ -1,4 +1,4 @@
 #lang racket
 (define x 12)
-(define msg (if (cond [(string? x) (string>? x 10)] [(string? 10) (string>? x 10)] [else (> x 10)]) "yes" "no"))
+(define msg (if (> x 10) "yes" "no"))
 (displayln msg)


### PR DESCRIPTION
## Summary
- simplify numeric comparison generation for the Racket backend
- regenerate machine output for `if_then_else`
- keep TODO section in machine README

## Testing
- `go test -tags slow ./compiler/x/racket` *(skipped: racket not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726e7f14848320898706c26f97f5d6