### PR TITLE
Improve Java compiler casts

### DIFF
--- a/compiler/x/java/compiler.go
+++ b/compiler/x/java/compiler.go
@@ -1772,10 +1772,10 @@ func (c *Compiler) compileAssign(a *parser.AssignStmt) error {
 				if c.hasField(typ, field) {
 					c.writeln(fmt.Sprintf("%s.%s = %s;", target, field, expr))
 				} else {
-					c.writeln(fmt.Sprintf("((Map)%s).put(%s, %s);", target, ix, expr))
+					c.writeln(fmt.Sprintf("((Map<?,?>)%s).put(%s, %s);", target, ix, expr))
 				}
 			} else {
-				c.writeln(fmt.Sprintf("((Map)%s).put(%s, %s);", target, ix, expr))
+				c.writeln(fmt.Sprintf("((Map<?,?>)%s).put(%s, %s);", target, ix, expr))
 			}
 		} else {
 			if strings.HasPrefix(typ, "Map<") {
@@ -2258,10 +2258,10 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 							val = fmt.Sprintf("%s.%s", val, field)
 							typ = c.fieldType(typ, field)
 						} else {
-							val = fmt.Sprintf("((Map)%s).get(%s)", val, idx)
+							val = fmt.Sprintf("((Map<?,?>)%s).get(%s)", val, idx)
 						}
 					} else {
-						val = fmt.Sprintf("((Map)%s).get(%s)", val, idx)
+						val = fmt.Sprintf("((Map<?,?>)%s).get(%s)", val, idx)
 					}
 				} else {
 					if strings.HasPrefix(typ, "Map<") {
@@ -2345,7 +2345,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 				for _, f := range pTail {
 					if strings.HasPrefix(typ, "Map<") {
 						typ = mapValueType(typ)
-						s = fmt.Sprintf("((Map)%s).get(\"%s\")", s, f)
+						s = fmt.Sprintf("((Map<?,?>)%s).get(\"%s\")", s, f)
 					} else {
 						s += "." + f
 						typ = c.fieldType(typ, f)
@@ -2365,7 +2365,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 				typ = itemType
 				for _, f := range p.Selector.Tail[1:] {
 					if strings.HasPrefix(typ, "Map<") {
-						s = fmt.Sprintf("((Map)%s).get(\"%s\")", s, f)
+						s = fmt.Sprintf("((Map<?,?>)%s).get(\"%s\")", s, f)
 						typ = mapValueType(typ)
 					} else {
 						s += "." + f
@@ -2377,7 +2377,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		}
 		for _, f := range p.Selector.Tail {
 			if strings.HasPrefix(typ, "Map<") || typ == "Map" || typ == "Object" || typ == "" {
-				s = fmt.Sprintf("((Map)%s).get(\"%s\")", s, f)
+				s = fmt.Sprintf("((Map<?,?>)%s).get(\"%s\")", s, f)
 				typ = mapValueType(typ)
 			} else {
 				s += "." + f

--- a/tests/machine/x/java/load_yaml.java
+++ b/tests/machine/x/java/load_yaml.java
@@ -77,8 +77,8 @@ public class LoadYaml {
     List<NameEmail> adults = (new java.util.function.Supplier<List<NameEmail>>(){public List<NameEmail> get(){
     List<NameEmail> res0 = new ArrayList<>();
     for (var p : people) {
-        if (!(((Number)((Map)p).get("age")).doubleValue() >= 18)) continue;
-        res0.add(new NameEmail(((Map)p).get("name"), ((Map)p).get("email")));
+        if (!(((Number)((Map<?,?>)p).get("age")).doubleValue() >= 18)) continue;
+        res0.add(new NameEmail(((Map<?,?>)p).get("name"), ((Map<?,?>)p).get("email")));
     }
     return res0;
 }}).get();


### PR DESCRIPTION
## Summary
- improve Map casts in Java compiler
- regenerate Java sample `load_yaml.java` with generic map casts

## Testing
- `go test -tags slow ./compiler/x/java -run TestCompileValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6872988634c88320b4636defbafa2601