### PR TITLE
Improve Racket compiler query features

### DIFF
--- a/tests/machine/x/racket/README.md
+++ b/tests/machine/x/racket/README.md
@@ -111,3 +111,4 @@ Compiled programs: 100/100
 
 - Ensure new features continue to compile correctly.
 - Keep generated code in sync with `tests/human/x/racket`.
+- Verify query features like `sort`, `skip`, and `take` remain accurate.

--- a/tests/machine/x/racket/dataset_sort_take_limit.rkt
+++ b/tests/machine/x/racket/dataset_sort_take_limit.rkt
@@ -1,6 +1,11 @@
 #lang racket
+(require racket/list)
 (define products (list (hash 'name "Laptop" 'price 1500) (hash 'name "Smartphone" 'price 900) (hash 'name "Tablet" 'price 600) (hash 'name "Monitor" 'price 300) (hash 'name "Keyboard" 'price 100) (hash 'name "Mouse" 'price 50) (hash 'name "Headphones" 'price 200)))
-(define expensive (for*/list ([p products]) p))
+(define expensive (let ([_items0 (for*/list ([p products]) p)])
+  (set! _items0 (sort _items0 (lambda (a b) (cond [(string? (let ([p a]) (hash-ref p 'price))) (string>? (let ([p a]) (hash-ref p 'price)) (let ([p b]) (hash-ref p 'price)))] [(string? (let ([p b]) (hash-ref p 'price))) (string>? (let ([p a]) (hash-ref p 'price)) (let ([p b]) (hash-ref p 'price)))] [else (> (let ([p a]) (hash-ref p 'price)) (let ([p b]) (hash-ref p 'price)))]))))
+  (set! _items0 (drop _items0 (max 1 0)))
+  (set! _items0 (take _items0 (max 3 0)))
+  (for/list ([p _items0]) p)))
 (displayln "--- Top products (excluding most expensive) ---")
 (for ([item (if (hash? expensive) (hash-keys expensive) expensive)])
 (displayln (string-join (map ~a (list (hash-ref item 'name) "costs $" (hash-ref item 'price))) " "))

--- a/tests/machine/x/racket/group_items_iteration.rkt
+++ b/tests/machine/x/racket/group_items_iteration.rkt
@@ -1,4 +1,5 @@
 #lang racket
+(require racket/list)
 (define data (list (hash 'tag "a" 'val 1) (hash 'tag "a" 'val 2) (hash 'tag "b" 'val 3)))
 (define groups (let ([groups (make-hash)])
   (for* ([d data]) (let* ([key (hash-ref d 'tag)] [bucket (hash-ref groups key '())]) (hash-set! groups key (cons d bucket))))
@@ -12,5 +13,7 @@
 )
 (set! tmp (append tmp (list (hash 'tag (hash-ref g 'key) 'total total))))
 )
-(define result (for*/list ([r tmp]) r))
+(define result (let ([_items0 (for*/list ([r tmp]) r)])
+  (set! _items0 (sort _items0 (lambda (a b) (cond [(string? (let ([r a]) (hash-ref r 'tag))) (string<? (let ([r a]) (hash-ref r 'tag)) (let ([r b]) (hash-ref r 'tag)))] [(string? (let ([r b]) (hash-ref r 'tag))) (string<? (let ([r a]) (hash-ref r 'tag)) (let ([r b]) (hash-ref r 'tag)))] [else (< (let ([r a]) (hash-ref r 'tag)) (let ([r b]) (hash-ref r 'tag)))]))))
+  (for/list ([r _items0]) r)))
 (displayln result)

--- a/tests/machine/x/racket/order_by_map.rkt
+++ b/tests/machine/x/racket/order_by_map.rkt
@@ -1,4 +1,7 @@
 #lang racket
+(require racket/list)
 (define data (list (hash 'a 1 'b 2) (hash 'a 1 'b 1) (hash 'a 0 'b 5)))
-(define sorted (for*/list ([x data]) x))
+(define sorted (let ([_items0 (for*/list ([x data]) x)])
+  (set! _items0 (sort _items0 (lambda (a b) (cond [(string? (let ([x a]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b)))) (string<? (let ([x a]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b))) (let ([x b]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b))))] [(string? (let ([x b]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b)))) (string<? (let ([x a]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b))) (let ([x b]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b))))] [else (< (let ([x a]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b))) (let ([x b]) (hash 'a (hash-ref x 'a) 'b (hash-ref x 'b))))]))))
+  (for/list ([x _items0]) x)))
 (displayln sorted)

--- a/tests/machine/x/racket/sort_stable.rkt
+++ b/tests/machine/x/racket/sort_stable.rkt
@@ -1,4 +1,7 @@
 #lang racket
+(require racket/list)
 (define items (list (hash 'n 1 'v "a") (hash 'n 1 'v "b") (hash 'n 2 'v "c")))
-(define result (for*/list ([i items]) (hash-ref i 'v)))
+(define result (let ([_items0 (for*/list ([i items]) i)])
+  (set! _items0 (sort _items0 (lambda (a b) (cond [(string? (let ([i a]) (hash-ref i 'n))) (string<? (let ([i a]) (hash-ref i 'n)) (let ([i b]) (hash-ref i 'n)))] [(string? (let ([i b]) (hash-ref i 'n))) (string<? (let ([i a]) (hash-ref i 'n)) (let ([i b]) (hash-ref i 'n)))] [else (< (let ([i a]) (hash-ref i 'n)) (let ([i b]) (hash-ref i 'n)))]))))
+  (for/list ([i _items0]) (hash-ref i 'v))))
 (displayln result)


### PR DESCRIPTION
## Summary
- support `sort`, `skip` and `take` in Racket query compiler
- regenerate machine outputs for Racket examples
- document remaining work in Racket machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68728b7a9584832098ba8f062affd406