### PR TITLE
Improve C compiler match defaults

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -1829,7 +1829,7 @@ func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) string {
 		c.writeln("default:")
 		c.indent++
 		if defaultVal == "" {
-			defaultVal = "0"
+			defaultVal = defaultCValue(retT)
 		}
 		c.writeln(fmt.Sprintf("%s = %s;", resVar, defaultVal))
 		c.writeln("break;")
@@ -1840,7 +1840,8 @@ func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) string {
 	}
 
 	target := c.compileExpr(m.Target)
-	expr := "0"
+	resT := c.exprType(m.Cases[0].Result)
+	expr := defaultCValue(resT)
 	for i := len(m.Cases) - 1; i >= 0; i-- {
 		pat := c.compileExpr(m.Cases[i].Pattern)
 		res := c.compileExpr(m.Cases[i].Result)


### PR DESCRIPTION
## Summary
- adjust C backend to use `defaultCValue` when compiling `match` expressions

## Testing
- `go test ./compiler/x/c -run TestCCompiler_ValidPrograms/match_full$ -tags slow -count=1 -v`
- `go test ./compiler/x/c -run TestCCompiler_ValidPrograms/two-sum$ -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_687314fc5cd083209068291fc9f94764