### PR TITLE
Add scheme JOB test scaffolding

### DIFF
--- a/compiler/x/scheme/compiler.go
+++ b/compiler/x/scheme/compiler.go
@@ -231,7 +231,7 @@ const groupHelpers = `(define (_count v)
     (when (not (null? lst))
       (set! m (car lst))
       (for-each (lambda (n)
-                  (when (> n m) (set! m n)))
+                  (when (_gt n m) (set! m n)))
                 (cdr lst)))
     m))
 
@@ -244,7 +244,7 @@ const groupHelpers = `(define (_count v)
     (when (not (null? lst))
       (set! m (car lst))
       (for-each (lambda (n)
-                  (when (< n m) (set! m n)))
+                  (when (_lt n m) (set! m n)))
                 (cdr lst)))
     m))
 (define (_group_by src keyfn)
@@ -264,7 +264,7 @@ const groupHelpers = `(define (_count v)
     (map (lambda (k) (cdr (assoc k groups))) order))))`
 
 const jsonHelper = `(define (_json v)
-  (write v)
+  (display (json->string v))
   (newline))`
 
 const testHelpers = `(define failures 0)

--- a/compiler/x/scheme/job_test.go
+++ b/compiler/x/scheme/job_test.go
@@ -1,0 +1,71 @@
+//go:build slow
+
+package schemecode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	schemecode "mochi/compiler/x/scheme"
+	"mochi/compiler/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestSchemeCompiler_JOB(t *testing.T) {
+	schemePath, err := schemecode.EnsureScheme()
+	if err != nil {
+		t.Skipf("scheme not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 5; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := schemecode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCodePath := filepath.Join(root, "tests", "dataset", "job", "compiler", "scheme", q+".scm.out")
+			wantCode, err := os.ReadFile(wantCodePath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s.scm.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.scm")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command(schemePath, "-m", "chibi", file)
+			cmd.Dir = root
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("scheme run error: %v\n%s", err, out)
+			}
+			gotOut := bytes.TrimSpace(out)
+			wantOutPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "scheme", q+".out")
+			wantOut, err := os.ReadFile(wantOutPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, gotOut, bytes.TrimSpace(wantOut))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add test for JOB query compilation in scheme backend
- extend runtime helpers for string comparisons
- improve JSON printing in scheme

## Testing
- `go test ./compiler/x/scheme -run TestSchemeCompiler_JOB -tags slow` *(fails: scheme run error)*

------
https://chatgpt.com/codex/tasks/task_e_68738f0153b883208a92d79eeccc4d04