### PR TITLE
Improve cpp compiler docs

### DIFF
--- a/compiler/x/cpp/TASKS.md
+++ b/compiler/x/cpp/TASKS.md
@@ -7,6 +7,8 @@
 - Added unary constant folding for numeric and boolean values.
 - Fallback to element type when variable struct info is missing in
   `structFromVars`.
+- Added fallback to element type when inferring field types in map literals
+  (2025-07-13 09:51 UTC).
 
 ## Remaining Enhancements
 - [ ] Improve formatting to better match human examples.

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -116,4 +116,5 @@ Compiled programs: 100/100
 
 ## Remaining Tasks
 - [ ] Review generated C++ code for closer match to human examples
-- [ ] Implement compilation for TPCH q1 and q5
+- [ ] Continue improving struct type inference for TPCH q1
+- [ ] Implement compilation for TPCH q5


### PR DESCRIPTION
## Summary
- add documentation about fallback during map literal inference
- track outstanding TPCH tasks for cpp backend

## Testing
- `go test ./compiler/x/cpp -tags slow -run TestCompilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68737fd3f2fc832087f1dc727fe33044