### PR TITLE
Add PHP dataset checklist

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -1,0 +1,9 @@
+# PHP Backend Tasks
+
+## Recent Enhancements
+- 2025-07-13 05:02 - Generated machine README includes dataset progress checklist.
+
+## Remaining Work
+- [ ] Compile and run `tests/dataset/tpc-h/q1.mochi`
+- [ ] Improve runtime helpers for grouping and aggregation
+- [ ] Keep machine output close to human reference implementations

--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	meta "mochi/compiler/meta"
 	"mochi/parser"
 	"mochi/types"
 )
@@ -32,7 +31,6 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.indent = 0
 	c.needsJSON = false
 	c.writeln("<?php")
-	c.buf.Write(meta.Header("//"))
 	for _, s := range prog.Statements {
 		if err := c.compileStmt(s); err != nil {
 			return nil, err

--- a/compiler/x/php/compiler_test.go
+++ b/compiler/x/php/compiler_test.go
@@ -119,6 +119,8 @@ func updateReadme() {
 	fmt.Fprintf(&buf, "## Summary\n%d/%d files compiled successfully\n\n", compiled, total)
 	buf.WriteString("## Checklist\n")
 	buf.WriteString(strings.Join(lines, "\n"))
-	buf.WriteString("\n")
+	buf.WriteString("\n\n")
+	buf.WriteString("## Dataset Tasks\n")
+	buf.WriteString("- [ ] tpch/q1.mochi\n")
 	os.WriteFile(filepath.Join(outDir, "README.md"), buf.Bytes(), 0644)
 }

--- a/tests/machine/x/php/README.md
+++ b/tests/machine/x/php/README.md
@@ -106,3 +106,6 @@ This directory stores PHP code produced by the compiler tests. Each Mochi progra
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## Dataset Tasks
+- [ ] tpch/q1.mochi


### PR DESCRIPTION
## Summary
- update PHP compiler to omit version header for closer match with hand written code
- generate machine README with new dataset tasks section
- record outstanding work in `compiler/x/php/TASKS.md`

## Testing
- `go test ./compiler/x/php -run TestPHPCompiler_ValidPrograms -tags slow -count=1`
- `go test ./compiler/x/php -run TestPHPCompiler_TPCH -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68733cd627a48320a8f5c5efc1931c02