### PR TITLE
Add missing F# examples

### DIFF
--- a/tests/human/x/fs/README.md
+++ b/tests/human/x/fs/README.md
@@ -28,6 +28,7 @@ The list below shows every Mochi program and whether a translation exists.
 - [x] fun_call
 - [x] fun_expr_in_let
 - [x] fun_three_args
+- [x] go_auto
 - [x] group_by
 - [x] group_by_conditional_sum
 - [x] group_by_having
@@ -75,6 +76,8 @@ The list below shows every Mochi program and whether a translation exists.
 - [x] print_hello
 - [x] pure_fold
 - [x] pure_global_fold
+- [x] python_auto
+- [x] python_math
 - [x] query_sum_select
 - [x] record_assign
 - [x] right_join

--- a/tests/human/x/fs/go_auto.fs
+++ b/tests/human/x/fs/go_auto.fs
@@ -1,0 +1,10 @@
+open System
+
+module testpkg
+let Add a b = a + b
+let Pi = 3.14
+let Answer = 42
+
+printfn "%A" (testpkg.Add(2, 3))
+printfn "%A" (testpkg.Pi)
+printfn "%A" (testpkg.Answer)

--- a/tests/human/x/fs/python_auto.fs
+++ b/tests/human/x/fs/python_auto.fs
@@ -1,0 +1,12 @@
+open System
+
+module math
+let pi : float = System.Math.PI
+let e : float = System.Math.E
+let sqrt (x: float) : float = System.Math.Sqrt x
+let pow (x: float) (y: float) : float = System.Math.Pow(x, y)
+let sin (x: float) : float = System.Math.Sin x
+let log (x: float) : float = System.Math.Log x
+
+printfn "%A" (math.sqrt(16))
+printfn "%A" (math.pi)

--- a/tests/human/x/fs/python_math.fs
+++ b/tests/human/x/fs/python_math.fs
@@ -1,0 +1,19 @@
+open System
+
+module math
+let pi : float = System.Math.PI
+let e : float = System.Math.E
+let sqrt (x: float) : float = System.Math.Sqrt x
+let pow (x: float) (y: float) : float = System.Math.Pow(x, y)
+let sin (x: float) : float = System.Math.Sin x
+let log (x: float) : float = System.Math.Log x
+
+let r: float = 3
+let area: obj = math.pi * math.pow(r, 2)
+let root: obj = math.sqrt(49)
+let sin45: obj = math.sin(math.pi / 4)
+let log_e: obj = math.log(math.e)
+printfn "%s" (String.concat " " [string "Circle area with r ="; string r; string "=>"; string area])
+printfn "%s" (String.concat " " [string "Square root of 49:"; string root])
+printfn "%s" (String.concat " " [string "sin(π/4):"; string sin45])
+printfn "%s" (String.concat " " [string "log(e):"; string log_e])


### PR DESCRIPTION
## Summary
- fill gaps in the F# reference implementations
- update F# README checklist

## Testing
- `go test ./compiler/x/fs -run '^TestFSCompiler$' -tags slow` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68729c1d73408320bb9290995439deba