### PR TITLE
Fix build with scripts doc build tag

### DIFF
--- a/scripts/doc.go
+++ b/scripts/doc.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 // Package scripts holds build-time utilities. Only compiled with specific build tags.


### PR DESCRIPTION
## Summary
- mark `scripts/doc.go` with `//go:build ignore`

## Testing
- `go build ./...`
- `go test ./... --vet=off -run TestDummy -count=0`


------
https://chatgpt.com/codex/tasks/task_e_6873092df1f88320b2a8189e983be197