### PR TITLE
Improve Go compiler and documentation

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -22,3 +22,11 @@ TPC-H progress:
 - 2025-07-13 07:13 - Ensured struct declarations are always written to the
   generated source.
 - 2025-07-13 07:30 - Began verifying TPCH q1 runtime output
+- 2025-07-13 08:04 - Skipped duplicate `_convSlice` calls and tidied printing
+  logic
+
+## Remaining Work
+
+- [ ] Validate TPCH q1 runtime results
+- [ ] Fix failing JOB query expectations
+- [ ] Investigate missing output for JOB q7

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -340,15 +340,19 @@ func (c *Compiler) castExpr(expr string, from, to types.Type) string {
 	}
 
 	// Handle list conversions specially to avoid unnecessary helper calls.
-	if fl, ok := from.(types.ListType); ok {
-		if tl, ok := to.(types.ListType); ok {
-			if equalTypes(fl.Elem, tl.Elem) {
-				return fmt.Sprintf("%s(%s)", toGo, expr)
-			}
-			c.use("_convSlice")
-			return fmt.Sprintf("_convSlice[%s,%s](%s)", goType(fl.Elem), goType(tl.Elem), expr)
-		}
-	}
+       if fl, ok := from.(types.ListType); ok {
+               if tl, ok := to.(types.ListType); ok {
+                       if equalTypes(fl.Elem, tl.Elem) {
+                               return fmt.Sprintf("%s(%s)", toGo, expr)
+                       }
+                       convPrefix := fmt.Sprintf("_convSlice[%s,%s](", goType(fl.Elem), goType(tl.Elem))
+                       if strings.HasPrefix(strings.TrimSpace(expr), convPrefix) {
+                               return expr
+                       }
+                       c.use("_convSlice")
+                       return fmt.Sprintf("_convSlice[%s,%s](%s)", goType(fl.Elem), goType(tl.Elem), expr)
+               }
+       }
 
 	if isString(from) {
 		c.imports["strconv"] = true

--- a/tests/machine/x/go/README.md
+++ b/tests/machine/x/go/README.md
@@ -109,16 +109,16 @@ Checklist:
 - [x] q1.mochi
 - [ ] q2.mochi
 
-### TPCH Progress
-
-- [ ] Confirm runtime output for `q1.mochi`
-
 ## Remaining Tasks
 
 - [ ] Simplify slice conversions and printing logic
 - [ ] Expand coverage to more examples in `tests/vm/valid`
 - [ ] Verify TPC-H `q1.mochi` output matches the VM
 - [x] Fix struct inference for dataset queries (e.g. `q1.mochi`)
+
+### TPCH Progress
+
+- [ ] Confirm runtime output for `q1.mochi`
 
 ### Recent Improvements
 

--- a/tests/machine/x/go/append_builtin.go
+++ b/tests/machine/x/go/append_builtin.go
@@ -19,8 +19,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/dataset_sort_take_limit.go
+++ b/tests/machine/x/go/dataset_sort_take_limit.go
@@ -304,9 +304,9 @@ func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
 }
 
 func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/machine/x/go/group_by_conditional_sum.go
+++ b/tests/machine/x/go/group_by_conditional_sum.go
@@ -86,7 +86,7 @@ func main() {
 		for _, g := range items {
 			results = append(results, Result{
 				g.Key,
-				(float64(_sum(func() []any {
+				(_sum(func() []any {
 					results := []any{}
 					for _, x := range g.Items {
 						results = append(results, func() any {
@@ -98,13 +98,13 @@ func main() {
 						}())
 					}
 					return results
-				}())) / float64(_sum(func() []any {
+				}()) / _sum(func() []any {
 					results := []any{}
 					for _, x := range g.Items {
 						results = append(results, _toAnyMap(x)["val"])
 					}
 					return results
-				}()))),
+				}())),
 			})
 		}
 		return results
@@ -157,8 +157,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/group_by_multi_join.go
+++ b/tests/machine/x/go/group_by_multi_join.go
@@ -106,8 +106,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/group_by_multi_join_sort.go
+++ b/tests/machine/x/go/group_by_multi_join_sort.go
@@ -185,8 +185,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/group_by_sort.go
+++ b/tests/machine/x/go/group_by_sort.go
@@ -117,8 +117,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/group_items_iteration.go
+++ b/tests/machine/x/go/group_items_iteration.go
@@ -72,8 +72,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/left_join.go
+++ b/tests/machine/x/go/left_join.go
@@ -317,9 +317,9 @@ func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
 }
 
 func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/machine/x/go/left_join_multi.go
+++ b/tests/machine/x/go/left_join_multi.go
@@ -361,9 +361,9 @@ func _query(src []any, joins []_joinSpec, opts _queryOpts) []any {
 }
 
 func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/machine/x/go/list_set_ops.go
+++ b/tests/machine/x/go/list_set_ops.go
@@ -100,8 +100,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/order_by_map.go
+++ b/tests/machine/x/go/order_by_map.go
@@ -57,8 +57,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}
@@ -322,9 +326,9 @@ func _sprint(v any) string {
 }
 
 func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/machine/x/go/outer_join.go
+++ b/tests/machine/x/go/outer_join.go
@@ -423,9 +423,9 @@ func _toAnyMap(m any) map[string]any {
 }
 
 func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/machine/x/go/query_sum_select.go
+++ b/tests/machine/x/go/query_sum_select.go
@@ -33,8 +33,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/right_join.go
+++ b/tests/machine/x/go/right_join.go
@@ -410,9 +410,9 @@ func _toAnyMap(m any) map[string]any {
 }
 
 func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/machine/x/go/slice.go
+++ b/tests/machine/x/go/slice.go
@@ -20,8 +20,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}

--- a/tests/machine/x/go/sort_stable.go
+++ b/tests/machine/x/go/sort_stable.go
@@ -54,8 +54,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}
@@ -319,9 +323,9 @@ func _sprint(v any) string {
 }
 
 func _toAnySlice[T any](s []T) []any {
-	out := []any{}
-	for _, v := range s {
-		out = append(out, v)
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/tests/machine/x/go/values_builtin.go
+++ b/tests/machine/x/go/values_builtin.go
@@ -23,8 +23,12 @@ func _print(args ...any) {
 			fmt.Print(" ")
 		}
 		first = false
+		if a == nil {
+			fmt.Print("<nil>")
+			continue
+		}
 		rv := reflect.ValueOf(a)
-		if a == nil || ((rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil()) {
+		if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice) && rv.IsNil() {
 			fmt.Print("<nil>")
 			continue
 		}


### PR DESCRIPTION
## Summary
- avoid redundant `_convSlice` calls when converting lists in Go compiler
- document recent Go backend changes
- update generated Go test outputs
- refresh machine README checklist

## Testing
- `MOCHI_NO_HEADER=1 go test ./compiler/x/go -run TestGoCompiler_ValidPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6873672a8d3c8320baa92009a0b0422a