### PR TITLE
Implement dictionary mode for C# compiler

### DIFF
--- a/compiler/x/cs/TASKS.md
+++ b/compiler/x/cs/TASKS.md
@@ -1,9 +1,9 @@
 # C# Compiler TODO
 
-## Recent Updates (2025-07-13 05:20)
-- Added JSON serialization options to include struct fields.
+## Recent Updates (2025-07-13 07:22)
+- Added `DictMode` option to emit dictionaries for anonymous structs.
 - Began work on tpc-h q1 support and group query detection.
 
 ## Remaining Work
-- Complete dictionary generation for grouped query results.
-- Verify property ordering matches golden outputs.
+- [ ] Verify dictionary generation for grouped query results across queries.
+- [ ] Ensure property ordering matches golden outputs.

--- a/compiler/x/cs/helpers.go
+++ b/compiler/x/cs/helpers.go
@@ -283,6 +283,9 @@ func (c *Compiler) findStructByFields(st types.StructType) (string, bool) {
 // compiled code can avoid "dynamic" fields. The returned type mirrors t but
 // with any unnamed structs replaced by named versions.
 func (c *Compiler) assignTypeNames(t types.Type, hint string) types.Type {
+	if c.DictMode {
+		return t
+	}
 	switch tt := t.(type) {
 	case types.StructType:
 		if tt.Name == "" {
@@ -312,6 +315,9 @@ func (c *Compiler) assignTypeNames(t types.Type, hint string) types.Type {
 // registerStructs adds all named struct types within t to the compiler
 // environment so later expressions can reference them by name.
 func (c *Compiler) registerStructs(t types.Type) {
+	if c.DictMode {
+		return
+	}
 	switch tt := t.(type) {
 	case types.StructType:
 		if tt.Name != "" && c.env != nil {

--- a/compiler/x/cs/tpch_test.go
+++ b/compiler/x/cs/tpch_test.go
@@ -30,7 +30,9 @@ func TestCSCompiler_TPCH_Q1(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	code, err := cscode.New(env).Compile(prog)
+	comp := cscode.New(env)
+	comp.DictMode = true
+	code, err := comp.Compile(prog)
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -106,8 +106,3 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-
-## Remaining Tasks
-
-- [ ] Complete dictionary generation for `tpc-h/q1.mochi`
-- [ ] Verify output order matches reference


### PR DESCRIPTION
## Summary
- add `DictMode` support in `compiler/x/cs` to emit dictionaries for anonymous structs
- tweak tpch test to enable dictionary compilation
- document new mode in `TASKS.md`
- update machine output notes for C#

## Testing
- `go test ./compiler/x/cs -run TestCSCompiler_TPCH_Q1 -tags slow -count=1` *(fails: dotnet run error)*

------
https://chatgpt.com/codex/tasks/task_e_68735cb276ec8320b9b70818e34df70e