### PR TITLE
Update clj tpch golden output

### DIFF
--- a/compiler/x/clj/tools.go
+++ b/compiler/x/clj/tools.go
@@ -128,6 +128,11 @@ func Format(src []byte) ([]byte, error) {
 		}
 	}
 	src = bytes.ReplaceAll(src, []byte("\t"), []byte("  "))
+	lines := bytes.Split(src, []byte("\n"))
+	for i, line := range lines {
+		lines[i] = bytes.TrimRight(line, " ")
+	}
+	src = bytes.Join(lines, []byte("\n"))
 	if len(src) > 0 && src[len(src)-1] != '\n' {
 		src = append(src, '\n')
 	}

--- a/tests/dataset/tpc-h/compiler/clj/q1.clj.out
+++ b/tests/dataset/tpc-h/compiler/clj/q1.clj.out
@@ -75,12 +75,12 @@
 )
 
 (defn -main []
-  (def lineitem [{:l_quantity 17 :l_extendedprice 1000.0 :l_discount 0.05 :l_tax 0.07 :l_returnflag "N" :l_linestatus "O" :l_shipdate "1998-08-01"} {:l_quantity 36 :l_extendedprice 2000.0 :l_discount 0.1 :l_tax 0.05 :l_returnflag "N" :l_linestatus "O" :l_shipdate "1998-09-01"} {:l_quantity 25 :l_extendedprice 1500.0 :l_discount 0.0 :l_tax 0.08 :l_returnflag "R" :l_linestatus "F" :l_shipdate "1998-09-03"}]) ;; list of 
+  (def lineitem [{:l_quantity 17 :l_extendedprice 1000.0 :l_discount 0.05 :l_tax 0.07 :l_returnflag "N" :l_linestatus "O" :l_shipdate "1998-08-01"} {:l_quantity 36 :l_extendedprice 2000.0 :l_discount 0.1 :l_tax 0.05 :l_returnflag "N" :l_linestatus "O" :l_shipdate "1998-09-01"} {:l_quantity 25 :l_extendedprice 1500.0 :l_discount 0.0 :l_tax 0.08 :l_returnflag "R" :l_linestatus "F" :l_shipdate "1998-09-03"}]) ;; list of
   (def result (let [_src lineitem
       _filtered (vec (filter (fn [row] (<= (compare (:l_shipdate row) "1998-09-02") 0)) _src))
       _groups (_group_by _filtered (fn [row] {:returnflag (:l_returnflag row) :linestatus (:l_linestatus row)}))
       ]
-  (->> _groups (map (fn [g] {:returnflag (:returnflag (:key g)) :linestatus (:linestatus (:key g)) :sum_qty (_sum (vec (->> (for [x (:Items g)] (:l_quantity x))))) :sum_base_price (_sum (vec (->> (for [x (:Items g)] (:l_extendedprice x))))) :sum_disc_price (_sum (vec (->> (for [x (:Items g)] (* (:l_extendedprice x) (- 1 (:l_discount x))))))) :sum_charge (_sum (vec (->> (for [x (:Items g)] (* (* (:l_extendedprice x) (- 1 (:l_discount x))) (+ 1 (:l_tax x))))))) :avg_qty (_avg (vec (->> (for [x (:Items g)] (:l_quantity x))))) :avg_price (_avg (vec (->> (for [x (:Items g)] (:l_extendedprice x))))) :avg_disc (_avg (vec (->> (for [x (:Items g)] (:l_discount x))))) :count_order (count (:Items g))})) vec))) ;; list of 
+  (->> _groups (map (fn [g] {:returnflag (:returnflag (:key g)) :linestatus (:linestatus (:key g)) :sum_qty (_sum (vec (->> (for [x (:Items g)] (:l_quantity x))))) :sum_base_price (_sum (vec (->> (for [x (:Items g)] (:l_extendedprice x))))) :sum_disc_price (_sum (vec (->> (for [x (:Items g)] (* (:l_extendedprice x) (- 1 (:l_discount x))))))) :sum_charge (_sum (vec (->> (for [x (:Items g)] (* (* (:l_extendedprice x) (- 1 (:l_discount x))) (+ 1 (:l_tax x))))))) :avg_qty (_avg (vec (->> (for [x (:Items g)] (:l_quantity x))))) :avg_price (_avg (vec (->> (for [x (:Items g)] (:l_extendedprice x))))) :avg_disc (_avg (vec (->> (for [x (:Items g)] (:l_discount x))))) :count_order (count (:Items g))})) vec))) ;; list of
   (_json result)
   (test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus)
 )

