### PR TITLE
Add Racket JOB dataset golden tests

### DIFF
--- a/compiler/x/racket/job_test.go
+++ b/compiler/x/racket/job_test.go
@@ -1,0 +1,69 @@
+//go:build slow
+
+package racket_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rack "mochi/compiler/x/racket"
+	"mochi/compiler/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestRacketCompiler_JOB_Golden(t *testing.T) {
+	if err := rack.EnsureRacket(); err != nil {
+		t.Skipf("racket not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 5; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := rack.New().Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCode, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "rkt", q+".rkt"))
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.rkt")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("racket", file)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("racket run error: %v\n%s", err, out)
+			}
+			gotRun := strings.TrimSpace(string(out))
+			wantRunBytes, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "rkt", q+".out"))
+			if err != nil {
+				t.Fatalf("read output golden: %v", err)
+			}
+			wantRun := strings.TrimSpace(string(wantRunBytes))
+			if gotRun != wantRun {
+				t.Errorf("%s runtime mismatch\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, gotRun, wantRun)
+			}
+		})
+	}
+}

--- a/tests/dataset/job/compiler/rkt/q1.rkt
+++ b/tests/dataset/job/compiler/rkt/q1.rkt
@@ -1,0 +1,11 @@
+#lang racket
+(require json)
+(define company_type (list (hash 'id 1 'kind "production companies") (hash 'id 2 'kind "distributors")))
+(define info_type (list (hash 'id 10 'info "top 250 rank") (hash 'id 20 'info "bottom 10 rank")))
+(define title (list (hash 'id 100 'title "Good Movie" 'production_year 1995) (hash 'id 200 'title "Bad Movie" 'production_year 2000)))
+(define movie_companies (list (hash 'movie_id 100 'company_type_id 1 'note "ACME (co-production)") (hash 'movie_id 200 'company_type_id 1 'note "MGM (as Metro-Goldwyn-Mayer Pictures)")))
+(define movie_info_idx (list (hash 'movie_id 100 'info_type_id 10) (hash 'movie_id 200 'info_type_id 20)))
+(define filtered (for*/list ([ct company_type] [mc movie_companies] [t title] [mi movie_info_idx] [it info_type] #:when (and (equal? (hash-ref ct 'id) (hash-ref mc 'company_type_id)) (equal? (hash-ref t 'id) (hash-ref mc 'movie_id)) (equal? (hash-ref mi 'movie_id) (hash-ref t 'id)) (equal? (hash-ref it 'id) (hash-ref mi 'info_type_id)) (and (and (and (string=? (hash-ref ct 'kind) "production companies") (string=? (hash-ref it 'info) "top 250 rank")) (not (regexp-match? (regexp "(as Metro-Goldwyn-Mayer Pictures)") (hash-ref mc 'note)))) (or (regexp-match? (regexp "(co-production)") (hash-ref mc 'note)) (regexp-match? (regexp "(presents)") (hash-ref mc 'note)))))) (hash 'note (hash-ref mc 'note) 'title (hash-ref t 'title) 'year (hash-ref t 'production_year))))
+(define result (hash 'production_note (apply min (for*/list ([r filtered]) (hash-ref r 'note))) 'movie_title (apply min (for*/list ([r filtered]) (hash-ref r 'title))) 'movie_year (apply min (for*/list ([r filtered]) (hash-ref r 'year)))))
+(displayln (jsexpr->string (list result)))
+(when (equal? result (hash 'production_note "ACME (co-production)" 'movie_title "Good Movie" 'movie_year 1995)) (displayln "ok"))

--- a/tests/dataset/job/compiler/rkt/q2.rkt
+++ b/tests/dataset/job/compiler/rkt/q2.rkt
@@ -1,0 +1,11 @@
+#lang racket
+(require json)
+(define company_name (list (hash 'id 1 'country_code "[de]") (hash 'id 2 'country_code "[us]")))
+(define keyword (list (hash 'id 1 'keyword "character-name-in-title") (hash 'id 2 'keyword "other")))
+(define movie_companies (list (hash 'movie_id 100 'company_id 1) (hash 'movie_id 200 'company_id 2)))
+(define movie_keyword (list (hash 'movie_id 100 'keyword_id 1) (hash 'movie_id 200 'keyword_id 2)))
+(define title (list (hash 'id 100 'title "Der Film") (hash 'id 200 'title "Other Movie")))
+(define titles (for*/list ([cn company_name] [mc movie_companies] [t title] [mk movie_keyword] [k keyword] #:when (and (equal? (hash-ref mc 'company_id) (hash-ref cn 'id)) (equal? (hash-ref mc 'movie_id) (hash-ref t 'id)) (equal? (hash-ref mk 'movie_id) (hash-ref t 'id)) (equal? (hash-ref mk 'keyword_id) (hash-ref k 'id)) (and (and (string=? (hash-ref cn 'country_code) "[de]") (string=? (hash-ref k 'keyword) "character-name-in-title")) (equal? (hash-ref mc 'movie_id) (hash-ref mk 'movie_id))))) (hash-ref t 'title)))
+(define result (apply min titles))
+(displayln (jsexpr->string result))
+(when (string=? result "Der Film") (displayln "ok"))

--- a/tests/dataset/job/compiler/rkt/q3.rkt
+++ b/tests/dataset/job/compiler/rkt/q3.rkt
@@ -1,0 +1,12 @@
+#lang racket
+(require racket/list)
+(require json)
+(define keyword (list (hash 'id 1 'keyword "amazing sequel") (hash 'id 2 'keyword "prequel")))
+(define movie_info (list (hash 'movie_id 10 'info "Germany") (hash 'movie_id 30 'info "Sweden") (hash 'movie_id 20 'info "France")))
+(define movie_keyword (list (hash 'movie_id 10 'keyword_id 1) (hash 'movie_id 30 'keyword_id 1) (hash 'movie_id 20 'keyword_id 1) (hash 'movie_id 10 'keyword_id 2)))
+(define title (list (hash 'id 10 'title "Alpha" 'production_year 2006) (hash 'id 30 'title "Beta" 'production_year 2008) (hash 'id 20 'title "Gamma" 'production_year 2009)))
+(define allowed_infos '("Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German"))
+(define candidate_titles (for*/list ([k keyword] [mk movie_keyword] [mi movie_info] [t title] #:when (and (equal? (hash-ref mk 'keyword_id) (hash-ref k 'id)) (equal? (hash-ref mi 'movie_id) (hash-ref mk 'movie_id)) (equal? (hash-ref t 'id) (hash-ref mi 'movie_id)) (and (and (and (regexp-match? (regexp "sequel") (hash-ref k 'keyword)) (cond [(string? allowed_infos) (regexp-match? (regexp (hash-ref mi 'info)) allowed_infos)] [(hash? allowed_infos) (hash-has-key? allowed_infos (hash-ref mi 'info))] [else (member (hash-ref mi 'info) allowed_infos)])) (> (hash-ref t 'production_year) 2005)) (equal? (hash-ref mk 'movie_id) (hash-ref mi 'movie_id))))) (hash-ref t 'title)))
+(define result (list (hash 'movie_title (apply min candidate_titles))))
+(displayln (jsexpr->string result))
+(when (equal? result (list (hash 'movie_title "Alpha"))) (displayln "ok"))

--- a/tests/dataset/job/compiler/rkt/q4.rkt
+++ b/tests/dataset/job/compiler/rkt/q4.rkt
@@ -1,0 +1,11 @@
+#lang racket
+(require json)
+(define info_type (list (hash 'id 1 'info "rating") (hash 'id 2 'info "other")))
+(define keyword (list (hash 'id 1 'keyword "great sequel") (hash 'id 2 'keyword "prequel")))
+(define title (list (hash 'id 10 'title "Alpha Movie" 'production_year 2006) (hash 'id 20 'title "Beta Film" 'production_year 2007) (hash 'id 30 'title "Old Film" 'production_year 2004)))
+(define movie_keyword (list (hash 'movie_id 10 'keyword_id 1) (hash 'movie_id 20 'keyword_id 1) (hash 'movie_id 30 'keyword_id 1)))
+(define movie_info_idx (list (hash 'movie_id 10 'info_type_id 1 'info "6.2") (hash 'movie_id 20 'info_type_id 1 'info "7.8") (hash 'movie_id 30 'info_type_id 1 'info "4.5")))
+(define rows (for*/list ([it info_type] [mi movie_info_idx] [t title] [mk movie_keyword] [k keyword] #:when (and (equal? (hash-ref it 'id) (hash-ref mi 'info_type_id)) (equal? (hash-ref t 'id) (hash-ref mi 'movie_id)) (equal? (hash-ref mk 'movie_id) (hash-ref t 'id)) (equal? (hash-ref k 'id) (hash-ref mk 'keyword_id)) (and (and (and (and (string=? (hash-ref it 'info) "rating") (regexp-match? (regexp "sequel") (hash-ref k 'keyword))) (string>? (hash-ref mi 'info) "5.0")) (> (hash-ref t 'production_year) 2005)) (equal? (hash-ref mk 'movie_id) (hash-ref mi 'movie_id))))) (hash 'rating (hash-ref mi 'info) 'title (hash-ref t 'title))))
+(define result (list (hash 'rating (apply min (for*/list ([r rows]) (hash-ref r 'rating))) 'movie_title (apply min (for*/list ([r rows]) (hash-ref r 'title))))))
+(displayln (jsexpr->string result))
+(when (equal? result (list (hash 'rating "6.2" 'movie_title "Alpha Movie"))) (displayln "ok"))

--- a/tests/dataset/job/compiler/rkt/q5.rkt
+++ b/tests/dataset/job/compiler/rkt/q5.rkt
@@ -1,0 +1,12 @@
+#lang racket
+(require racket/list)
+(require json)
+(define company_type (list (hash 'ct_id 1 'kind "production companies") (hash 'ct_id 2 'kind "other")))
+(define info_type (list (hash 'it_id 10 'info "languages")))
+(define title (list (hash 't_id 100 'title "B Movie" 'production_year 2010) (hash 't_id 200 'title "A Film" 'production_year 2012) (hash 't_id 300 'title "Old Movie" 'production_year 2000)))
+(define movie_companies (list (hash 'movie_id 100 'company_type_id 1 'note "ACME (France) (theatrical)") (hash 'movie_id 200 'company_type_id 1 'note "ACME (France) (theatrical)") (hash 'movie_id 300 'company_type_id 1 'note "ACME (France) (theatrical)")))
+(define movie_info (list (hash 'movie_id 100 'info "German" 'info_type_id 10) (hash 'movie_id 200 'info "Swedish" 'info_type_id 10) (hash 'movie_id 300 'info "German" 'info_type_id 10)))
+(define candidate_titles (for*/list ([ct company_type] [mc movie_companies] [mi movie_info] [it info_type] [t title] #:when (and (equal? (hash-ref mc 'company_type_id) (hash-ref ct 'ct_id)) (equal? (hash-ref mi 'movie_id) (hash-ref mc 'movie_id)) (equal? (hash-ref it 'it_id) (hash-ref mi 'info_type_id)) (equal? (hash-ref t 't_id) (hash-ref mc 'movie_id)) (and (and (and (and (string=? (hash-ref ct 'kind) "production companies") (cond [(string? (hash-ref mc 'note)) (regexp-match? (regexp "(theatrical)") (hash-ref mc 'note))] [(hash? (hash-ref mc 'note)) (hash-has-key? (hash-ref mc 'note) "(theatrical)")] [else (member "(theatrical)" (hash-ref mc 'note))])) (cond [(string? (hash-ref mc 'note)) (regexp-match? (regexp "(France)") (hash-ref mc 'note))] [(hash? (hash-ref mc 'note)) (hash-has-key? (hash-ref mc 'note) "(France)")] [else (member "(France)" (hash-ref mc 'note))])) (> (hash-ref t 'production_year) 2005)) (cond [(string? '("Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German")) (regexp-match? (regexp (hash-ref mi 'info)) '("Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German"))] [(hash? '("Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German")) (hash-has-key? '("Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German") (hash-ref mi 'info))] [else (member (hash-ref mi 'info) '("Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German"))])))) (hash-ref t 'title)))
+(define result (list (hash 'typical_european_movie (apply min candidate_titles))))
+(displayln (jsexpr->string result))
+(when (equal? result (list (hash 'typical_european_movie "A Film"))) (displayln "ok"))


### PR DESCRIPTION
## Summary
- add generated Racket code for JOB dataset queries q1–q5
- add golden test verifying compilation and runtime for these queries

## Testing
- `go test ./compiler/x/racket -tags slow -run JOB -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68738eefa6b48320a258c9faaaae6805