### PR TITLE
Fix Scheme comparison helper logic

### DIFF
--- a/compiler/x/scheme/compiler.go
+++ b/compiler/x/scheme/compiler.go
@@ -994,13 +994,9 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 					c.needListOps = true
 					expr = fmt.Sprintf("(_intersect %s %s)", l, r)
 				case "<", "<=", ">", ">=":
-					if !(strFlags[i] || strFlags[i+1] || listFlags[i] || listFlags[i+1]) {
-						expr = fmt.Sprintf("(%s %s %s)", op, l, r)
-					} else {
-						fn := map[string]string{"<": "_lt", "<=": "_le", ">": "_gt", ">=": "_ge"}[op]
-						expr = fmt.Sprintf("(%s %s %s)", fn, l, r)
-						c.needDataset = true
-					}
+					fn := map[string]string{"<": "_lt", "<=": "_le", ">": "_gt", ">=": "_ge"}[op]
+					expr = fmt.Sprintf("(%s %s %s)", fn, l, r)
+					c.needDataset = true
 				}
 				operands[i] = expr
 				strFlags[i] = strFlags[i] || strFlags[i+1]


### PR DESCRIPTION
## Summary
- always use generic helpers for comparison operators in Scheme backend

## Testing
- `go test ./compiler/x/scheme -run TestNothing -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68734ae5c57083209916df099c3c9f17