--- a/tests/dataset/tpc-h/compiler/clj/q2.clj.out
+++ b/tests/dataset/tpc-h/compiler/clj/q2.clj.out
@@ -43,18 +43,18 @@
 )
 
 (defn -main []
-  (def region [{:r_regionkey 1 :r_name "EUROPE"} {:r_regionkey 2 :r_name "ASIA"}]) ;; list of 
-  (def nation [{:n_nationkey 10 :n_regionkey 1 :n_name "FRANCE"} {:n_nationkey 20 :n_regionkey 2 :n_name "CHINA"}]) ;; list of 
-  (def supplier [{:s_suppkey 100 :s_name "BestSupplier" :s_address "123 Rue" :s_nationkey 10 :s_phone "123" :s_acctbal 1000.0 :s_comment "Fast and reliable"} {:s_suppkey 200 :s_name "AltSupplier" :s_address "456 Way" :s_nationkey 20 :s_phone "456" :s_acctbal 500.0 :s_comment "Slow"}]) ;; list of 
-  (def part [{:p_partkey 1000 :p_type "LARGE BRASS" :p_size 15 :p_mfgr "M1"} {:p_partkey 2000 :p_type "SMALL COPPER" :p_size 15 :p_mfgr "M2"}]) ;; list of 
-  (def partsupp [{:ps_partkey 1000 :ps_suppkey 100 :ps_supplycost 10.0} {:ps_partkey 1000 :ps_suppkey 200 :ps_supplycost 15.0}]) ;; list of 
-  (def europe_nations (vec (->> (for [r region :when (_equal (:r_name r) "EUROPE") n nation :when (_equal (:n_regionkey n) (:r_regionkey r))] n)))) ;; list of 
-  (def europe_suppliers (vec (->> (for [s supplier n europe_nations :when (_equal (:s_nationkey s) (:n_nationkey n))] {:s s :n n})))) ;; list of 
-  (def target_parts (vec (->> (for [p part :when (and (_equal (:p_size p) 15) (_equal (:p_type p) "LARGE BRASS"))] p)))) ;; list of 
-  (def target_partsupp (vec (->> (for [ps partsupp p target_parts :when (_equal (:ps_partkey ps) (:p_partkey p)) s europe_suppliers :when (_equal (:ps_suppkey ps) (:s_suppkey (:s s)))] {:s_acctbal (:s_acctbal (:s s)) :s_name (:s_name (:s s)) :n_name (:n_name (:n s)) :p_partkey (:p_partkey p) :p_mfgr (:p_mfgr p) :s_address (:s_address (:s s)) :s_phone (:s_phone (:s s)) :s_comment (:s_comment (:s s)) :ps_supplycost (:ps_supplycost ps)})))) ;; list of 
+  (def region [{:r_regionkey 1 :r_name "EUROPE"} {:r_regionkey 2 :r_name "ASIA"}]) ;; list of
+  (def nation [{:n_nationkey 10 :n_regionkey 1 :n_name "FRANCE"} {:n_nationkey 20 :n_regionkey 2 :n_name "CHINA"}]) ;; list of
+  (def supplier [{:s_suppkey 100 :s_name "BestSupplier" :s_address "123 Rue" :s_nationkey 10 :s_phone "123" :s_acctbal 1000.0 :s_comment "Fast and reliable"} {:s_suppkey 200 :s_name "AltSupplier" :s_address "456 Way" :s_nationkey 20 :s_phone "456" :s_acctbal 500.0 :s_comment "Slow"}]) ;; list of
+  (def part [{:p_partkey 1000 :p_type "LARGE BRASS" :p_size 15 :p_mfgr "M1"} {:p_partkey 2000 :p_type "SMALL COPPER" :p_size 15 :p_mfgr "M2"}]) ;; list of
+  (def partsupp [{:ps_partkey 1000 :ps_suppkey 100 :ps_supplycost 10.0} {:ps_partkey 1000 :ps_suppkey 200 :ps_supplycost 15.0}]) ;; list of
+  (def europe_nations (vec (->> (for [r region :when (_equal (:r_name r) "EUROPE") n nation :when (_equal (:n_regionkey n) (:r_regionkey r))] n)))) ;; list of
+  (def europe_suppliers (vec (->> (for [s supplier n europe_nations :when (_equal (:s_nationkey s) (:n_nationkey n))] {:s s :n n})))) ;; list of
+  (def target_parts (vec (->> (for [p part :when (and (_equal (:p_size p) 15) (_equal (:p_type p) "LARGE BRASS"))] p)))) ;; list of
+  (def target_partsupp (vec (->> (for [ps partsupp p target_parts :when (_equal (:ps_partkey ps) (:p_partkey p)) s europe_suppliers :when (_equal (:ps_suppkey ps) (:s_suppkey (:s s)))] {:s_acctbal (:s_acctbal (:s s)) :s_name (:s_name (:s s)) :n_name (:n_name (:n s)) :p_partkey (:p_partkey p) :p_mfgr (:p_mfgr p) :s_address (:s_address (:s s)) :s_phone (:s_phone (:s s)) :s_comment (:s_comment (:s s)) :ps_supplycost (:ps_supplycost ps)})))) ;; list of
   (def costs (vec (->> (for [x target_partsupp] (:ps_supplycost x))))) ;; list of float
   (def min_cost (apply min costs)) ;; float
-  (def result (vec (->> (for [x target_partsupp :when (_equal (:ps_supplycost x) min_cost)] x) (sort-by (fn [x] (_sort_key (- (:s_acctbal x)))))))) ;; list of 
+  (def result (vec (->> (for [x target_partsupp :when (_equal (:ps_supplycost x) min_cost)] x) (sort-by (fn [x] (_sort_key (- (:s_acctbal x)))))))) ;; list of
   (_json result)
   (test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part)
 )


### PR DESCRIPTION
## Summary
- trim trailing spaces when formatting Clojure code
- regenerate TPCH q1 and q2 Clojure golden files without trailing spaces

## Testing
- `go test ./compiler/x/clj -run TPCH -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687290b04e98832092d0e70d9e88a919