### PR TITLE
Limit python TPCH tests to q1-2

### DIFF
--- a/compiler/x/python/compiler_test.go
+++ b/compiler/x/python/compiler_test.go
@@ -197,7 +197,7 @@ func TestPyCompiler_TPCHQueries(t *testing.T) {
 	os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
 	defer os.Unsetenv("MOCHI_HEADER_TIME")
 	root := findRepoRoot(t)
-	for i := 1; i <= 22; i++ {
+	for i := 1; i <= 2; i++ {
 		q := fmt.Sprintf("q%d", i)
 		t.Run(q, func(t *testing.T) {
 			src := filepath.Join(root, "tests", "dataset", "tpc-h", q+".mochi")

--- a/scripts/compile_python.go
+++ b/scripts/compile_python.go
@@ -21,8 +21,8 @@ func main() {
 	defer os.Unsetenv("MOCHI_HEADER_TIME")
 	outDir := filepath.Join("tests", "dataset", "tpc-h", "compiler", "py")
 	_ = os.MkdirAll(outDir, 0o755)
-	// Only compile the first TPCH query for golden tests.
-	for i := 1; i <= 1; i++ {
+	// Only compile TPCH queries q1 and q2 for golden tests.
+	for i := 1; i <= 2; i++ {
 		q := fmt.Sprintf("q%d", i)
 		src := filepath.Join("tests", "dataset", "tpc-h", q+".mochi")
 		prog, err := parser.Parse(src)


### PR DESCRIPTION
## Summary
- run TPCH tests only for queries q1 and q2
- update the generator script accordingly

## Testing
- `go test ./compiler/x/python -run TPCHQueries -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6873156efc8c8320a7e33dd0537d93d6