### PR TITLE
Improve C# compiler sum handling

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -2901,7 +2901,21 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return fmt.Sprintf("Enumerable.Sum(%s)", args[0]), nil
 		}
 		c.use("_sum")
-		return fmt.Sprintf("_sum(%s)", args[0]), nil
+		expr := fmt.Sprintf("_sum(%s)", args[0])
+		if lt, ok := t.(types.ListType); ok {
+			if isInt(lt.Elem) {
+				expr = fmt.Sprintf("(int)%s", expr)
+			} else if isInt64(lt.Elem) {
+				expr = fmt.Sprintf("(long)%s", expr)
+			}
+		} else if gt, ok := t.(types.GroupType); ok {
+			if isInt(gt.Elem) {
+				expr = fmt.Sprintf("(int)%s", expr)
+			} else if isInt64(gt.Elem) {
+				expr = fmt.Sprintf("(long)%s", expr)
+			}
+		}
+		return expr, nil
 	case "min":
 		if len(args) != 1 {
 			return "", fmt.Errorf("min() expects 1 arg")

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -109,5 +109,6 @@ Checklist:
 
 ## Remaining Tasks
 
-- [ ] Support dataset tpc-h/q1.mochi via dotnet
-
+- [ ] Fix numeric casting so `tpc-h/q1.mochi` compiles cleanly
+- [ ] Verify generated C# runs via `dotnet run`
+- [ ] Compare output against `tests/dataset/tpc-h/compiler/cs/q1.out`

--- a/types/infer.go
+++ b/types/infer.go
@@ -396,15 +396,19 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 					if _, ok := tt.Elem.(FloatType); ok {
 						return FloatType{}
 					}
-					return IntType{}
+					if isNumeric(tt.Elem) {
+						return FloatType{}
+					}
 				case GroupType:
 					if _, ok := tt.Elem.(FloatType); ok {
 						return FloatType{}
 					}
-					return IntType{}
+					if isNumeric(tt.Elem) {
+						return FloatType{}
+					}
 				}
 			}
-			return IntType{}
+			return FloatType{}
 		case "min", "max":
 			if len(p.Call.Args) == 1 {
 				t := ExprType(p.Call.Args[0], env)


### PR DESCRIPTION
## Summary
- improve C# compiler to cast `sum` results based on element type
- infer `sum()` as float to match runtime
- add remaining tasks for TPCH query compilation

## Testing
- `go test ./compiler/x/cs -run TestCSCompiler_TPCH_Q1 -count=1 -tags slow` *(fails: operator '==' cannot be applied)*

------
https://chatgpt.com/codex/tasks/task_e_68730f9530fc8320b805a93e39dcb14f