### PR TITLE
Improve Rust compiler output

### DIFF
--- a/tests/machine/x/rust/README.md
+++ b/tests/machine/x/rust/README.md
@@ -120,3 +120,5 @@ Compiled programs: 100/100
 - [ ] Enhance type inference for nested structs
 - [ ] Implement benchmarking harness
 - [ ] Add code formatting similar to rustfmt
+
+- [ ] Compile `tpc-h/q1.mochi` with Rust compiler (derive `PartialOrd` for key structs and cast int literals to `f64` when mixing with floats)

--- a/tests/machine/x/rust/cross_join.rs
+++ b/tests/machine/x/rust/cross_join.rs
@@ -1,17 +1,17 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
     total: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     orderId: i32,
     orderCustomerId: i32,

--- a/tests/machine/x/rust/cross_join_filter.rs
+++ b/tests/machine/x/rust/cross_join_filter.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     n: i32,
     l: &'static str,

--- a/tests/machine/x/rust/cross_join_triple.rs
+++ b/tests/machine/x/rust/cross_join_triple.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     n: i32,
     l: &'static str,

--- a/tests/machine/x/rust/dataset_sort_take_limit.rs
+++ b/tests/machine/x/rust/dataset_sort_take_limit.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Product {
     name: &'static str,
     price: i32,

--- a/tests/machine/x/rust/dataset_where_filter.rs
+++ b/tests/machine/x/rust/dataset_where_filter.rs
@@ -1,10 +1,10 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct People {
     name: &'static str,
     age: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     name: &'static str,
     age: i32,

--- a/tests/machine/x/rust/group_by.rs
+++ b/tests/machine/x/rust/group_by.rs
@@ -1,17 +1,17 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct People {
     name: &'static str,
     age: i32,
     city: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Group {
     key: &'static str,
     items: Vec<People>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Result {
     city: &'static str,
     count: i32,

--- a/tests/machine/x/rust/group_by_conditional_sum.rs
+++ b/tests/machine/x/rust/group_by_conditional_sum.rs
@@ -1,17 +1,17 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     cat: &'static str,
     val: i32,
     flag: bool,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Group {
     key: &'static str,
     items: Vec<Item>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Result {
     cat: &'static str,
     share: f64,

--- a/tests/machine/x/rust/group_by_having.rs
+++ b/tests/machine/x/rust/group_by_having.rs
@@ -1,16 +1,16 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct People {
     name: &'static str,
     city: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Group {
     key: &'static str,
     items: Vec<People>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     city: &'static str,
     num: i32,

--- a/tests/machine/x/rust/group_by_join.rs
+++ b/tests/machine/x/rust/group_by_join.rs
@@ -1,28 +1,28 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     o: Order,
     c: Customer,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Group {
     key: &'static str,
     items: Vec<Item>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     name: &'static str,
     count: i32,

--- a/tests/machine/x/rust/group_by_left_join.rs
+++ b/tests/machine/x/rust/group_by_left_join.rs
@@ -1,28 +1,28 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     c: Customer,
     o: Order,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Group {
     key: &'static str,
     items: Vec<Item>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     name: &'static str,
     count: i32,

--- a/tests/machine/x/rust/group_by_multi_join.rs
+++ b/tests/machine/x/rust/group_by_multi_join.rs
@@ -1,16 +1,16 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Nation {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Supplier {
     id: i32,
     nation: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Partsupp {
     part: i32,
     supplier: i32,
@@ -18,19 +18,19 @@ struct Partsupp {
     qty: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Result {
     part: i32,
     value: f64,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Group {
     key: i32,
     items: Vec<Result>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Result1 {
     part: i32,
     total: f64,

--- a/tests/machine/x/rust/group_by_multi_join_sort.rs
+++ b/tests/machine/x/rust/group_by_multi_join_sort.rs
@@ -1,10 +1,10 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Nation {
     n_nationkey: i32,
     n_name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Customer {
     c_custkey: i32,
     c_name: &'static str,
@@ -15,14 +15,14 @@ struct Customer {
     c_comment: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     o_orderkey: i32,
     o_custkey: i32,
     o_orderdate: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Lineitem {
     l_orderkey: i32,
     l_returnflag: &'static str,
@@ -30,7 +30,7 @@ struct Lineitem {
     l_discount: f64,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Key {
     c_custkey: i32,
     c_name: &'static str,
@@ -41,7 +41,7 @@ struct Key {
     n_name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Item {
     c: Customer,
     o: Order,
@@ -49,13 +49,13 @@ struct Item {
     n: Nation,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Group {
     key: Key,
     items: Vec<Item>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 struct Result {
     c_custkey: i32,
     c_name: &'static str,

--- a/tests/machine/x/rust/group_by_sort.rs
+++ b/tests/machine/x/rust/group_by_sort.rs
@@ -1,16 +1,16 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     cat: &'static str,
     val: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Group {
     key: &'static str,
     items: Vec<Item>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     cat: &'static str,
     total: i32,

--- a/tests/machine/x/rust/group_items_iteration.rs
+++ b/tests/machine/x/rust/group_items_iteration.rs
@@ -1,16 +1,16 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Data {
     tag: &'static str,
     val: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Group {
     key: &'static str,
     items: Vec<Data>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     tag: &'static str,
     total: i32,

--- a/tests/machine/x/rust/inner_join.rs
+++ b/tests/machine/x/rust/inner_join.rs
@@ -1,17 +1,17 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
     total: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     orderId: i32,
     customerName: &'static str,

--- a/tests/machine/x/rust/join_multi.rs
+++ b/tests/machine/x/rust/join_multi.rs
@@ -1,22 +1,22 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     orderId: i32,
     sku: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     name: &'static str,
     sku: &'static str,

--- a/tests/machine/x/rust/left_join.rs
+++ b/tests/machine/x/rust/left_join.rs
@@ -1,17 +1,17 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
     total: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     orderId: i32,
     customer: Customer,

--- a/tests/machine/x/rust/left_join_multi.rs
+++ b/tests/machine/x/rust/left_join_multi.rs
@@ -1,22 +1,22 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     orderId: i32,
     sku: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     orderId: i32,
     name: &'static str,

--- a/tests/machine/x/rust/load_yaml.rs
+++ b/tests/machine/x/rust/load_yaml.rs
@@ -5,7 +5,7 @@ struct Person {
         email: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     name: &'static str,
     email: &'static str,

--- a/tests/machine/x/rust/order_by_map.rs
+++ b/tests/machine/x/rust/order_by_map.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Data {
     a: i32,
     b: i32,

--- a/tests/machine/x/rust/outer_join.rs
+++ b/tests/machine/x/rust/outer_join.rs
@@ -1,17 +1,17 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
     total: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     order: Order,
     customer: Customer,

--- a/tests/machine/x/rust/right_join.rs
+++ b/tests/machine/x/rust/right_join.rs
@@ -1,17 +1,17 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Customer {
     id: i32,
     name: &'static str,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Order {
     id: i32,
     customerId: i32,
     total: i32,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Result {
     customerName: &'static str,
     order: Order,

--- a/tests/machine/x/rust/save_jsonl_stdout.rs
+++ b/tests/machine/x/rust/save_jsonl_stdout.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct People {
     name: &'static str,
     age: i32,

--- a/tests/machine/x/rust/sort_stable.rs
+++ b/tests/machine/x/rust/sort_stable.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Item {
     n: i32,
     v: &'static str,


### PR DESCRIPTION
## Summary
- support ordering derived structs with `PartialOrd` and `Ord`
- adjust numeric casting in `+` operations
- update generated Rust fixtures accordingly
- document TODO for TPCH q1

## Testing
- `go test -tags=slow ./compiler/x/rust -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68730da4c5f08320955c56a0452faae9