### PR TITLE
Update C backend tasks

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -6,6 +6,7 @@ Initial work added support for generating C structs and list helpers when a prog
 ## Progress log
 
 - 2025-08-16 02:15 – Reviewed YAML and JSONL features; noted missing runtime helpers.
+- 2025-07-13 09:37 – Added experimental map-literal grouping for two string keys to begin TPC-H q1 support.
 
 - 2025-07-13 05:01 – Added struct printing and basic left join support so `left_join.mochi` and `left_join_multi.mochi` compile and run.
 - 2025-07-13 05:50 – Implemented list equality for struct elements and captured globals in test blocks. `update_stmt.mochi` now compiles and passes.

--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -1920,8 +1920,8 @@ func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) string {
 	if ml := asMapLiteral(l.With); ml != nil {
 		for _, it := range ml.Items {
 			if k, ok := identName(it.Key); ok && k == "format" {
-				if it.Value != nil && it.Value.Literal != nil && it.Value.Literal.String != nil {
-					format = strings.Trim(*it.Value.Literal.String, "\"")
+				if typ, val, ok := constLiteralTypeVal(it.Value); ok && typ == "char*" {
+					format = strings.Trim(val, "\"")
 				}
 			}
 		}

--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -118,3 +118,4 @@ Checklist:
 - [ ] python_math
 - [ ] save_jsonl_stdout
 - [ ] tpc-h q1 grouping
+- [ ] TPC-H q1 grouping (wip)


### PR DESCRIPTION
## Summary
- tweak YAML load parsing in C compiler
- note experimental map literal grouping for TPC-H q1
- note WIP TPC-H task in C machine README

## Testing
- `go build -tags slow ./compiler/x/c`

------
https://chatgpt.com/codex/tasks/task_e_68737bde840c8320a929ad2d70a88806