### PR TITLE
Note struct issue in Go TPCH tests

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -14,4 +14,6 @@ determine why `q7` is skipped during compilation.
 
 TPC-H progress:
 
-- `q1` and `q2` now compile and execute successfully with the Go backend.
+- `q1` and `q2` compile with the Go backend, but the generated programs lack
+  several struct type definitions. This prevents the golden tests from running
+  the code with `go run`.


### PR DESCRIPTION
## Summary
- document Go backend struct issue for TPC-H queries

## Testing
- `go test ./... -run TPCH -tags slow` *(fails: build issues)*

------
https://chatgpt.com/codex/tasks/task_e_68732d6ff8188320bb8ab4023985c57d