### PR TITLE
Extend PHP JOB tests to q10

### DIFF
--- a/compiler/x/php/job_golden_test.go
+++ b/compiler/x/php/job_golden_test.go
@@ -20,10 +20,10 @@ func TestPHPCompiler_JOB_Golden(t *testing.T) {
 		t.Skip("php not installed")
 	}
 	root := repoRoot(t)
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 10; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "job", base+".mochi")
-               codeWant := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", base+".php")
+		codeWant := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", base+".php")
 		outWant := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", base+".out")
 		if _, err := os.Stat(codeWant); err != nil {
 			continue
@@ -53,9 +53,9 @@ func TestPHPCompiler_JOB_Golden(t *testing.T) {
 			}
 			got := strip(code)
 			want := strip(wantCode)
-                       if !bytes.Equal(got, want) {
-                               t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base+".php", got, want)
-                       }
+			if !bytes.Equal(got, want) {
+				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base+".php", got, want)
+			}
 			dir := t.TempDir()
 			file := filepath.Join(dir, "main.php")
 			if err := os.WriteFile(file, code, 0644); err != nil {

--- a/compiler/x/php/job_test.go
+++ b/compiler/x/php/job_test.go
@@ -17,7 +17,7 @@ func TestPHPCompiler_JOB(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not installed")
 	}
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 10; i++ {
 		q := fmt.Sprintf("q%d", i)
 		testutil.CompileJOB(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
 			return phpcode.New(env).Compile(prog)

--- a/tests/dataset/job/compiler/php/q10.php
+++ b/tests/dataset/job/compiler/php/q10.php
@@ -1,119 +1,108 @@
 <?php
-function mochi_test_Q10_finds_uncredited_voice_actor_in_Russian_movie() {
-	global $result, $russian_movie, $uncredited_voiced_character;
-	if (!(($result == [["uncredited_voiced_character" => "Ivan", "russian_movie" => "Vodka Dreams"]]))) { throw new Exception('expect failed'); }
-}
-
-$char_name = [["id" => 1, "name" => "Ivan"], ["id" => 2, "name" => "Alex"]];
-$cast_info = [["movie_id" => 10, "person_role_id" => 1, "role_id" => 1, "note" => "Soldier (voice) (uncredited)"], ["movie_id" => 11, "person_role_id" => 2, "role_id" => 1, "note" => "(voice)"]];
-$company_name = [["id" => 1, "country_code" => "[ru]"], ["id" => 2, "country_code" => "[us]"]];
+$char_name = [
+    ["id" => 1, "name" => "Ivan"],
+    ["id" => 2, "name" => "Alex"]
+];
+$cast_info = [
+    [
+        "movie_id" => 10,
+        "person_role_id" => 1,
+        "role_id" => 1,
+        "note" => "Soldier (voice) (uncredited)"
+    ],
+    [
+        "movie_id" => 11,
+        "person_role_id" => 2,
+        "role_id" => 1,
+        "note" => "(voice)"
+    ]
+];
+$company_name = [
+    ["id" => 1, "country_code" => "[ru]"],
+    ["id" => 2, "country_code" => "[us]"]
+];
 $company_type = [["id" => 1], ["id" => 2]];
-$movie_companies = [["movie_id" => 10, "company_id" => 1, "company_type_id" => 1], ["movie_id" => 11, "company_id" => 2, "company_type_id" => 1]];
-$role_type = [["id" => 1, "role" => "actor"], ["id" => 2, "role" => "director"]];
-$title = [["id" => 10, "title" => "Vodka Dreams", "production_year" => 2006], ["id" => 11, "title" => "Other Film", "production_year" => 2004]];
+$movie_companies = [
+    [
+        "movie_id" => 10,
+        "company_id" => 1,
+        "company_type_id" => 1
+    ],
+    [
+        "movie_id" => 11,
+        "company_id" => 2,
+        "company_type_id" => 1
+    ]
+];
+$role_type = [
+    ["id" => 1, "role" => "actor"],
+    ["id" => 2, "role" => "director"]
+];
+$title = [
+    [
+        "id" => 10,
+        "title" => "Vodka Dreams",
+        "production_year" => 2006
+    ],
+    [
+        "id" => 11,
+        "title" => "Other Film",
+        "production_year" => 2004
+    ]
+];
 $matches = (function() use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) {
-	$_src = $char_name;
-	return _query($_src, [
-		[ 'items' => $cast_info, 'on' => function($chn, $ci) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($chn['id'] == $ci['person_role_id']); } ],
-		[ 'items' => $role_type, 'on' => function($chn, $ci, $rt) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($rt['id'] == $ci['role_id']); } ],
-		[ 'items' => $title, 'on' => function($chn, $ci, $rt, $t) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($t['id'] == $ci['movie_id']); } ],
-		[ 'items' => $movie_companies, 'on' => function($chn, $ci, $rt, $t, $mc) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($mc['movie_id'] == $t['id']); } ],
-		[ 'items' => $company_name, 'on' => function($chn, $ci, $rt, $t, $mc, $cn) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($cn['id'] == $mc['company_id']); } ],
-		[ 'items' => $company_type, 'on' => function($chn, $ci, $rt, $t, $mc, $cn, $ct) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($ct['id'] == $mc['company_type_id']); } ]
-	], [ 'select' => function($chn, $ci, $rt, $t, $mc, $cn, $ct) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ["character" => $chn['name'], "movie" => $t['title']]; }, 'where' => function($chn, $ci, $rt, $t, $mc, $cn, $ct) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ((((((is_array($ci['note']) ? (array_key_exists("(voice)", $ci['note']) || in_array("(voice)", $ci['note'], true)) : (is_string($ci['note']) ? strpos($ci['note'], strval("(voice)")) !== false : false)) && (is_array($ci['note']) ? (array_key_exists("(uncredited)", $ci['note']) || in_array("(uncredited)", $ci['note'], true)) : (is_string($ci['note']) ? strpos($ci['note'], strval("(uncredited)")) !== false : false))) && ($cn['country_code'] == "[ru]")) && ($rt['role'] == "actor")) && ($t['production_year'] > 2005))); } ]);
-})();
-$result = [["uncredited_voiced_character" => min((function() use ($matches) {
-	$res = [];
-	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
-		$res[] = $x['character'];
-	}
-	return $res;
-})()), "russian_movie" => min((function() use ($matches) {
-	$res = [];
-	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
-		$res[] = $x['movie'];
-	}
-	return $res;
-})())]];
-echo json_encode($result), PHP_EOL;
-mochi_test_Q10_finds_uncredited_voice_actor_in_Russian_movie();
-
-function _query($src, $joins, $opts) {
-    $items = array_map(fn($v) => [$v], $src);
-    foreach ($joins as $j) {
-        $joined = [];
-        if (!empty($j['right']) && !empty($j['left'])) {
-            $matched = array_fill(0, count($j['items']), false);
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $ri => $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $matched[$ri] = true;
-                    $joined[] = array_merge($left, [$right]);
+    $result = [];
+    foreach ($char_name as $chn) {
+        foreach ($cast_info as $ci) {
+            if ($chn['id'] == $ci['person_role_id']) {
+                foreach ($role_type as $rt) {
+                    if ($rt['id'] == $ci['role_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $ci['movie_id']) {
+                                foreach ($movie_companies as $mc) {
+                                    if ($mc['movie_id'] == $t['id']) {
+                                        foreach ($company_name as $cn) {
+                                            if ($cn['id'] == $mc['company_id']) {
+                                                foreach ($company_type as $ct) {
+                                                    if ($ct['id'] == $mc['company_type_id']) {
+                                                        if (strpos($ci['note'], "(voice)") !== false && strpos($ci['note'], "(uncredited)") !== false && $cn['country_code'] == "[ru]" && $rt['role'] == "actor" && $t['production_year'] > 2005) {
+                                                            $result[] = [
+    "character" => $chn['name'],
+    "movie" => $t['title']
+];
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
-                if (!$m) { $joined[] = array_merge($left, [null]); }
-            }
-            foreach ($j['items'] as $ri => $right) {
-                if (!$matched[$ri]) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } elseif (!empty($j['right'])) {
-            foreach ($j['items'] as $right) {
-                $m = false;
-                foreach ($items as $left) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!$m) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } else {
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
             }
         }
-        $items = $joined;
     }
-    if (isset($opts['where'])) {
-        $filtered = [];
-        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
-        $items = $filtered;
-    }
-    if (isset($opts['sortKey'])) {
-        $pairs = [];
-        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
-        usort($pairs, function($a, $b) {
-            $ak = $a['key']; $bk = $b['key'];
-            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
-            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
-            return strcmp(strval($ak), strval($bk));
-        });
-        $items = array_map(fn($p) => $p['item'], $pairs);
-    }
-    if (array_key_exists('skip', $opts)) {
-        $n = $opts['skip'];
-        $items = $n < count($items) ? array_slice($items, $n) : [];
-    }
-    if (array_key_exists('take', $opts)) {
-        $n = $opts['take'];
-        if ($n < count($items)) $items = array_slice($items, 0, $n);
-    }
-    $res = [];
-    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
-    return $res;
-}
+    return $result;
+})();
+$result = [
+    [
+        "uncredited_voiced_character" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['character'];
+            }
+            return $result;
+        })()),
+        "russian_movie" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q6.php
+++ b/tests/dataset/job/compiler/php/q6.php
@@ -1,102 +1,66 @@
 <?php
-function mochi_test_Q6_finds_marvel_movie_with_Robert_Downey() {
-	global $actor_name, $marvel_movie, $movie_keyword, $result;
-	if (!(($result == [["movie_keyword" => "marvel-cinematic-universe", "actor_name" => "Downey Robert Jr.", "marvel_movie" => "Iron Man 3"]]))) { throw new Exception('expect failed'); }
-}
-
-$cast_info = [["movie_id" => 1, "person_id" => 101], ["movie_id" => 2, "person_id" => 102]];
-$keyword = [["id" => 100, "keyword" => "marvel-cinematic-universe"], ["id" => 200, "keyword" => "other"]];
-$movie_keyword = [["movie_id" => 1, "keyword_id" => 100], ["movie_id" => 2, "keyword_id" => 200]];
-$name = [["id" => 101, "name" => "Downey Robert Jr."], ["id" => 102, "name" => "Chris Evans"]];
-$title = [["id" => 1, "title" => "Iron Man 3", "production_year" => 2013], ["id" => 2, "title" => "Old Movie", "production_year" => 2000]];
+$cast_info = [
+    ["movie_id" => 1, "person_id" => 101],
+    ["movie_id" => 2, "person_id" => 102]
+];
+$keyword = [
+    [
+        "id" => 100,
+        "keyword" => "marvel-cinematic-universe"
+    ],
+    ["id" => 200, "keyword" => "other"]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 100],
+    ["movie_id" => 2, "keyword_id" => 200]
+];
+$name = [
+    [
+        "id" => 101,
+        "name" => "Downey Robert Jr."
+    ],
+    ["id" => 102, "name" => "Chris Evans"]
+];
+$title = [
+    [
+        "id" => 1,
+        "title" => "Iron Man 3",
+        "production_year" => 2013
+    ],
+    [
+        "id" => 2,
+        "title" => "Old Movie",
+        "production_year" => 2000
+    ]
+];
 $result = (function() use ($cast_info, $keyword, $movie_keyword, $name, $title) {
-	$_src = $cast_info;
-	return _query($_src, [
-		[ 'items' => $movie_keyword, 'on' => function($ci, $mk) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($ci['movie_id'] == $mk['movie_id']); } ],
-		[ 'items' => $keyword, 'on' => function($ci, $mk, $k) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($mk['keyword_id'] == $k['id']); } ],
-		[ 'items' => $name, 'on' => function($ci, $mk, $k, $n) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($ci['person_id'] == $n['id']); } ],
-		[ 'items' => $title, 'on' => function($ci, $mk, $k, $n, $t) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($ci['movie_id'] == $t['id']); } ]
-	], [ 'select' => function($ci, $mk, $k, $n, $t) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ["movie_keyword" => $k['keyword'], "actor_name" => $n['name'], "marvel_movie" => $t['title']]; }, 'where' => function($ci, $mk, $k, $n, $t) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ((((($k['keyword'] == "marvel-cinematic-universe") && (is_array($n['name']) ? (array_key_exists("Downey", $n['name']) || in_array("Downey", $n['name'], true)) : (is_string($n['name']) ? strpos($n['name'], strval("Downey")) !== false : false))) && (is_array($n['name']) ? (array_key_exists("Robert", $n['name']) || in_array("Robert", $n['name'], true)) : (is_string($n['name']) ? strpos($n['name'], strval("Robert")) !== false : false))) && ($t['production_year'] > 2010))); } ]);
-})();
-echo json_encode($result), PHP_EOL;
-mochi_test_Q6_finds_marvel_movie_with_Robert_Downey();
-
-function _query($src, $joins, $opts) {
-    $items = array_map(fn($v) => [$v], $src);
-    foreach ($joins as $j) {
-        $joined = [];
-        if (!empty($j['right']) && !empty($j['left'])) {
-            $matched = array_fill(0, count($j['items']), false);
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $ri => $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $matched[$ri] = true;
-                    $joined[] = array_merge($left, [$right]);
+    $result = [];
+    foreach ($cast_info as $ci) {
+        foreach ($movie_keyword as $mk) {
+            if ($ci['movie_id'] == $mk['movie_id']) {
+                foreach ($keyword as $k) {
+                    if ($mk['keyword_id'] == $k['id']) {
+                        foreach ($name as $n) {
+                            if ($ci['person_id'] == $n['id']) {
+                                foreach ($title as $t) {
+                                    if ($ci['movie_id'] == $t['id']) {
+                                        if ($k['keyword'] == "marvel-cinematic-universe" && strpos($n['name'], "Downey") !== false && strpos($n['name'], "Robert") !== false && $t['production_year'] > 2010) {
+                                            $result[] = [
+    "movie_keyword" => $k['keyword'],
+    "actor_name" => $n['name'],
+    "marvel_movie" => $t['title']
+];
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
-                if (!$m) { $joined[] = array_merge($left, [null]); }
-            }
-            foreach ($j['items'] as $ri => $right) {
-                if (!$matched[$ri]) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } elseif (!empty($j['right'])) {
-            foreach ($j['items'] as $right) {
-                $m = false;
-                foreach ($items as $left) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!$m) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } else {
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
             }
         }
-        $items = $joined;
     }
-    if (isset($opts['where'])) {
-        $filtered = [];
-        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
-        $items = $filtered;
-    }
-    if (isset($opts['sortKey'])) {
-        $pairs = [];
-        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
-        usort($pairs, function($a, $b) {
-            $ak = $a['key']; $bk = $b['key'];
-            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
-            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
-            return strcmp(strval($ak), strval($bk));
-        });
-        $items = array_map(fn($p) => $p['item'], $pairs);
-    }
-    if (array_key_exists('skip', $opts)) {
-        $n = $opts['skip'];
-        $items = $n < count($items) ? array_slice($items, $n) : [];
-    }
-    if (array_key_exists('take', $opts)) {
-        $n = $opts['take'];
-        if ($n < count($items)) $items = array_slice($items, 0, $n);
-    }
-    $res = [];
-    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
-    return $res;
-}
+    return $result;
+})();
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q7.php
+++ b/tests/dataset/job/compiler/php/q7.php
@@ -1,121 +1,125 @@
 <?php
-function mochi_test_Q7_finds_movie_features_biography_for_person() {
-	global $biography_movie, $of_person, $result;
-	if (!(($result == [["of_person" => "Alan Brown", "biography_movie" => "Feature Film"]]))) { throw new Exception('expect failed'); }
-}
-
-$aka_name = [["person_id" => 1, "name" => "Anna Mae"], ["person_id" => 2, "name" => "Chris"]];
-$cast_info = [["person_id" => 1, "movie_id" => 10], ["person_id" => 2, "movie_id" => 20]];
-$info_type = [["id" => 1, "info" => "mini biography"], ["id" => 2, "info" => "trivia"]];
-$link_type = [["id" => 1, "link" => "features"], ["id" => 2, "link" => "references"]];
-$movie_link = [["linked_movie_id" => 10, "link_type_id" => 1], ["linked_movie_id" => 20, "link_type_id" => 2]];
-$name = [["id" => 1, "name" => "Alan Brown", "name_pcode_cf" => "B", "gender" => "m"], ["id" => 2, "name" => "Zoe", "name_pcode_cf" => "Z", "gender" => "f"]];
-$person_info = [["person_id" => 1, "info_type_id" => 1, "note" => "Volker Boehm"], ["person_id" => 2, "info_type_id" => 1, "note" => "Other"]];
-$title = [["id" => 10, "title" => "Feature Film", "production_year" => 1990], ["id" => 20, "title" => "Late Film", "production_year" => 2000]];
+$aka_name = [
+    ["person_id" => 1, "name" => "Anna Mae"],
+    ["person_id" => 2, "name" => "Chris"]
+];
+$cast_info = [
+    ["person_id" => 1, "movie_id" => 10],
+    ["person_id" => 2, "movie_id" => 20]
+];
+$info_type = [
+    ["id" => 1, "info" => "mini biography"],
+    ["id" => 2, "info" => "trivia"]
+];
+$link_type = [
+    ["id" => 1, "link" => "features"],
+    ["id" => 2, "link" => "references"]
+];
+$movie_link = [
+    [
+        "linked_movie_id" => 10,
+        "link_type_id" => 1
+    ],
+    [
+        "linked_movie_id" => 20,
+        "link_type_id" => 2
+    ]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Alan Brown",
+        "name_pcode_cf" => "B",
+        "gender" => "m"
+    ],
+    [
+        "id" => 2,
+        "name" => "Zoe",
+        "name_pcode_cf" => "Z",
+        "gender" => "f"
+    ]
+];
+$person_info = [
+    [
+        "person_id" => 1,
+        "info_type_id" => 1,
+        "note" => "Volker Boehm"
+    ],
+    [
+        "person_id" => 2,
+        "info_type_id" => 1,
+        "note" => "Other"
+    ]
+];
+$title = [
+    [
+        "id" => 10,
+        "title" => "Feature Film",
+        "production_year" => 1990
+    ],
+    [
+        "id" => 20,
+        "title" => "Late Film",
+        "production_year" => 2000
+    ]
+];
 $rows = (function() use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) {
-	$_src = $aka_name;
-	return _query($_src, [
-		[ 'items' => $name, 'on' => function($an, $n) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($n['id'] == $an['person_id']); } ],
-		[ 'items' => $person_info, 'on' => function($an, $n, $pi) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($pi['person_id'] == $an['person_id']); } ],
-		[ 'items' => $info_type, 'on' => function($an, $n, $pi, $it) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($it['id'] == $pi['info_type_id']); } ],
-		[ 'items' => $cast_info, 'on' => function($an, $n, $pi, $it, $ci) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($ci['person_id'] == $n['id']); } ],
-		[ 'items' => $title, 'on' => function($an, $n, $pi, $it, $ci, $t) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($t['id'] == $ci['movie_id']); } ],
-		[ 'items' => $movie_link, 'on' => function($an, $n, $pi, $it, $ci, $t, $ml) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($ml['linked_movie_id'] == $t['id']); } ],
-		[ 'items' => $link_type, 'on' => function($an, $n, $pi, $it, $ci, $t, $ml, $lt) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($lt['id'] == $ml['link_type_id']); } ]
-	], [ 'select' => function($an, $n, $pi, $it, $ci, $t, $ml, $lt) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ["person_name" => $n['name'], "movie_title" => $t['title']]; }, 'where' => function($an, $n, $pi, $it, $ci, $t, $ml, $lt) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return (((((((((((((((is_array($an['name']) ? (array_key_exists("a", $an['name']) || in_array("a", $an['name'], true)) : (is_string($an['name']) ? strpos($an['name'], strval("a")) !== false : false)) && ($it['info'] == "mini biography")) && ($lt['link'] == "features")) && ($n['name_pcode_cf'] >= "A")) && ($n['name_pcode_cf'] <= "F")) && ((($n['gender'] == "m") || ((($n['gender'] == "f") && $n['name']['starts_with']("B")))))) && ($pi['note'] == "Volker Boehm")) && ($t['production_year'] >= 1980)) && ($t['production_year'] <= 1995)) && ($pi['person_id'] == $an['person_id'])) && ($pi['person_id'] == $ci['person_id'])) && ($an['person_id'] == $ci['person_id'])) && ($ci['movie_id'] == $ml['linked_movie_id'])))); } ]);
-})();
-$result = [["of_person" => min((function() use ($rows) {
-	$res = [];
-	foreach ((is_string($rows) ? str_split($rows) : $rows) as $r) {
-		$res[] = $r['person_name'];
-	}
-	return $res;
-})()), "biography_movie" => min((function() use ($rows) {
-	$res = [];
-	foreach ((is_string($rows) ? str_split($rows) : $rows) as $r) {
-		$res[] = $r['movie_title'];
-	}
-	return $res;
-})())]];
-echo json_encode($result), PHP_EOL;
-mochi_test_Q7_finds_movie_features_biography_for_person();
-
-function _query($src, $joins, $opts) {
-    $items = array_map(fn($v) => [$v], $src);
-    foreach ($joins as $j) {
-        $joined = [];
-        if (!empty($j['right']) && !empty($j['left'])) {
-            $matched = array_fill(0, count($j['items']), false);
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $ri => $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $matched[$ri] = true;
-                    $joined[] = array_merge($left, [$right]);
+    $result = [];
+    foreach ($aka_name as $an) {
+        foreach ($name as $n) {
+            if ($n['id'] == $an['person_id']) {
+                foreach ($person_info as $pi) {
+                    if ($pi['person_id'] == $an['person_id']) {
+                        foreach ($info_type as $it) {
+                            if ($it['id'] == $pi['info_type_id']) {
+                                foreach ($cast_info as $ci) {
+                                    if ($ci['person_id'] == $n['id']) {
+                                        foreach ($title as $t) {
+                                            if ($t['id'] == $ci['movie_id']) {
+                                                foreach ($movie_link as $ml) {
+                                                    if ($ml['linked_movie_id'] == $t['id']) {
+                                                        foreach ($link_type as $lt) {
+                                                            if ($lt['id'] == $ml['link_type_id']) {
+                                                                if ((strpos($an['name'], "a") !== false && $it['info'] == "mini biography" && $lt['link'] == "features" && $n['name_pcode_cf'] >= "A" && $n['name_pcode_cf'] <= "F" && ($n['gender'] == "m" || ($n['gender'] == "f" && $n['name']['starts_with']("B"))) && $pi['note'] == "Volker Boehm" && $t['production_year'] >= 1980 && $t['production_year'] <= 1995 && $pi['person_id'] == $an['person_id'] && $pi['person_id'] == $ci['person_id'] && $an['person_id'] == $ci['person_id'] && $ci['movie_id'] == $ml['linked_movie_id'])) {
+                                                                    $result[] = [
+    "person_name" => $n['name'],
+    "movie_title" => $t['title']
+];
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
-                if (!$m) { $joined[] = array_merge($left, [null]); }
-            }
-            foreach ($j['items'] as $ri => $right) {
-                if (!$matched[$ri]) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } elseif (!empty($j['right'])) {
-            foreach ($j['items'] as $right) {
-                $m = false;
-                foreach ($items as $left) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!$m) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } else {
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
             }
         }
-        $items = $joined;
     }
-    if (isset($opts['where'])) {
-        $filtered = [];
-        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
-        $items = $filtered;
-    }
-    if (isset($opts['sortKey'])) {
-        $pairs = [];
-        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
-        usort($pairs, function($a, $b) {
-            $ak = $a['key']; $bk = $b['key'];
-            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
-            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
-            return strcmp(strval($ak), strval($bk));
-        });
-        $items = array_map(fn($p) => $p['item'], $pairs);
-    }
-    if (array_key_exists('skip', $opts)) {
-        $n = $opts['skip'];
-        $items = $n < count($items) ? array_slice($items, $n) : [];
-    }
-    if (array_key_exists('take', $opts)) {
-        $n = $opts['take'];
-        if ($n < count($items)) $items = array_slice($items, 0, $n);
-    }
-    $res = [];
-    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
-    return $res;
-}
+    return $result;
+})();
+$result = [
+    [
+        "of_person" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['person_name'];
+            }
+            return $result;
+        })()),
+        "biography_movie" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['movie_title'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q8.php
+++ b/tests/dataset/job/compiler/php/q8.php
@@ -1,126 +1,80 @@
 <?php
-function mochi_test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() {
-	global $actress_pseudonym, $japanese_movie_dubbed, $result;
-	if (!(($result == [["actress_pseudonym" => "Y. S.", "japanese_movie_dubbed" => "Dubbed Film"]]))) { throw new Exception('expect failed'); }
-}
-
 $aka_name = [["person_id" => 1, "name" => "Y. S."]];
-$cast_info = [["person_id" => 1, "movie_id" => 10, "note" => "(voice: English version)", "role_id" => 1000]];
+$cast_info = [
+    [
+        "person_id" => 1,
+        "movie_id" => 10,
+        "note" => "(voice: English version)",
+        "role_id" => 1000
+    ]
+];
 $company_name = [["id" => 50, "country_code" => "[jp]"]];
-$movie_companies = [["movie_id" => 10, "company_id" => 50, "note" => "Studio (Japan)"]];
-$name = [["id" => 1, "name" => "Yoko Ono"], ["id" => 2, "name" => "Yuichi"]];
+$movie_companies = [
+    [
+        "movie_id" => 10,
+        "company_id" => 50,
+        "note" => "Studio (Japan)"
+    ]
+];
+$name = [
+    ["id" => 1, "name" => "Yoko Ono"],
+    ["id" => 2, "name" => "Yuichi"]
+];
 $role_type = [["id" => 1000, "role" => "actress"]];
 $title = [["id" => 10, "title" => "Dubbed Film"]];
 $eligible = (function() use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) {
-	$_src = $aka_name;
-	return _query($_src, [
-		[ 'items' => $name, 'on' => function($an1, $n1) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($n1['id'] == $an1['person_id']); } ],
-		[ 'items' => $cast_info, 'on' => function($an1, $n1, $ci) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($ci['person_id'] == $an1['person_id']); } ],
-		[ 'items' => $title, 'on' => function($an1, $n1, $ci, $t) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($t['id'] == $ci['movie_id']); } ],
-		[ 'items' => $movie_companies, 'on' => function($an1, $n1, $ci, $t, $mc) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($mc['movie_id'] == $ci['movie_id']); } ],
-		[ 'items' => $company_name, 'on' => function($an1, $n1, $ci, $t, $mc, $cn) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($cn['id'] == $mc['company_id']); } ],
-		[ 'items' => $role_type, 'on' => function($an1, $n1, $ci, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($rt['id'] == $ci['role_id']); } ]
-	], [ 'select' => function($an1, $n1, $ci, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ["pseudonym" => $an1['name'], "movie_title" => $t['title']]; }, 'where' => function($an1, $n1, $ci, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return (((((((($ci['note'] == "(voice: English version)") && ($cn['country_code'] == "[jp]")) && (is_array($mc['note']) ? (array_key_exists("(Japan)", $mc['note']) || in_array("(Japan)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(Japan)")) !== false : false))) && (!(is_array($mc['note']) ? (array_key_exists("(USA)", $mc['note']) || in_array("(USA)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(USA)")) !== false : false)))) && (is_array($n1['name']) ? (array_key_exists("Yo", $n1['name']) || in_array("Yo", $n1['name'], true)) : (is_string($n1['name']) ? strpos($n1['name'], strval("Yo")) !== false : false))) && (!(is_array($n1['name']) ? (array_key_exists("Yu", $n1['name']) || in_array("Yu", $n1['name'], true)) : (is_string($n1['name']) ? strpos($n1['name'], strval("Yu")) !== false : false)))) && ($rt['role'] == "actress"))); } ]);
-})();
-$result = [["actress_pseudonym" => min((function() use ($eligible) {
-	$res = [];
-	foreach ((is_string($eligible) ? str_split($eligible) : $eligible) as $x) {
-		$res[] = $x['pseudonym'];
-	}
-	return $res;
-})()), "japanese_movie_dubbed" => min((function() use ($eligible) {
-	$res = [];
-	foreach ((is_string($eligible) ? str_split($eligible) : $eligible) as $x) {
-		$res[] = $x['movie_title'];
-	}
-	return $res;
-})())]];
-_print($result);
-mochi_test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing();
-
-function _print(...$args) {
-    $parts = [];
-    foreach ($args as $a) {
-        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
-    }
-    echo implode(' ', $parts), PHP_EOL;
-}
-function _query($src, $joins, $opts) {
-    $items = array_map(fn($v) => [$v], $src);
-    foreach ($joins as $j) {
-        $joined = [];
-        if (!empty($j['right']) && !empty($j['left'])) {
-            $matched = array_fill(0, count($j['items']), false);
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $ri => $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $matched[$ri] = true;
-                    $joined[] = array_merge($left, [$right]);
+    $result = [];
+    foreach ($aka_name as $an1) {
+        foreach ($name as $n1) {
+            if ($n1['id'] == $an1['person_id']) {
+                foreach ($cast_info as $ci) {
+                    if ($ci['person_id'] == $an1['person_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $ci['movie_id']) {
+                                foreach ($movie_companies as $mc) {
+                                    if ($mc['movie_id'] == $ci['movie_id']) {
+                                        foreach ($company_name as $cn) {
+                                            if ($cn['id'] == $mc['company_id']) {
+                                                foreach ($role_type as $rt) {
+                                                    if ($rt['id'] == $ci['role_id']) {
+                                                        if ($ci['note'] == "(voice: English version)" && $cn['country_code'] == "[jp]" && strpos($mc['note'], "(Japan)") !== false && (!strpos($mc['note'], "(USA)") !== false) && strpos($n1['name'], "Yo") !== false && (!strpos($n1['name'], "Yu") !== false) && $rt['role'] == "actress") {
+                                                            $result[] = [
+    "pseudonym" => $an1['name'],
+    "movie_title" => $t['title']
+];
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
-                if (!$m) { $joined[] = array_merge($left, [null]); }
-            }
-            foreach ($j['items'] as $ri => $right) {
-                if (!$matched[$ri]) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } elseif (!empty($j['right'])) {
-            foreach ($j['items'] as $right) {
-                $m = false;
-                foreach ($items as $left) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!$m) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } else {
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
             }
         }
-        $items = $joined;
     }
-    if (isset($opts['where'])) {
-        $filtered = [];
-        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
-        $items = $filtered;
-    }
-    if (isset($opts['sortKey'])) {
-        $pairs = [];
-        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
-        usort($pairs, function($a, $b) {
-            $ak = $a['key']; $bk = $b['key'];
-            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
-            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
-            return strcmp(strval($ak), strval($bk));
-        });
-        $items = array_map(fn($p) => $p['item'], $pairs);
-    }
-    if (array_key_exists('skip', $opts)) {
-        $n = $opts['skip'];
-        $items = $n < count($items) ? array_slice($items, $n) : [];
-    }
-    if (array_key_exists('take', $opts)) {
-        $n = $opts['take'];
-        if ($n < count($items)) $items = array_slice($items, 0, $n);
-    }
-    $res = [];
-    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
-    return $res;
-}
+    return $result;
+})();
+$result = [
+    [
+        "actress_pseudonym" => min((function() use ($eligible) {
+            $result = [];
+            foreach ($eligible as $x) {
+                $result[] = $x['pseudonym'];
+            }
+            return $result;
+        })()),
+        "japanese_movie_dubbed" => min((function() use ($eligible) {
+            $result = [];
+            foreach ($eligible as $x) {
+                $result[] = $x['movie_title'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q9.php
+++ b/tests/dataset/job/compiler/php/q9.php
@@ -1,127 +1,142 @@
 <?php
-function mochi_test_Q9_selects_minimal_alternative_name__character_and_movie() {
-	global $alternative_name, $character_name, $movie, $result;
-	if (!(($result == [["alternative_name" => "A. N. G.", "character_name" => "Angel", "movie" => "Famous Film"]]))) { throw new Exception('expect failed'); }
-}
-
-$aka_name = [["person_id" => 1, "name" => "A. N. G."], ["person_id" => 2, "name" => "J. D."]];
-$char_name = [["id" => 10, "name" => "Angel"], ["id" => 20, "name" => "Devil"]];
-$cast_info = [["person_id" => 1, "person_role_id" => 10, "movie_id" => 100, "role_id" => 1000, "note" => "(voice)"], ["person_id" => 2, "person_role_id" => 20, "movie_id" => 200, "role_id" => 1000, "note" => "(voice)"]];
-$company_name = [["id" => 100, "country_code" => "[us]"], ["id" => 200, "country_code" => "[gb]"]];
-$movie_companies = [["movie_id" => 100, "company_id" => 100, "note" => "ACME Studios (USA)"], ["movie_id" => 200, "company_id" => 200, "note" => "Maple Films"]];
-$name = [["id" => 1, "name" => "Angela Smith", "gender" => "f"], ["id" => 2, "name" => "John Doe", "gender" => "m"]];
-$role_type = [["id" => 1000, "role" => "actress"], ["id" => 2000, "role" => "actor"]];
-$title = [["id" => 100, "title" => "Famous Film", "production_year" => 2010], ["id" => 200, "title" => "Old Movie", "production_year" => 1999]];
+$aka_name = [
+    ["person_id" => 1, "name" => "A. N. G."],
+    ["person_id" => 2, "name" => "J. D."]
+];
+$char_name = [
+    ["id" => 10, "name" => "Angel"],
+    ["id" => 20, "name" => "Devil"]
+];
+$cast_info = [
+    [
+        "person_id" => 1,
+        "person_role_id" => 10,
+        "movie_id" => 100,
+        "role_id" => 1000,
+        "note" => "(voice)"
+    ],
+    [
+        "person_id" => 2,
+        "person_role_id" => 20,
+        "movie_id" => 200,
+        "role_id" => 1000,
+        "note" => "(voice)"
+    ]
+];
+$company_name = [
+    ["id" => 100, "country_code" => "[us]"],
+    ["id" => 200, "country_code" => "[gb]"]
+];
+$movie_companies = [
+    [
+        "movie_id" => 100,
+        "company_id" => 100,
+        "note" => "ACME Studios (USA)"
+    ],
+    [
+        "movie_id" => 200,
+        "company_id" => 200,
+        "note" => "Maple Films"
+    ]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Angela Smith",
+        "gender" => "f"
+    ],
+    [
+        "id" => 2,
+        "name" => "John Doe",
+        "gender" => "m"
+    ]
+];
+$role_type = [
+    ["id" => 1000, "role" => "actress"],
+    ["id" => 2000, "role" => "actor"]
+];
+$title = [
+    [
+        "id" => 100,
+        "title" => "Famous Film",
+        "production_year" => 2010
+    ],
+    [
+        "id" => 200,
+        "title" => "Old Movie",
+        "production_year" => 1999
+    ]
+];
 $matches = (function() use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) {
-	$_src = $aka_name;
-	return _query($_src, [
-		[ 'items' => $name, 'on' => function($an, $n) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($an['person_id'] == $n['id']); } ],
-		[ 'items' => $cast_info, 'on' => function($an, $n, $ci) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($ci['person_id'] == $n['id']); } ],
-		[ 'items' => $char_name, 'on' => function($an, $n, $ci, $chn) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($chn['id'] == $ci['person_role_id']); } ],
-		[ 'items' => $title, 'on' => function($an, $n, $ci, $chn, $t) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($t['id'] == $ci['movie_id']); } ],
-		[ 'items' => $movie_companies, 'on' => function($an, $n, $ci, $chn, $t, $mc) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($mc['movie_id'] == $t['id']); } ],
-		[ 'items' => $company_name, 'on' => function($an, $n, $ci, $chn, $t, $mc, $cn) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($cn['id'] == $mc['company_id']); } ],
-		[ 'items' => $role_type, 'on' => function($an, $n, $ci, $chn, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($rt['id'] == $ci['role_id']); } ]
-	], [ 'select' => function($an, $n, $ci, $chn, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ["alt" => $an['name'], "character" => $chn['name'], "movie" => $t['title']]; }, 'where' => function($an, $n, $ci, $chn, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ((((((((((is_array(["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) ? (array_key_exists($ci['note'], ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) || in_array($ci['note'], ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"], true)) : (is_string(["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) ? strpos(["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"], strval($ci['note'])) !== false : false))) && ($cn['country_code'] == "[us]")) && (((is_array($mc['note']) ? (array_key_exists("(USA)", $mc['note']) || in_array("(USA)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(USA)")) !== false : false)) || (is_array($mc['note']) ? (array_key_exists("(worldwide)", $mc['note']) || in_array("(worldwide)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(worldwide)")) !== false : false))))) && ($n['gender'] == "f")) && (is_array($n['name']) ? (array_key_exists("Ang", $n['name']) || in_array("Ang", $n['name'], true)) : (is_string($n['name']) ? strpos($n['name'], strval("Ang")) !== false : false))) && ($rt['role'] == "actress")) && ($t['production_year'] >= 2005)) && ($t['production_year'] <= 2015))); } ]);
-})();
-$result = [["alternative_name" => min((function() use ($matches) {
-	$res = [];
-	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
-		$res[] = $x['alt'];
-	}
-	return $res;
-})()), "character_name" => min((function() use ($matches) {
-	$res = [];
-	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
-		$res[] = $x['character'];
-	}
-	return $res;
-})()), "movie" => min((function() use ($matches) {
-	$res = [];
-	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
-		$res[] = $x['movie'];
-	}
-	return $res;
-})())]];
-echo json_encode($result), PHP_EOL;
-mochi_test_Q9_selects_minimal_alternative_name__character_and_movie();
-
-function _query($src, $joins, $opts) {
-    $items = array_map(fn($v) => [$v], $src);
-    foreach ($joins as $j) {
-        $joined = [];
-        if (!empty($j['right']) && !empty($j['left'])) {
-            $matched = array_fill(0, count($j['items']), false);
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $ri => $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $matched[$ri] = true;
-                    $joined[] = array_merge($left, [$right]);
+    $result = [];
+    foreach ($aka_name as $an) {
+        foreach ($name as $n) {
+            if ($an['person_id'] == $n['id']) {
+                foreach ($cast_info as $ci) {
+                    if ($ci['person_id'] == $n['id']) {
+                        foreach ($char_name as $chn) {
+                            if ($chn['id'] == $ci['person_role_id']) {
+                                foreach ($title as $t) {
+                                    if ($t['id'] == $ci['movie_id']) {
+                                        foreach ($movie_companies as $mc) {
+                                            if ($mc['movie_id'] == $t['id']) {
+                                                foreach ($company_name as $cn) {
+                                                    if ($cn['id'] == $mc['company_id']) {
+                                                        foreach ($role_type as $rt) {
+                                                            if ($rt['id'] == $ci['role_id']) {
+                                                                if ((in_array($ci['note'], [
+    "(voice)",
+    "(voice: Japanese version)",
+    "(voice) (uncredited)",
+    "(voice: English version)"
+])) && $cn['country_code'] == "[us]" && (strpos($mc['note'], "(USA)") !== false || strpos($mc['note'], "(worldwide)") !== false) && $n['gender'] == "f" && strpos($n['name'], "Ang") !== false && $rt['role'] == "actress" && $t['production_year'] >= 2005 && $t['production_year'] <= 2015) {
+                                                                    $result[] = [
+    "alt" => $an['name'],
+    "character" => $chn['name'],
+    "movie" => $t['title']
+];
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
-                if (!$m) { $joined[] = array_merge($left, [null]); }
-            }
-            foreach ($j['items'] as $ri => $right) {
-                if (!$matched[$ri]) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } elseif (!empty($j['right'])) {
-            foreach ($j['items'] as $right) {
-                $m = false;
-                foreach ($items as $left) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!$m) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $joined[] = array_merge($undef, [$right]);
-                }
-            }
-        } else {
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($j['items'] as $right) {
-                    $keep = true;
-                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
-                    if (!$keep) continue;
-                    $m = true; $joined[] = array_merge($left, [$right]);
-                }
-                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
             }
         }
-        $items = $joined;
     }
-    if (isset($opts['where'])) {
-        $filtered = [];
-        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
-        $items = $filtered;
-    }
-    if (isset($opts['sortKey'])) {
-        $pairs = [];
-        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
-        usort($pairs, function($a, $b) {
-            $ak = $a['key']; $bk = $b['key'];
-            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
-            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
-            return strcmp(strval($ak), strval($bk));
-        });
-        $items = array_map(fn($p) => $p['item'], $pairs);
-    }
-    if (array_key_exists('skip', $opts)) {
-        $n = $opts['skip'];
-        $items = $n < count($items) ? array_slice($items, $n) : [];
-    }
-    if (array_key_exists('take', $opts)) {
-        $n = $opts['take'];
-        if ($n < count($items)) $items = array_slice($items, 0, $n);
-    }
-    $res = [];
-    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
-    return $res;
-}
+    return $result;
+})();
+$result = [
+    [
+        "alternative_name" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['alt'];
+            }
+            return $result;
+        })()),
+        "character_name" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['character'];
+            }
+            return $result;
+        })()),
+        "movie" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>


### PR DESCRIPTION
## Summary
- update PHP compiler JOB tests to cover q1-q10
- regenerate golden PHP output for JOB queries 6-10

## Testing
- `go test ./compiler/x/php -run JOB -tags=slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68739cc0caac8320b9b45480b9d8745b