### PR TITLE
Add struct name reuse for TPCH q1 compilation

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -1371,6 +1371,18 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		if lt, ok := c.inferExprType(q.Source).(types.ListType); ok {
 			elemType = lt.Elem
 		}
+		if gt, ok := c.inferExprType(q.Source).(types.GroupType); ok {
+			elemType = gt.Elem
+			src += ".Items"
+		}
+		if gt, ok := c.inferExprType(q.Source).(types.GroupType); ok {
+			elemType = gt.Elem
+			src += ".Items"
+		}
+		if gt, ok := c.inferExprType(q.Source).(types.GroupType); ok {
+			elemType = gt.Elem
+			src += ".Items"
+		}
 		child := types.NewEnv(c.env)
 		child.SetVar(q.Var, elemType, true)
 
@@ -1520,7 +1532,12 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 
 		groupElem := strings.TrimPrefix(zigTypeOf(elemType), "[]const ")
 		resElem := strings.TrimPrefix(resType, "[]const ")
-		groupType := "struct { key: " + keyType + ", Items: std.ArrayList(" + groupElem + ") }"
+		groupStruct := c.newStructName()
+		groupType := groupStruct
+		if !c.structs[groupStruct] {
+			c.writeln(fmt.Sprintf("const %s = struct { key: %s, Items: std.ArrayList(%s) };", groupStruct, keyType, groupElem))
+			c.structs[groupStruct] = true
+		}
 		tmp := c.newTmp()
 		var b strings.Builder
 		c.needsEqual = true

--- a/tests/dataset/tpc-h/compiler/zig/q1.zig.out
+++ b/tests/dataset/tpc-h/compiler/zig/q1.zig.out
@@ -4,11 +4,15 @@ fn expect(cond: bool) void {
     if (!cond) @panic("expect failed");
 }
 
