### PR TITLE
Ensure deterministic Elixir TPCH tests

### DIFF
--- a/compiler/x/ex/compiler_test.go
+++ b/compiler/x/ex/compiler_test.go
@@ -116,6 +116,8 @@ func findRepoRoot(t *testing.T) string {
 }
 
 func TestMain(m *testing.M) {
+	// Ensure generated headers are deterministic for golden tests
+	os.Setenv("SOURCE_DATE_EPOCH", "1136214245")
 	code := m.Run()
 	updateReadme()
 	os.Exit(code)


### PR DESCRIPTION
## Summary
- make Elixir compiler tests set `SOURCE_DATE_EPOCH`
- keeps header timestamps stable so golden tests pass

## Testing
- `go test ./compiler/x/ex -run TestExCompiler_TPCHQueries -tags=slow -v`

------
https://chatgpt.com/codex/tasks/task_e_68730d175ed883209419a6ccba1899fc