### PR TITLE
Add TypeScript support for TPCH q1-q4

### DIFF
--- a/compiler/x/typescript/compiler_test.go
+++ b/compiler/x/typescript/compiler_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func findRepoRoot(t *testing.T) string {
+	t.Helper()
 	dir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)

--- a/compiler/x/typescript/tpch_golden_test.go
+++ b/compiler/x/typescript/tpch_golden_test.go
@@ -4,6 +4,7 @@ package typescriptcode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,12 +15,12 @@ import (
 	"mochi/types"
 )
 
-func TestTypeScriptCompiler_TPCHQuery1(t *testing.T) {
+func runTPCHQuery(t *testing.T, base string) {
+	t.Helper()
 	if _, err := exec.LookPath("deno"); err != nil {
 		t.Skip("deno not installed")
 	}
 	root := findRepoRoot(t)
-	base := "q1"
 	src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
 	codeWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "typescript", base+".ts.out")
 	outWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "typescript", base+".out")
@@ -60,5 +61,12 @@ func TestTypeScriptCompiler_TPCHQuery1(t *testing.T) {
 	}
 	if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
 		t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, gotOut, bytes.TrimSpace(wantOut))
+	}
+}
+
+func TestTypeScriptCompiler_TPCH(t *testing.T) {
+	for i := 1; i <= 4; i++ {
+		base := fmt.Sprintf("q%d", i)
+		t.Run(base, func(t *testing.T) { runTPCHQuery(t, base) })
 	}
 }

--- a/tests/dataset/tpc-h/compiler/typescript/q4.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q4.out
@@ -1,0 +1,1 @@
+[{"o_orderpriority":"1-URGENT","order_count":1},{"o_orderpriority":"2-HIGH","order_count":1}]

--- a/tests/dataset/tpc-h/compiler/typescript/q4.ts.out
+++ b/tests/dataset/tpc-h/compiler/typescript/q4.ts.out
@@ -1,0 +1,92 @@
+function _json(v: any) {
+  function _sort(x: any): any {
+    if (Array.isArray(x)) return x.map(_sort);
+    if (x && typeof x === "object") {
+      const keys = Object.keys(x).sort();
+      const o: any = {};
+      for (const k of keys) o[k] = _sort(x[k]);
+      return o;
+    }
+    return x;
+  }
+  return JSON.stringify(_sort(v));
+}
+const orders = [
+  {
+  o_orderkey: 1,
+  o_orderdate: "1993-07-01",
+  o_orderpriority: "1-URGENT"
+},
+  {
+  o_orderkey: 2,
+  o_orderdate: "1993-07-15",
+  o_orderpriority: "2-HIGH"
+},
+  {
+  o_orderkey: 3,
+  o_orderdate: "1993-08-01",
+  o_orderpriority: "3-NORMAL"
+}
+];
+const lineitem = [
+  {
+  l_orderkey: 1,
+  l_commitdate: "1993-07-10",
+  l_receiptdate: "1993-07-12"
+},
+  {
+  l_orderkey: 1,
+  l_commitdate: "1993-07-12",
+  l_receiptdate: "1993-07-10"
+},
+  {
+  l_orderkey: 2,
+  l_commitdate: "1993-07-20",
+  l_receiptdate: "1993-07-25"
+},
+  {
+  l_orderkey: 3,
+  l_commitdate: "1993-08-02",
+  l_receiptdate: "1993-08-01"
+},
+  {
+  l_orderkey: 3,
+  l_commitdate: "1993-08-05",
+  l_receiptdate: "1993-08-10"
+}
+];
+const start_date = "1993-07-01";
+const end_date = "1993-08-01";
+const date_filtered_orders = orders.filter((o) => (((o.o_orderdate >= start_date) && o.o_orderdate) < end_date));
+const late_orders = date_filtered_orders.filter((o) => lineitem.some((l) => (((l.l_orderkey == o.o_orderkey) && l.l_commitdate) < l.l_receiptdate)));
+const result = (() => {
+  let _tmp1: Array<{ o_orderpriority: any; order_count: number }> = [];
+  const groups = {};
+  for (const o of late_orders) {
+    const _k = JSON.stringify(o.o_orderpriority);
+    let g = groups[_k];
+    if (!g) { g = []; g.key = o.o_orderpriority; g.items = g; groups[_k] = g; }
+    g.push(o);
+  }
+  for (const _k in groups) {
+    const g = groups[_k];
+    _tmp1.push({item: {
+  o_orderpriority: g.key,
+  order_count: g.length
+}, key: g.key});
+  }
+  _tmp1 = _tmp1.sort((a,b)=> a.key < b.key ? -1 : a.key > b.key ? 1 : 0).map(x=>x.item);
+  return _tmp1;
+})()
+;
+console.log(_json(result));
+if (!(JSON.stringify(result) === JSON.stringify([
+  {
+  o_orderpriority: "1-URGENT",
+  order_count: 1
+},
+  {
+  o_orderpriority: "2-HIGH",
+  order_count: 1
+}
+]))) { throw new Error("Q4 returns count of orders with late lineitems in range failed"); }


### PR DESCRIPTION
## Summary
- allow TypeScript compiler tests to run for TPCH queries q1–q4
- generate golden TypeScript code and output for q4
- mark helper functions in compiler tests for clearer error reporting

## Testing
- `go test ./compiler/x/typescript -tags=slow -run TPCH -v`


------
https://chatgpt.com/codex/tasks/task_e_6872a506a02883208259c9299992878e