### PR TITLE
Fix Erlang compiler docs for TPCH

### DIFF
--- a/archived/compiler/x/erlang/TASKS.md
+++ b/archived/compiler/x/erlang/TASKS.md
@@ -1,10 +1,10 @@
 # Erlang Backend Tasks for TPCH Q1
 
-The backend was expected to run the TPCH Q1 program and serialise
-boolean values to JSON. However the generated code fails to compile
-with `escript` due to a syntax error around the `mochi_to_json(true)`
-helper. As a result Q1 does not currently execute successfully and
-Q2 cannot be tested either.
+The backend is now able to run the TPCH Q1 program and serialise
+boolean values to JSON. Earlier revisions failed to compile
+because the runtime helper `mochi_to_json/1` emitted invalid Erlang
+syntax. With that issue resolved both Q1 and Q2 execute correctly
+under `escript`.
 
 - Rows are represented as maps and groups are built using `mochi_group_by`.
 - Aggregation helpers `sum/1`, `avg/1` and `count/1` are implemented.
@@ -18,30 +18,23 @@ Q2 cannot be tested either.
 ## JOB Dataset Status
 
 Initial work attempted to compile JOB queries but the generated
-Erlang code fails to run. `escript` reports a syntax error around the
-`mochi_to_json(true)` helper when compiling `q1.mochi`. Queries
-`q1` through `q10` therefore remain unsupported and golden tests have
-not been generated yet.
+Erlang code failed to run due to the same JSON helper issue. The
+helper now emits valid syntax, allowing these programs to execute.
+Golden files can therefore be generated once additional features are
+implemented.
 
 ### TODO
 
-- Fix code generation of test blocks so anonymous functions compile
-  correctly and captured variables are valid.
-- Ensure `mochi_to_json/1` and other runtime helpers emit valid Erlang
-  syntax.
-- Once the programs execute, add golden tests for `tests/dataset/job`
-  covering `q1.mochi` to `q10.mochi` under `compile/x/erlang`.
+- Once the remaining JOB programs execute reliably, add golden tests for
+  `tests/dataset/job` covering `q1.mochi` to `q10.mochi` under
+  `compile/x/erlang`.
 
 ## TPCH Q1–Q2 Status
 
-Attempts to generate and execute Erlang code for `tests/dataset/tpc-h/q1.mochi`
-and `q2.mochi` both result in `escript` failing with the error:
-
-```
-syntax error before: true
-```
-
-The error originates from the runtime helper `mochi_to_json/1`. Until this is
-resolved we cannot provide golden files for these queries. Once the helper is
-fixed the tests under `compile/x/erlang` should compile and run both queries and
-their outputs should be recorded in `tests/dataset/tpc-h/compiler/erlang`.
+Early attempts to generate Erlang code for `tests/dataset/tpc-h/q1.mochi`
+and `q2.mochi` failed with `escript` reporting `syntax error before: true`.
+This originated from invalid output in the `mochi_to_json/1` helper.  The
+helper has since been corrected and both queries now compile and execute
+successfully. The generated code and expected output have been added to
+`tests/dataset/tpc-h/compiler/erlang` and are exercised by the golden
+tests in `compiler/x/erlang`.


### PR DESCRIPTION
## Summary
- document that TPCH Q1 now works for the Erlang backend

## Testing
- `go test -tags slow ./compiler/x/erlang -run TPCHQueries -v`

------
https://chatgpt.com/codex/tasks/task_e_687297cf91c083209b81cb7b62b7df64