### PR TITLE
Improve F# compiler inference

### DIFF
--- a/compiler/x/fs/TASKS.md
+++ b/compiler/x/fs/TASKS.md
@@ -1,0 +1,12 @@
+# F# Compiler Enhancement Notes
+
+## Recent Updates
+
+- 2025-07-13 05:03 - Added simple type inference for identifiers and selectors so
+  generated record fields use concrete types.
+
+## Remaining Work
+
+- [ ] Ensure `tpch/q1.mochi` builds by providing the required .NET assemblies.
+- [ ] Add coverage tests exercising dataset queries.
+- [ ] Continue refining inference to reduce `obj` usage.

--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -115,9 +115,14 @@ go test ./compiler/x/fs -tags slow
 All 100 example programs compile successfully and produce output matching the
 hand-written versions under `tests/human/x/fs`.
 
+## TPC-H Progress
+
+- [ ] `q1.mochi` – compiler now emits typed records but build still fails due to
+  missing `System.Text.Json` and other runtime references.
+
 ## Remaining Tasks
 
 - Ensure new features continue to compile correctly.
 - Keep generated code in sync with `tests/human/x/fs` when changes occur.
-- Investigate compilation of `tests/dataset/tpc-h/q1.mochi` which currently
-  fails due to missing .NET references and type inference issues.
+- Finish wiring .NET runtime references so `q1.mochi` builds.
+- Expand unit tests for the improved type inference logic.


### PR DESCRIPTION
## Summary
- improve type inference in the F# backend
- add a short TASKS file for the F# compiler
- document TPCH progress and remaining tasks

## Testing
- `go test ./compiler/x/fs -tags slow -run TestFSCompiler_TPCH -count=1` *(fails: missing .NET assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68733ba0e2ac83208b29fe18985d2bca