### PR TITLE
Improve Kotlin compiler runtime

### DIFF
--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -112,3 +112,4 @@ The table below lists every Mochi example and whether the generated Kotlin code 
 - Implement dataset join and group-by operations in the Kotlin backend.
 - Provide better support for the Python `math` helpers and other foreign imports.
 - Finish compiling the remaining unchecked programs above.
+- Extend numeric helpers so TPCH query `q1.mochi` compiles and runs.


### PR DESCRIPTION
## Summary
- enhance Kotlin runtime with `_sum` helper for floating point totals
- use `_sum` when summing lists of unknown numeric type
- document TPCH task in Kotlin machine README

## Testing
- `go test -tags=slow ./compiler/x/kotlin -run TestKotlinPrograms -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_6872b09405888320be6377b3dcd0b1b5