### PR TITLE
Improve Kotlin backend keyword escaping

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -293,7 +293,8 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		out.WriteByte('\n')
 	}
 	out.Write(body)
-	return out.Bytes(), nil
+	code := escapeKeywords(out.String())
+	return []byte(code), nil
 }
 
 func (c *Compiler) stmt(s *parser.Statement) error {
@@ -2178,6 +2179,14 @@ func escapeIdent(name string) string {
 		return "`" + name + "`"
 	}
 	return name
+}
+
+func escapeKeywords(src string) string {
+	for kw := range kotlinKeywords {
+		re := regexp.MustCompile(`\.` + regexp.QuoteMeta(kw) + `\b`)
+		src = re.ReplaceAllString(src, ".`"+kw+"`")
+	}
+	return src
 }
 
 func isStructType(t types.Type) bool {

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -32,4 +32,4 @@ Successful programs have matching `.kt` and `.out` files.
 - Provide better support for the Python `math` helpers and other foreign
   imports.
 - Finish compiling the remaining programs listed above.
-- Escape Kotlin keywords such as `val` when used as record fields.
+- Escape Kotlin keywords such as `val` when used as record fields. *(done)*


### PR DESCRIPTION
## Summary
- escape Kotlin keywords in generated code
- mark README task as done for keyword escaping

## Testing
- `go vet ./compiler/x/kotlin/...` *(no packages to vet)*

------
https://chatgpt.com/codex/tasks/task_e_687298931f408320a4c24fe7527f5a91