### PR TITLE
Improve Racket backend

### DIFF
--- a/compiler/x/racket/TASKS.md
+++ b/compiler/x/racket/TASKS.md
@@ -1,0 +1,11 @@
+# Racket Backend Progress
+
+Recent enhancements:
+
+- 2025-07-13 05:04 - Added string specialisation for `len` builtin. When the argument is a known string literal the compiler now emits `(string-length x)`.
+
+## Remaining Work
+
+- [ ] Investigate running `tests/dataset/tpc-h/q1.mochi` end-to-end.
+- [ ] Keep generated code aligned with manual translations under `tests/human/x/racket`.
+- [ ] Review query features such as `sort`, `skip`, and `take` for parity with other backends.

--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -518,12 +518,15 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 				return fmt.Sprintf("(length (hash-ref %s 'items))", args[0]), nil
 			}
 			return fmt.Sprintf("(length %s)", args[0]), nil
-		case "len":
-			if len(args) != 1 {
-				return "", fmt.Errorf("len expects 1 arg")
-			}
-			x := args[0]
-			return fmt.Sprintf("(cond [(string? %s) (string-length %s)] [(hash? %s) (hash-count %s)] [else (length %s)])", x, x, x, x, x), nil
+               case "len":
+                       if len(args) != 1 {
+                               return "", fmt.Errorf("len expects 1 arg")
+                       }
+                       x := args[0]
+                       if isStringExpr(p.Call.Args[0]) {
+                               return fmt.Sprintf("(string-length %s)", x), nil
+                       }
+                       return fmt.Sprintf("(cond [(string? %s) (string-length %s)] [(hash? %s) (hash-count %s)] [else (length %s)])", x, x, x, x, x), nil
 		case "min":
 			if len(args) != 1 {
 				return "", fmt.Errorf("min expects 1 arg")

--- a/tests/machine/x/racket/README.md
+++ b/tests/machine/x/racket/README.md
@@ -112,3 +112,4 @@ Compiled programs: 100/100
 - Ensure new features continue to compile correctly.
 - Keep generated code in sync with `tests/human/x/racket`.
 - Verify query features like `sort`, `skip`, and `take` remain accurate.
+- Work towards running `tests/dataset/tpc-h/q1.mochi` successfully.


### PR DESCRIPTION
## Summary
- specialize Racket `len` builtin for string literals
- add TODO tracker in `compiler/x/racket/TASKS.md`
- document outstanding work in the Racket machine README

## Testing
- `go test ./compiler/x/racket -run TestRacketCompiler -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68733d25ef408320bd11e095d3b480bf