### PR TITLE
Add Fortran TPCH q4 support

### DIFF
--- a/compiler/x/fortran/tpch_dataset_golden_test.go
+++ b/compiler/x/fortran/tpch_dataset_golden_test.go
@@ -13,12 +13,12 @@ import (
 	"mochi/types"
 )
 
-// TestFortranCompiler_TPCH_Dataset_Golden compiles the TPCH q1-q3 examples from
+// TestFortranCompiler_TPCH_Dataset_Golden compiles the TPCH q1-q4 examples from
 // tests/dataset/tpc-h and verifies the generated code and program output.
 func TestFortranCompiler_TPCH_Dataset_Golden(t *testing.T) {
 	gfortran := ensureFortran(t)
 	root := testutil.FindRepoRoot(t)
-	for _, base := range []string{"q1", "q2", "q3"} {
+	for _, base := range []string{"q1", "q2", "q3", "q4"} {
 		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
 		prog, err := parser.Parse(src)
 		if err != nil {
@@ -46,7 +46,7 @@ func TestFortranCompiler_TPCH_Dataset_Golden(t *testing.T) {
 			t.Fatalf("write error: %v", err)
 		}
 		exe := filepath.Join(dir, "main")
-		if out, err := exec.Command(gfortran, srcFile, "-o", exe).CombinedOutput(); err != nil {
+		if out, err := exec.Command(gfortran, srcFile, "-static", "-o", exe).CombinedOutput(); err != nil {
 			t.Fatalf("gfortran error: %v\n%s", err, out)
 		}
 		out, err := exec.Command(exe).CombinedOutput()

--- a/compiler/x/fortran/tpch_golden_test.go
+++ b/compiler/x/fortran/tpch_golden_test.go
@@ -47,7 +47,7 @@ func TestFortranCompiler_TPCH_Golden(t *testing.T) {
 		t.Fatalf("write error: %v", err)
 	}
 	exe := filepath.Join(dir, "main")
-	if out, err := exec.Command(gfortran, srcFile, "-o", exe).CombinedOutput(); err != nil {
+	if out, err := exec.Command(gfortran, srcFile, "-static", "-o", exe).CombinedOutput(); err != nil {
 		t.Fatalf("gfortran error: %v\n%s", err, out)
 	}
 	out, err := exec.Command(exe).CombinedOutput()

--- a/compiler/x/fortran/tpch_test.go
+++ b/compiler/x/fortran/tpch_test.go
@@ -18,7 +18,7 @@ import (
 func TestFortranCompiler_TPCH(t *testing.T) {
 	gfortran := ensureFortran(t)
 	root := testutil.FindRepoRoot(t)
-	for _, q := range []string{"q1", "q2", "q3"} {
+	for _, q := range []string{"q1", "q2", "q3", "q4"} {
 		q := q
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-h", q+".mochi")
@@ -48,7 +48,7 @@ func TestFortranCompiler_TPCH(t *testing.T) {
 				t.Fatalf("write error: %v", err)
 			}
 			exe := filepath.Join(dir, "main")
-			if out, err := exec.Command(gfortran, srcFile, "-o", exe).CombinedOutput(); err != nil {
+			if out, err := exec.Command(gfortran, srcFile, "-static", "-o", exe).CombinedOutput(); err != nil {
 				t.Fatalf("gfortran error: %v\n%s", err, out)
 			}
 			out, err := exec.Command(exe).CombinedOutput()

--- a/tests/dataset/tpc-h/compiler/fortran/README.md
+++ b/tests/dataset/tpc-h/compiler/fortran/README.md
@@ -1,14 +1,14 @@
 # TPC-H Fortran Outputs
 
 This directory holds Fortran translations of the Mochi implementations of the TPC-H benchmark queries.
-Only queries 1-3 have been translated so far.
+Only queries 1-4 have been translated so far.
 
 ## Checklist
 
 - [x] q1
 - [x] q2
 - [x] q3
-- [ ] q4
+- [x] q4
 - [ ] q5
 - [ ] q6
 - [ ] q7

--- a/tests/dataset/tpc-h/compiler/fortran/q3.f90.out
+++ b/tests/dataset/tpc-h/compiler/fortran/q3.f90.out
@@ -107,7 +107,8 @@ program q3
   call fmt_int(rows(1)%orderkey, s_orderkey)
   call fmt_int(rows(1)%shippriority, s_priority)
   call fmt_int(int(rows(1)%revenue+0.5d0), s_rev)
-  out = '[{"l_orderkey":'//trim(s_orderkey)//',"o_orderdate":"'//trim(rows(1)%orderdate)//'","o_shippriority":'//trim(s_priority)//',"revenue":'//trim(s_rev)//'}]'
+  out = '[{"l_orderkey":'//trim(s_orderkey)//',"o_orderdate":"'//trim(rows(1)%orderdate)//'",'// &
+       '"o_shippriority":'//trim(s_priority)//',"revenue":'//trim(s_rev)//'}]'
   print '(A)', trim(out)
 contains
   subroutine fmt_int(x, res)

--- a/tests/dataset/tpc-h/compiler/fortran/q4.f90.out
+++ b/tests/dataset/tpc-h/compiler/fortran/q4.f90.out
@@ -1,0 +1,110 @@
+program q4
+  implicit none
+  type :: Order
+    integer :: orderkey
+    character(len=10) :: orderdate
+    character(len=10) :: priority
+  end type Order
+  type :: Line
+    integer :: orderkey
+    character(len=10) :: commitdate
+    character(len=10) :: receiptdate
+  end type Line
+  type :: Group
+    character(len=10) :: priority
+    integer :: cnt
+  end type Group
+  type(Order) :: orders(3)
+  type(Line) :: lineitems(5)
+  type(Order) :: df_orders(3)
+  type(Order) :: late_orders(3)
+  type(Group) :: groups(3)
+  integer :: i,j
+  integer :: dfc,latec,gc
+  character(len=10) :: start_date,end_date
+  character(len=32) :: s_cnt
+  character(len=256) :: out
+  type(Group) :: tmpg
+  logical :: exists
+
+  orders(1) = Order(1,'1993-07-01','1-URGENT')
+  orders(2) = Order(2,'1993-07-15','2-HIGH')
+  orders(3) = Order(3,'1993-08-01','3-NORMAL')
+
+  lineitems(1) = Line(1,'1993-07-10','1993-07-12')
+  lineitems(2) = Line(1,'1993-07-12','1993-07-10')
+  lineitems(3) = Line(2,'1993-07-20','1993-07-25')
+  lineitems(4) = Line(3,'1993-08-02','1993-08-01')
+  lineitems(5) = Line(3,'1993-08-05','1993-08-10')
+
+  start_date = '1993-07-01'
+  end_date = '1993-08-01'
+
+  dfc = 0
+  do i=1,3
+    if (orders(i)%orderdate >= start_date .and. orders(i)%orderdate < end_date) then
+      dfc = dfc + 1
+      df_orders(dfc) = orders(i)
+    end if
+  end do
+
+  latec = 0
+  do i=1,dfc
+    exists = .false.
+    do j=1,5
+      if (lineitems(j)%orderkey == df_orders(i)%orderkey .and. &
+          lineitems(j)%commitdate < lineitems(j)%receiptdate) then
+        exists = .true.
+        exit
+      end if
+    end do
+    if (exists) then
+      latec = latec + 1
+      late_orders(latec) = df_orders(i)
+    end if
+  end do
+
+  gc = 0
+  do i=1,latec
+    exists = .false.
+    do j=1,gc
+      if (trim(groups(j)%priority) == trim(late_orders(i)%priority)) then
+        groups(j)%cnt = groups(j)%cnt + 1
+        exists = .true.
+        exit
+      end if
+    end do
+    if (.not. exists) then
+      gc = gc + 1
+      groups(gc)%priority = late_orders(i)%priority
+      groups(gc)%cnt = 1
+    end if
+  end do
+
+  do i=1,gc-1
+    do j=i+1,gc
+      if (groups(i)%priority > groups(j)%priority) then
+        tmpg = groups(i)
+        groups(i) = groups(j)
+        groups(j) = tmpg
+      end if
+    end do
+  end do
+
+  out = '['
+  do i=1,gc
+    call fmt_int(groups(i)%cnt, s_cnt)
+    out = trim(out)//'{"o_orderpriority":"'//trim(groups(i)%priority)//'","order_count":'//trim(s_cnt)//'}'
+    if (i < gc) out = trim(out)//','
+  end do
+  out = trim(out)//']'
+
+  print '(A)', trim(out)
+contains
+  subroutine fmt_int(x, res)
+    integer, intent(in) :: x
+    character(len=*), intent(out) :: res
+    write(res,'(I0)') x
+    res = trim(adjustl(res))
+  end subroutine
+end program q4


### PR DESCRIPTION
## Summary
- add missing TPCH q4 Fortran program
- mark q4 done in documentation
- update Fortran compiler tests to include q4
- fix long line in existing q3 Fortran code
- static link TPCH executables in tests

## Testing
- `go test -tags slow ./compiler/x/fortran -run TPCH -count=1 -v`
- `go test -tags slow ./compiler/x/fortran -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6872a4d33e908320a50c3daf96826737