### PR TITLE
Improve C runtime float printing

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -7,6 +7,7 @@ Initial work added support for generating C structs and list helpers when a prog
 
 - 2025-08-16 02:15 – Reviewed YAML and JSONL features; noted missing runtime helpers.
 - 2025-08-23 10:20 – Fixed relative path resolution in `compileLoadExpr` so `load_yaml.mochi` compiles.
+- 2025-07-13 10:05 – Increased float print precision to `%.17g` and updated list helpers so `python_math.mochi` matches expected output.
 - 2025-07-13 09:37 – Added experimental map-literal grouping for two string keys to begin TPC-H q1 support.
 
 - 2025-07-13 05:01 – Added struct printing and basic left join support so `left_join.mochi` and `left_join_multi.mochi` compile and run.

--- a/compiler/x/c/runtime.go
+++ b/compiler/x/c/runtime.go
@@ -719,7 +719,7 @@ static void _save_json(list_map_string rows,const char* path){ FILE* f=(!path||p
 	helperPrintListFloat = `static void _print_list_float(list_float v) {
     for (int i = 0; i < v.len; i++) {
         if (i > 0) printf(" ");
-        printf("%g", v.data[i]);
+        printf("%.17g", v.data[i]);
     }
 }`
 	helperPrintListString = `static void _print_list_string(list_string v) {


### PR DESCRIPTION
## Summary
- adjust C runtime float list printing to use 17-digit precision
- log the enhancement in TASKS

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6873842340848320b2630cd82ae8592c