### PR TITLE
Add note on tpch q1 compilation needs

### DIFF
--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -116,3 +116,5 @@ dataset joins, grouping, or advanced built-ins. Outstanding tasks include:
 - Add full grouping logic so `group_by` and `group_items_iteration` work.
 - Improve built-in handling for YAML loading and `sum_builtin`.
 - Finish translation for programs like `two-sum` and `update_stmt`.
+- Extend grouping logic to handle structured keys so dataset queries like
+  `tests/dataset/tpc-h/q1.mochi` can compile.


### PR DESCRIPTION
## Summary
- document missing structured key grouping needed for dataset queries like tpch q1

## Testing
- `go test -tags slow -run ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6872ab465a888320a796870623d2705f