### PR TITLE
Add TypeScript TPCH q1 golden test

### DIFF
--- a/compiler/x/typescript/tpch_golden_test.go
+++ b/compiler/x/typescript/tpch_golden_test.go
@@ -1,0 +1,64 @@
+//go:build slow
+
+package typescriptcode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	typescriptcode "mochi/compiler/x/typescript"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestTypeScriptCompiler_TPCHQuery1(t *testing.T) {
+	if _, err := exec.LookPath("deno"); err != nil {
+		t.Skip("deno not installed")
+	}
+	root := findRepoRoot(t)
+	base := "q1"
+	src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
+	codeWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "typescript", base+".ts.out")
+	outWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "typescript", base+".out")
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := typescriptcode.New().Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	wantCode, err := os.ReadFile(codeWant)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for %s.ts.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, got, bytes.TrimSpace(wantCode))
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.ts")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("deno", "run", "--quiet", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("deno run error: %v\n%s", err, out)
+	}
+	gotOut := bytes.TrimSpace(out)
+	wantOut, err := os.ReadFile(outWant)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+		t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, gotOut, bytes.TrimSpace(wantOut))
+	}
+}

--- a/tests/dataset/tpc-h/compiler/typescript/q1.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q1.out
@@ -1,0 +1,1 @@
+[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]

--- a/tests/dataset/tpc-h/compiler/typescript/q1.ts.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q1.ts.out
@@ -1,0 +1,91 @@
+function _json(v: any) {
+  function _sort(x: any): any {
+    if (Array.isArray(x)) return x.map(_sort);
+    if (x && typeof x === "object") {
+      const keys = Object.keys(x).sort();
+      const o: any = {};
+      for (const k of keys) o[k] = _sort(x[k]);
+      return o;
+    }
+    return x;
+  }
+  return JSON.stringify(_sort(v));
+}
+const lineitem = [
+  {
+  l_quantity: 17,
+  l_extendedprice: 1000,
+  l_discount: 0.05,
+  l_tax: 0.07,
+  l_returnflag: "N",
+  l_linestatus: "O",
+  l_shipdate: "1998-08-01"
+},
+  {
+  l_quantity: 36,
+  l_extendedprice: 2000,
+  l_discount: 0.1,
+  l_tax: 0.05,
+  l_returnflag: "N",
+  l_linestatus: "O",
+  l_shipdate: "1998-09-01"
+},
+  {
+  l_quantity: 25,
+  l_extendedprice: 1500,
+  l_discount: 0,
+  l_tax: 0.08,
+  l_returnflag: "R",
+  l_linestatus: "F",
+  l_shipdate: "1998-09-03"
+}
+];
+const result = (() => {
+  const _tmp1: Array<{ avg_disc: number; avg_price: number; avg_qty: number; count_order: number; linestatus: any; returnflag: any; sum_base_price: number; sum_charge: number; sum_disc_price: number; sum_qty: number }> = [];
+  const groups = {};
+  for (const row of lineitem) {
+    if (!((row.l_shipdate <= "1998-09-02"))) continue;
+    const _k = JSON.stringify({
+  returnflag: row.l_returnflag,
+  linestatus: row.l_linestatus
+});
+    let g = groups[_k];
+    if (!g) { g = []; g.key = {
+  returnflag: row.l_returnflag,
+  linestatus: row.l_linestatus
+}; g.items = g; groups[_k] = g; }
+    g.push(row);
+  }
+  for (const _k in groups) {
+    const g = groups[_k];
+    _tmp1.push({
+  returnflag: g.key.returnflag,
+  linestatus: g.key.linestatus,
+  sum_qty: (g.map((x) => x.l_quantity).reduce((a,b)=>a+b,0)),
+  sum_base_price: (g.map((x) => x.l_extendedprice).reduce((a,b)=>a+b,0)),
+  sum_disc_price: (g.map((x) => (x.l_extendedprice * ((1 - x.l_discount)))).reduce((a,b)=>a+b,0)),
+  sum_charge: (g.map((x) => ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax)))).reduce((a,b)=>a+b,0)),
+  avg_qty: (g.map((x) => x.l_quantity).reduce((a,b)=>a+b,0)/g.map((x) => x.l_quantity).length),
+  avg_price: (g.map((x) => x.l_extendedprice).reduce((a,b)=>a+b,0)/g.map((x) => x.l_extendedprice).length),
+  avg_disc: (g.map((x) => x.l_discount).reduce((a,b)=>a+b,0)/g.map((x) => x.l_discount).length),
+  count_order: g.length
+});
+  }
+  return _tmp1;
+})()
+;
+console.log(_json(result));
+if (!(JSON.stringify(result) === JSON.stringify([
+  {
+  returnflag: "N",
+  linestatus: "O",
+  sum_qty: 53,
+  sum_base_price: 3000,
+  sum_disc_price: (950 + 1800),
+  sum_charge: (((950 * 1.07)) + ((1800 * 1.05))),
+  avg_qty: 26.5,
+  avg_price: 1500,
+  avg_disc: 0.07500000000000001,
+  count_order: 2
+}
+]))) { throw new Error("Q1 aggregates revenue and quantity by returnflag + linestatus failed"); }


### PR DESCRIPTION
## Summary
- add golden output for TPCH q1 using the experimental TypeScript compiler
- verify q1 via new `TestTypeScriptCompiler_TPCHQuery1`

## Testing
- `go test ./compiler/x/typescript -tags slow -run TestTypeScriptCompiler_TPCHQuery1 -count=1 -v`
- `go test ./... -tags ''` *(fails: packages failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872968e676c832098d02876eb4d8b17