### PR TITLE
Improve Rust compiler with operator assignments

### DIFF
--- a/tests/machine/x/rust/group_items_iteration.rs
+++ b/tests/machine/x/rust/group_items_iteration.rs
@@ -28,7 +28,7 @@ fn main() {
     for g in groups {
         let mut total = 0;
         for x in g.items {
-            total = total + x.val;
+            total += x.val;
         }
         tmp = append(tmp, Item { tag: g.key, total: total });
     }

--- a/tests/machine/x/rust/record_assign.rs
+++ b/tests/machine/x/rust/record_assign.rs
@@ -5,7 +5,7 @@ struct Counter {
 
 fn main() {
     fn inc(c: &mut Counter) -> () {
-        c.n = c.n + 1;
+        c.n += 1;
     }
     let mut c = Counter { n: 0 };
     inc(&mut c.clone());

--- a/tests/machine/x/rust/while_loop.rs
+++ b/tests/machine/x/rust/while_loop.rs
@@ -2,6 +2,6 @@ fn main() {
     let mut i = 0;
     while i < 3 {
         println!("{}", i);
-        i = i + 1;
+        i += 1;
     }
 }


### PR DESCRIPTION
## Summary
- enhance Rust compiler to use operator assignments when possible
- regenerate machine-compiled Rust examples

## Testing
- `go test ./compiler/x/rust -tags=slow -run TestCompilePrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68726eb59f7c8320ab4f7eb01568e5dd