### PR TITLE
Improve C# compiler struct literals

### DIFF
--- a/compiler/x/cs/TASKS.md
+++ b/compiler/x/cs/TASKS.md
@@ -1,9 +1,12 @@
 # C# Compiler TODO
 
-## Recent Updates (2025-07-13 07:22)
+## Recent Updates (2025-07-13 09:13)
 - Added `DictMode` option to emit dictionaries for anonymous structs.
 - Began work on tpc-h q1 support and group query detection.
+- Extracted struct literal generation into `compileStructLiteral` for cleaner
+  dictionary output.
 
 ## Remaining Work
 - [ ] Verify dictionary generation for grouped query results across queries.
 - [ ] Ensure property ordering matches golden outputs.
+- [ ] Run tpc-h q1 end-to-end using `DictMode`.

--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -106,3 +106,7 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+
+### Remaining Tasks
+
+- [ ] Compile and execute `tests/dataset/tpc-h/q1.mochi` using the C# backend.


### PR DESCRIPTION
## Summary
- add compileStructLiteral helper to centralise struct literal codegen
- type list elements as Dictionary when DictMode is on
- document remaining tasks in CS machine README
- update CS compiler tasks log

## Testing
- `go test ./compiler/x/cs -run TestCSCompiler_TPCH_Q1 -tags slow -count=1` *(fails: compile error)*

------
https://chatgpt.com/codex/tasks/task_e_68737789ca8c8320b8ac0ecf1fdedb6e