### PR TITLE
Update Go tools

### DIFF
--- a/compiler/x/go/tools.go
+++ b/compiler/x/go/tools.go
@@ -117,6 +117,9 @@ func EnsureGopls() error {
 // additional cleanup. The input is returned with a trailing newline.
 func FormatGo(src []byte) []byte {
 	header := meta.Header("//")
+	if os.Getenv("MOCHI_NO_HEADER") != "" {
+		header = nil
+	}
 	var prefix []byte
 	if bytes.HasPrefix(src, []byte("//go:")) || bytes.HasPrefix(src, []byte("// +build")) {
 		if i := bytes.IndexByte(src, '\n'); i != -1 {

--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -107,6 +107,7 @@ Checklist:
 - [x] var_assignment
 - [x] while_loop
 - [ ] q1.mochi
+- [ ] q2.mochi
 
 ## Remaining Tasks
 


### PR DESCRIPTION
## Summary
- allow skipping header generation via `MOCHI_NO_HEADER`
- track TPCH q1/q2 status in machine README

## Testing
- `go vet ./...`
- `go test ./compiler/x/go -run TestGoCompiler_ValidPrograms/append_builtin -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68730b923fc08320aa2c789b83845b5a