### PR TITLE
Improve Swift compiler inference

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,0 +1,8 @@
+# Swift Compiler Progress
+
+## Recent Enhancements
+- 2025-07-13 05:09 – improved type inference for `append()` calls so list variables adopt the element type.
+
+## Remaining Work
+- [ ] Generate safer optional handling in join queries
+- [ ] Compile full TPC-H `q1.mochi` without manual adjustments

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -1604,6 +1604,13 @@ func (c *compiler) inferType(t *parser.TypeRef, val *parser.Expr) string {
 				return "list"
 			}
 		}
+		if p.Target.Call != nil && p.Target.Call.Func == "append" && len(p.Target.Call.Args) == 2 {
+			et := c.exprType(p.Target.Call.Args[1])
+			if et != "" {
+				return "list_" + et
+			}
+			return "list"
+		}
 	}
 	return ""
 }

--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -108,3 +108,11 @@ Compiled: 100/100 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
+
+## Remaining Tasks
+
+- Fix generation for `group_by_multi_join.mochi` and `group_by_multi_join_sort.mochi`.
+- Resolve runtime issues in `group_items_iteration.mochi`.
+- Implement outer and right join support.
+- Begin compiling the TPCH `q1.mochi` benchmark.
+


### PR DESCRIPTION
## Summary
- enhance type inference for append() expressions in Swift compiler
- add progress tracker and todo list
- document remaining tasks for the Swift machine output

## Testing
- `go test ./compiler/x/swift -run TestCompileValidPrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68733cfcf9648320ac3e78233440f0df