### PR TITLE
Improve comment for Prolog match equality

### DIFF
--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -2092,6 +2092,8 @@ func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) (string, bool, error) {
 			return "", false, err
 		}
 		tmp := c.newTmp()
+		// equality is used here instead of unification so that pattern
+		// variables are not bound when the clause does not match.
 		c.writeln(fmt.Sprintf("(%s == %s -> %s = %s ; %s = %s),", target, pat, tmp, res, tmp, cur))
 		cur = tmp
 		ar = ar && resAr


### PR DESCRIPTION
## Summary
- clarify why the Prolog compiler uses `==` when comparing match patterns

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6872880a4f1c8320974da2ba085a9747