### PR TITLE
Update Zig compiler for grouped slices

### DIFF
--- a/compiler/x/zig/TASKS.md
+++ b/compiler/x/zig/TASKS.md
@@ -1,0 +1,9 @@
+# Zig Backend Progress
+
+## Recent Enhancements
+- 2025-07-13 05:12 - Added `ensureGroupSlice` helper to avoid repeated `.Items.items` chains when iterating grouped data.
+
+## Remaining Work
+- Support struct field type inference for TPCH data sets.
+- Improve float aggregation for q3 query.
+- Confirm length handling for group expressions.

--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -1387,9 +1387,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		}
 		if gt, ok := c.inferExprType(q.Source).(types.GroupType); ok {
 			elemType = gt.Elem
-			if !strings.HasSuffix(src, ".Items") {
-				src += ".Items.items"
-			}
+			src = ensureGroupSlice(src)
 		}
 		child := types.NewEnv(c.env)
 		child.SetVar(q.Var, elemType, true)
@@ -1894,9 +1892,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		}
 		if gt, ok := c.inferExprType(q.Source).(types.GroupType); ok {
 			elemType = gt.Elem
-			if !strings.HasSuffix(src, ".Items") {
-				src += ".Items.items"
-			}
+			src = ensureGroupSlice(src)
 		}
 		child := types.NewEnv(c.env)
 		child.SetVar(q.Var, elemType, true)
@@ -2018,9 +2014,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	}
 	if gt, ok := c.inferExprType(q.Source).(types.GroupType); ok {
 		elemType = gt.Elem
-		if !strings.HasSuffix(src, ".Items") {
-			src += ".Items.items"
-		}
+		src = ensureGroupSlice(src)
 	}
 	child := types.NewEnv(c.env)
 	child.SetVar(q.Var, elemType, true)
@@ -4377,6 +4371,18 @@ func stripOuterParens(s string) string {
 		}
 	}
 	return s
+}
+
+// ensureGroupSlice ensures the correct ".Items.items" suffix is applied to a
+// group source expression without duplicating it.
+func ensureGroupSlice(src string) string {
+	if strings.HasSuffix(src, ".Items.items") || strings.HasSuffix(src, ".items") {
+		return src
+	}
+	if strings.HasSuffix(src, ".Items") {
+		return src + ".items"
+	}
+	return src + ".Items.items"
 }
 
 func (c *Compiler) rangeArgs(e *parser.Expr) (*parser.Expr, *parser.Expr, *parser.Expr, bool) {

--- a/tests/machine/x/zig/README.md
+++ b/tests/machine/x/zig/README.md
@@ -109,12 +109,13 @@ The files in this directory were produced by the Zig compiler tests. Each Mochi 
 - [x] while_loop.mochi
 
 ## Remaining Tasks
-* Improve handling of group slices to avoid extra `.Items.items` chains.
-* Implement missing struct field type inference for TPCH datasets.
-* Verify float field handling across TPCH queries (q2 works).
-* Continue work on TPCH q3 query; aggregation uses `_sum_int` instead of float.
+* [x] Group slices no longer emit repeated `.Items.items` chains.
+* [ ] Implement struct field type inference for TPCH datasets.
+* [ ] Verify float field handling across TPCH queries (q2 works).
+* [ ] Continue work on TPCH q3 query; aggregation uses `_sum_int` instead of float.
 
 ## Recent Improvements
+- Added helper `ensureGroupSlice` to simplify grouped list access.
 - Join group elements now include all joined rows for q3.
 - Generated Zig for q3 query compiles further but fails due to float sums.
 - Documentation checklist updated.


### PR DESCRIPTION
## Summary
- update Zig compiler to avoid repeating `.Items.items`
- track progress and future tasks in `compiler/x/zig/TASKS.md`
- document completed task and improvements in `tests/machine/x/zig/README.md`

## Testing
- `go vet -tags slow ./compiler/x/zig`
- `go test -tags slow ./compiler/x/zig -run TestZigCompiler_TPCH_Golden/q1 -count=1` *(fails: generated code mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68733d3b2d8883209dd2898f677f252e