### PR TITLE
Enable tpch q1-3 for typescript compiler

### DIFF
--- a/compiler/x/typescript/compiler.go
+++ b/compiler/x/typescript/compiler.go
@@ -931,7 +931,7 @@ func (c *Compiler) queryExpr(q *parser.QueryExpr) (string, error) {
 		writeln(fmt.Sprintf("const _k = JSON.stringify(%s);", keyStr))
 		writeln("let g = groups[_k];")
 		writeln(fmt.Sprintf("if (!g) { g = []; g.key = %s; g.items = g; groups[_k] = g; }", keyStr))
-		if len(q.Froms)+len(q.Joins) <= 1 {
+		if len(q.Froms)+len(q.Joins) < 1 {
 			writeln(fmt.Sprintf("g.push(%s);", q.Var))
 		} else {
 			parts := []string{fmt.Sprintf("%s: %s", q.Var, q.Var)}

--- a/tests/dataset/tpc-h/compiler/typescript/q2.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q2.out
@@ -1,0 +1,1 @@
+[{"n_name":"FRANCE","p_mfgr":"M1","p_partkey":1000,"ps_supplycost":10,"s_acctbal":1000,"s_address":"123 Rue","s_comment":"Fast and reliable","s_name":"BestSupplier","s_phone":"123"}]

--- a/tests/dataset/tpc-h/compiler/typescript/q2.ts.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q2.ts.out
@@ -1,0 +1,141 @@
+function _json(v: any) {
+  function _sort(x: any): any {
+    if (Array.isArray(x)) return x.map(_sort);
+    if (x && typeof x === "object") {
+      const keys = Object.keys(x).sort();
+      const o: any = {};
+      for (const k of keys) o[k] = _sort(x[k]);
+      return o;
+    }
+    return x;
+  }
+  return JSON.stringify(_sort(v));
+}
+const region = [
+  {r_regionkey: 1, r_name: "EUROPE"},
+  {r_regionkey: 2, r_name: "ASIA"}
+];
+const nation = [
+  {
+  n_nationkey: 10,
+  n_regionkey: 1,
+  n_name: "FRANCE"
+},
+  {
+  n_nationkey: 20,
+  n_regionkey: 2,
+  n_name: "CHINA"
+}
+];
+const supplier = [
+  {
+  s_suppkey: 100,
+  s_name: "BestSupplier",
+  s_address: "123 Rue",
+  s_nationkey: 10,
+  s_phone: "123",
+  s_acctbal: 1000,
+  s_comment: "Fast and reliable"
+},
+  {
+  s_suppkey: 200,
+  s_name: "AltSupplier",
+  s_address: "456 Way",
+  s_nationkey: 20,
+  s_phone: "456",
+  s_acctbal: 500,
+  s_comment: "Slow"
+}
+];
+const part = [
+  {
+  p_partkey: 1000,
+  p_type: "LARGE BRASS",
+  p_size: 15,
+  p_mfgr: "M1"
+},
+  {
+  p_partkey: 2000,
+  p_type: "SMALL COPPER",
+  p_size: 15,
+  p_mfgr: "M2"
+}
+];
+const partsupp = [
+  {
+  ps_partkey: 1000,
+  ps_suppkey: 100,
+  ps_supplycost: 10
+},
+  {
+  ps_partkey: 1000,
+  ps_suppkey: 200,
+  ps_supplycost: 15
+}
+];
+const europe_nations = (() => {
+  const _tmp1: any[] = [];
+  for (const r of region) {
+    for (const n of nation) {
+      if (!((n.n_regionkey == r.r_regionkey))) continue;
+      if (!((r.r_name == "EUROPE"))) continue;
+      _tmp1.push(n);
+    }
+  }
+  return _tmp1;
+})()
+;
+const europe_suppliers = (() => {
+  const _tmp2: Array<{ n: any; s: any }> = [];
+  for (const s of supplier) {
+    for (const n of europe_nations) {
+      if (!((s.s_nationkey == n.n_nationkey))) continue;
+      _tmp2.push({s: s, n: n});
+    }
+  }
+  return _tmp2;
+})()
+;
+const target_parts = part.filter((p) => (((p.p_size == 15) && p.p_type) == "LARGE BRASS"));
+const target_partsupp = (() => {
+  const _tmp3: Array<{ n_name: any; p_mfgr: any; p_partkey: any; ps_supplycost: any; s_acctbal: any; s_address: any; s_comment: any; s_name: any; s_phone: any }> = [];
+  for (const ps of partsupp) {
+    for (const p of target_parts) {
+      if (!((ps.ps_partkey == p.p_partkey))) continue;
+      for (const s of europe_suppliers) {
+        if (!((ps.ps_suppkey == s.s.s_suppkey))) continue;
+        _tmp3.push({
+  s_acctbal: s.s.s_acctbal,
+  s_name: s.s.s_name,
+  n_name: s.n.n_name,
+  p_partkey: p.p_partkey,
+  p_mfgr: p.p_mfgr,
+  s_address: s.s.s_address,
+  s_phone: s.s.s_phone,
+  s_comment: s.s.s_comment,
+  ps_supplycost: ps.ps_supplycost
+});
+      }
+    }
+  }
+  return _tmp3;
+})()
+;
+const costs = target_partsupp.map((x) => x.ps_supplycost);
+const min_cost = Math.min(...costs);
+const result = target_partsupp.slice().sort((a,b)=> (-a.s_acctbal) < (-b.s_acctbal) ? -1 : (-a.s_acctbal) > (-b.s_acctbal) ? 1 : 0).filter((x) => (x.ps_supplycost == min_cost));
+console.log(_json(result));
+if (!(JSON.stringify(result) === JSON.stringify([
+  {
+  s_acctbal: 1000,
+  s_name: "BestSupplier",
+  n_name: "FRANCE",
+  p_partkey: 1000,
+  p_mfgr: "M1",
+  s_address: "123 Rue",
+  s_phone: "123",
+  s_comment: "Fast and reliable",
+  ps_supplycost: 10
+}
+]))) { throw new Error("Q2 returns only supplier with min cost in Europe for brass part failed"); }
+

--- a/tests/dataset/tpc-h/compiler/typescript/q3.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q3.out
@@ -1,0 +1,1 @@
+[{"l_orderkey":100,"o_orderdate":"1995-03-14","o_shippriority":1,"revenue":1450}]

--- a/tests/dataset/tpc-h/compiler/typescript/q3.ts.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q3.ts.out
@@ -1,0 +1,116 @@
+function _json(v: any) {
+  function _sort(x: any): any {
+    if (Array.isArray(x)) return x.map(_sort);
+    if (x && typeof x === "object") {
+      const keys = Object.keys(x).sort();
+      const o: any = {};
+      for (const k of keys) o[k] = _sort(x[k]);
+      return o;
+    }
+    return x;
+  }
+  return JSON.stringify(_sort(v));
+}
+const customer = [
+  {c_custkey: 1, c_mktsegment: "BUILDING"},
+  {
+  c_custkey: 2,
+  c_mktsegment: "AUTOMOBILE"
+}
+];
+const orders = [
+  {
+  o_orderkey: 100,
+  o_custkey: 1,
+  o_orderdate: "1995-03-14",
+  o_shippriority: 1
+},
+  {
+  o_orderkey: 200,
+  o_custkey: 2,
+  o_orderdate: "1995-03-10",
+  o_shippriority: 2
+}
+];
+const lineitem = [
+  {
+  l_orderkey: 100,
+  l_extendedprice: 1000,
+  l_discount: 0.05,
+  l_shipdate: "1995-03-16"
+},
+  {
+  l_orderkey: 100,
+  l_extendedprice: 500,
+  l_discount: 0,
+  l_shipdate: "1995-03-20"
+},
+  {
+  l_orderkey: 200,
+  l_extendedprice: 1000,
+  l_discount: 0.1,
+  l_shipdate: "1995-03-14"
+}
+];
+const cutoff = "1995-03-15";
+const segment = "BUILDING";
+const building_customers = customer.filter((c) => (c.c_mktsegment == segment));
+const valid_orders = (() => {
+  const _tmp1: any[] = [];
+  for (const o of orders) {
+    for (const c of building_customers) {
+      if (!((o.o_custkey == c.c_custkey))) continue;
+      if (!((o.o_orderdate < cutoff))) continue;
+      _tmp1.push(o);
+    }
+  }
+  return _tmp1;
+})()
+;
+const valid_lineitems = lineitem.filter((l) => (l.l_shipdate > cutoff));
+const order_line_join = (() => {
+  let _tmp2: Array<{ l_orderkey: any; o_orderdate: any; o_shippriority: any; revenue: number }> = [];
+  const groups = {};
+  for (const o of valid_orders) {
+    for (const l of valid_lineitems) {
+      if (!((l.l_orderkey == o.o_orderkey))) continue;
+      const _k = JSON.stringify({
+  o_orderkey: o.o_orderkey,
+  o_orderdate: o.o_orderdate,
+  o_shippriority: o.o_shippriority
+});
+      let g = groups[_k];
+      if (!g) { g = []; g.key = {
+  o_orderkey: o.o_orderkey,
+  o_orderdate: o.o_orderdate,
+  o_shippriority: o.o_shippriority
+}; g.items = g; groups[_k] = g; }
+      g.push({o: o, l: l});
+    }
+  }
+  for (const _k in groups) {
+    const g = groups[_k];
+    _tmp2.push({item: {
+  l_orderkey: g.key.o_orderkey,
+  revenue: (g.map((r) => (r.l.l_extendedprice * ((1 - r.l.l_discount)))).reduce((a,b)=>a+b,0)),
+  o_orderdate: g.key.o_orderdate,
+  o_shippriority: g.key.o_shippriority
+}, key: [
+  (-(g.map((r) => (r.l.l_extendedprice * ((1 - r.l.l_discount)))).reduce((a,b)=>a+b,0))),
+  g.key.o_orderdate
+]});
+  }
+  _tmp2 = _tmp2.sort((a,b)=> JSON.stringify(a.key) < JSON.stringify(b.key) ? -1 : JSON.stringify(a.key) > JSON.stringify(b.key) ? 1 : 0).map(x=>x.item);
+  return _tmp2;
+})()
+;
+console.log(_json(order_line_join));
+if (!(JSON.stringify(order_line_join) === JSON.stringify([
+  {
+  l_orderkey: 100,
+  revenue: ((1000 * 0.95) + 500),
+  o_orderdate: "1995-03-14",
+  o_shippriority: 1
+}
+]))) { throw new Error("Q3 returns revenue per order with correct priority failed"); }
+


### PR DESCRIPTION
## Summary
- fix grouping logic when joins are present in TypeScript compiler
- add generated TypeScript outputs for tpch queries 2 and 3

## Testing
- `go test ./compiler/x/typescript -tags slow -run TPCH -v`


------
https://chatgpt.com/codex/tasks/task_e_687299168a488320ab239117e8d3fb93