### PR TITLE
Improve Scala compiler arithmetic typing

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -57,6 +57,15 @@ func (c *Compiler) detectStructMap(e *parser.Expr, env *types.Env) (types.Struct
 
 const indentStep = 2
 
+func isInt(t types.Type) bool { _, ok := t.(types.IntType); return ok }
+func isFloat(t types.Type) bool {
+	switch t.(type) {
+	case types.FloatType, types.BigRatType:
+		return true
+	}
+	return false
+}
+
 func New(env *types.Env) *Compiler {
 	return &Compiler{
 		env:         env,
@@ -1123,7 +1132,13 @@ func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 			case "&&", "||", "==", "!=", "<", "<=", ">", ">=":
 				leftType = types.BoolType{}
 			default:
-				leftType = types.AnyType{}
+				if isFloat(leftType) || isFloat(rightType) {
+					leftType = types.FloatType{}
+				} else if isInt(leftType) && isInt(rightType) {
+					leftType = types.IntType{}
+				} else {
+					leftType = types.AnyType{}
+				}
 			}
 		case "in":
 			ct := types.TypeOfPostfix(op.Right, c.env)

--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -111,5 +111,5 @@ Recent improvements:
 
 ## Remaining Tasks
 - [ ] Review generated Scala code for idiomatic style
-- [ ] Investigate TPCH `q1.mochi` compilation failures and update helper
+- [x] Investigate TPCH `q1.mochi` compilation failures and update helper
       functions as needed


### PR DESCRIPTION
## Summary
- fix binary expression typing in the Scala compiler so arithmetic results
  keep the correct numeric type instead of degrading to `Any`
- add small helpers `isInt` and `isFloat`
- mark TPCH q1 task as completed in Scala machine README

## Testing
- `go test ./compiler/x/scala -tags slow -run TestScalaCompilerGolden -count=1`
- `go test ./compiler/x/scala -tags slow -run TestScalaCompilerMachine -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6872b658751c8320841b19ce2ea5a13d