### PR TITLE
Support tpch q3 for lua backend

### DIFF
--- a/compiler/x/lua/compiler_test.go
+++ b/compiler/x/lua/compiler_test.go
@@ -153,7 +153,7 @@ func TestLuaCompiler_TPCH(t *testing.T) {
 	}
 
 	root := findRepoRoot(t)
-	for i := 1; i <= 2; i++ {
+       for i := 1; i <= 3; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-h", q+".mochi")

--- a/tests/dataset/tpc-h/compiler/lua/q3.lua.out
+++ b/tests/dataset/tpc-h/compiler/lua/q3.lua.out
@@ -1,0 +1,342 @@
+_Group = {}
+function _Group.new(k)
+    return {key = k, items = {}}
+end
+function __group_by_rows(rows, keyfn, valfn)
+    local groups = {}
+    local order = {}
+    for _, r in ipairs(rows) do
+        local key = keyfn(table.unpack(r))
+        local ks
+        if type(key) == 'table' then
+            local fields = {}
+            for k,_ in pairs(key) do fields[#fields+1] = k end
+            table.sort(fields)
+            local parts = {}
+            for _,k in ipairs(fields) do parts[#parts+1] = tostring(k)..'='..tostring(key[k]) end
+            ks = table.concat(parts, ',')
+        else
+            ks = tostring(key)
+        end
+        local g = groups[ks]
+        if not g then
+            g = _Group.new(key)
+            groups[ks] = g
+            order[#order+1] = ks
+        end
+        table.insert(g.items, valfn(table.unpack(r)))
+    end
+    local res = {}
+    for _, ks in ipairs(order) do
+        res[#res+1] = groups[ks]
+    end
+    return res
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    if type(v) == 'table' and next(v) == nil then print('[]'); return end
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __merge(...)
+    local res = {}
+    for i=1,select('#', ...) do
+        local t = select(i, ...)
+        if type(t) == 'table' then
+            for k,v in pairs(t) do res[k] = v end
+        end
+    end
+    return res
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local row = {}
+                    for _=1,ji do row[#row+1] = nil end
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {}
+                    for _=1,ji do row[#row+1] = nil end
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function __sum(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('sum() expects list or group')
+    end
+    local sum = 0
+    for _, it in ipairs(items) do sum = sum + it end
+    return sum
+end
+function test_Q3_returns_revenue_per_order_with_correct_priority()
+    if not (__eq(order_line_join, {{["l_orderkey"]=100, ["revenue"]=((1000.0 * 0.95) + 500.0), ["o_orderdate"]="1995-03-14", ["o_shippriority"]=1}})) then error('expect failed') end
+end
+
+customer = {{["c_custkey"]=1, ["c_mktsegment"]="BUILDING"}, {["c_custkey"]=2, ["c_mktsegment"]="AUTOMOBILE"}}
+orders = {{["o_orderkey"]=100, ["o_custkey"]=1, ["o_orderdate"]="1995-03-14", ["o_shippriority"]=1}, {["o_orderkey"]=200, ["o_custkey"]=2, ["o_orderdate"]="1995-03-10", ["o_shippriority"]=2}}
+lineitem = {{["l_orderkey"]=100, ["l_extendedprice"]=1000.0, ["l_discount"]=0.05, ["l_shipdate"]="1995-03-16"}, {["l_orderkey"]=100, ["l_extendedprice"]=500.0, ["l_discount"]=0.0, ["l_shipdate"]="1995-03-20"}, {["l_orderkey"]=200, ["l_extendedprice"]=1000.0, ["l_discount"]=0.1, ["l_shipdate"]="1995-03-14"}}
+cutoff = "1995-03-15"
+segment = "BUILDING"
+building_customers = (function()
+    local _res = {}
+    for _, c in ipairs(customer) do
+        if __eq(c.c_mktsegment, segment) then
+            _res[#_res+1] = c
+        end
+    end
+    return _res
+end)()
+valid_orders = (function()
+    local _src = orders
+    return __query(_src, {
+        { items = building_customers, on = function(o, c) return __eq(o.o_custkey, c.c_custkey) end }
+    }, { selectFn = function(o, c) return o end, where = function(o, c) return ((o.o_orderdate < cutoff)) end })
+end)()
+valid_lineitems = (function()
+    local _res = {}
+    for _, l in ipairs(lineitem) do
+        if (l.l_shipdate > cutoff) then
+            _res[#_res+1] = l
+        end
+    end
+    return _res
+end)()
+order_line_join = (function()
+    local _src = valid_orders
+    local _rows = __query(_src, {
+        { items = valid_lineitems, on = function(o, l) return __eq(l.l_orderkey, o.o_orderkey) end }
+    }, { selectFn = function(o, l) return {o, l} end })
+    local _groups = __group_by_rows(_rows, function(o, l) return {["o_orderkey"]=o.o_orderkey, ["o_orderdate"]=o.o_orderdate, ["o_shippriority"]=o.o_shippriority} end, function(o, l) local _row = __merge(o, l); _row.o = o; _row.l = l; return _row end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["l_orderkey"]=g.key.o_orderkey, ["revenue"]=__sum((function()
+    local _res = {}
+    for _, r in ipairs(g.items) do
+        _res[#_res+1] = (r.l.l_extendedprice * ((1 - r.l.l_discount)))
+    end
+    return _res
+end)()), ["o_orderdate"]=g.key.o_orderdate, ["o_shippriority"]=g.key.o_shippriority}
+    end
+    return _res
+end)()
+__json(order_line_join)
+local __tests = {
+    {name="Q3 returns revenue per order with correct priority", fn=test_Q3_returns_revenue_per_order_with_correct_priority},
+}

--- a/tests/dataset/tpc-h/compiler/lua/q3.out
+++ b/tests/dataset/tpc-h/compiler/lua/q3.out
@@ -1,0 +1,1 @@
+[{"revenue":1450,"o_shippriority":1,"l_orderkey":100,"o_orderdate":"1995-03-14"}]


### PR DESCRIPTION
## Summary
- ensure the Lua backend compiles TPCH queries q1–q3
- add golden Lua output for q3
- run q3 as part of TPCH compiler tests

## Testing
- `go test -tags=slow ./compiler/x/lua -run TestLuaCompiler_TPCH -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68729b574b488320923fde455eb3e7c9