### PR TITLE
Improve Go code generation

### DIFF
--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -109,5 +109,5 @@ Checklist:
 
 ## Remaining Tasks
 
-- [x] Simplify slice conversions and printing logic
+- [ ] Simplify slice conversions and printing logic
 - [ ] Expand coverage to more examples in `tests/vm/valid`

--- a/tests/machine/x/go/append_builtin.go
+++ b/tests/machine/x/go/append_builtin.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var a []int = []int{1, 2}
+	a := []int{1, 2}
 	_print(append(a, 3))
 }
 

--- a/tests/machine/x/go/basic_compare.go
+++ b/tests/machine/x/go/basic_compare.go
@@ -7,8 +7,8 @@ import (
 )
 
 func main() {
-	var a int = (10 - 3)
-	var b int = (2 + 2)
+	a := (10 - 3)
+	b := (2 + 2)
 	fmt.Println(a)
 	fmt.Println((a == 7))
 	fmt.Println((b < 5))

--- a/tests/machine/x/go/break_continue.go
+++ b/tests/machine/x/go/break_continue.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var numbers []int = []int{
+	numbers := []int{
 		1,
 		2,
 		3,

--- a/tests/machine/x/go/cast_string_to_int.go
+++ b/tests/machine/x/go/cast_string_to_int.go
@@ -8,6 +8,5 @@ import (
 )
 
 func main() {
-	n, _ := strconv.Atoi("1995")
-	fmt.Println(n)
+	fmt.Println(func() int { v, _ := strconv.Atoi("1995"); return v }())
 }

--- a/tests/machine/x/go/cast_struct.error
+++ b/tests/machine/x/go/cast_struct.error
@@ -1,5 +1,5 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/cast_struct.go:14:11: undefined: Todo1
+../../../tests/machine/x/go/cast_struct.go:14:10: undefined: Todo1
 
 1: //go:build ignore

--- a/tests/machine/x/go/cast_struct.go
+++ b/tests/machine/x/go/cast_struct.go
@@ -11,7 +11,7 @@ type Todo struct {
 }
 
 func main() {
-	var todo Todo1 = Todo1{"hi"}
+	todo := Todo1{"hi"}
 	_ = todo
 	fmt.Println(todo.Title)
 }

--- a/tests/machine/x/go/closure.go
+++ b/tests/machine/x/go/closure.go
@@ -14,6 +14,6 @@ func makeAdder(n int) func(int) int {
 }
 
 func main() {
-	var add10 func(int) int = makeAdder(10)
+	add10 := makeAdder(10)
 	fmt.Println(add10(7))
 }

--- a/tests/machine/x/go/cross_join.error
+++ b/tests/machine/x/go/cross_join.error
@@ -1,12 +1,12 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/cross_join.go:10:18: undefined: CustomersItem
+../../../tests/machine/x/go/cross_join.go:10:17: undefined: CustomersItem
 ../../../tests/machine/x/go/cross_join.go:13:5: undefined: CustomersItem
 ../../../tests/machine/x/go/cross_join.go:16:5: undefined: CustomersItem
-../../../tests/machine/x/go/cross_join.go:21:15: undefined: OrdersItem
+../../../tests/machine/x/go/cross_join.go:21:14: undefined: OrdersItem
 ../../../tests/machine/x/go/cross_join.go:25:5: undefined: OrdersItem
 ../../../tests/machine/x/go/cross_join.go:29:5: undefined: OrdersItem
-../../../tests/machine/x/go/cross_join.go:34:15: undefined: Result
+../../../tests/machine/x/go/cross_join.go:34:21: undefined: Result
 ../../../tests/machine/x/go/cross_join.go:35:16: undefined: Result
 ../../../tests/machine/x/go/cross_join.go:38:31: undefined: Result
 

--- a/tests/machine/x/go/cross_join.go
+++ b/tests/machine/x/go/cross_join.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{CustomersItem{
+	customers := []CustomersItem{CustomersItem{
 		1,
 		"Alice",
 	}, CustomersItem{
@@ -18,7 +18,7 @@ func main() {
 		"Charlie",
 	}}
 	_ = customers
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		100,
 		1,
 		250,
@@ -31,7 +31,7 @@ func main() {
 		1,
 		300,
 	}}
-	var result []Result = func() []Result {
+	result := func() []Result {
 		results := []Result{}
 		for _, o := range orders {
 			for _, c := range customers {

--- a/tests/machine/x/go/cross_join_filter.error
+++ b/tests/machine/x/go/cross_join_filter.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/cross_join_filter.go:13:14: undefined: Pairs
+../../../tests/machine/x/go/cross_join_filter.go:13:20: undefined: Pairs
 ../../../tests/machine/x/go/cross_join_filter.go:14:16: undefined: Pairs
 ../../../tests/machine/x/go/cross_join_filter.go:18:32: undefined: Pairs
 

--- a/tests/machine/x/go/cross_join_filter.go
+++ b/tests/machine/x/go/cross_join_filter.go
@@ -7,10 +7,10 @@ import (
 )
 
 func main() {
-	var nums []int = []int{1, 2, 3}
-	var letters []string = []string{"A", "B"}
+	nums := []int{1, 2, 3}
+	letters := []string{"A", "B"}
 	_ = letters
-	var pairs []Pairs = func() []Pairs {
+	pairs := func() []Pairs {
 		results := []Pairs{}
 		for _, n := range nums {
 			if (n % 2) == 0 {

--- a/tests/machine/x/go/cross_join_triple.error
+++ b/tests/machine/x/go/cross_join_triple.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/cross_join_triple.go:15:15: undefined: Combos
+../../../tests/machine/x/go/cross_join_triple.go:15:21: undefined: Combos
 ../../../tests/machine/x/go/cross_join_triple.go:16:16: undefined: Combos
 ../../../tests/machine/x/go/cross_join_triple.go:20:32: undefined: Combos
 

--- a/tests/machine/x/go/cross_join_triple.go
+++ b/tests/machine/x/go/cross_join_triple.go
@@ -7,12 +7,12 @@ import (
 )
 
 func main() {
-	var nums []int = []int{1, 2}
-	var letters []string = []string{"A", "B"}
+	nums := []int{1, 2}
+	letters := []string{"A", "B"}
 	_ = letters
-	var bools []bool = []bool{true, false}
+	bools := []bool{true, false}
 	_ = bools
-	var combos []Combos = func() []Combos {
+	combos := func() []Combos {
 		results := []Combos{}
 		for _, n := range nums {
 			for _, l := range letters {

--- a/tests/machine/x/go/dataset_sort_take_limit.error
+++ b/tests/machine/x/go/dataset_sort_take_limit.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/dataset_sort_take_limit.go:11:17: undefined: ProductsItem
+../../../tests/machine/x/go/dataset_sort_take_limit.go:11:16: undefined: ProductsItem
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:12:3: undefined: ProductsItem
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:16:3: undefined: ProductsItem
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:20:3: undefined: ProductsItem
@@ -8,7 +8,7 @@ Error on line 0: run error: exit status 1
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:28:3: undefined: ProductsItem
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:32:3: undefined: ProductsItem
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:36:3: undefined: ProductsItem
-../../../tests/machine/x/go/dataset_sort_take_limit.go:41:18: undefined: ProductsItem
+../../../tests/machine/x/go/dataset_sort_take_limit.go:41:24: undefined: ProductsItem
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:45:10: undefined: ProductsItem
 ../../../tests/machine/x/go/dataset_sort_take_limit.go:45:10: too many errors
 

--- a/tests/machine/x/go/dataset_sort_take_limit.go
+++ b/tests/machine/x/go/dataset_sort_take_limit.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var products []ProductsItem = []ProductsItem{
+	products := []ProductsItem{
 		ProductsItem{
 			"Laptop",
 			1500,
@@ -38,7 +38,7 @@ func main() {
 			200,
 		},
 	}
-	var expensive []ProductsItem = func() []ProductsItem {
+	expensive := func() []ProductsItem {
 		src := _toAnySlice(products)
 		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any {
 			tmp0 := _a[0]

--- a/tests/machine/x/go/dataset_where_filter.error
+++ b/tests/machine/x/go/dataset_where_filter.error
@@ -1,11 +1,11 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/dataset_where_filter.go:10:15: undefined: PeopleItem
+../../../tests/machine/x/go/dataset_where_filter.go:10:14: undefined: PeopleItem
 ../../../tests/machine/x/go/dataset_where_filter.go:11:3: undefined: PeopleItem
 ../../../tests/machine/x/go/dataset_where_filter.go:15:3: undefined: PeopleItem
 ../../../tests/machine/x/go/dataset_where_filter.go:19:3: undefined: PeopleItem
 ../../../tests/machine/x/go/dataset_where_filter.go:23:3: undefined: PeopleItem
-../../../tests/machine/x/go/dataset_where_filter.go:28:15: undefined: Adults
+../../../tests/machine/x/go/dataset_where_filter.go:28:21: undefined: Adults
 ../../../tests/machine/x/go/dataset_where_filter.go:29:16: undefined: Adults
 ../../../tests/machine/x/go/dataset_where_filter.go:33:32: undefined: Adults
 

--- a/tests/machine/x/go/dataset_where_filter.go
+++ b/tests/machine/x/go/dataset_where_filter.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var people []PeopleItem = []PeopleItem{
+	people := []PeopleItem{
 		PeopleItem{
 			"Alice",
 			30,
@@ -25,7 +25,7 @@ func main() {
 			45,
 		},
 	}
-	var adults []Adults = func() []Adults {
+	adults := func() []Adults {
 		results := []Adults{}
 		for _, person := range people {
 			if person.Age >= 18 {

--- a/tests/machine/x/go/exists_builtin.go
+++ b/tests/machine/x/go/exists_builtin.go
@@ -7,8 +7,8 @@ import (
 )
 
 func main() {
-	var dataVar []int = []int{1, 2}
-	var flag bool = len(func() []int {
+	dataVar := []int{1, 2}
+	flag := len(func() []int {
 		results := []int{}
 		for _, x := range dataVar {
 			if x == 1 {

--- a/tests/machine/x/go/fun_expr_in_let.go
+++ b/tests/machine/x/go/fun_expr_in_let.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var square func(int) int = func(x int) int {
+	square := func(x int) int {
 		return (x * x)
 	}
 	fmt.Println(square(6))

--- a/tests/machine/x/go/group_by.error
+++ b/tests/machine/x/go/group_by.error
@@ -1,13 +1,13 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by.go:13:15: undefined: PeopleItem
+../../../tests/machine/x/go/group_by.go:13:14: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by.go:14:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by.go:19:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by.go:24:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by.go:29:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by.go:34:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by.go:39:3: undefined: PeopleItem
-../../../tests/machine/x/go/group_by.go:45:14: undefined: Stats
+../../../tests/machine/x/go/group_by.go:45:20: undefined: Stats
 ../../../tests/machine/x/go/group_by.go:59:16: undefined: Stats
 ../../../tests/machine/x/go/group_by.go:62:30: undefined: Stats
 ../../../tests/machine/x/go/group_by.go:62:30: too many errors

--- a/tests/machine/x/go/group_by.go
+++ b/tests/machine/x/go/group_by.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	var people []PeopleItem = []PeopleItem{
+	people := []PeopleItem{
 		PeopleItem{
 			"Alice",
 			30,
@@ -42,7 +42,7 @@ func main() {
 			"Hanoi",
 		},
 	}
-	var stats []Stats = func() []Stats {
+	stats := func() []Stats {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, person := range people {

--- a/tests/machine/x/go/group_by_conditional_sum.error
+++ b/tests/machine/x/go/group_by_conditional_sum.error
@@ -1,9 +1,9 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_conditional_sum.go:14:14: undefined: ItemsItem
+../../../tests/machine/x/go/group_by_conditional_sum.go:14:13: undefined: ItemsItem
 ../../../tests/machine/x/go/group_by_conditional_sum.go:18:5: undefined: ItemsItem
 ../../../tests/machine/x/go/group_by_conditional_sum.go:22:5: undefined: ItemsItem
-../../../tests/machine/x/go/group_by_conditional_sum.go:27:15: undefined: Result
+../../../tests/machine/x/go/group_by_conditional_sum.go:27:21: undefined: Result
 ../../../tests/machine/x/go/group_by_conditional_sum.go:85:16: undefined: Result
 ../../../tests/machine/x/go/group_by_conditional_sum.go:87:30: undefined: Result
 

--- a/tests/machine/x/go/group_by_conditional_sum.go
+++ b/tests/machine/x/go/group_by_conditional_sum.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	var items []ItemsItem = []ItemsItem{ItemsItem{
+	items := []ItemsItem{ItemsItem{
 		"a",
 		10,
 		true,
@@ -24,7 +24,7 @@ func main() {
 		20,
 		true,
 	}}
-	var result []Result = func() []Result {
+	result := func() []Result {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, i := range items {

--- a/tests/machine/x/go/group_by_having.error
+++ b/tests/machine/x/go/group_by_having.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_having.go:12:15: undefined: PeopleItem
+../../../tests/machine/x/go/group_by_having.go:12:14: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by_having.go:13:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by_having.go:17:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by_having.go:21:3: undefined: PeopleItem
@@ -8,7 +8,7 @@ Error on line 0: run error: exit status 1
 ../../../tests/machine/x/go/group_by_having.go:29:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by_having.go:33:3: undefined: PeopleItem
 ../../../tests/machine/x/go/group_by_having.go:37:3: undefined: PeopleItem
-../../../tests/machine/x/go/group_by_having.go:42:12: undefined: Big
+../../../tests/machine/x/go/group_by_having.go:42:18: undefined: Big
 ../../../tests/machine/x/go/group_by_having.go:56:16: undefined: Big
 ../../../tests/machine/x/go/group_by_having.go:56:16: too many errors
 

--- a/tests/machine/x/go/group_by_having.go
+++ b/tests/machine/x/go/group_by_having.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	var people []PeopleItem = []PeopleItem{
+	people := []PeopleItem{
 		PeopleItem{
 			"Alice",
 			"Paris",
@@ -39,7 +39,7 @@ func main() {
 			"Paris",
 		},
 	}
-	var big []Big = func() []Big {
+	big := func() []Big {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, p := range people {

--- a/tests/machine/x/go/group_by_join.error
+++ b/tests/machine/x/go/group_by_join.error
@@ -1,11 +1,11 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_join.go:11:18: undefined: CustomersItem
+../../../tests/machine/x/go/group_by_join.go:11:17: undefined: CustomersItem
 ../../../tests/machine/x/go/group_by_join.go:14:5: undefined: CustomersItem
-../../../tests/machine/x/go/group_by_join.go:19:15: undefined: OrdersItem
+../../../tests/machine/x/go/group_by_join.go:19:14: undefined: OrdersItem
 ../../../tests/machine/x/go/group_by_join.go:22:5: undefined: OrdersItem
 ../../../tests/machine/x/go/group_by_join.go:25:5: undefined: OrdersItem
-../../../tests/machine/x/go/group_by_join.go:29:14: undefined: Stats
+../../../tests/machine/x/go/group_by_join.go:29:20: undefined: Stats
 ../../../tests/machine/x/go/group_by_join.go:59:16: undefined: Stats
 ../../../tests/machine/x/go/group_by_join.go:61:30: undefined: Stats
 

--- a/tests/machine/x/go/group_by_join.go
+++ b/tests/machine/x/go/group_by_join.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{CustomersItem{
+	customers := []CustomersItem{CustomersItem{
 		1,
 		"Alice",
 	}, CustomersItem{
@@ -16,7 +16,7 @@ func main() {
 		"Bob",
 	}}
 	_ = customers
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		100,
 		1,
 	}, OrdersItem{
@@ -26,7 +26,7 @@ func main() {
 		102,
 		2,
 	}}
-	var stats []Stats = func() []Stats {
+	stats := func() []Stats {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, o := range orders {

--- a/tests/machine/x/go/group_by_left_join.error
+++ b/tests/machine/x/go/group_by_left_join.error
@@ -1,12 +1,12 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_left_join.go:13:18: undefined: CustomersItem
+../../../tests/machine/x/go/group_by_left_join.go:13:17: undefined: CustomersItem
 ../../../tests/machine/x/go/group_by_left_join.go:16:5: undefined: CustomersItem
 ../../../tests/machine/x/go/group_by_left_join.go:19:5: undefined: CustomersItem
-../../../tests/machine/x/go/group_by_left_join.go:23:15: undefined: OrdersItem
+../../../tests/machine/x/go/group_by_left_join.go:23:14: undefined: OrdersItem
 ../../../tests/machine/x/go/group_by_left_join.go:26:5: undefined: OrdersItem
 ../../../tests/machine/x/go/group_by_left_join.go:29:5: undefined: OrdersItem
-../../../tests/machine/x/go/group_by_left_join.go:34:14: undefined: Stats
+../../../tests/machine/x/go/group_by_left_join.go:34:20: undefined: Stats
 ../../../tests/machine/x/go/group_by_left_join.go:62:11: undefined: OrdersItem
 ../../../tests/machine/x/go/group_by_left_join.go:85:16: undefined: Stats
 ../../../tests/machine/x/go/group_by_left_join.go:87:30: undefined: Stats

--- a/tests/machine/x/go/group_by_left_join.go
+++ b/tests/machine/x/go/group_by_left_join.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{CustomersItem{
+	customers := []CustomersItem{CustomersItem{
 		1,
 		"Alice",
 	}, CustomersItem{
@@ -20,7 +20,7 @@ func main() {
 		3,
 		"Charlie",
 	}}
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		100,
 		1,
 	}, OrdersItem{
@@ -31,7 +31,7 @@ func main() {
 		2,
 	}}
 	_ = orders
-	var stats []Stats = func() []Stats {
+	stats := func() []Stats {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, c := range customers {

--- a/tests/machine/x/go/group_by_multi_join.error
+++ b/tests/machine/x/go/group_by_multi_join.error
@@ -1,13 +1,13 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_multi_join.go:13:16: undefined: NationsItem
+../../../tests/machine/x/go/group_by_multi_join.go:13:15: undefined: NationsItem
 ../../../tests/machine/x/go/group_by_multi_join.go:16:5: undefined: NationsItem
-../../../tests/machine/x/go/group_by_multi_join.go:21:18: undefined: SuppliersItem
+../../../tests/machine/x/go/group_by_multi_join.go:21:17: undefined: SuppliersItem
 ../../../tests/machine/x/go/group_by_multi_join.go:24:5: undefined: SuppliersItem
-../../../tests/machine/x/go/group_by_multi_join.go:29:17: undefined: PartsuppItem
+../../../tests/machine/x/go/group_by_multi_join.go:29:16: undefined: PartsuppItem
 ../../../tests/machine/x/go/group_by_multi_join.go:34:5: undefined: PartsuppItem
 ../../../tests/machine/x/go/group_by_multi_join.go:39:5: undefined: PartsuppItem
-../../../tests/machine/x/go/group_by_multi_join.go:45:17: undefined: Filtered
+../../../tests/machine/x/go/group_by_multi_join.go:45:23: undefined: Filtered
 ../../../tests/machine/x/go/group_by_multi_join.go:46:16: undefined: Filtered
 ../../../tests/machine/x/go/group_by_multi_join.go:58:34: undefined: Filtered
 ../../../tests/machine/x/go/group_by_multi_join.go:58:34: too many errors

--- a/tests/machine/x/go/group_by_multi_join.go
+++ b/tests/machine/x/go/group_by_multi_join.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	var nations []NationsItem = []NationsItem{NationsItem{
+	nations := []NationsItem{NationsItem{
 		1,
 		"A",
 	}, NationsItem{
@@ -18,7 +18,7 @@ func main() {
 		"B",
 	}}
 	_ = nations
-	var suppliers []SuppliersItem = []SuppliersItem{SuppliersItem{
+	suppliers := []SuppliersItem{SuppliersItem{
 		1,
 		1,
 	}, SuppliersItem{
@@ -26,7 +26,7 @@ func main() {
 		2,
 	}}
 	_ = suppliers
-	var partsupp []PartsuppItem = []PartsuppItem{PartsuppItem{
+	partsupp := []PartsuppItem{PartsuppItem{
 		100,
 		1,
 		10.0,
@@ -42,7 +42,7 @@ func main() {
 		5.0,
 		3,
 	}}
-	var filtered []Filtered = func() []Filtered {
+	filtered := func() []Filtered {
 		results := []Filtered{}
 		for _, ps := range partsupp {
 			for _, s := range suppliers {
@@ -66,7 +66,7 @@ func main() {
 		}
 		return results
 	}()
-	var grouped []Grouped = func() []Grouped {
+	grouped := func() []Grouped {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, x := range filtered {

--- a/tests/machine/x/go/group_by_multi_join_sort.error
+++ b/tests/machine/x/go/group_by_multi_join_sort.error
@@ -1,12 +1,12 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_multi_join_sort.go:14:15: undefined: NationItem
-../../../tests/machine/x/go/group_by_multi_join_sort.go:19:17: undefined: CustomerItem
-../../../tests/machine/x/go/group_by_multi_join_sort.go:28:15: undefined: OrdersItem
+../../../tests/machine/x/go/group_by_multi_join_sort.go:14:14: undefined: NationItem
+../../../tests/machine/x/go/group_by_multi_join_sort.go:19:16: undefined: CustomerItem
+../../../tests/machine/x/go/group_by_multi_join_sort.go:28:14: undefined: OrdersItem
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:32:5: undefined: OrdersItem
-../../../tests/machine/x/go/group_by_multi_join_sort.go:38:17: undefined: LineitemItem
+../../../tests/machine/x/go/group_by_multi_join_sort.go:38:16: undefined: LineitemItem
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:43:5: undefined: LineitemItem
-../../../tests/machine/x/go/group_by_multi_join_sort.go:52:15: undefined: Result
+../../../tests/machine/x/go/group_by_multi_join_sort.go:52:21: undefined: Result
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:69:15: undefined: v
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:126:95: invalid operation: (float64(1) - (_toAnyMap(_toAnyMap(x)["l"])["l_discount"]).(float64)) (value of type float64) is not an interface
 ../../../tests/machine/x/go/group_by_multi_join_sort.go:157:16: undefined: Result

--- a/tests/machine/x/go/group_by_multi_join_sort.go
+++ b/tests/machine/x/go/group_by_multi_join_sort.go
@@ -11,12 +11,12 @@ import (
 )
 
 func main() {
-	var nation []NationItem = []NationItem{NationItem{
+	nation := []NationItem{NationItem{
 		1,
 		"BRAZIL",
 	}}
 	_ = nation
-	var customer []CustomerItem = []CustomerItem{CustomerItem{
+	customer := []CustomerItem{CustomerItem{
 		1,
 		"Alice",
 		100.0,
@@ -25,7 +25,7 @@ func main() {
 		"123-456",
 		"Loyal",
 	}}
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		1000,
 		1,
 		"1993-10-15",
@@ -35,7 +35,7 @@ func main() {
 		"1994-01-02",
 	}}
 	_ = orders
-	var lineitem []LineitemItem = []LineitemItem{LineitemItem{
+	lineitem := []LineitemItem{LineitemItem{
 		1000,
 		"R",
 		1000.0,
@@ -47,9 +47,9 @@ func main() {
 		0.0,
 	}}
 	_ = lineitem
-	var start_date string = "1993-10-01"
-	var end_date string = "1994-01-01"
-	var result []Result = func() []Result {
+	start_date := "1993-10-01"
+	end_date := "1994-01-01"
+	result := func() []Result {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, c := range customer {

--- a/tests/machine/x/go/group_by_sort.error
+++ b/tests/machine/x/go/group_by_sort.error
@@ -1,11 +1,11 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_by_sort.go:14:14: undefined: ItemsItem
+../../../tests/machine/x/go/group_by_sort.go:14:13: undefined: ItemsItem
 ../../../tests/machine/x/go/group_by_sort.go:15:3: undefined: ItemsItem
 ../../../tests/machine/x/go/group_by_sort.go:19:3: undefined: ItemsItem
 ../../../tests/machine/x/go/group_by_sort.go:23:3: undefined: ItemsItem
 ../../../tests/machine/x/go/group_by_sort.go:27:3: undefined: ItemsItem
-../../../tests/machine/x/go/group_by_sort.go:32:16: undefined: Grouped
+../../../tests/machine/x/go/group_by_sort.go:32:22: undefined: Grouped
 ../../../tests/machine/x/go/group_by_sort.go:95:16: undefined: Grouped
 ../../../tests/machine/x/go/group_by_sort.go:97:30: undefined: Grouped
 

--- a/tests/machine/x/go/group_by_sort.go
+++ b/tests/machine/x/go/group_by_sort.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	var items []ItemsItem = []ItemsItem{
+	items := []ItemsItem{
 		ItemsItem{
 			"a",
 			3,
@@ -29,7 +29,7 @@ func main() {
 			2,
 		},
 	}
-	var grouped []Grouped = func() []Grouped {
+	grouped := func() []Grouped {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, i := range items {

--- a/tests/machine/x/go/group_items_iteration.error
+++ b/tests/machine/x/go/group_items_iteration.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/group_items_iteration.go:14:16: undefined: DataVarItem
+../../../tests/machine/x/go/group_items_iteration.go:14:15: undefined: DataVarItem
 ../../../tests/machine/x/go/group_items_iteration.go:17:5: undefined: DataVarItem
 ../../../tests/machine/x/go/group_items_iteration.go:20:5: undefined: DataVarItem
 ../../../tests/machine/x/go/group_items_iteration.go:49:23: x.Val undefined (type any has no field or method Val)

--- a/tests/machine/x/go/group_items_iteration.go
+++ b/tests/machine/x/go/group_items_iteration.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	var dataVar []DataVarItem = []DataVarItem{DataVarItem{
+	dataVar := []DataVarItem{DataVarItem{
 		"a",
 		1,
 	}, DataVarItem{
@@ -21,7 +21,7 @@ func main() {
 		"b",
 		3,
 	}}
-	var groups []*data.Group = func() []*data.Group {
+	groups := func() []*data.Group {
 		groups := map[string]*data.Group{}
 		order := []string{}
 		for _, d := range dataVar {
@@ -42,9 +42,9 @@ func main() {
 		}
 		return results
 	}()
-	var tmp []any = []any{}
+	tmp := []any{}
 	for _, g := range groups {
-		var total int = 0
+		total := 0
 		for _, x := range g.Items {
 			total = (total + x.Val)
 		}
@@ -53,7 +53,7 @@ func main() {
 			Total: total,
 		})
 	}
-	var result []any = func() []any {
+	result := func() []any {
 		src := tmp
 		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any { r := _a[0]; _ = r; return r }, sortKey: func(_a ...any) any { r := _a[0]; _ = r; return _toAnyMap(r)["tag"] }, skip: -1, take: -1})
 		out := make([]any, len(resAny))

--- a/tests/machine/x/go/if_else.go
+++ b/tests/machine/x/go/if_else.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var x int = 5
+	x := 5
 	if x > 3 {
 		fmt.Println("big")
 	} else {

--- a/tests/machine/x/go/if_then_else.go
+++ b/tests/machine/x/go/if_then_else.go
@@ -7,9 +7,9 @@ import (
 )
 
 func main() {
-	var x int = 12
+	x := 12
 	_ = x
-	var msg string = func() string {
+	msg := func() string {
 		if x > 10 {
 			return "yes"
 		} else {

--- a/tests/machine/x/go/if_then_else_nested.go
+++ b/tests/machine/x/go/if_then_else_nested.go
@@ -7,9 +7,9 @@ import (
 )
 
 func main() {
-	var x int = 8
+	x := 8
 	_ = x
-	var msg string = func() string {
+	msg := func() string {
 		if x > 10 {
 			return "big"
 		} else {

--- a/tests/machine/x/go/in_operator.go
+++ b/tests/machine/x/go/in_operator.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var xs []int = []int{1, 2, 3}
+	xs := []int{1, 2, 3}
 	fmt.Println(slices.Contains(xs, 2))
 	fmt.Println(!(slices.Contains(xs, 5)))
 }

--- a/tests/machine/x/go/inner_join.error
+++ b/tests/machine/x/go/inner_join.error
@@ -1,14 +1,14 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/inner_join.go:10:18: undefined: CustomersItem
+../../../tests/machine/x/go/inner_join.go:10:17: undefined: CustomersItem
 ../../../tests/machine/x/go/inner_join.go:13:5: undefined: CustomersItem
 ../../../tests/machine/x/go/inner_join.go:16:5: undefined: CustomersItem
-../../../tests/machine/x/go/inner_join.go:21:15: undefined: OrdersItem
+../../../tests/machine/x/go/inner_join.go:21:14: undefined: OrdersItem
 ../../../tests/machine/x/go/inner_join.go:22:3: undefined: OrdersItem
 ../../../tests/machine/x/go/inner_join.go:27:3: undefined: OrdersItem
 ../../../tests/machine/x/go/inner_join.go:32:3: undefined: OrdersItem
 ../../../tests/machine/x/go/inner_join.go:37:3: undefined: OrdersItem
-../../../tests/machine/x/go/inner_join.go:43:15: undefined: Result
+../../../tests/machine/x/go/inner_join.go:43:21: undefined: Result
 ../../../tests/machine/x/go/inner_join.go:44:16: undefined: Result
 ../../../tests/machine/x/go/inner_join.go:44:16: too many errors
 

--- a/tests/machine/x/go/inner_join.go
+++ b/tests/machine/x/go/inner_join.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{CustomersItem{
+	customers := []CustomersItem{CustomersItem{
 		1,
 		"Alice",
 	}, CustomersItem{
@@ -18,7 +18,7 @@ func main() {
 		"Charlie",
 	}}
 	_ = customers
-	var orders []OrdersItem = []OrdersItem{
+	orders := []OrdersItem{
 		OrdersItem{
 			100,
 			1,
@@ -40,7 +40,7 @@ func main() {
 			80,
 		},
 	}
-	var result []Result = func() []Result {
+	result := func() []Result {
 		results := []Result{}
 		for _, o := range orders {
 			for _, c := range customers {

--- a/tests/machine/x/go/join_multi.error
+++ b/tests/machine/x/go/join_multi.error
@@ -1,12 +1,12 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/join_multi.go:10:18: undefined: CustomersItem
+../../../tests/machine/x/go/join_multi.go:10:17: undefined: CustomersItem
 ../../../tests/machine/x/go/join_multi.go:13:5: undefined: CustomersItem
-../../../tests/machine/x/go/join_multi.go:18:15: undefined: OrdersItem
+../../../tests/machine/x/go/join_multi.go:18:14: undefined: OrdersItem
 ../../../tests/machine/x/go/join_multi.go:21:5: undefined: OrdersItem
-../../../tests/machine/x/go/join_multi.go:25:14: undefined: ItemsItem
+../../../tests/machine/x/go/join_multi.go:25:13: undefined: ItemsItem
 ../../../tests/machine/x/go/join_multi.go:28:5: undefined: ItemsItem
-../../../tests/machine/x/go/join_multi.go:33:15: undefined: Result
+../../../tests/machine/x/go/join_multi.go:33:21: undefined: Result
 ../../../tests/machine/x/go/join_multi.go:34:16: undefined: Result
 ../../../tests/machine/x/go/join_multi.go:44:32: undefined: Result
 

--- a/tests/machine/x/go/join_multi.go
+++ b/tests/machine/x/go/join_multi.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{CustomersItem{
+	customers := []CustomersItem{CustomersItem{
 		1,
 		"Alice",
 	}, CustomersItem{
@@ -15,14 +15,14 @@ func main() {
 		"Bob",
 	}}
 	_ = customers
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		100,
 		1,
 	}, OrdersItem{
 		101,
 		2,
 	}}
-	var items []ItemsItem = []ItemsItem{ItemsItem{
+	items := []ItemsItem{ItemsItem{
 		100,
 		"a",
 	}, ItemsItem{
@@ -30,7 +30,7 @@ func main() {
 		"b",
 	}}
 	_ = items
-	var result []Result = func() []Result {
+	result := func() []Result {
 		results := []Result{}
 		for _, o := range orders {
 			for _, c := range customers {

--- a/tests/machine/x/go/json_builtin.error
+++ b/tests/machine/x/go/json_builtin.error
@@ -1,5 +1,5 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/json_builtin.go:11:8: undefined: M
+../../../tests/machine/x/go/json_builtin.go:11:7: undefined: M
 
 1: //go:build ignore

--- a/tests/machine/x/go/json_builtin.go
+++ b/tests/machine/x/go/json_builtin.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var m M = M{
+	m := M{
 		1,
 		2,
 	}

--- a/tests/machine/x/go/left_join.error
+++ b/tests/machine/x/go/left_join.error
@@ -1,10 +1,10 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/left_join.go:11:18: undefined: CustomersItem
+../../../tests/machine/x/go/left_join.go:11:17: undefined: CustomersItem
 ../../../tests/machine/x/go/left_join.go:14:5: undefined: CustomersItem
-../../../tests/machine/x/go/left_join.go:19:15: undefined: OrdersItem
+../../../tests/machine/x/go/left_join.go:19:14: undefined: OrdersItem
 ../../../tests/machine/x/go/left_join.go:23:5: undefined: OrdersItem
-../../../tests/machine/x/go/left_join.go:28:15: undefined: Result
+../../../tests/machine/x/go/left_join.go:28:21: undefined: Result
 ../../../tests/machine/x/go/left_join.go:33:11: undefined: OrdersItem
 ../../../tests/machine/x/go/left_join.go:35:16: undefined: OrdersItem
 ../../../tests/machine/x/go/left_join.go:39:11: undefined: CustomersItem

--- a/tests/machine/x/go/left_join.go
+++ b/tests/machine/x/go/left_join.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{CustomersItem{
+	customers := []CustomersItem{CustomersItem{
 		1,
 		"Alice",
 	}, CustomersItem{
@@ -16,7 +16,7 @@ func main() {
 		"Bob",
 	}}
 	_ = customers
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		100,
 		1,
 		250,
@@ -25,7 +25,7 @@ func main() {
 		3,
 		80,
 	}}
-	var result []Result = func() []Result {
+	result := func() []Result {
 		src := _toAnySlice(orders)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(customers), on: func(_a ...any) bool {

--- a/tests/machine/x/go/left_join_multi.error
+++ b/tests/machine/x/go/left_join_multi.error
@@ -1,11 +1,11 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/left_join_multi.go:11:18: undefined: CustomersItem
+../../../tests/machine/x/go/left_join_multi.go:11:17: undefined: CustomersItem
 ../../../tests/machine/x/go/left_join_multi.go:14:5: undefined: CustomersItem
-../../../tests/machine/x/go/left_join_multi.go:19:15: undefined: OrdersItem
+../../../tests/machine/x/go/left_join_multi.go:19:14: undefined: OrdersItem
 ../../../tests/machine/x/go/left_join_multi.go:22:5: undefined: OrdersItem
-../../../tests/machine/x/go/left_join_multi.go:26:14: undefined: ItemsItem
-../../../tests/machine/x/go/left_join_multi.go:31:15: undefined: Result
+../../../tests/machine/x/go/left_join_multi.go:26:13: undefined: ItemsItem
+../../../tests/machine/x/go/left_join_multi.go:31:21: undefined: Result
 ../../../tests/machine/x/go/left_join_multi.go:36:11: undefined: OrdersItem
 ../../../tests/machine/x/go/left_join_multi.go:38:16: undefined: OrdersItem
 ../../../tests/machine/x/go/left_join_multi.go:42:11: undefined: CustomersItem

--- a/tests/machine/x/go/left_join_multi.go
+++ b/tests/machine/x/go/left_join_multi.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{CustomersItem{
+	customers := []CustomersItem{CustomersItem{
 		1,
 		"Alice",
 	}, CustomersItem{
@@ -16,19 +16,19 @@ func main() {
 		"Bob",
 	}}
 	_ = customers
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		100,
 		1,
 	}, OrdersItem{
 		101,
 		2,
 	}}
-	var items []ItemsItem = []ItemsItem{ItemsItem{
+	items := []ItemsItem{ItemsItem{
 		100,
 		"a",
 	}}
 	_ = items
-	var result []Result = func() []Result {
+	result := func() []Result {
 		src := _toAnySlice(orders)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(customers), on: func(_a ...any) bool {

--- a/tests/machine/x/go/let_and_print.go
+++ b/tests/machine/x/go/let_and_print.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var a int = 10
+	a := 10
 	var b int = 20
 	fmt.Println((a + b))
 }

--- a/tests/machine/x/go/list_assign.go
+++ b/tests/machine/x/go/list_assign.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var nums []int = []int{1, 2}
+	nums := []int{1, 2}
 	nums[1] = 3
 	fmt.Println(nums[1])
 }

--- a/tests/machine/x/go/list_index.go
+++ b/tests/machine/x/go/list_index.go
@@ -7,6 +7,6 @@ import (
 )
 
 func main() {
-	var xs []int = []int{10, 20, 30}
+	xs := []int{10, 20, 30}
 	fmt.Println(xs[1])
 }

--- a/tests/machine/x/go/list_nested_assign.go
+++ b/tests/machine/x/go/list_nested_assign.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var matrix [][]int = [][]int{[]int{1, 2}, []int{3, 4}}
+	matrix := [][]int{[]int{1, 2}, []int{3, 4}}
 	matrix[1][0] = 5
 	fmt.Println(matrix[1][0])
 }

--- a/tests/machine/x/go/load_yaml.error
+++ b/tests/machine/x/go/load_yaml.error
@@ -2,7 +2,7 @@ Error on line 0: run error: exit status 1
 # command-line-arguments
 ../../../tests/machine/x/go/load_yaml.go:21:75: undefined: v
 ../../../tests/machine/x/go/load_yaml.go:24:13: invalid operation: r (variable of type map[string]any) is not an interface
-../../../tests/machine/x/go/load_yaml.go:28:15: undefined: Adults
+../../../tests/machine/x/go/load_yaml.go:28:21: undefined: Adults
 ../../../tests/machine/x/go/load_yaml.go:29:16: undefined: Adults
 ../../../tests/machine/x/go/load_yaml.go:33:32: undefined: Adults
 

--- a/tests/machine/x/go/load_yaml.go
+++ b/tests/machine/x/go/load_yaml.go
@@ -17,7 +17,7 @@ type Person struct {
 }
 
 func main() {
-	var people []Person = func() []Person {
+	people := func() []Person {
 		rows := _load("../../../tests/interpreter/valid/people.yaml", _toAnyMap(v{Format: "yaml"}))
 		out := make([]Person, len(rows))
 		for i, r := range rows {
@@ -25,7 +25,7 @@ func main() {
 		}
 		return out
 	}()
-	var adults []Adults = func() []Adults {
+	adults := func() []Adults {
 		results := []Adults{}
 		for _, p := range people {
 			if p.Age >= 18 {

--- a/tests/machine/x/go/map_in_operator.go
+++ b/tests/machine/x/go/map_in_operator.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var m map[int]string = map[int]string{1: "a", 2: "b"}
+	m := map[int]string{1: "a", 2: "b"}
 	key0 := 1
 	m1 := m
 	_, ok2 := m1[key0]

--- a/tests/machine/x/go/map_int_key.go
+++ b/tests/machine/x/go/map_int_key.go
@@ -7,6 +7,6 @@ import (
 )
 
 func main() {
-	var m map[int]string = map[int]string{1: "a", 2: "b"}
+	m := map[int]string{1: "a", 2: "b"}
 	fmt.Println(m[1])
 }

--- a/tests/machine/x/go/match_expr.go
+++ b/tests/machine/x/go/match_expr.go
@@ -8,8 +8,8 @@ import (
 )
 
 func main() {
-	var x int = 2
-	var label string = func() string {
+	x := 2
+	label := func() string {
 		_t := x
 		if _equal(_t, 1) {
 			return "one"

--- a/tests/machine/x/go/match_full.go
+++ b/tests/machine/x/go/match_full.go
@@ -22,8 +22,8 @@ func classify(n int) string {
 }
 
 func main() {
-	var x int = 2
-	var label string = func() string {
+	x := 2
+	label := func() string {
 		_t := x
 		if _equal(_t, 1) {
 			return "one"
@@ -37,8 +37,8 @@ func main() {
 		return "unknown"
 	}()
 	fmt.Println(label)
-	var day string = "sun"
-	var mood string = func() string {
+	day := "sun"
+	mood := func() string {
 		_t := day
 		if _equal(_t, "mon") {
 			return "tired"
@@ -52,8 +52,8 @@ func main() {
 		return "normal"
 	}()
 	fmt.Println(mood)
-	var ok bool = true
-	var status string = func() string {
+	ok := true
+	status := func() string {
 		_t := ok
 		if _equal(_t, true) {
 			return "confirmed"

--- a/tests/machine/x/go/membership.go
+++ b/tests/machine/x/go/membership.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var nums []int = []int{1, 2, 3}
+	nums := []int{1, 2, 3}
 	fmt.Println(slices.Contains(nums, 2))
 	fmt.Println(slices.Contains(nums, 4))
 }

--- a/tests/machine/x/go/min_max_builtin.go
+++ b/tests/machine/x/go/min_max_builtin.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	var nums []int = []int{3, 1, 4}
+	nums := []int{3, 1, 4}
 	fmt.Println(_minOrdered[int](nums))
 	fmt.Println(_maxOrdered[int](nums))
 }

--- a/tests/machine/x/go/order_by_map.error
+++ b/tests/machine/x/go/order_by_map.error
@@ -1,9 +1,9 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/order_by_map.go:12:16: undefined: DataVarItem
+../../../tests/machine/x/go/order_by_map.go:12:15: undefined: DataVarItem
 ../../../tests/machine/x/go/order_by_map.go:15:5: undefined: DataVarItem
 ../../../tests/machine/x/go/order_by_map.go:18:5: undefined: DataVarItem
-../../../tests/machine/x/go/order_by_map.go:22:15: undefined: DataVarItem
+../../../tests/machine/x/go/order_by_map.go:22:21: undefined: DataVarItem
 ../../../tests/machine/x/go/order_by_map.go:26:10: undefined: DataVarItem
 ../../../tests/machine/x/go/order_by_map.go:28:15: undefined: DataVarItem
 ../../../tests/machine/x/go/order_by_map.go:34:10: undefined: DataVarItem

--- a/tests/machine/x/go/order_by_map.go
+++ b/tests/machine/x/go/order_by_map.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	var dataVar []DataVarItem = []DataVarItem{DataVarItem{
+	dataVar := []DataVarItem{DataVarItem{
 		1,
 		2,
 	}, DataVarItem{
@@ -19,7 +19,7 @@ func main() {
 		0,
 		5,
 	}}
-	var sorted []DataVarItem = func() []DataVarItem {
+	sorted := func() []DataVarItem {
 		src := _toAnySlice(dataVar)
 		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any {
 			tmp0 := _a[0]

--- a/tests/machine/x/go/outer_join.error
+++ b/tests/machine/x/go/outer_join.error
@@ -1,11 +1,11 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/outer_join.go:14:18: undefined: CustomersItem
+../../../tests/machine/x/go/outer_join.go:14:17: undefined: CustomersItem
 ../../../tests/machine/x/go/outer_join.go:15:3: undefined: CustomersItem
 ../../../tests/machine/x/go/outer_join.go:19:3: undefined: CustomersItem
 ../../../tests/machine/x/go/outer_join.go:23:3: undefined: CustomersItem
 ../../../tests/machine/x/go/outer_join.go:27:3: undefined: CustomersItem
-../../../tests/machine/x/go/outer_join.go:33:15: undefined: OrdersItem
+../../../tests/machine/x/go/outer_join.go:33:14: undefined: OrdersItem
 ../../../tests/machine/x/go/outer_join.go:34:3: undefined: OrdersItem
 ../../../tests/machine/x/go/outer_join.go:39:3: undefined: OrdersItem
 ../../../tests/machine/x/go/outer_join.go:44:3: undefined: OrdersItem

--- a/tests/machine/x/go/outer_join.go
+++ b/tests/machine/x/go/outer_join.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{
+	customers := []CustomersItem{
 		CustomersItem{
 			1,
 			"Alice",
@@ -30,7 +30,7 @@ func main() {
 		},
 	}
 	_ = customers
-	var orders []OrdersItem = []OrdersItem{
+	orders := []OrdersItem{
 		OrdersItem{
 			100,
 			1,
@@ -52,7 +52,7 @@ func main() {
 			80,
 		},
 	}
-	var result []Result = func() []Result {
+	result := func() []Result {
 		src := _toAnySlice(orders)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(customers), on: func(_a ...any) bool {

--- a/tests/machine/x/go/partial_application.go
+++ b/tests/machine/x/go/partial_application.go
@@ -12,6 +12,6 @@ func add(a int, b int) int {
 }
 
 func main() {
-	var add5 int = func(p0 int) int { return add(5, p0) }
+	add5 := func(p0 int) int { return add(5, p0) }
 	fmt.Println(add5(3))
 }

--- a/tests/machine/x/go/python_math.go
+++ b/tests/machine/x/go/python_math.go
@@ -8,14 +8,14 @@ import (
 )
 
 func main() {
-	var r float64 = 3.0
-	var area float64 = (func() float64 { v, _ := python.Attr("math", "pi"); return v.(float64) }() * func() float64 { v, _ := python.Attr("math", "pow", r, 2.0); return v.(float64) }())
-	var root float64 = func() float64 { v, _ := python.Attr("math", "sqrt", 49.0); return v.(float64) }()
-	var sin45 float64 = func() float64 {
+	r := 3.0
+	area := (func() float64 { v, _ := python.Attr("math", "pi"); return v.(float64) }() * func() float64 { v, _ := python.Attr("math", "pow", r, 2.0); return v.(float64) }())
+	root := func() float64 { v, _ := python.Attr("math", "sqrt", 49.0); return v.(float64) }()
+	sin45 := func() float64 {
 		v, _ := python.Attr("math", "sin", (func() float64 { v, _ := python.Attr("math", "pi"); return v.(float64) }() / 4.0))
 		return v.(float64)
 	}()
-	var log_e float64 = func() float64 {
+	log_e := func() float64 {
 		v, _ := python.Attr("math", "log", func() float64 { v, _ := python.Attr("math", "e"); return v.(float64) }())
 		return v.(float64)
 	}()

--- a/tests/machine/x/go/query_sum_select.go
+++ b/tests/machine/x/go/query_sum_select.go
@@ -11,8 +11,8 @@ import (
 )
 
 func main() {
-	var nums []int = []int{1, 2, 3}
-	var result []int = _sumOrdered[int](func() []int {
+	nums := []int{1, 2, 3}
+	result := _sumOrdered[int](func() []int {
 		results := []int{}
 		for _, n := range nums {
 			if n > 1 {

--- a/tests/machine/x/go/right_join.error
+++ b/tests/machine/x/go/right_join.error
@@ -1,14 +1,14 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/right_join.go:14:18: undefined: CustomersItem
+../../../tests/machine/x/go/right_join.go:14:17: undefined: CustomersItem
 ../../../tests/machine/x/go/right_join.go:15:3: undefined: CustomersItem
 ../../../tests/machine/x/go/right_join.go:19:3: undefined: CustomersItem
 ../../../tests/machine/x/go/right_join.go:23:3: undefined: CustomersItem
 ../../../tests/machine/x/go/right_join.go:27:3: undefined: CustomersItem
-../../../tests/machine/x/go/right_join.go:32:15: undefined: OrdersItem
+../../../tests/machine/x/go/right_join.go:32:14: undefined: OrdersItem
 ../../../tests/machine/x/go/right_join.go:36:5: undefined: OrdersItem
 ../../../tests/machine/x/go/right_join.go:40:5: undefined: OrdersItem
-../../../tests/machine/x/go/right_join.go:46:15: undefined: Result
+../../../tests/machine/x/go/right_join.go:46:21: undefined: Result
 ../../../tests/machine/x/go/right_join.go:51:11: undefined: CustomersItem
 ../../../tests/machine/x/go/right_join.go:51:11: too many errors
 

--- a/tests/machine/x/go/right_join.go
+++ b/tests/machine/x/go/right_join.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	var customers []CustomersItem = []CustomersItem{
+	customers := []CustomersItem{
 		CustomersItem{
 			1,
 			"Alice",
@@ -29,7 +29,7 @@ func main() {
 			"Diana",
 		},
 	}
-	var orders []OrdersItem = []OrdersItem{OrdersItem{
+	orders := []OrdersItem{OrdersItem{
 		100,
 		1,
 		250,
@@ -43,7 +43,7 @@ func main() {
 		300,
 	}}
 	_ = orders
-	var result []Result = func() []Result {
+	result := func() []Result {
 		src := _toAnySlice(customers)
 		resAny := _query(src, []_joinSpec{
 			{items: _toAnySlice(orders), on: func(_a ...any) bool {

--- a/tests/machine/x/go/save_jsonl_stdout.error
+++ b/tests/machine/x/go/save_jsonl_stdout.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/save_jsonl_stdout.go:14:15: undefined: PeopleItem
+../../../tests/machine/x/go/save_jsonl_stdout.go:14:14: undefined: PeopleItem
 ../../../tests/machine/x/go/save_jsonl_stdout.go:17:5: undefined: PeopleItem
 ../../../tests/machine/x/go/save_jsonl_stdout.go:21:31: undefined: v
 

--- a/tests/machine/x/go/save_jsonl_stdout.go
+++ b/tests/machine/x/go/save_jsonl_stdout.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	var people []PeopleItem = []PeopleItem{PeopleItem{
+	people := []PeopleItem{PeopleItem{
 		"Alice",
 		30,
 	}, PeopleItem{

--- a/tests/machine/x/go/sort_stable.error
+++ b/tests/machine/x/go/sort_stable.error
@@ -1,6 +1,6 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/sort_stable.go:12:14: undefined: ItemsItem
+../../../tests/machine/x/go/sort_stable.go:12:13: undefined: ItemsItem
 ../../../tests/machine/x/go/sort_stable.go:15:5: undefined: ItemsItem
 ../../../tests/machine/x/go/sort_stable.go:18:5: undefined: ItemsItem
 ../../../tests/machine/x/go/sort_stable.go:26:10: undefined: ItemsItem

--- a/tests/machine/x/go/sort_stable.go
+++ b/tests/machine/x/go/sort_stable.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	var items []ItemsItem = []ItemsItem{ItemsItem{
+	items := []ItemsItem{ItemsItem{
 		1,
 		"a",
 	}, ItemsItem{
@@ -19,7 +19,7 @@ func main() {
 		2,
 		"c",
 	}}
-	var result []string = func() []string {
+	result := func() []string {
 		src := _toAnySlice(items)
 		resAny := _query(src, []_joinSpec{}, _queryOpts{selectFn: func(_a ...any) any {
 			tmp0 := _a[0]

--- a/tests/machine/x/go/string_contains.go
+++ b/tests/machine/x/go/string_contains.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var s string = "catch"
+	s := "catch"
 	_ = s
 	fmt.Println(strings.Contains(s, "cat"))
 	fmt.Println(strings.Contains(s, "dog"))

--- a/tests/machine/x/go/string_in_operator.go
+++ b/tests/machine/x/go/string_in_operator.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var s string = "catch"
+	s := "catch"
 	fmt.Println(strings.Contains(s, "cat"))
 	fmt.Println(strings.Contains(s, "dog"))
 }

--- a/tests/machine/x/go/string_index.go
+++ b/tests/machine/x/go/string_index.go
@@ -7,6 +7,6 @@ import (
 )
 
 func main() {
-	var s string = "mochi"
+	s := "mochi"
 	fmt.Println(string([]rune(s)[1]))
 }

--- a/tests/machine/x/go/string_prefix_slice.go
+++ b/tests/machine/x/go/string_prefix_slice.go
@@ -7,9 +7,9 @@ import (
 )
 
 func main() {
-	var prefix string = "fore"
-	var s1 string = "forest"
+	prefix := "fore"
+	s1 := "forest"
 	fmt.Println((string([]rune(s1)[0:4]) == prefix))
-	var s2 string = "desert"
+	s2 := "desert"
 	fmt.Println((string([]rune(s2)[0:4]) == prefix))
 }

--- a/tests/machine/x/go/test_block.go
+++ b/tests/machine/x/go/test_block.go
@@ -39,7 +39,7 @@ func printTestFail(err error, d time.Duration) {
 }
 
 func test_addition_works() {
-	var x int = (1 + 2)
+	x := (1 + 2)
 	_ = x
 	expect((x == 3))
 }

--- a/tests/machine/x/go/two-sum.go
+++ b/tests/machine/x/go/two-sum.go
@@ -8,7 +8,7 @@ import (
 
 // line 1
 func twoSum(nums []int, target int) []int {
-	var n int = len(nums)
+	n := len(nums)
 	for i := 0; i < n; i++ {
 		for j := (i + 1); j < n; j++ {
 			if (nums[i] + nums[j]) == target {
@@ -20,7 +20,7 @@ func twoSum(nums []int, target int) []int {
 }
 
 func main() {
-	var result []int = twoSum([]int{
+	result := twoSum([]int{
 		2,
 		7,
 		11,

--- a/tests/machine/x/go/user_type_literal.go
+++ b/tests/machine/x/go/user_type_literal.go
@@ -17,7 +17,7 @@ type Book struct {
 }
 
 func main() {
-	var book Book = Book{"Go", Person{"Bob", 42}}
+	book := Book{"Go", Person{"Bob", 42}}
 	_ = book
 	fmt.Println(book.Author.Name)
 }

--- a/tests/machine/x/go/values_builtin.error
+++ b/tests/machine/x/go/values_builtin.error
@@ -1,5 +1,5 @@
 Error on line 0: run error: exit status 1
 # command-line-arguments
-../../../tests/machine/x/go/values_builtin.go:11:8: undefined: M
+../../../tests/machine/x/go/values_builtin.go:11:7: undefined: M
 
 1: //go:build ignore

--- a/tests/machine/x/go/values_builtin.go
+++ b/tests/machine/x/go/values_builtin.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var m M = M{
+	m := M{
 		1,
 		2,
 		3,

--- a/tests/machine/x/go/var_assignment.go
+++ b/tests/machine/x/go/var_assignment.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var x int = 1
+	x := 1
 	x = 2
 	fmt.Println(x)
 }

--- a/tests/machine/x/go/while_loop.go
+++ b/tests/machine/x/go/while_loop.go
@@ -7,11 +7,8 @@ import (
 )
 
 func main() {
-	var i int = 0
-	for {
-		if !(i < 3) {
-			break
-		}
+	i := 0
+	for i < 3 {
 		fmt.Println(i)
 		i = (i + 1)
 	}


### PR DESCRIPTION
## Summary
- refine Go backend to emit idiomatic while-loops
- restore `_print` helper for complex values
- regenerate machine Go output

## Testing
- `go test -tags slow ./compiler/x/go -run TestGoCompiler_ValidPrograms`

------
https://chatgpt.com/codex/tasks/task_e_68728b1880d48320aa509577dfd63344