### PR TITLE
Improve C# equality handling

### DIFF
--- a/compiler/x/cs/runtime.go
+++ b/compiler/x/cs/runtime.go
@@ -282,6 +282,16 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("return Convert.ToDouble(a) == Convert.ToDouble(b);")
 				c.indent--
 				c.writeln("}")
+				c.writeln("if (a != null && b != null && a.GetType() != b.GetType()) {")
+				c.indent++
+				c.writeln("return JsonSerializer.Serialize(a) == JsonSerializer.Serialize(b);")
+				c.indent--
+				c.writeln("}")
+				c.writeln("if (a != null && b != null && !a.GetType().IsPrimitive && !b.GetType().IsPrimitive && a is not string && b is not string) {")
+				c.indent++
+				c.writeln("return JsonSerializer.Serialize(a) == JsonSerializer.Serialize(b);")
+				c.indent--
+				c.writeln("}")
 				c.writeln("return Equals(a, b);")
 				c.indent--
 				c.writeln("}")


### PR DESCRIPTION
## Summary
- update C# compiler equality logic
- augment runtime `_equal` to handle mismatched object types
- keep machine README tasks

## Testing
- `go test ./compiler/x/cs -tags slow -run TestCSCompiler_TPCH_Q1 -count=1` *(fails: output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6873145cd3588320b92ffcd3f280c968