### PR TITLE
Improve cpp struct inference

### DIFF
--- a/compiler/x/cpp/TASKS.md
+++ b/compiler/x/cpp/TASKS.md
@@ -1,10 +1,12 @@
 # C++ Compiler Tasks
 
-## Recent Enhancements (2025-07-13 08:03 UTC)
+## Recent Enhancements (2025-07-13 09:34 UTC)
 - Improved struct field type inference when the base variable's struct type is
   available only via a vector element type.
 - Added constant numeric folding in binary expressions.
 - Added unary constant folding for numeric and boolean values.
+- Fallback to element type when variable struct info is missing in
+  `structFromVars`.
 
 ## Remaining Enhancements
 - [ ] Improve formatting to better match human examples.

--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -3543,6 +3543,8 @@ func (c *Compiler) structFromVars(names []string) string {
 			case "int", "double", "bool":
 				fieldType = typ
 			}
+		} else if t := c.elemType[n]; t != "" {
+			fieldType = t
 		}
 		info.Types[i] = fieldType
 	}

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -109,7 +109,7 @@ Compiled programs: 100/100
 
 ## TPCH Queries
 
-- [ ] q1 – still failing
+- [ ] q1 – compilation still fails due to struct type inference
 - [x] q4
 - [ ] q5 – compilation fails
 - [x] q6


### PR DESCRIPTION
## Summary
- enhance `structFromVars` to fall back on element type information when the
  variable's own struct type is unknown
- document TPCH compilation status in C++ README
- record recent enhancement in compiler tasks

## Testing
- `go test ./compiler/x/cpp -run TestCompilePrograms -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68737b5e35b08320b050c41d352592b6