### PR TITLE
Improve Kotlin compiler README and tasks

### DIFF
--- a/compiler/x/kotlin/TASKS.md
+++ b/compiler/x/kotlin/TASKS.md
@@ -1,0 +1,13 @@
+# Kotlin Compiler Tasks
+
+## Recent Enhancements
+
+- 2025-07-13 04:59 UTC: Added README checklist for TPC-H q1 and improved formatting.
+
+## Remaining Work
+
+- [ ] Implement dataset join and group-by operations fully.
+- [ ] Better support foreign imports like Python `math` helpers.
+- [ ] Complete compilation of remaining unchecked programs.
+- [ ] Get TPC-H `q2.mochi` compiling and running.
+- [ ] Improve numeric division precision in queries.

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -109,6 +109,13 @@ The table below lists every Mochi example and whether the generated Kotlin code 
  - [x] q1.mochi (TPC-H)
  - [ ] q2.mochi (TPC-H)
 
+## Running TPC-H q1
+
+1. Ensure `kotlinc` and `java` are installed and on your `PATH`.
+2. Run `go test ./compiler/x/kotlin -tags slow -run TestKotlinCompiler_TPCH -count=1`.
+3. Generated code is written to `tests/machine/x/kotlin/q1.kt` with output in `q1.out`.
+4. Compare the output with the expected results.
+
 ## TODO
 
 - Implement dataset join and group-by operations in the Kotlin backend.


### PR DESCRIPTION
## Summary
- add Kotlin compiler tasks file
- document how to run the TPC-H q1 example in the Kotlin README

## Testing
- `go test ./compiler/x/kotlin -run TestKotlinPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68733cb2bbec83209906ef6cb9499cc3