### PR TITLE
Add tpch q3 support to Erlang compiler

### DIFF
--- a/compiler/x/erlang/compiler.go
+++ b/compiler/x/erlang/compiler.go
@@ -203,6 +203,10 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 }
 
 func (c *Compiler) compileLet(l *parser.LetStmt) (string, error) {
+	if l.Value != nil && isLiteralExpr(l.Value) {
+		// inline constant literals; no variable declaration needed
+		return "", nil
+	}
 	c.lets[l.Name] = true
 	val := "undefined"
 	if l.Value != nil {

--- a/compiler/x/erlang/tpch_golden_test.go
+++ b/compiler/x/erlang/tpch_golden_test.go
@@ -20,7 +20,7 @@ func TestErlangCompiler_TPCHQueries(t *testing.T) {
 		t.Skip("escript not installed")
 	}
 	root := repoRoot(t)
-	for i := 1; i <= 2; i++ {
+	for i := 1; i <= 3; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
 		codeWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "erlang", base+".erl.out")

--- a/tests/dataset/tpc-h/compiler/erlang/q3.erl.out
+++ b/tests/dataset/tpc-h/compiler/erlang/q3.erl.out
@@ -1,0 +1,33 @@
+#!/usr/bin/env escript
+% q3.erl - generated from q3.mochi
+
+main(_) ->
+    Customer = [#{c_custkey => 1, c_mktsegment => "BUILDING"}, #{c_custkey => 2, c_mktsegment => "AUTOMOBILE"}],
+    Orders = [#{o_orderkey => 100, o_custkey => 1, o_orderdate => "1995-03-14", o_shippriority => 1}, #{o_orderkey => 200, o_custkey => 2, o_orderdate => "1995-03-10", o_shippriority => 2}],
+    Lineitem = [#{l_orderkey => 100, l_extendedprice => 1000, l_discount => 0.05, l_shipdate => "1995-03-16"}, #{l_orderkey => 100, l_extendedprice => 500, l_discount => 0, l_shipdate => "1995-03-20"}, #{l_orderkey => 200, l_extendedprice => 1000, l_discount => 0.1, l_shipdate => "1995-03-14"}],
+    Building_customers = [C || C <- Customer, (maps:get(c_mktsegment, C) == "BUILDING")],
+    Valid_orders = [O || O <- Orders, C <- Building_customers, (maps:get(o_custkey, O) == maps:get(c_custkey, C)), (maps:get(o_orderdate, O) < "1995-03-15")],
+    Valid_lineitems = [L || L <- Lineitem, (maps:get(l_shipdate, L) > "1995-03-15")],
+    Order_line_join = [V || {_, V} <- lists:keysort(1, [{[-lists:sum([(maps:get(l_extendedprice, maps:get(l, R)) * ((1 - maps:get(l_discount, maps:get(l, R))))) || R <- Val0]), maps:get(o_orderdate, Key0)], #{l_orderkey => maps:get(o_orderkey, Key0), revenue => lists:sum([(maps:get(l_extendedprice, maps:get(l, R)) * ((1 - maps:get(l_discount, maps:get(l, R))))) || R <- Val0]), o_orderdate => maps:get(o_orderdate, Key0), o_shippriority => maps:get(o_shippriority, Key0)}} || {Key0, Val0} <- maps:to_list(lists:foldl(fun({Key0, Val0}, Acc0) -> L = maps:get(Key0, Acc0, []), maps:put(Key0, [Val0 | L], Acc0) end, #{}, [{#{o_orderkey => maps:get(o_orderkey, O), o_orderdate => maps:get(o_orderdate, O), o_shippriority => maps:get(o_shippriority, O)}, #{o => O, l => L}} || O <- Valid_orders, L <- Valid_lineitems, (maps:get(l_orderkey, L) == maps:get(o_orderkey, O))]))])],
+    mochi_json(Order_line_join),
+    (case (Order_line_join == [#{l_orderkey => 100, revenue => ((1000 * 0.95) + 500), o_orderdate => "1995-03-14", o_shippriority => 1}]) of true -> ok; _ -> erlang:error(test_failed) end).
+
+mochi_escape_json([]) -> [];
+mochi_escape_json([H|T]) ->
+    E = case H of
+        $\ -> "\\";
+        $" -> "\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
+
+mochi_to_json(true) -> "true";
+mochi_to_json(false) -> "false";
+mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
+mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
+mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
+mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
+mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
+
+mochi_json(V) -> io:format("~s
+", [mochi_to_json(V)]).

--- a/tests/dataset/tpc-h/compiler/erlang/q3.out
+++ b/tests/dataset/tpc-h/compiler/erlang/q3.out
@@ -1,0 +1,1 @@
+[{"o_orderdate":"1995-03-14","o_shippriority":1,"l_orderkey":100,"revenue":1450.0}]


### PR DESCRIPTION
## Summary
- skip emitting let bindings for literal constants in Erlang compiler
- update golden test to run q1–q3
- add generated Erlang code and output for TPCH q3

## Testing
- `go test ./compiler/x/erlang -tags slow -run TestErlangCompiler_TPCHQueries -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687299b2cd608320abdc020de1565cea