-fn _avg_int(v: []const i32) f64 {
+fn handleError(err: anyerror) noreturn {
+    std.debug.panic("{any}", .{err});
+}
+
+fn _avg_int(v: []const i32) i32 {
     if (v.len == 0) return 0;
-    var sum: f64 = 0;
-    for (v) |it| { sum += @floatFromInt(it); }
-    return sum / @as(f64, @floatFromInt(v.len));
+    var sum: i32 = 0;
+    for (v) |it| { sum += it; }
+    return @divTrunc(sum, @as(i32, @intCast(v.len)));
 }
 
 fn _sum_int(v: []const i32) i32 {
@@ -17,10 +21,16 @@ fn _sum_int(v: []const i32) i32 {
     return sum;
 }
 
+fn _sum_float(v: []const f64) f64 {
+    var sum: f64 = 0;
+    for (v) |it| { sum += it; }
+    return sum;
+}
+
 fn _json(v: anytype) void {
     var buf = std.ArrayList(u8).init(std.heap.page_allocator);
     defer buf.deinit();
-    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.json.stringify(v, .{}, buf.writer()) catch |err| handleError(err);
     std.debug.print("{s}\n", .{buf.items});
 }
 
@@ -32,13 +42,105 @@ fn _equal(a: anytype, b: anytype) bool {
     };
 }
 
+const LineitemItem = struct {
+    l_quantity: i32,
+    l_extendedprice: f64,
+    l_discount: f64,
+    l_tax: f64,
+    l_returnflag: []const u8,
+    l_linestatus: []const u8,
+    l_shipdate: []const u8,
+};
+const lineitem = &[_]LineitemItem{
+    LineitemItem{
+    .l_quantity = 17,
+    .l_extendedprice = 1000.0,
+    .l_discount = 0.05,
+    .l_tax = 0.07,
+    .l_returnflag = "N",
+    .l_linestatus = "O",
+    .l_shipdate = "1998-08-01",
+},
+    LineitemItem{
+    .l_quantity = 36,
+    .l_extendedprice = 2000.0,
+    .l_discount = 0.1,
+    .l_tax = 0.05,
+    .l_returnflag = "N",
+    .l_linestatus = "O",
+    .l_shipdate = "1998-09-01",
+},
+    LineitemItem{
+    .l_quantity = 25,
+    .l_extendedprice = 1500.0,
+    .l_discount = 0.0,
+    .l_tax = 0.08,
+    .l_returnflag = "R",
+    .l_linestatus = "F",
+    .l_shipdate = "1998-09-03",
+},
+}; // []const LineitemItem
+const ResultStruct0 = struct {
+    returnflag: []const u8,
+    linestatus: []const u8,
+};
+const ResultStruct1 = struct {
+    returnflag: i32,
+    linestatus: i32,
+    sum_qty: i32,
+    sum_base_price: i32,
+    sum_disc_price: i32,
+    sum_charge: i32,
+    avg_qty: i32,
+    avg_price: i32,
+    avg_disc: i32,
+    count_order: i32,
+};
+const ResultStruct30 = struct { key: ResultStruct0, Items: std.ArrayList(LineitemItem) };
+var result: []const std.StringHashMap(i32) = undefined; // []const std.StringHashMap(i32)
+
 fn test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() void {
-    expect((result == &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put("returnflag", "N") catch unreachable; m.put("linestatus", "O") catch unreachable; m.put("sum_qty", @as(i32,@intCast(53))) catch unreachable; m.put("sum_base_price", @as(i32,@intCast(3000))) catch unreachable; m.put("sum_disc_price", (950 + 1800)) catch unreachable; m.put("sum_charge", (((950 * 1.07)) + ((1800 * 1.05)))) catch unreachable; m.put("avg_qty", 26.5) catch unreachable; m.put("avg_price", @as(i32,@intCast(1500))) catch unreachable; m.put("avg_disc", 0.07500000000000001) catch unreachable; m.put("count_order", @as(i32,@intCast(2))) catch unreachable; break :blk m; }}));
+    expect((result == &[_]ResultStruct1{ResultStruct1{
+    .returnflag = "N",
+    .linestatus = "O",
+    .sum_qty = 53,
+    .sum_base_price = 3000,
+    .sum_disc_price = (950.0 + 1800.0),
+    .sum_charge = (((950.0 * 1.07)) + ((1800.0 * 1.05))),
+    .avg_qty = 26.5,
+    .avg_price = 1500,
+    .avg_disc = 0.07500000000000001,
+    .count_order = 2,
+}}));
 }
 
 pub fn main() void {
-    const lineitem: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put("l_quantity", @as(i32,@intCast(17))) catch unreachable; m.put("l_extendedprice", 1000) catch unreachable; m.put("l_discount", 0.05) catch unreachable; m.put("l_tax", 0.07) catch unreachable; m.put("l_returnflag", "N") catch unreachable; m.put("l_linestatus", "O") catch unreachable; m.put("l_shipdate", "1998-08-01") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put("l_quantity", @as(i32,@intCast(36))) catch unreachable; m.put("l_extendedprice", 2000) catch unreachable; m.put("l_discount", 0.1) catch unreachable; m.put("l_tax", 0.05) catch unreachable; m.put("l_returnflag", "N") catch unreachable; m.put("l_linestatus", "O") catch unreachable; m.put("l_shipdate", "1998-09-01") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put("l_quantity", @as(i32,@intCast(25))) catch unreachable; m.put("l_extendedprice", 1500) catch unreachable; m.put("l_discount", 0) catch unreachable; m.put("l_tax", 0.08) catch unreachable; m.put("l_returnflag", "R") catch unreachable; m.put("l_linestatus", "F") catch unreachable; m.put("l_shipdate", "1998-09-03") catch unreachable; break :blk m; }};
-    const result: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp14 = std.ArrayList(struct { key: std.AutoHashMap([]const u8, i32), Items: std.ArrayList(std.AutoHashMap([]const u8, i32)) }).init(std.heap.page_allocator); var _tmp15 = std.AutoHashMap(std.AutoHashMap([]const u8, i32), usize).init(std.heap.page_allocator); for (lineitem) |row| { if (!((row.l_shipdate <= "1998-09-02"))) continue; const _tmp16 = blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put("returnflag", row.l_returnflag) catch unreachable; m.put("linestatus", row.l_linestatus) catch unreachable; break :blk m; }; if (_tmp15.get(_tmp16)) |idx| { _tmp14.items[idx].Items.append(row) catch unreachable; } else { var g = struct { key: std.AutoHashMap([]const u8, i32), Items: std.ArrayList(std.AutoHashMap([]const u8, i32)) }{ .key = _tmp16, .Items = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator) }; g.Items.append(row) catch unreachable; _tmp14.append(g) catch unreachable; _tmp15.put(_tmp16, _tmp14.items.len - 1) catch unreachable; } } var _tmp17 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator);for (_tmp14.items) |g| { _tmp17.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put("returnflag", g.key.returnflag) catch unreachable; m.put("linestatus", g.key.linestatus) catch unreachable; m.put("sum_qty", _sum_int(blk: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp0.append(x.l_quantity) catch unreachable; } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; })) catch unreachable; m.put("sum_base_price", _sum_int(blk: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp2.append(x.l_extendedprice) catch unreachable; } var _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk _tmp3; })) catch unreachable; m.put("sum_disc_price", _sum_int(blk: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp4.append((x.l_extendedprice * ((@as(i32,@intCast(1)) - x.l_discount)))) catch unreachable; } var _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk _tmp5; })) catch unreachable; m.put("sum_charge", _sum_int(blk: { var _tmp6 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp6.append(((x.l_extendedprice * ((@as(i32,@intCast(1)) - x.l_discount))) * ((@as(i32,@intCast(1)) + x.l_tax)))) catch unreachable; } var _tmp7 = _tmp6.toOwnedSlice() catch unreachable; break :blk _tmp7; })) catch unreachable; m.put("avg_qty", _avg_int(blk: { var _tmp8 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp8.append(x.l_quantity) catch unreachable; } var _tmp9 = _tmp8.toOwnedSlice() catch unreachable; break :blk _tmp9; })) catch unreachable; m.put("avg_price", _avg_int(blk: { var _tmp10 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp10.append(x.l_extendedprice) catch unreachable; } var _tmp11 = _tmp10.toOwnedSlice() catch unreachable; break :blk _tmp11; })) catch unreachable; m.put("avg_disc", _avg_int(blk: { var _tmp12 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp12.append(x.l_discount) catch unreachable; } var _tmp13 = _tmp12.toOwnedSlice() catch unreachable; break :blk _tmp13; })) catch unreachable; m.put("count_order", (g.Items.len)) catch unreachable; break :blk m; }) catch unreachable; } break :blk _tmp17.toOwnedSlice() catch unreachable; };
+    result = blk14: { var _tmp31 = std.ArrayList(ResultStruct30).init(std.heap.page_allocator); for (lineitem) |row| { if (!(std.mem.order(u8, row.l_shipdate, "1998-09-02") != .gt)) continue; const _tmp32 = ResultStruct0{
+    .returnflag = row.l_returnflag,
+    .linestatus = row.l_linestatus,
+}; var _found = false; var _idx: usize = 0; for (_tmp31.items, 0..) |it, i| { if (_equal(it.key, _tmp32)) { _found = true; _idx = i; break; } } if (_found) { _tmp31.items[_idx].Items.append(row) catch |err| handleError(err); } else { var g = ResultStruct30{ .key = _tmp32, .Items = std.ArrayList(LineitemItem).init(std.heap.page_allocator) }; g.Items.append(row) catch |err| handleError(err); _tmp31.append(g) catch |err| handleError(err); } } var _tmp33 = std.ArrayList(ResultStruct30).init(std.heap.page_allocator);for (_tmp31.items) |g| { _tmp33.append(g) catch |err| handleError(err); } var _tmp34 = std.ArrayList(struct {
+    returnflag: i32,
+    linestatus: i32,
+    sum_qty: f64,
+    sum_base_price: f64,
+    sum_disc_price: f64,
+    sum_charge: f64,
+    avg_qty: f64,
+    avg_price: f64,
+    avg_disc: f64,
+    count_order: i32,
+}).init(std.heap.page_allocator);for (_tmp33.items) |g| { _tmp34.append(ResultStruct1{
+    .returnflag = g.key.returnflag,
+    .linestatus = g.key.linestatus,
+    .sum_qty = _sum_int(blk7: { var _tmp16 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp16.append(x.l_quantity) catch |err| handleError(err); } const _tmp17 = _tmp16.toOwnedSlice() catch |err| handleError(err); break :blk7 _tmp17; }),
+    .sum_base_price = _sum_float(blk8: { var _tmp18 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp18.append(x.l_extendedprice) catch |err| handleError(err); } const _tmp19 = _tmp18.toOwnedSlice() catch |err| handleError(err); break :blk8 _tmp19; }),
+    .sum_disc_price = _sum_float(blk9: { var _tmp20 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp20.append((x.l_extendedprice * ((1 - x.l_discount)))) catch |err| handleError(err); } const _tmp21 = _tmp20.toOwnedSlice() catch |err| handleError(err); break :blk9 _tmp21; }),
+    .sum_charge = _sum_float(blk10: { var _tmp22 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp22.append(((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax)))) catch |err| handleError(err); } const _tmp23 = _tmp22.toOwnedSlice() catch |err| handleError(err); break :blk10 _tmp23; }),
+    .avg_qty = _avg_int(blk11: { var _tmp24 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp24.append(x.l_quantity) catch |err| handleError(err); } const _tmp25 = _tmp24.toOwnedSlice() catch |err| handleError(err); break :blk11 _tmp25; }),
+    .avg_price = _avg_int(blk12: { var _tmp26 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp26.append(x.l_extendedprice) catch |err| handleError(err); } const _tmp27 = _tmp26.toOwnedSlice() catch |err| handleError(err); break :blk12 _tmp27; }),
+    .avg_disc = _avg_int(blk13: { var _tmp28 = std.ArrayList(i32).init(std.heap.page_allocator); for (g) |x| { _tmp28.append(x.l_discount) catch |err| handleError(err); } const _tmp29 = _tmp28.toOwnedSlice() catch |err| handleError(err); break :blk13 _tmp29; }),
+    .count_order = (g.Items.len),
+}) catch |err| handleError(err); } const _tmp34Slice = _tmp34.toOwnedSlice() catch |err| handleError(err); break :blk14 _tmp34Slice; };
     _json(result);
     test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus();
 }


### PR DESCRIPTION
## Summary
- update Zig compiler to declare a named struct when grouping
- regenerate golden file for q1

## Testing
- `go test ./compiler/x/zig -tags slow -run TestZigCompiler_TPCH_Golden/q1 -count=1 -v` *(fails: zig build error)*

------
https://chatgpt.com/codex/tasks/task_e_68729d42697c832095bc48502d03f3a5