### PR TITLE
Improve Kotlin grouped join types

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -1622,14 +1622,15 @@ func (c *Compiler) queryExpr(q *parser.QueryExpr) (string, error) {
 			rowParts = append(rowParts, fmt.Sprintf("\"%s\" to %s", j.Var, j.Var))
 		}
 		var row string
+		rowType := kotlinTypeOf(elem)
 		if len(rowParts) == 1 {
 			if t, err := c.env.GetVar(q.Var); err == nil && isStructType(t) {
 				row = q.Var
 			} else {
-				row = "mutableMapOf(" + rowParts[0] + ") as MutableMap<Any?, Any?>"
+				row = fmt.Sprintf("mutableMapOf(%s) as %s", rowParts[0], rowType)
 			}
 		} else {
-			row = "mutableMapOf(" + strings.Join(rowParts, ", ") + ") as MutableMap<Any?, Any?>"
+			row = fmt.Sprintf("mutableMapOf(%s) as %s", strings.Join(rowParts, ", "), rowType)
 		}
 		b.WriteString(fmt.Sprintf("__g.add(%s)\n", row))
 	} else {

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -122,3 +122,4 @@ The table below lists every Mochi example and whether the generated Kotlin code 
 
 - Added support for pattern matching on union variants.
 - Grouped query results can now be sorted by group keys.
+- Fixed row type inference so grouped join results use proper map types.


### PR DESCRIPTION
## Summary
- refine grouped join logic in Kotlin compiler so row elements keep map types
- note fix in Kotlin machine README

## Testing
- `gofmt -w compiler/x/kotlin/compiler.go`

------
https://chatgpt.com/codex/tasks/task_e_6873190a53fc8320b622388971fff5de