### PR TITLE
Improve Rust for-loop generation

### DIFF
--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -1053,7 +1053,7 @@ func (c *Compiler) compileFor(f *parser.ForStmt) error {
 			return err
 		}
 		elemType = types.IntType{}
-		c.writeln(fmt.Sprintf("for %s in (%s as i32)..(%s as i32) {", f.Name, src, end))
+		c.writeln(fmt.Sprintf("for %s in %s..%s {", f.Name, src, end))
 	} else if mt, ok := types.TypeOfExprBasic(f.Source, c.env).(types.MapType); ok {
 		elemType = mt.Key
 		c.writeln(fmt.Sprintf("for %s in %s.keys() {", f.Name, src))

--- a/tests/machine/x/rust/for_loop.rs
+++ b/tests/machine/x/rust/for_loop.rs
@@ -1,5 +1,5 @@
 fn main() {
-    for i in (1 as i32)..(4 as i32) {
+    for i in 1..4 {
         println!("{}", i);
     }
 }

--- a/tests/machine/x/rust/two-sum.rs
+++ b/tests/machine/x/rust/two-sum.rs
@@ -1,8 +1,8 @@
 fn main() {
     fn twoSum(nums: Vec<i32>, target: i32) -> Vec<i32> {
         let n = nums.len() as i32;
-        for i in (0 as i32)..(n as i32) {
-            for j in (i + 1 as i32)..(n as i32) {
+        for i in 0..n {
+            for j in i + 1..n {
                 if nums[i as usize] + nums[j as usize] == target {
                     return vec![i, j];
                 }


### PR DESCRIPTION
## Summary
- tweak Rust compiler output to remove unnecessary `as i32` casts in range loops
- regenerate machine outputs for `for_loop` and `two-sum`

## Testing
- `go test ./compiler/x/rust -run TestCompilePrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68729bbde6bc83208f78029e2883ea9d