### PR TITLE
Improve fs compiler inference

### DIFF
--- a/compiler/x/fs/TASKS.md
+++ b/compiler/x/fs/TASKS.md
@@ -4,9 +4,12 @@
 
 - 2025-07-13 05:03 - Added simple type inference for identifiers and selectors so
   generated record fields use concrete types.
+- 2025-07-13 05:19 - Fixed binary expression inference crash by wrapping
+  the left-hand side in an `Expr` node.
 
 ## Remaining Work
 
 - [ ] Ensure `tpch/q1.mochi` builds by providing the required .NET assemblies.
+- [ ] Generate F# code for `tpch/q1.mochi` during tests.
 - [ ] Add coverage tests exercising dataset queries.
 - [ ] Continue refining inference to reduce `obj` usage.

--- a/compiler/x/fs/compiler.go
+++ b/compiler/x/fs/compiler.go
@@ -1859,7 +1859,8 @@ func (c *Compiler) inferType(e *parser.Expr) string {
 	}
 
 	if e.Binary != nil && len(e.Binary.Right) > 0 {
-		t := c.inferType(e.Binary.Left.Value)
+		// Infer type from the left-hand side of a binary expression.
+		t := c.inferType(&parser.Expr{Binary: &parser.BinaryExpr{Left: e.Binary.Left}})
 		if t != "obj" {
 			return t
 		}

--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -117,12 +117,13 @@ hand-written versions under `tests/human/x/fs`.
 
 ## TPC-H Progress
 
-- [ ] `q1.mochi` – compiler now emits typed records but build still fails due to
-  missing `System.Text.Json` and other runtime references.
+- [x] Generated F# code for `q1.mochi`.
+- [ ] Provide `System.Text.Json` and other runtime references so it builds.
+- [ ] Run the compiled program and compare output.
 
 ## Remaining Tasks
 
-- Ensure new features continue to compile correctly.
-- Keep generated code in sync with `tests/human/x/fs` when changes occur.
-- Finish wiring .NET runtime references so `q1.mochi` builds.
-- Expand unit tests for the improved type inference logic.
+- [ ] Ensure new features continue to compile correctly.
+- [ ] Keep generated code in sync with `tests/human/x/fs` when changes occur.
+- [ ] Finish wiring .NET runtime references so `q1.mochi` builds.
+- [ ] Expand unit tests for the improved type inference logic.


### PR DESCRIPTION
## Summary
- fix panic in fs compiler type inference
- update F# compiler task list
- track progress of tpch q1 in the fs machine README

## Testing
- `go test ./compiler/x/fs -run TestFSCompiler_TPCH -tags slow -count=1 -v` *(fails: fsharpc not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687340f123088320b82db92adb9680f3