### PR TITLE
Improve pascal backend grouping

### DIFF
--- a/compiler/x/pascal/TASKS.md
+++ b/compiler/x/pascal/TASKS.md
@@ -1,0 +1,9 @@
+# Pascal Compiler Tasks
+
+## Recent Enhancements
+- [2025-07-13 05:05] Installed FPC in CI environment and regenerated Pascal outputs.
+- [2025-07-13 05:05] Fixed element type inference for grouped query results.
+
+## Remaining Work
+- [ ] Support advanced dataset queries required for TPC-H Q1.
+- [ ] Ensure all programs in `tests/vm/valid` compile without manual edits.


### PR DESCRIPTION
## Summary
- support grouped query element type inference in Pascal backend
- document recent changes in new TASKS checklist

## Testing
- `go test -tags slow ./compiler/x/pascal -run TestCompileValidPrograms -count=1 -timeout=0`

------
https://chatgpt.com/codex/tasks/task_e_68733cdfda388320a6b4b0c90d55e051