### PR TITLE
Add v0.10.25 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # 📦 CHANGELOG.md
+## [0.10.25] – 2025-07-13T09:42:07+07:00
+
+### Added
+
+* TPCH queries 1–22 compiled across languages with golden outputs
+* Deterministic version headers for reproducible builds
+* New scripts and artifacts for dataset compilation
+
+### Changed
+
+* Zig infers structs for query results with improved group slices
+* C#, Java and Kotlin refine equality, comparisons and numeric handling
+* C and C++ simplify initialization with better match defaults
+* Rust and Python improve float casting and typed dataclasses
+
+### Fixed
+
+* C backend list helpers with dynamic loops
+* Build headers consistent across machines
+* Updated machine checklists for Go, Rust and others
+
+
 ## [0.10.24] – 2025-07-12T16:18:37+07:00
 
 ### Added
@@ -1512,5 +1534,6 @@ composability, and testability — ideal for intelligent tools, AI agents, and e
 - Testable components with minimal external dependencies
 - Self-contained golden test framework
 - Support for `Mochi` as a compiler backend or teaching tool
+
 
 

--- a/releases/v0.10.25.md
+++ b/releases/v0.10.25.md
@@ -1,0 +1,28 @@
+# Jul 2025 (v0.10.25)
+
+Released on Sun Jul 13 09:42:07 2025 +0700.
+
+Mochi v0.10.25 finalizes TPC‑H coverage across all compilers with deterministic headers and numerous code generation improvements. Language backends see refined type inference and printing while examples expand to queries 1‑22.
+
+## Examples
+
+- Generated artifacts for TPC‑H queries 1–22 across languages
+- Updated machine READMEs and golden outputs
+
+## Compilers
+
+- Zig infers structs for query results and handles group slices
+- C#, Java and Kotlin improve equality checks, integer division and map typing
+- C and C++ compilers simplify initialization and match defaults
+- Rust and Python better handle float casting and typed dataclasses
+- TypeScript, Dart and Ex/Erlang gain full TPCH support
+- Added version headers with deterministic timestamps
+
+## Runtime
+
+- C backend fixes list helpers and supports dynamic list loops
+
+## Documentation
+
+- Task checklists updated for Go, Rust, Kotlin and more
+


### PR DESCRIPTION
## Summary
- add release notes for v0.10.25
- update CHANGELOG

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68731d5720448320a7c75bb6348b0c66