### PR TITLE
Add F# TPCH q3 support

### DIFF
--- a/compiler/x/fs/compiler.go
+++ b/compiler/x/fs/compiler.go
@@ -156,7 +156,7 @@ func (c *Compiler) Compile(p *parser.Program) ([]byte, error) {
 		c.prelude.WriteString("        if groups.TryGetValue(ks, &g) then ()\n")
 		c.prelude.WriteString("        else\n")
 		c.prelude.WriteString("            g <- _Group<'K,'T>(key)\n")
-		c.prelude.WriteString("            groups[ks] <- g\n")
+		c.prelude.WriteString("            groups.Add(ks, g)\n")
 		c.prelude.WriteString("            order.Add(ks)\n")
 		c.prelude.WriteString("        g.Items.Add(it)\n")
 		c.prelude.WriteString("    [ for ks in order -> groups[ks] ]\n\n")

--- a/tests/dataset/tpc-h/compiler/fs/q1.fs.out
+++ b/tests/dataset/tpc-h/compiler/fs/q1.fs.out
@@ -1,122 +1,65 @@
 open System
+open System.Text.Json
 
-let l_quantity = "l_quantity"
-let l_extendedprice = "l_extendedprice"
-let l_discount = "l_discount"
-let l_tax = "l_tax"
-let l_returnflag = "l_returnflag"
-let l_linestatus = "l_linestatus"
-let l_shipdate = "l_shipdate"
-let returnflag = "returnflag"
-let linestatus = "linestatus"
-let sum_qty = "sum_qty"
-let sum_base_price = "sum_base_price"
-let sum_disc_price = "sum_disc_price"
-let sum_charge = "sum_charge"
-let avg_qty = "avg_qty"
-let avg_price = "avg_price"
-let avg_disc = "avg_disc"
-let count_order = "count_order"
-type _Group<'T>(key: obj) =
-  member val key = key with get, set
-  member val Items = System.Collections.Generic.List<'T>() with get
-  member this.size = this.Items.Count
-let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
-  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
-  let order = System.Collections.Generic.List<string>()
-  for it in src do
-    let key = keyfn it
-    let ks = string key
-    let mutable g = Unchecked.defaultof<_Group<'T>>
-    if groups.TryGetValue(ks, &g) then ()
-    else
-      g <- _Group<'T>(key)
-      groups[ks] <- g
-      order.Add(ks)
-    g.Items.Add(it)
-  [ for ks in order -> groups[ks] ]
-let rec _to_json (v: obj) : string =
-  match v with
-  | null -> "null"
-  | :? string as s ->
-      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
-  | :? bool
-  | :? int | :? int64
-  | :? double -> string v
-  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
-      m
-      |> Seq.map (fun (KeyValue(k,v)) ->
-          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
-      |> String.concat ","
-      |> fun s -> "{" + s + "}"
-  | :? System.Collections.IEnumerable as e ->
-      e
-      |> Seq.cast<obj>
-      |> Seq.map _to_json
-      |> String.concat ","
-      |> fun s -> "[" + s + "]"
-  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
-let _json (v: obj) : unit =
-  printfn "%s" (_to_json v)
-let _run_test (name: string) (f: unit -> unit) : bool =
-  printf "%s ... " name
-  try
-    f()
-    printfn "PASS"
-    true
-  with e ->
-    printfn "FAIL (%s)" e.Message
-    false
-let inline sum (xs: seq< ^T >) : ^T =
-  Seq.sum xs
-let inline avg (xs: seq< ^T >) : ^T =
-  Seq.average xs
-let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
-  Seq.min xs
-let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
-  Seq.max xs
-let count (xs: seq<'T>) : int =
-  Seq.length xs
+type Anon1 = {
+    l_quantity: int
+    l_extendedprice: float
+    l_discount: float
+    l_tax: float
+    l_returnflag: string
+    l_linestatus: string
+    l_shipdate: string
+}
+type Anon2 = {
+    returnflag: obj
+    linestatus: obj
+    sum_qty: obj
+    sum_base_price: obj
+    sum_disc_price: obj
+    sum_charge: obj
+    avg_qty: obj
+    avg_price: obj
+    avg_disc: obj
+    count_order: obj
+}
+type Anon3 = {
+    returnflag: obj
+    linestatus: obj
+}
+type Anon4 = {
+    returnflag: string
+    linestatus: string
+    sum_qty: int
+    sum_base_price: int
+    sum_disc_price: float
+    sum_charge: obj
+    avg_qty: float
+    avg_price: int
+    avg_disc: float
+    count_order: int
+}
+type _Group<'K,'T>(key: 'K) =
+    member val key = key with get, set
+    member val Items = System.Collections.Generic.List<'T>() with get
+    member this.size = this.Items.Count
 
-let lineitem = [|Map.ofList [(l_quantity, 17); (l_extendedprice, 1000.0); (l_discount, 0.05); (l_tax, 0.07); (l_returnflag, "N"); (l_linestatus, "O"); (l_shipdate, "1998-08-01")]; Map.ofList [(l_quantity, 36); (l_extendedprice, 2000.0); (l_discount, 0.1); (l_tax, 0.05); (l_returnflag, "N"); (l_linestatus, "O"); (l_shipdate, "1998-09-01")]; Map.ofList [(l_quantity, 25); (l_extendedprice, 1500.0); (l_discount, 0.0); (l_tax, 0.08); (l_returnflag, "R"); (l_linestatus, "F"); (l_shipdate, "1998-09-03")]|]
-let result = [| for g in _group_by [|
-    for row in lineitem do
-        if (row.l_shipdate <= "1998-09-02") then
-            yield row
-|] (fun row -> Map.ofList [(returnflag, row.l_returnflag); (linestatus, row.l_linestatus)]) do let g = g yield Map.ofList [(returnflag, g.key.returnflag); (linestatus, g.key.linestatus); (sum_qty, sum 
-    [|
-    for x in g do
-        yield x.l_quantity
-    |]); (sum_base_price, sum 
-    [|
-    for x in g do
-        yield x.l_extendedprice
-    |]); (sum_disc_price, sum 
-    [|
-    for x in g do
-        yield (x.l_extendedprice * ((1 - x.l_discount)))
-    |]); (sum_charge, sum 
-    [|
-    for x in g do
-        yield ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax)))
-    |]); (avg_qty, avg 
-    [|
-    for x in g do
-        yield x.l_quantity
-    |]); (avg_price, avg 
-    [|
-    for x in g do
-        yield x.l_extendedprice
-    |]); (avg_disc, avg 
-    [|
-    for x in g do
-        yield x.l_discount
-    |]); (count_order, count g)] |]
-ignore (_json result)
-let test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() =
-    if not ((result = [|Map.ofList [(returnflag, "N"); (linestatus, "O"); (sum_qty, 53); (sum_base_price, 3000); (sum_disc_price, (950.0 + 1800.0)); (sum_charge, (((950.0 * 1.07)) + ((1800.0 * 1.05)))); (avg_qty, 26.5); (avg_price, 1500); (avg_disc, 0.07500000000000001); (count_order, 2)]|])) then failwith "expect failed"
+let _group_by (src: 'T list) (keyfn: 'T -> 'K) : _Group<'K,'T> list =
+    let groups = System.Collections.Generic.Dictionary<string,_Group<'K,'T>>()
+    let order = System.Collections.Generic.List<string>()
+    for it in src do
+        let key = keyfn it
+        let ks = string key
+        let mutable g = Unchecked.defaultof<_Group<'K,'T>>
+        if groups.TryGetValue(ks, &g) then ()
+        else
+            g <- _Group<'K,'T>(key)
+            groups.Add(ks, g)
+            order.Add(ks)
+        g.Items.Add(it)
+    [ for ks in order -> groups[ks] ]
 
-let mutable failures = 0
-if not (_run_test "Q1 aggregates revenue and quantity by returnflag + linestatus" test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus) then failures <- failures + 1
-if failures > 0 then
-    printfn "\n[FAIL] %d test(s) failed." failures
+let lineitem: obj list = [{ l_quantity = 17; l_extendedprice = 1000; l_discount = 0.05; l_tax = 0.07; l_returnflag = "N"; l_linestatus = "O"; l_shipdate = "1998-08-01" }; { l_quantity = 36; l_extendedprice = 2000; l_discount = 0.1; l_tax = 0.05; l_returnflag = "N"; l_linestatus = "O"; l_shipdate = "1998-09-01" }; { l_quantity = 25; l_extendedprice = 1500; l_discount = 0; l_tax = 0.08; l_returnflag = "R"; l_linestatus = "F"; l_shipdate = "1998-09-03" }]
+let result: obj list = [ for g in _group_by [ for row in lineitem do if row.l_shipdate <= "1998-09-02" then yield row ] (fun row -> { returnflag = row.l_returnflag; linestatus = row.l_linestatus }) do
+    yield { returnflag = g.key.returnflag; linestatus = g.key.linestatus; sum_qty = List.sum [ for x in g do yield x.l_quantity ]; sum_base_price = List.sum [ for x in g do yield x.l_extendedprice ]; sum_disc_price = List.sum [ for x in g do yield x.l_extendedprice * (1 - x.l_discount) ]; sum_charge = List.sum [ for x in g do yield x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax) ]; avg_qty = (List.sum [ for x in g do yield x.l_quantity ] / List.length [ for x in g do yield x.l_quantity ]); avg_price = (List.sum [ for x in g do yield x.l_extendedprice ] / List.length [ for x in g do yield x.l_extendedprice ]); avg_disc = (List.sum [ for x in g do yield x.l_discount ] / List.length [ for x in g do yield x.l_discount ]); count_order = List.length g.items } ]
+printfn "%A" (JsonSerializer.Serialize(result))
+assert (result = [{ returnflag = "N"; linestatus = "O"; sum_qty = 53; sum_base_price = 3000; sum_disc_price = 950 + 1800; sum_charge = (950 * 1.07) + (1800 * 1.05); avg_qty = 26.5; avg_price = 1500; avg_disc = 0.07500000000000001; count_order = 2 }])

--- a/tests/dataset/tpc-h/compiler/fs/q2.fs.out
+++ b/tests/dataset/tpc-h/compiler/fs/q2.fs.out
@@ -1,123 +1,76 @@
 open System
+open System.Text.Json
 
-let r_regionkey = "r_regionkey"
-let r_name = "r_name"
-let n_nationkey = "n_nationkey"
-let n_regionkey = "n_regionkey"
-let n_name = "n_name"
-let s_suppkey = "s_suppkey"
-let s_name = "s_name"
-let s_address = "s_address"
-let s_nationkey = "s_nationkey"
-let s_phone = "s_phone"
-let s_acctbal = "s_acctbal"
-let s_comment = "s_comment"
-let p_partkey = "p_partkey"
-let p_type = "p_type"
-let p_size = "p_size"
-let p_mfgr = "p_mfgr"
-let ps_partkey = "ps_partkey"
-let ps_suppkey = "ps_suppkey"
-let ps_supplycost = "ps_supplycost"
-let s = "s"
-let n = "n"
-let rec _to_json (v: obj) : string =
-  match v with
-  | null -> "null"
-  | :? string as s ->
-      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
-  | :? bool
-  | :? int | :? int64
-  | :? double -> string v
-  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
-      m
-      |> Seq.map (fun (KeyValue(k,v)) ->
-          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
-      |> String.concat ","
-      |> fun s -> "{" + s + "}"
-  | :? System.Collections.IEnumerable as e ->
-      e
-      |> Seq.cast<obj>
-      |> Seq.map _to_json
-      |> String.concat ","
-      |> fun s -> "[" + s + "]"
-  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
-let _json (v: obj) : unit =
-  printfn "%s" (_to_json v)
-let _run_test (name: string) (f: unit -> unit) : bool =
-  printf "%s ... " name
-  try
-    f()
-    printfn "PASS"
-    true
-  with e ->
-    printfn "FAIL (%s)" e.Message
-    false
-let inline sum (xs: seq< ^T >) : ^T =
-  Seq.sum xs
-let inline avg (xs: seq< ^T >) : ^T =
-  Seq.average xs
-let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
-  Seq.min xs
-let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
-  Seq.max xs
-let count (xs: seq<'T>) : int =
-  Seq.length xs
-
-let region = [|Map.ofList [(r_regionkey, 1); (r_name, "EUROPE")]; Map.ofList [(r_regionkey, 2); (r_name, "ASIA")]|]
-let nation = [|Map.ofList [(n_nationkey, 10); (n_regionkey, 1); (n_name, "FRANCE")]; Map.ofList [(n_nationkey, 20); (n_regionkey, 2); (n_name, "CHINA")]|]
-let supplier = [|Map.ofList [(s_suppkey, 100); (s_name, "BestSupplier"); (s_address, "123 Rue"); (s_nationkey, 10); (s_phone, "123"); (s_acctbal, 1000.0); (s_comment, "Fast and reliable")]; Map.ofList [(s_suppkey, 200); (s_name, "AltSupplier"); (s_address, "456 Way"); (s_nationkey, 20); (s_phone, "456"); (s_acctbal, 500.0); (s_comment, "Slow")]|]
-let part = [|Map.ofList [(p_partkey, 1000); (p_type, "LARGE BRASS"); (p_size, 15); (p_mfgr, "M1")]; Map.ofList [(p_partkey, 2000); (p_type, "SMALL COPPER"); (p_size, 15); (p_mfgr, "M2")]|]
-let partsupp = [|Map.ofList [(ps_partkey, 1000); (ps_suppkey, 100); (ps_supplycost, 10.0)]; Map.ofList [(ps_partkey, 1000); (ps_suppkey, 200); (ps_supplycost, 15.0)]|]
-let europe_nations = 
-    [|
-    for r in region do
-        for n in nation do
-            if (n.n_regionkey = r.r_regionkey) then
-                if (r.r_name = "EUROPE") then
-                    yield n
-    |]
-let europe_suppliers = 
-    [|
-    for s in supplier do
-        for n in europe_nations do
-            if (s.s_nationkey = n.n_nationkey) then
-                yield Map.ofList [(s, s); (n, n)]
-    |]
-let target_parts = 
-    [|
-    for p in part do
-        if ((p.p_size = 15) && (p.p_type = "LARGE BRASS")) then
-            yield p
-    |]
-let target_partsupp = 
-    [|
-    for ps in partsupp do
-        for p in target_parts do
-            if (ps.ps_partkey = p.p_partkey) then
-                for s in europe_suppliers do
-                    if (ps.ps_suppkey = s.s.s_suppkey) then
-                        yield Map.ofList [(s_acctbal, s.s.s_acctbal); (s_name, s.s.s_name); (n_name, s.n.n_name); (p_partkey, p.p_partkey); (p_mfgr, p.p_mfgr); (s_address, s.s.s_address); (s_phone, s.s.s_phone); (s_comment, s.s.s_comment); (ps_supplycost, ps.ps_supplycost)]
-    |]
-let costs = 
-    [|
-    for x in target_partsupp do
-        yield x.ps_supplycost
-    |]
-let min_cost = _min costs
-let result = 
-    [|
-    for x in target_partsupp do
-        if (x.ps_supplycost = min_cost) then
-            yield ((-x.s_acctbal), x)
-    |]
-    |> Array.sortBy fst
-    |> Array.map snd
-ignore (_json result)
-let test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part() =
-    if not ((result = [|Map.ofList [(s_acctbal, 1000.0); (s_name, "BestSupplier"); (n_name, "FRANCE"); (p_partkey, 1000); (p_mfgr, "M1"); (s_address, "123 Rue"); (s_phone, "123"); (s_comment, "Fast and reliable"); (ps_supplycost, 10.0)]|])) then failwith "expect failed"
-
-let mutable failures = 0
-if not (_run_test "Q2 returns only supplier with min cost in Europe for brass part" test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part) then failures <- failures + 1
-if failures > 0 then
-    printfn "\n[FAIL] %d test(s) failed." failures
+type Anon1 = {
+    r_regionkey: int
+    r_name: string
+}
+type Anon2 = {
+    n_nationkey: int
+    n_regionkey: int
+    n_name: string
+}
+type Anon3 = {
+    s_suppkey: int
+    s_name: string
+    s_address: string
+    s_nationkey: int
+    s_phone: string
+    s_acctbal: float
+    s_comment: string
+}
+type Anon4 = {
+    p_partkey: int
+    p_type: string
+    p_size: int
+    p_mfgr: string
+}
+type Anon5 = {
+    ps_partkey: int
+    ps_suppkey: int
+    ps_supplycost: float
+}
+type Anon6 = {
+    s: obj
+    n: obj
+}
+type Anon7 = {
+    s_acctbal: obj
+    s_name: obj
+    n_name: obj
+    p_partkey: obj
+    p_mfgr: obj
+    s_address: obj
+    s_phone: obj
+    s_comment: obj
+    ps_supplycost: obj
+}
+type Anon8 = {
+    s_acctbal: float
+    s_name: string
+    n_name: string
+    p_partkey: int
+    p_mfgr: string
+    s_address: string
+    s_phone: string
+    s_comment: string
+    ps_supplycost: float
+}
+let region: obj list = [{ r_regionkey = 1; r_name = "EUROPE" }; { r_regionkey = 2; r_name = "ASIA" }]
+let nation: obj list = [{ n_nationkey = 10; n_regionkey = 1; n_name = "FRANCE" }; { n_nationkey = 20; n_regionkey = 2; n_name = "CHINA" }]
+let supplier: obj list = [{ s_suppkey = 100; s_name = "BestSupplier"; s_address = "123 Rue"; s_nationkey = 10; s_phone = "123"; s_acctbal = 1000; s_comment = "Fast and reliable" }; { s_suppkey = 200; s_name = "AltSupplier"; s_address = "456 Way"; s_nationkey = 20; s_phone = "456"; s_acctbal = 500; s_comment = "Slow" }]
+let part: obj list = [{ p_partkey = 1000; p_type = "LARGE BRASS"; p_size = 15; p_mfgr = "M1" }; { p_partkey = 2000; p_type = "SMALL COPPER"; p_size = 15; p_mfgr = "M2" }]
+let partsupp: obj list = [{ ps_partkey = 1000; ps_suppkey = 100; ps_supplycost = 10 }; { ps_partkey = 1000; ps_suppkey = 200; ps_supplycost = 15 }]
+let europe_nations: obj list = [ for r in region do 
+  for n in nation do if n.n_regionkey = r.r_regionkey && r.r_name = "EUROPE" then yield n ]
+let europe_suppliers: obj list = [ for s in supplier do 
+  for n in europe_nations do if s.s_nationkey = n.n_nationkey then yield { s = s; n = n } ]
+let target_parts: obj list = [ for p in part do if p.p_size = 15 && p.p_type = "LARGE BRASS" then yield p ]
+let target_partsupp: obj list = [ for ps in partsupp do 
+  for p in target_parts do 
+  for s in europe_suppliers do if ps.ps_partkey = p.p_partkey && ps.ps_suppkey = s.s.s_suppkey then yield { s_acctbal = s.s.s_acctbal; s_name = s.s.s_name; n_name = s.n.n_name; p_partkey = p.p_partkey; p_mfgr = p.p_mfgr; s_address = s.s.s_address; s_phone = s.s.s_phone; s_comment = s.s.s_comment; ps_supplycost = ps.ps_supplycost } ]
+let costs: obj list = [ for x in target_partsupp do yield x.ps_supplycost ]
+let min_cost: obj = List.min costs
+let result: obj list = [ for x in target_partsupp do if x.ps_supplycost = min_cost then yield x ] |> List.sortByDescending (fun x -> x.s_acctbal)
+printfn "%A" (JsonSerializer.Serialize(result))
+assert (result = [{ s_acctbal = 1000; s_name = "BestSupplier"; n_name = "FRANCE"; p_partkey = 1000; p_mfgr = "M1"; s_address = "123 Rue"; s_phone = "123"; s_comment = "Fast and reliable"; ps_supplycost = 10 }])

--- a/tests/dataset/tpc-h/compiler/fs/q3.fs.out
+++ b/tests/dataset/tpc-h/compiler/fs/q3.fs.out
@@ -1,0 +1,70 @@
+open System
+open System.Text.Json
+
+type Anon1 = {
+    c_custkey: int
+    c_mktsegment: string
+}
+type Anon2 = {
+    o_orderkey: int
+    o_custkey: int
+    o_orderdate: string
+    o_shippriority: int
+}
+type Anon3 = {
+    l_orderkey: int
+    l_extendedprice: float
+    l_discount: float
+    l_shipdate: string
+}
+type Anon4 = {
+    l_orderkey: obj
+    revenue: obj
+    o_orderdate: obj
+    o_shippriority: obj
+}
+type Anon5 = {
+    o_orderkey: obj
+    o_orderdate: obj
+    o_shippriority: obj
+}
+type Anon6 = {
+    l_orderkey: int
+    revenue: float
+    o_orderdate: string
+    o_shippriority: int
+}
+type _Group<'K,'T>(key: 'K) =
+    member val key = key with get, set
+    member val Items = System.Collections.Generic.List<'T>() with get
+    member this.size = this.Items.Count
+
+let _group_by (src: 'T list) (keyfn: 'T -> 'K) : _Group<'K,'T> list =
+    let groups = System.Collections.Generic.Dictionary<string,_Group<'K,'T>>()
+    let order = System.Collections.Generic.List<string>()
+    for it in src do
+        let key = keyfn it
+        let ks = string key
+        let mutable g = Unchecked.defaultof<_Group<'K,'T>>
+        if groups.TryGetValue(ks, &g) then ()
+        else
+            g <- _Group<'K,'T>(key)
+            groups.Add(ks, g)
+            order.Add(ks)
+        g.Items.Add(it)
+    [ for ks in order -> groups[ks] ]
+
+let customer: obj list = [{ c_custkey = 1; c_mktsegment = "BUILDING" }; { c_custkey = 2; c_mktsegment = "AUTOMOBILE" }]
+let orders: obj list = [{ o_orderkey = 100; o_custkey = 1; o_orderdate = "1995-03-14"; o_shippriority = 1 }; { o_orderkey = 200; o_custkey = 2; o_orderdate = "1995-03-10"; o_shippriority = 2 }]
+let lineitem: obj list = [{ l_orderkey = 100; l_extendedprice = 1000; l_discount = 0.05; l_shipdate = "1995-03-16" }; { l_orderkey = 100; l_extendedprice = 500; l_discount = 0; l_shipdate = "1995-03-20" }; { l_orderkey = 200; l_extendedprice = 1000; l_discount = 0.1; l_shipdate = "1995-03-14" }]
+let cutoff: string = "1995-03-15"
+let segment: string = "BUILDING"
+let building_customers: obj list = [ for c in customer do if c.c_mktsegment = segment then yield c ]
+let valid_orders: obj list = [ for o in orders do 
+  for c in building_customers do if o.o_custkey = c.c_custkey && o.o_orderdate < cutoff then yield o ]
+let valid_lineitems: obj list = [ for l in lineitem do if l.l_shipdate > cutoff then yield l ]
+let order_line_join: obj list = [ for g in _group_by [ for o in valid_orders do 
+  for l in valid_lineitems do if l.l_orderkey = o.o_orderkey then yield (o, l) ] (fun (o, l) -> { o_orderkey = o.o_orderkey; o_orderdate = o.o_orderdate; o_shippriority = o.o_shippriority }) |> List.sortBy (fun gTmp -> let g = gTmp in [-List.sum [ for r in g do yield r.l.l_extendedprice * (1 - r.l.l_discount) ]; g.key.o_orderdate]) do
+    yield { l_orderkey = g.key.o_orderkey; revenue = List.sum [ for r in g do yield r.l.l_extendedprice * (1 - r.l.l_discount) ]; o_orderdate = g.key.o_orderdate; o_shippriority = g.key.o_shippriority } ]
+printfn "%A" (JsonSerializer.Serialize(order_line_join))
+assert (order_line_join = [{ l_orderkey = 100; revenue = 1000 * 0.95 + 500; o_orderdate = "1995-03-14"; o_shippriority = 1 }])


### PR DESCRIPTION
## Summary
- tweak F# compiler group-by implementation for older Mono
- regenerate F# golden files
- include generated code for `q3.mochi`

## Testing
- `go test ./...` *(fails: packages failed; go list error)*

------
https://chatgpt.com/codex/tasks/task_e_68729c6219e483208139a31a484b0101