### PR TITLE
Add Kotlin safe division helper and update docs

### DIFF
--- a/compiler/x/kotlin/TASKS.md
+++ b/compiler/x/kotlin/TASKS.md
@@ -3,11 +3,11 @@
 ## Recent Enhancements
 
 - 2025-07-13 04:59 UTC: Added README checklist for TPC-H q1 and improved formatting.
+- 2025-07-13 05:26 UTC: Added `div` helper for safe numeric division.
 
 ## Remaining Work
-
 - [ ] Implement dataset join and group-by operations fully.
-- [ ] Better support foreign imports like Python `math` helpers.
-- [ ] Complete compilation of remaining unchecked programs.
+- [ ] Improve foreign import support (Python `math`, etc.).
+- [ ] Compile the remaining unchecked programs.
 - [ ] Get TPC-H `q2.mochi` compiling and running.
 - [ ] Improve numeric division precision in queries.

--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -26,6 +26,11 @@ var runtimePieces = map[string]string{
     for (n in list) s += toDouble(n)
     return s / list.size
 }`,
+	"div": `fun div(a: Any?, b: Any?): Double {
+    val x = toDouble(a)
+    val y = toDouble(b)
+    return if (y == 0.0) 0.0 else x / y
+}`,
 	"count":  `fun count(list: Collection<Any?>): Int = list.size`,
 	"exists": `fun exists(list: Collection<Any?>): Boolean = list.isNotEmpty()`,
 	"values": `fun <T> values(m: Map<*, T>): MutableList<T> = m.values.toMutableList()`,
@@ -170,7 +175,7 @@ var runtimePieces = map[string]string{
 	"Group": `class Group<K, T>(val key: K, val items: MutableList<T>) : MutableList<T> by items`,
 }
 
-var runtimeOrder = []string{"append", "avg", "count", "exists", "values", "len", "max", "min", "sum", "str", "substring", "toInt", "toDouble", "toBool", "union", "except", "intersect", "_load", "loadYamlSimple", "parseSimpleValue", "_save", "json", "toJson", "Group"}
+var runtimeOrder = []string{"append", "avg", "div", "count", "exists", "values", "len", "max", "min", "sum", "str", "substring", "toInt", "toDouble", "toBool", "union", "except", "intersect", "_load", "loadYamlSimple", "parseSimpleValue", "_save", "json", "toJson", "Group"}
 
 func buildRuntime(used map[string]bool) string {
 	var parts []string
@@ -902,7 +907,12 @@ func (c *Compiler) binary(b *parser.BinaryExpr) (string, error) {
 				}
 			}
 		}
-		res = fmt.Sprintf("%s %s %s", res, op.Op, r)
+		if op.Op == "/" && (isAnyType(lType) || isAnyType(rType)) {
+			c.use("div")
+			res = fmt.Sprintf("div(%s, %s)", res, r)
+		} else {
+			res = fmt.Sprintf("%s %s %s", res, op.Op, r)
+		}
 		lType = rType
 	}
 	return res, nil

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -111,19 +111,26 @@ The table below lists every Mochi example and whether the generated Kotlin code 
 
 ## Running TPC-H q1
 
-1. Ensure `kotlinc` and `java` are installed and on your `PATH`.
-2. Run `go test ./compiler/x/kotlin -tags slow -run TestKotlinCompiler_TPCH -count=1`.
-3. Generated code is written to `tests/machine/x/kotlin/q1.kt` with output in `q1.out`.
-4. Compare the output with the expected results.
+Follow the steps below to compile and run the first TPC‑H query:
+
+1. **Install tools** &mdash; ensure `kotlinc` and `java` are available on your `PATH`.
+2. **Generate the program** by running:
+
+   ```bash
+   go test ./compiler/x/kotlin -tags slow -run TestKotlinCompiler_TPCH -count=1
+   ```
+
+   This writes `q1.kt` and its output `q1.out` to this directory.
+3. **Review** the generated Kotlin source and compare `q1.out` to the expected
+   results in `tests/dataset/tpc-h/compiler/kt/q1.out`.
 
 ## TODO
 
-- Implement dataset join and group-by operations in the Kotlin backend.
-- Provide better support for the Python `math` helpers and other foreign imports.
-- Finish compiling the remaining unchecked programs above.
-- Get TPC-H `q2.mochi` compiling and running successfully.
-- Improve numeric division so queries like `q1.mochi` compute floating point
-  results correctly.
+- [ ] Implement dataset join and group-by operations in the Kotlin backend.
+- [ ] Provide better support for the Python `math` helpers and other foreign imports.
+- [ ] Finish compiling the remaining unchecked programs above.
+- [ ] Get TPC-H `q2.mochi` compiling and running successfully.
+- [ ] Improve numeric division so queries like `q1.mochi` compute floating point results correctly.
 
 ## Recent improvements
 


### PR DESCRIPTION
## Summary
- add `div` runtime helper for Kotlin backend
- use the helper when dividing unknown numeric types
- record the improvement in `TASKS.md`
- improve Kotlin machine README with clearer q1 instructions and checkbox TODO list

## Testing
- `go vet -tags slow ./compiler/x/kotlin`
- `go test -c -tags slow ./compiler/x/kotlin`

------
https://chatgpt.com/codex/tasks/task_e_6873423b0dd483208dd588efddf02380