### PR TITLE
Update Scala compiler docs and print formatting

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -1103,6 +1103,10 @@ func (c *Compiler) compileExprStmt(s *parser.ExprStmt) error {
 			msg = strings.ReplaceAll(msg, " ,", ",")
 			msg = strings.ReplaceAll(msg, " ;", ";")
 			msg = strings.ReplaceAll(msg, " .", ".")
+			msg = strings.ReplaceAll(msg, " ?", "?")
+			msg = strings.ReplaceAll(msg, " !", "!")
+			msg = strings.ReplaceAll(msg, " )", ")")
+			msg = strings.ReplaceAll(msg, "( ", "(")
 			c.writeln(fmt.Sprintf("println(s\"%s\")", msg))
 		}
 		return nil

--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -119,3 +119,21 @@ Recent improvements:
 - [x] Investigate TPCH `q1.mochi` compilation failures and update helper
       functions as needed
 - [ ] Compile additional TPCH queries
+
+## Running the TPCH Q1 example
+
+To generate and run the Scala code for `q1.mochi`:
+
+1. Use `mochix` to compile the Mochi source:
+   ```bash
+   go run ./cmd/mochix buildx -t scala tests/dataset/tpc-h/q1.mochi > Main.scala
+   ```
+2. Compile the resulting Scala file:
+   ```bash
+   scalac Main.scala
+   ```
+3. Execute the program using `scala` (or `scala-cli`):
+   ```bash
+   scala Main
+   ```
+   The program prints the aggregated JSON result.


### PR DESCRIPTION
## Summary
- improve spacing around punctuation in Scala string interpolation
- document how to generate and run `q1.mochi` in Scala

## Testing
- `go test ./compiler/x/scala -run TestScalaCompilerMachine -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687317d429448320844097b4b09aa08a