### PR TITLE
Remove outdated header env

### DIFF
--- a/compiler/meta/meta.go
+++ b/compiler/meta/meta.go
@@ -26,13 +26,7 @@ func Version() string {
 // (e.g. "//" or "#").
 func Header(prefix string) []byte {
 	t := time.Now().UTC()
-	if v := os.Getenv("MOCHI_HEADER_TIME"); v != "" {
-		if ts, err := time.Parse(time.RFC3339, v); err == nil {
-			t = ts
-		} else if secs, err := strconv.ParseInt(v, 10, 64); err == nil {
-			t = time.Unix(secs, 0).UTC()
-		}
-	} else if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
+	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
 		if secs, err := strconv.ParseInt(v, 10, 64); err == nil {
 			t = time.Unix(secs, 0).UTC()
 		}

--- a/compiler/x/ex/tpch_golden_test.go
+++ b/compiler/x/ex/tpch_golden_test.go
@@ -38,7 +38,6 @@ func TestExCompiler_TPCHQueries(t *testing.T) {
 	if err := excode.EnsureElixir(); err != nil {
 		t.Skipf("elixir not installed: %v", err)
 	}
-	os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
 	root := repoRoot(t)
 	for i := 1; i <= 4; i++ {
 		base := fmt.Sprintf("q%d", i)


### PR DESCRIPTION
## Summary
- simplify header timestamp logic
- stop setting `MOCHI_HEADER_TIME` in Ex compiler test

## Testing
- `go test ./compiler/x/ex -tags slow -run TestExCompiler_TPCHQueries -count=1` *(fails: Main.main)*

------
https://chatgpt.com/codex/tasks/task_e_6872b59cb7f48320bc219521d1ed98c1