### PR TITLE
Enhance Kotlin group key typing

### DIFF
--- a/archived/compiler/x/kt/compiler.go
+++ b/archived/compiler/x/kt/compiler.go
@@ -879,8 +879,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			c.env = orig
 			return "", err
 		}
+		keyType := c.inferExprType(q.Group.Exprs[0])
 		genv := types.NewEnv(child)
-		genv.SetVar(q.Group.Name, types.GroupType{Elem: types.AnyType{}}, true)
+		genv.SetVar(q.Group.Name, types.GroupType{Key: keyType, Elem: types.AnyType{}}, true)
 		c.env = genv
 		valExpr, err := c.compileExpr(q.Select)
 		if err != nil {
@@ -1114,8 +1115,9 @@ func (c *Compiler) compileAdvancedQueryExpr(q *parser.QueryExpr, src string) (st
 			return "", err
 		}
 		keyExpr = k
+		keyType := c.inferExprType(q.Group.Exprs[0])
 		genv := types.NewEnv(child)
-		genv.SetVar(q.Group.Name, types.GroupType{Elem: types.AnyType{}}, true)
+		genv.SetVar(q.Group.Name, types.GroupType{Key: keyType, Elem: types.AnyType{}}, true)
 		c.env = genv
 		gs, err := c.compileExpr(q.Select)
 		if err != nil {
@@ -1911,7 +1913,7 @@ func ktUnpackArgs(names []string, indent string, env *types.Env) string {
 				case types.StructType, types.UnionType:
 					b.WriteString(" as " + ktType(tt))
 				case types.GroupType:
-					b.WriteString(" as _Group")
+					b.WriteString(" as _Group<" + ktType(tt.Key) + ">")
 				}
 			}
 		}

--- a/archived/compiler/x/kt/runtime.go
+++ b/archived/compiler/x/kt/runtime.go
@@ -317,7 +317,7 @@ inline fun <reified T> _cast(v: Any?): T {
             }
             if (items != null) list = items as List<Any?>
         }
-        is _Group -> list = v.Items
+        is _Group<*> -> list = v.Items
     }
     if (list == null || list.isEmpty()) return 0.0
     var sum = 0.0
@@ -339,7 +339,7 @@ inline fun <reified T> _cast(v: Any?): T {
             }
             if (items != null) list = items as List<Any?>
         }
-        is _Group -> list = v.Items
+        is _Group<*> -> list = v.Items
     }
     if (list == null || list.isEmpty()) return 0.0
     var sum = 0.0
@@ -361,7 +361,7 @@ inline fun <reified T> _cast(v: Any?): T {
             }
             if (items != null) list = items as List<Any?>
         }
-        is _Group -> list = v.Items
+        is _Group<*> -> list = v.Items
     }
     if (list == null || list.isEmpty()) return 0
     var m = list[0]
@@ -383,7 +383,7 @@ inline fun <reified T> _cast(v: Any?): T {
             }
             if (items != null) list = items as List<Any?>
         }
-        is _Group -> list = v.Items
+        is _Group<*> -> list = v.Items
     }
     if (list == null || list.isEmpty()) return 0
     var m = list[0]
@@ -393,14 +393,14 @@ inline fun <reified T> _cast(v: Any?): T {
     return m
 }`
 
-	helperGroup = `class _Group(var key: Any?) {
+	helperGroup = `class _Group<K>(var key: K) {
     val Items = mutableListOf<Any?>()
     val size: Int
         get() = Items.size
 }`
 
-	helperGroupBy = `fun _group_by(src: List<Any?>, keyfn: (Any?) -> Any?): List<_Group> {
-    val groups = mutableMapOf<String, _Group>()
+	helperGroupBy = `fun <T, K> _group_by(src: List<T>, keyfn: (T) -> K): List<_Group<K>> {
+    val groups = mutableMapOf<String, _Group<K>>()
     val order = mutableListOf<String>()
     for (it in src) {
         val key = keyfn(it)


### PR DESCRIPTION
## Summary
- type the Kotlin `_Group` class with a key type parameter
- make `_group_by` generic and return typed groups
- track group key types in the Kotlin compiler
- cast unpacked group variables to `_Group<type>`

## Testing
- `go test ./...` *(fails: go list error and missing language toolchains)*

------
https://chatgpt.com/codex/tasks/task_e_68729cafda0c8320a559957fafcfe64b