### PR TITLE
Fix slow build scripts tests

### DIFF
--- a/scripts/compile_tpch_go.go
+++ b/scripts/compile_tpch_go.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/scripts/doc.go
+++ b/scripts/doc.go
@@ -1,0 +1,3 @@
+package main
+
+// Package scripts holds build-time utilities. Only compiled with specific build tags.


### PR DESCRIPTION
## Summary
- mark `compile_tpch_go.go` as slow
- add a small `doc.go` so the scripts package has buildable source

## Testing
- `go test ./scripts`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6872acd4009c83208ca84d6c41cc902f