### PR TITLE
Fix struct literal type propagation in C++ compiler

### DIFF
--- a/compiler/x/cpp/TASKS.md
+++ b/compiler/x/cpp/TASKS.md
@@ -5,6 +5,8 @@
   available only via a vector element type.
 - Added constant numeric folding in binary expressions.
 - Added unary constant folding for numeric and boolean values.
+- Added propagation of struct types for variables initialized with struct
+  literals (2025-07-13 09:21 UTC).
 
 ## Remaining Enhancements
 - [ ] Improve formatting to better match human examples.

--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -554,6 +554,8 @@ func (c *Compiler) compileLet(st *parser.LetStmt) error {
 		c.varStruct[st.Name] = s
 	} else if t := c.varStruct[exprStr]; t != "" {
 		c.varStruct[st.Name] = t
+	} else if t := c.structLiteralType(exprStr); t != "" {
+		c.varStruct[st.Name] = t
 	}
 	if et := c.extractVectorElemType(exprStr); et != "" {
 		c.elemType[st.Name] = et
@@ -638,6 +640,8 @@ func (c *Compiler) compileVar(st *parser.VarStmt) error {
 	if s := c.extractVectorStruct(exprStr); s != "" {
 		c.varStruct[st.Name] = s
 	} else if t := c.varStruct[exprStr]; t != "" {
+		c.varStruct[st.Name] = t
+	} else if t := c.structLiteralType(exprStr); t != "" {
 		c.varStruct[st.Name] = t
 	}
 	if et := c.extractVectorElemType(exprStr); et != "" {
@@ -2866,6 +2870,8 @@ func (c *Compiler) compileGroupedQueryExpr(q *parser.QueryExpr) (string, error) 
 	itemStruct := ""
 	if len(itemVars) == 1 {
 		if t := c.varStruct[itemVars[0]]; t != "" {
+			itemStruct = t
+		} else if t := c.elemType[itemVars[0]]; t != "" && c.isStructName(t) {
 			itemStruct = t
 		}
 	}


### PR DESCRIPTION
## Summary
- ensure variables assigned a struct literal record their struct type
- fallback to element type when deriving grouped query item structs
- note new enhancement in `TASKS.md`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68737766c8ec832092ea965fa864e4e6