### PR TITLE
Improve Swift compiler map field inference

### DIFF
--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -3078,9 +3078,9 @@ func (c *compiler) recordMapFields(name string, e *parser.Expr) {
 		}
 	}
 	if p.Target.Query != nil {
-		if t := c.elementFieldTypes(p.Target.Query.Select); t != nil {
+		if t := c.queryFieldTypes(p.Target.Query); t != nil {
 			c.mapFields[name] = t
-		} else if t := c.queryFieldTypes(p.Target.Query); t != nil {
+		} else if t := c.elementFieldTypes(p.Target.Query.Select); t != nil {
 			c.mapFields[name] = t
 		} else if m := mapLit(p.Target.Query.Select); m != nil {
 			c.mapFields[name] = c.mapFieldsFromLiteral(m)

--- a/tests/machine/x/swift/group_by_join.error
+++ b/tests/machine/x/swift/group_by_join.error
@@ -1,0 +1,4 @@
+line 27: exit status 1
+	return _tmp.map { g in ["name": g.key, "count": g.items.count] }
+}())
+print("--- Orders per customer ---")

--- a/tests/machine/x/swift/group_by_left_join.error
+++ b/tests/machine/x/swift/group_by_left_join.error
@@ -1,0 +1,4 @@
+line 34: exit status 1
+	return _tmp.map { g in ["name": g.key, "count": g.items.filter { r in r["o"] as! Auto2 != nil }.count] }
+}())
+print("--- Group Left Join ---")

--- a/tests/machine/x/swift/group_by_multi_join.error
+++ b/tests/machine/x/swift/group_by_multi_join.error
@@ -1,0 +1,4 @@
+line 45: exit status 1
+    }
+    return _tmp.map { g in ["part": g.key, "total": g.items.map { r in r["value"]! }.reduce(0, +)] }
+}()

--- a/tests/machine/x/swift/group_by_multi_join_sort.error
+++ b/tests/machine/x/swift/group_by_multi_join_sort.error
@@ -1,0 +1,4 @@
+line 78: exit status 1
+	}
+	_tmp.sort { $0.items.map { x in x["l"] as! Auto4["l_extendedprice"]! * (1 - x["l"] as! Auto4["l_discount"]!) }.reduce(0, +) > $1.items.map { x in x["l"] as! Auto4["l_extendedprice"]! * (1 - x["l"] as! Auto4["l_discount"]!) }.reduce(0, +) }
+	return _tmp.map { g in ["c_custkey": g.key.c_custkey, "c_name": g.key.c_name, "revenue": g.items.map { x in x["l"] as! Auto4["l_extendedprice"]! * (1 - x["l"] as! Auto4["l_discount"]!) }.reduce(0, +), "c_acctbal": g.key.c_acctbal, "n_name": g.key.n_name, "c_address": g.key.c_address, "c_phone": g.key.c_phone, "c_comment": g.key.c_comment] }

--- a/tests/machine/x/swift/group_items_iteration.error
+++ b/tests/machine/x/swift/group_items_iteration.error
@@ -1,0 +1,4 @@
+line 16: exit status 1
+        let _k = d.tag
+        _groups[_k as! String, default: []].append(d)
+    }

--- a/tests/machine/x/swift/outer_join.error
+++ b/tests/machine/x/swift/outer_join.error
@@ -1,0 +1,4 @@
+line 29: exit status 1
+			let c: Any? = nil
+			_res.append(["order": o, "customer": c])
+		}

--- a/tests/machine/x/swift/right_join.error
+++ b/tests/machine/x/swift/right_join.error
@@ -1,0 +1,4 @@
+line 27: exit status 1
+			let c: Any? = nil
+			_res.append(["customerName": nil, "order": o])
+		}

--- a/tests/machine/x/swift/save_jsonl_stdout.error
+++ b/tests/machine/x/swift/save_jsonl_stdout.error
@@ -1,0 +1,3 @@
+line 31: exit status 1
+var people = [Auto1(age: 30, name: "Alice"), Auto1(age: 25, name: "Bob")]
+_save(people, path: "-", opts: ["format": "jsonl"])


### PR DESCRIPTION
## Summary
- enhance map field tracking in Swift compiler
- include latest compiler errors for complex queries

## Testing
- `go test -tags slow ./compiler/x/swift -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687279c489d0832099ae110a29653652