### PR TITLE
Expand Scala JOB tests

### DIFF
--- a/compiler/x/scala/job_test.go
+++ b/compiler/x/scala/job_test.go
@@ -97,8 +97,10 @@ func runJOBQuery(t *testing.T, base string) {
 	}
 }
 
+// TestScalaCompilerJOB compiles and executes JOB dataset queries q1 through q10
+// and compares the results against golden .scala and .out files.
 func TestScalaCompilerJOB(t *testing.T) {
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 10; i++ {
 		base := fmt.Sprintf("q%d", i)
 		t.Run(base, func(t *testing.T) { runJOBQuery(t, base) })
 	}


### PR DESCRIPTION
## Summary
- run dataset JOB queries `q1` through `q10` for the Scala compiler
- document the extended coverage in tests

## Testing
- `go test ./compiler/x/scala -run TestScalaCompilerJOB -count=1 -tags slow`
- `go test ./compiler/x/scala -run TestScalaCompilerTPCH -count=1 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68739b2ea0b083209358eb742892d918