### PR TITLE
Improve Scala print generation

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -1086,7 +1086,15 @@ func (c *Compiler) compileExprStmt(s *parser.ExprStmt) error {
 		if len(args) == 1 {
 			c.writeln(fmt.Sprintf("println(%s)", args[0]))
 		} else {
-			c.writeln(fmt.Sprintf("println(%s)", strings.Join(args, " + \" \" + ")))
+			parts := make([]string, len(args))
+			for i, a := range args {
+				if strings.HasPrefix(a, "\"") && strings.HasSuffix(a, "\"") {
+					parts[i] = strings.Trim(a, "\"")
+				} else {
+					parts[i] = fmt.Sprintf("${%s}", a)
+				}
+			}
+			c.writeln(fmt.Sprintf("println(s\"%s\")", strings.Join(parts, " ")))
 		}
 		return nil
 	}

--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -109,6 +109,8 @@ Recent improvements:
 - Map literal values no longer include extraneous parentheses.
 - Conditional expressions used in print statements are now wrapped in
   parentheses for valid Scala syntax.
+- Print statements with multiple arguments now use Scala string
+  interpolation for clearer output.
 
 ## Remaining Tasks
 - [ ] Review generated Scala code for idiomatic style


### PR DESCRIPTION
## Summary
- generate Scala print statements with string interpolation when multiple arguments
- document the improvement in Scala machine README

## Testing
- `go test ./compiler/x/scala -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687312c29690832084edb829821fd39c