### PR TITLE
Update C compiler helpers

### DIFF
--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -106,3 +106,13 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+## Remaining work
+
+The C backend still fails to compile several Mochi programs that rely on complex
+dataset joins, grouping, or advanced built-ins. Outstanding tasks include:
+
+- Implement join support for `left_join`, `right_join`, and related examples.
+- Add full grouping logic so `group_by` and `group_items_iteration` work.
+- Improve built-in handling for YAML loading and `sum_builtin`.
+- Finish translation for programs like `two-sum` and `update_stmt`.


### PR DESCRIPTION
## Summary
- fix stack list generation in the C backend
- wrap constant int arrays when slicing
- document remaining C backend tasks

## Testing
- `go test ./...` *(fails: packages_test.go: packages failed: go list failed)*

------
https://chatgpt.com/codex/tasks/task_e_68729d7d1dd8832096e355177d6f86e1