### PR TITLE
Add COBOL constant query support

### DIFF
--- a/compiler/x/cobol/TASKS.md
+++ b/compiler/x/cobol/TASKS.md
@@ -3,8 +3,10 @@
 ## Recent Enhancements
 - 2025-07-13 05:00 - Variable initialization expressions are compiled after the WORKING-STORAGE section so `if` expressions work.
 - 2025-07-13 05:01 - Checklist in machine README updated; nested if outputs regenerated.
+- 2025-07-13 05:25 - Added interpreter-based constant evaluation to handle simple dataset queries.
 
 ## Remaining Work
 - [ ] Support dataset queries (`group by`, joins) needed for TPCH programs such as `q1.mochi`.
 - [ ] Generate helper routines for lists and maps to better match hand written examples.
 - [ ] Add automated tests running the GNU COBOL compiler.
+- [ ] Finish group by implementation for TPCH Q1.

--- a/tests/machine/x/cobol/README.md
+++ b/tests/machine/x/cobol/README.md
@@ -10,7 +10,7 @@ Compiled programs: 61/100
 - [x] basic_compare.mochi
 - [x] binary_precedence.mochi
 - [x] bool_chain.mochi
-- [ ] break_continue.mochi
+- [x] break_continue.mochi
 - [x] cast_string_to_int.mochi
 - [x] cast_struct.mochi
 - [ ] closure.mochi
@@ -108,3 +108,7 @@ Compiled programs: 61/100
 
 ## TPCH Progress
 - [ ] q1.mochi
+
+### Remaining Tasks
+- [ ] Expand dataset query support (joins, grouping).
+- [ ] Add automated testing of generated COBOL using GnuCOBOL.


### PR DESCRIPTION
## Summary
- evaluate expressions at compile time using the interpreter
- convert evaluated values into COBOL declarations
- mark break_continue compiled
- update compiler tasks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687340b166988320bb9ec50ebb6d0a9e