### PR TITLE
Add JOB q11-20 php golden tests

### DIFF
--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -653,6 +653,16 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				t = types.BoolType{}
 				continue
 			}
+			if len(op.Call.Args) == 1 && (strings.HasSuffix(val, "->starts_with") || strings.HasSuffix(val, "['starts_with']")) {
+				base := strings.TrimSuffix(strings.TrimSuffix(val, "->starts_with"), "['starts_with']")
+				arg, err := c.compileExpr(op.Call.Args[0])
+				if err != nil {
+					return "", err
+				}
+				val = fmt.Sprintf("str_starts_with(%s, %s)", base, arg)
+				t = types.BoolType{}
+				continue
+			}
 			args := make([]string, len(op.Call.Args))
 			for j, a := range op.Call.Args {
 				s, err := c.compileExpr(a)

--- a/compiler/x/php/job_golden_test.go
+++ b/compiler/x/php/job_golden_test.go
@@ -20,7 +20,7 @@ func TestPHPCompiler_JOB_Golden(t *testing.T) {
 		t.Skip("php not installed")
 	}
 	root := repoRoot(t)
-	for i := 1; i <= 10; i++ {
+	for i := 1; i <= 20; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "job", base+".mochi")
 		codeWant := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", base+".php")

--- a/compiler/x/php/job_test.go
+++ b/compiler/x/php/job_test.go
@@ -17,7 +17,7 @@ func TestPHPCompiler_JOB(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not installed")
 	}
-	for i := 1; i <= 10; i++ {
+	for i := 1; i <= 20; i++ {
 		q := fmt.Sprintf("q%d", i)
 		testutil.CompileJOB(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
 			return phpcode.New(env).Compile(prog)

--- a/tests/dataset/job/compiler/php/q11.out
+++ b/tests/dataset/job/compiler/php/q11.out
@@ -1,0 +1,1 @@
+[{"from_company":"Best Film Co","movie_link_type":"follow-up","non_polish_sequel_movie":"Alpha"}]

--- a/tests/dataset/job/compiler/php/q11.php
+++ b/tests/dataset/job/compiler/php/q11.php
@@ -1,0 +1,150 @@
+<?php
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "Best Film Co",
+        "country_code" => "[us]"
+    ],
+    [
+        "id" => 2,
+        "name" => "Warner Studios",
+        "country_code" => "[de]"
+    ],
+    [
+        "id" => 3,
+        "name" => "Polish Films",
+        "country_code" => "[pl]"
+    ]
+];
+$company_type = [
+    [
+        "id" => 1,
+        "kind" => "production companies"
+    ],
+    ["id" => 2, "kind" => "distributors"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "sequel"],
+    ["id" => 2, "keyword" => "thriller"]
+];
+$link_type = [
+    ["id" => 1, "link" => "follow-up"],
+    ["id" => 2, "link" => "follows from"],
+    ["id" => 3, "link" => "remake"]
+];
+$movie_companies = [
+    [
+        "movie_id" => 10,
+        "company_id" => 1,
+        "company_type_id" => 1,
+        "note" => null
+    ],
+    [
+        "movie_id" => 20,
+        "company_id" => 2,
+        "company_type_id" => 1,
+        "note" => null
+    ],
+    [
+        "movie_id" => 30,
+        "company_id" => 3,
+        "company_type_id" => 1,
+        "note" => null
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 10, "keyword_id" => 1],
+    ["movie_id" => 20, "keyword_id" => 1],
+    ["movie_id" => 20, "keyword_id" => 2],
+    ["movie_id" => 30, "keyword_id" => 1]
+];
+$movie_link = [
+    ["movie_id" => 10, "link_type_id" => 1],
+    ["movie_id" => 20, "link_type_id" => 2],
+    ["movie_id" => 30, "link_type_id" => 3]
+];
+$title = [
+    [
+        "id" => 10,
+        "production_year" => 1960,
+        "title" => "Alpha"
+    ],
+    [
+        "id" => 20,
+        "production_year" => 1970,
+        "title" => "Beta"
+    ],
+    [
+        "id" => 30,
+        "production_year" => 1985,
+        "title" => "Polish Movie"
+    ]
+];
+$matches = (function() use ($company_name, $company_type, $keyword, $link_type, $movie_companies, $movie_keyword, $movie_link, $title) {
+    $result = [];
+    foreach ($company_name as $cn) {
+        foreach ($movie_companies as $mc) {
+            if ($mc['company_id'] == $cn['id']) {
+                foreach ($company_type as $ct) {
+                    if ($ct['id'] == $mc['company_type_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $mc['movie_id']) {
+                                foreach ($movie_keyword as $mk) {
+                                    if ($mk['movie_id'] == $t['id']) {
+                                        foreach ($keyword as $k) {
+                                            if ($k['id'] == $mk['keyword_id']) {
+                                                foreach ($movie_link as $ml) {
+                                                    if ($ml['movie_id'] == $t['id']) {
+                                                        foreach ($link_type as $lt) {
+                                                            if ($lt['id'] == $ml['link_type_id']) {
+                                                                if ($cn['country_code'] != "[pl]" && (strpos($cn['name'], "Film") !== false || strpos($cn['name'], "Warner") !== false) && $ct['kind'] == "production companies" && $k['keyword'] == "sequel" && strpos($lt['link'], "follow") !== false && $mc['note'] == null && $t['production_year'] >= 1950 && $t['production_year'] <= 2000 && $ml['movie_id'] == $mk['movie_id'] && $ml['movie_id'] == $mc['movie_id'] && $mk['movie_id'] == $mc['movie_id']) {
+                                                                    $result[] = [
+    "company" => $cn['name'],
+    "link" => $lt['link'],
+    "title" => $t['title']
+];
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "from_company" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['company'];
+            }
+            return $result;
+        })()),
+        "movie_link_type" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['link'];
+            }
+            return $result;
+        })()),
+        "non_polish_sequel_movie" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['title'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q12.out
+++ b/tests/dataset/job/compiler/php/q12.out
@@ -1,0 +1,1 @@
+[{"movie_company":"Best Pictures","rating":8.3,"drama_horror_movie":"Great Drama"}]

--- a/tests/dataset/job/compiler/php/q12.php
+++ b/tests/dataset/job/compiler/php/q12.php
@@ -1,0 +1,115 @@
+<?php
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "Best Pictures",
+        "country_code" => "[us]"
+    ],
+    [
+        "id" => 2,
+        "name" => "Foreign Films",
+        "country_code" => "[uk]"
+    ]
+];
+$company_type = [
+    [
+        "id" => 10,
+        "kind" => "production companies"
+    ],
+    ["id" => 20, "kind" => "distributors"]
+];
+$info_type = [
+    ["id" => 100, "info" => "genres"],
+    ["id" => 200, "info" => "rating"]
+];
+$movie_companies = [
+    [
+        "movie_id" => 1000,
+        "company_id" => 1,
+        "company_type_id" => 10
+    ],
+    [
+        "movie_id" => 2000,
+        "company_id" => 2,
+        "company_type_id" => 10
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 1000,
+        "info_type_id" => 100,
+        "info" => "Drama"
+    ],
+    [
+        "movie_id" => 2000,
+        "info_type_id" => 100,
+        "info" => "Horror"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 1000,
+        "info_type_id" => 200,
+        "info" => 8.3
+    ],
+    [
+        "movie_id" => 2000,
+        "info_type_id" => 200,
+        "info" => 7.5
+    ]
+];
+$title = [
+    [
+        "id" => 1000,
+        "production_year" => 2006,
+        "title" => "Great Drama"
+    ],
+    [
+        "id" => 2000,
+        "production_year" => 2007,
+        "title" => "Low Rated"
+    ]
+];
+$result = (function() use ($company_name, $company_type, $info_type, $movie_companies, $movie_info, $movie_info_idx, $title) {
+    $result = [];
+    foreach ($company_name as $cn) {
+        foreach ($movie_companies as $mc) {
+            if ($mc['company_id'] == $cn['id']) {
+                foreach ($company_type as $ct) {
+                    if ($ct['id'] == $mc['company_type_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $mc['movie_id']) {
+                                foreach ($movie_info as $mi) {
+                                    if ($mi['movie_id'] == $t['id']) {
+                                        foreach ($info_type as $it1) {
+                                            if ($it1['id'] == $mi['info_type_id']) {
+                                                foreach ($movie_info_idx as $mi_idx) {
+                                                    if ($mi_idx['movie_id'] == $t['id']) {
+                                                        foreach ($info_type as $it2) {
+                                                            if ($it2['id'] == $mi_idx['info_type_id']) {
+                                                                if ($cn['country_code'] == "[us]" && $ct['kind'] == "production companies" && $it1['info'] == "genres" && $it2['info'] == "rating" && ($mi['info'] == "Drama" || $mi['info'] == "Horror") && $mi_idx['info'] > 8 && $t['production_year'] >= 2005 && $t['production_year'] <= 2008) {
+                                                                    $result[] = [
+    "movie_company" => $cn['name'],
+    "rating" => $mi_idx['info'],
+    "drama_horror_movie" => $t['title']
+];
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q13.out
+++ b/tests/dataset/job/compiler/php/q13.out
@@ -1,0 +1,1 @@
+{"release_date":"1997-05-10","rating":"6.0","german_movie":"Alpha"}

--- a/tests/dataset/job/compiler/php/q13.php
+++ b/tests/dataset/job/compiler/php/q13.php
@@ -1,0 +1,164 @@
+<?php
+$company_name = [
+    ["id" => 1, "country_code" => "[de]"],
+    ["id" => 2, "country_code" => "[us]"]
+];
+$company_type = [
+    [
+        "id" => 1,
+        "kind" => "production companies"
+    ],
+    ["id" => 2, "kind" => "distributors"]
+];
+$info_type = [
+    ["id" => 1, "info" => "rating"],
+    ["id" => 2, "info" => "release dates"]
+];
+$kind_type = [
+    ["id" => 1, "kind" => "movie"],
+    ["id" => 2, "kind" => "video"]
+];
+$title = [
+    [
+        "id" => 10,
+        "kind_id" => 1,
+        "title" => "Alpha"
+    ],
+    [
+        "id" => 20,
+        "kind_id" => 1,
+        "title" => "Beta"
+    ],
+    [
+        "id" => 30,
+        "kind_id" => 2,
+        "title" => "Gamma"
+    ]
+];
+$movie_companies = [
+    [
+        "movie_id" => 10,
+        "company_id" => 1,
+        "company_type_id" => 1
+    ],
+    [
+        "movie_id" => 20,
+        "company_id" => 1,
+        "company_type_id" => 1
+    ],
+    [
+        "movie_id" => 30,
+        "company_id" => 2,
+        "company_type_id" => 1
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 10,
+        "info_type_id" => 2,
+        "info" => "1997-05-10"
+    ],
+    [
+        "movie_id" => 20,
+        "info_type_id" => 2,
+        "info" => "1998-03-20"
+    ],
+    [
+        "movie_id" => 30,
+        "info_type_id" => 2,
+        "info" => "1999-07-30"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 10,
+        "info_type_id" => 1,
+        "info" => "6.0"
+    ],
+    [
+        "movie_id" => 20,
+        "info_type_id" => 1,
+        "info" => "7.5"
+    ],
+    [
+        "movie_id" => 30,
+        "info_type_id" => 1,
+        "info" => "5.5"
+    ]
+];
+$candidates = (function() use ($company_name, $company_type, $info_type, $kind_type, $movie_companies, $movie_info, $movie_info_idx, $title) {
+    $result = [];
+    foreach ($company_name as $cn) {
+        foreach ($movie_companies as $mc) {
+            if ($mc['company_id'] == $cn['id']) {
+                foreach ($company_type as $ct) {
+                    if ($ct['id'] == $mc['company_type_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $mc['movie_id']) {
+                                foreach ($kind_type as $kt) {
+                                    if ($kt['id'] == $t['kind_id']) {
+                                        foreach ($movie_info as $mi) {
+                                            if ($mi['movie_id'] == $t['id']) {
+                                                foreach ($info_type as $it2) {
+                                                    if ($it2['id'] == $mi['info_type_id']) {
+                                                        foreach ($movie_info_idx as $miidx) {
+                                                            if ($miidx['movie_id'] == $t['id']) {
+                                                                foreach ($info_type as $it) {
+                                                                    if ($it['id'] == $miidx['info_type_id']) {
+                                                                        if ($cn['country_code'] == "[de]" && $ct['kind'] == "production companies" && $it['info'] == "rating" && $it2['info'] == "release dates" && $kt['kind'] == "movie") {
+                                                                            $result[] = [
+    "release_date" => $mi['info'],
+    "rating" => $miidx['info'],
+    "german_movie" => $t['title']
+];
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    "release_date" => ((function() use ($candidates) {
+        $result = [];
+        foreach ($candidates as $x) {
+            $result[] = [$x['release_date'], $x['release_date']];
+        }
+        usort($result, function($a, $b) { return $a[0] <=> $b[0]; });
+        $result = array_map(fn($r) => $r[1], $result);
+        return $result;
+    })())[0],
+    "rating" => ((function() use ($candidates) {
+        $result = [];
+        foreach ($candidates as $x) {
+            $result[] = [$x['rating'], $x['rating']];
+        }
+        usort($result, function($a, $b) { return $a[0] <=> $b[0]; });
+        $result = array_map(fn($r) => $r[1], $result);
+        return $result;
+    })())[0],
+    "german_movie" => ((function() use ($candidates) {
+        $result = [];
+        foreach ($candidates as $x) {
+            $result[] = [$x['german_movie'], $x['german_movie']];
+        }
+        usort($result, function($a, $b) { return $a[0] <=> $b[0]; });
+        $result = array_map(fn($r) => $r[1], $result);
+        return $result;
+    })())[0]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q14.out
+++ b/tests/dataset/job/compiler/php/q14.out
@@ -1,0 +1,1 @@
+{"rating":7,"northern_dark_movie":"A Dark Movie"}

--- a/tests/dataset/job/compiler/php/q14.php
+++ b/tests/dataset/job/compiler/php/q14.php
@@ -1,0 +1,132 @@
+<?php
+$info_type = [
+    ["id" => 1, "info" => "countries"],
+    ["id" => 2, "info" => "rating"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "murder"],
+    ["id" => 2, "keyword" => "blood"],
+    ["id" => 3, "keyword" => "romance"]
+];
+$kind_type = [["id" => 1, "kind" => "movie"]];
+$title = [
+    [
+        "id" => 1,
+        "kind_id" => 1,
+        "production_year" => 2012,
+        "title" => "A Dark Movie"
+    ],
+    [
+        "id" => 2,
+        "kind_id" => 1,
+        "production_year" => 2013,
+        "title" => "Brutal Blood"
+    ],
+    [
+        "id" => 3,
+        "kind_id" => 1,
+        "production_year" => 2008,
+        "title" => "Old Film"
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "info" => "Sweden"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 1,
+        "info" => "USA"
+    ],
+    [
+        "movie_id" => 3,
+        "info_type_id" => 1,
+        "info" => "USA"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 2,
+        "info" => 7
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 2,
+        "info" => 7.5
+    ],
+    [
+        "movie_id" => 3,
+        "info_type_id" => 2,
+        "info" => 9.1
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2],
+    ["movie_id" => 3, "keyword_id" => 3]
+];
+$allowed_keywords = [
+    "murder",
+    "murder-in-title",
+    "blood",
+    "violence"
+];
+$allowed_countries = [
+    "Sweden",
+    "Norway",
+    "Germany",
+    "Denmark",
+    "Swedish",
+    "Denish",
+    "Norwegian",
+    "German",
+    "USA",
+    "American"
+];
+$matches = (function() use ($allowed_countries, $allowed_keywords, $info_type, $keyword, $kind_type, $movie_info, $movie_info_idx, $movie_keyword, $title) {
+    $result = [];
+    foreach ($info_type as $it1) {
+        foreach ($info_type as $it2) {
+            foreach ($keyword as $k) {
+                foreach ($kind_type as $kt) {
+                    foreach ($movie_info as $mi) {
+                        foreach ($movie_info_idx as $mi_idx) {
+                            foreach ($movie_keyword as $mk) {
+                                foreach ($title as $t) {
+                                    if (($it1['info'] == "countries" && $it2['info'] == "rating" && (in_array($k['keyword'], $allowed_keywords)) && $kt['kind'] == "movie" && (in_array($mi['info'], $allowed_countries)) && $mi_idx['info'] < 8.5 && $t['production_year'] > 2010 && $kt['id'] == $t['kind_id'] && $t['id'] == $mi['movie_id'] && $t['id'] == $mk['movie_id'] && $t['id'] == $mi_idx['movie_id'] && $mk['movie_id'] == $mi['movie_id'] && $mk['movie_id'] == $mi_idx['movie_id'] && $mi['movie_id'] == $mi_idx['movie_id'] && $k['id'] == $mk['keyword_id'] && $it1['id'] == $mi['info_type_id'] && $it2['id'] == $mi_idx['info_type_id'])) {
+                                        $result[] = [
+    "rating" => $mi_idx['info'],
+    "title" => $t['title']
+];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    "rating" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['rating'];
+        }
+        return $result;
+    })()),
+    "northern_dark_movie" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['title'];
+        }
+        return $result;
+    })())
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q15.out
+++ b/tests/dataset/job/compiler/php/q15.out
@@ -1,0 +1,1 @@
+[{"release_date":"USA: March 2005","internet_movie":"Example Movie"}]

--- a/tests/dataset/job/compiler/php/q15.php
+++ b/tests/dataset/job/compiler/php/q15.php
@@ -1,0 +1,120 @@
+<?php
+$aka_title = [["movie_id" => 1], ["movie_id" => 2]];
+$company_name = [
+    ["id" => 1, "country_code" => "[us]"],
+    ["id" => 2, "country_code" => "[gb]"]
+];
+$company_type = [["id" => 10], ["id" => 20]];
+$info_type = [
+    ["id" => 5, "info" => "release dates"],
+    ["id" => 6, "info" => "other"]
+];
+$keyword = [["id" => 100], ["id" => 200]];
+$movie_companies = [
+    [
+        "movie_id" => 1,
+        "company_id" => 1,
+        "company_type_id" => 10,
+        "note" => "release (2005) (worldwide)"
+    ],
+    [
+        "movie_id" => 2,
+        "company_id" => 2,
+        "company_type_id" => 20,
+        "note" => "release (1999) (worldwide)"
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 5,
+        "note" => "internet",
+        "info" => "USA: March 2005"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 5,
+        "note" => "theater",
+        "info" => "USA: May 1999"
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 100],
+    ["movie_id" => 2, "keyword_id" => 200]
+];
+$title = [
+    [
+        "id" => 1,
+        "title" => "Example Movie",
+        "production_year" => 2005
+    ],
+    [
+        "id" => 2,
+        "title" => "Old Movie",
+        "production_year" => 1999
+    ]
+];
+$rows = (function() use ($aka_title, $company_name, $company_type, $info_type, $keyword, $movie_companies, $movie_info, $movie_keyword, $title) {
+    $result = [];
+    foreach ($title as $t) {
+        foreach ($aka_title as $at) {
+            if ($at['movie_id'] == $t['id']) {
+                foreach ($movie_info as $mi) {
+                    if ($mi['movie_id'] == $t['id']) {
+                        foreach ($movie_keyword as $mk) {
+                            if ($mk['movie_id'] == $t['id']) {
+                                foreach ($movie_companies as $mc) {
+                                    if ($mc['movie_id'] == $t['id']) {
+                                        foreach ($keyword as $k) {
+                                            if ($k['id'] == $mk['keyword_id']) {
+                                                foreach ($info_type as $it1) {
+                                                    if ($it1['id'] == $mi['info_type_id']) {
+                                                        foreach ($company_name as $cn) {
+                                                            if ($cn['id'] == $mc['company_id']) {
+                                                                foreach ($company_type as $ct) {
+                                                                    if ($ct['id'] == $mc['company_type_id']) {
+                                                                        if ($cn['country_code'] == "[us]" && $it1['info'] == "release dates" && strpos($mc['note'], "200") !== false && strpos($mc['note'], "worldwide") !== false && strpos($mi['note'], "internet") !== false && strpos($mi['info'], "USA:") !== false && strpos($mi['info'], "200") !== false && $t['production_year'] > 2000) {
+                                                                            $result[] = [
+    "release_date" => $mi['info'],
+    "internet_movie" => $t['title']
+];
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "release_date" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['release_date'];
+            }
+            return $result;
+        })()),
+        "internet_movie" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['internet_movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q16.out
+++ b/tests/dataset/job/compiler/php/q16.out
@@ -1,0 +1,1 @@
+[{"cool_actor_pseudonym":"Alpha","series_named_after_char":"Hero Bob"}]

--- a/tests/dataset/job/compiler/php/q16.php
+++ b/tests/dataset/job/compiler/php/q16.php
@@ -1,0 +1,101 @@
+<?php
+$aka_name = [
+    ["person_id" => 1, "name" => "Alpha"],
+    ["person_id" => 2, "name" => "Beta"]
+];
+$cast_info = [
+    ["person_id" => 1, "movie_id" => 101],
+    ["person_id" => 2, "movie_id" => 102]
+];
+$company_name = [
+    ["id" => 1, "country_code" => "[us]"],
+    ["id" => 2, "country_code" => "[de]"]
+];
+$keyword = [
+    [
+        "id" => 1,
+        "keyword" => "character-name-in-title"
+    ],
+    ["id" => 2, "keyword" => "other"]
+];
+$movie_companies = [
+    ["movie_id" => 101, "company_id" => 1],
+    ["movie_id" => 102, "company_id" => 2]
+];
+$movie_keyword = [
+    ["movie_id" => 101, "keyword_id" => 1],
+    ["movie_id" => 102, "keyword_id" => 2]
+];
+$name = [["id" => 1], ["id" => 2]];
+$title = [
+    [
+        "id" => 101,
+        "title" => "Hero Bob",
+        "episode_nr" => 60
+    ],
+    [
+        "id" => 102,
+        "title" => "Other Show",
+        "episode_nr" => 40
+    ]
+];
+$rows = (function() use ($aka_name, $cast_info, $company_name, $keyword, $movie_companies, $movie_keyword, $name, $title) {
+    $result = [];
+    foreach ($aka_name as $an) {
+        foreach ($name as $n) {
+            if ($n['id'] == $an['person_id']) {
+                foreach ($cast_info as $ci) {
+                    if ($ci['person_id'] == $n['id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $ci['movie_id']) {
+                                foreach ($movie_keyword as $mk) {
+                                    if ($mk['movie_id'] == $t['id']) {
+                                        foreach ($keyword as $k) {
+                                            if ($k['id'] == $mk['keyword_id']) {
+                                                foreach ($movie_companies as $mc) {
+                                                    if ($mc['movie_id'] == $t['id']) {
+                                                        foreach ($company_name as $cn) {
+                                                            if ($cn['id'] == $mc['company_id']) {
+                                                                if ($cn['country_code'] == "[us]" && $k['keyword'] == "character-name-in-title" && $t['episode_nr'] >= 50 && $t['episode_nr'] < 100) {
+                                                                    $result[] = [
+    "pseudonym" => $an['name'],
+    "series" => $t['title']
+];
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "cool_actor_pseudonym" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['pseudonym'];
+            }
+            return $result;
+        })()),
+        "series_named_after_char" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['series'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q17.out
+++ b/tests/dataset/job/compiler/php/q17.out
@@ -1,0 +1,1 @@
+[{"member_in_charnamed_american_movie":"Bob Smith","a1":"Bob Smith"}]

--- a/tests/dataset/job/compiler/php/q17.php
+++ b/tests/dataset/job/compiler/php/q17.php
@@ -1,0 +1,73 @@
+<?php
+$cast_info = [
+    ["movie_id" => 1, "person_id" => 1],
+    ["movie_id" => 2, "person_id" => 2]
+];
+$company_name = [
+    ["id" => 1, "country_code" => "[us]"],
+    ["id" => 2, "country_code" => "[ca]"]
+];
+$keyword = [
+    [
+        "id" => 10,
+        "keyword" => "character-name-in-title"
+    ],
+    ["id" => 20, "keyword" => "other"]
+];
+$movie_companies = [
+    ["movie_id" => 1, "company_id" => 1],
+    ["movie_id" => 2, "company_id" => 2]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 10],
+    ["movie_id" => 2, "keyword_id" => 20]
+];
+$name = [
+    ["id" => 1, "name" => "Bob Smith"],
+    ["id" => 2, "name" => "Alice Jones"]
+];
+$title = [
+    ["id" => 1, "title" => "Bob's Journey"],
+    ["id" => 2, "title" => "Foreign Film"]
+];
+$matches = (function() use ($cast_info, $company_name, $keyword, $movie_companies, $movie_keyword, $name, $title) {
+    $result = [];
+    foreach ($name as $n) {
+        foreach ($cast_info as $ci) {
+            if ($ci['person_id'] == $n['id']) {
+                foreach ($title as $t) {
+                    if ($t['id'] == $ci['movie_id']) {
+                        foreach ($movie_keyword as $mk) {
+                            if ($mk['movie_id'] == $t['id']) {
+                                foreach ($keyword as $k) {
+                                    if ($k['id'] == $mk['keyword_id']) {
+                                        foreach ($movie_companies as $mc) {
+                                            if ($mc['movie_id'] == $t['id']) {
+                                                foreach ($company_name as $cn) {
+                                                    if ($cn['id'] == $mc['company_id']) {
+                                                        if ($cn['country_code'] == "[us]" && $k['keyword'] == "character-name-in-title" && str_starts_with($n['name'], "B") && $ci['movie_id'] == $mk['movie_id'] && $ci['movie_id'] == $mc['movie_id'] && $mc['movie_id'] == $mk['movie_id']) {
+                                                            $result[] = $n['name'];
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "member_in_charnamed_american_movie" => min($matches),
+        "a1" => min($matches)
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q18.out
+++ b/tests/dataset/job/compiler/php/q18.out
@@ -1,0 +1,1 @@
+{"movie_budget":90,"movie_votes":400,"movie_title":"Alpha"}

--- a/tests/dataset/job/compiler/php/q18.php
+++ b/tests/dataset/job/compiler/php/q18.php
@@ -1,0 +1,141 @@
+<?php
+$info_type = [
+    ["id" => 1, "info" => "budget"],
+    ["id" => 2, "info" => "votes"],
+    ["id" => 3, "info" => "rating"]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Big Tim",
+        "gender" => "m"
+    ],
+    [
+        "id" => 2,
+        "name" => "Slim Tim",
+        "gender" => "m"
+    ],
+    [
+        "id" => 3,
+        "name" => "Alice",
+        "gender" => "f"
+    ]
+];
+$title = [
+    ["id" => 10, "title" => "Alpha"],
+    ["id" => 20, "title" => "Beta"],
+    ["id" => 30, "title" => "Gamma"]
+];
+$cast_info = [
+    [
+        "movie_id" => 10,
+        "person_id" => 1,
+        "note" => "(producer)"
+    ],
+    [
+        "movie_id" => 20,
+        "person_id" => 2,
+        "note" => "(executive producer)"
+    ],
+    [
+        "movie_id" => 30,
+        "person_id" => 3,
+        "note" => "(producer)"
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 10,
+        "info_type_id" => 1,
+        "info" => 90
+    ],
+    [
+        "movie_id" => 20,
+        "info_type_id" => 1,
+        "info" => 120
+    ],
+    [
+        "movie_id" => 30,
+        "info_type_id" => 1,
+        "info" => 110
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 10,
+        "info_type_id" => 2,
+        "info" => 500
+    ],
+    [
+        "movie_id" => 20,
+        "info_type_id" => 2,
+        "info" => 400
+    ],
+    [
+        "movie_id" => 30,
+        "info_type_id" => 2,
+        "info" => 800
+    ]
+];
+$rows = (function() use ($cast_info, $info_type, $movie_info, $movie_info_idx, $name, $title) {
+    $result = [];
+    foreach ($cast_info as $ci) {
+        foreach ($name as $n) {
+            if ($n['id'] == $ci['person_id']) {
+                foreach ($title as $t) {
+                    if ($t['id'] == $ci['movie_id']) {
+                        foreach ($movie_info as $mi) {
+                            if ($mi['movie_id'] == $t['id']) {
+                                foreach ($movie_info_idx as $mi_idx) {
+                                    if ($mi_idx['movie_id'] == $t['id']) {
+                                        foreach ($info_type as $it1) {
+                                            if ($it1['id'] == $mi['info_type_id']) {
+                                                foreach ($info_type as $it2) {
+                                                    if ($it2['id'] == $mi_idx['info_type_id']) {
+                                                        if ((in_array($ci['note'], ["(producer)", "(executive producer)"]) && $it1['info'] == "budget" && $it2['info'] == "votes" && $n['gender'] == "m" && strpos($n['name'], "Tim") !== false && $t['id'] == $ci['movie_id'] && $ci['movie_id'] == $mi['movie_id'] && $ci['movie_id'] == $mi_idx['movie_id'] && $mi['movie_id'] == $mi_idx['movie_id'])) {
+                                                            $result[] = [
+    "budget" => $mi['info'],
+    "votes" => $mi_idx['info'],
+    "title" => $t['title']
+];
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    "movie_budget" => min((function() use ($rows) {
+        $result = [];
+        foreach ($rows as $r) {
+            $result[] = $r['budget'];
+        }
+        return $result;
+    })()),
+    "movie_votes" => min((function() use ($rows) {
+        $result = [];
+        foreach ($rows as $r) {
+            $result[] = $r['votes'];
+        }
+        return $result;
+    })()),
+    "movie_title" => min((function() use ($rows) {
+        $result = [];
+        foreach ($rows as $r) {
+            $result[] = $r['title'];
+        }
+        return $result;
+    })())
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q19.out
+++ b/tests/dataset/job/compiler/php/q19.out
@@ -1,0 +1,1 @@
+[{"voicing_actress":"Angela Stone","voiced_movie":"Voiced Movie"}]

--- a/tests/dataset/job/compiler/php/q19.php
+++ b/tests/dataset/job/compiler/php/q19.php
@@ -1,0 +1,157 @@
+<?php
+$aka_name = [
+    ["person_id" => 1, "name" => "A. Stone"],
+    ["person_id" => 2, "name" => "J. Doe"]
+];
+$char_name = [
+    ["id" => 1, "name" => "Protagonist"],
+    ["id" => 2, "name" => "Extra"]
+];
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_role_id" => 1,
+        "person_id" => 1,
+        "role_id" => 1,
+        "note" => "(voice)"
+    ],
+    [
+        "movie_id" => 2,
+        "person_role_id" => 2,
+        "person_id" => 2,
+        "role_id" => 2,
+        "note" => "Cameo"
+    ]
+];
+$company_name = [
+    ["id" => 10, "country_code" => "[us]"],
+    ["id" => 20, "country_code" => "[gb]"]
+];
+$info_type = [
+    ["id" => 100, "info" => "release dates"]
+];
+$movie_companies = [
+    [
+        "movie_id" => 1,
+        "company_id" => 10,
+        "note" => "Studio (USA)"
+    ],
+    [
+        "movie_id" => 2,
+        "company_id" => 20,
+        "note" => "Other (worldwide)"
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 100,
+        "info" => "USA: June 2006"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 100,
+        "info" => "UK: 1999"
+    ]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Angela Stone",
+        "gender" => "f"
+    ],
+    [
+        "id" => 2,
+        "name" => "Bob Angstrom",
+        "gender" => "m"
+    ]
+];
+$role_type = [
+    ["id" => 1, "role" => "actress"],
+    ["id" => 2, "role" => "actor"]
+];
+$title = [
+    [
+        "id" => 1,
+        "title" => "Voiced Movie",
+        "production_year" => 2006
+    ],
+    [
+        "id" => 2,
+        "title" => "Other Movie",
+        "production_year" => 2010
+    ]
+];
+$matches = (function() use ($aka_name, $cast_info, $char_name, $company_name, $info_type, $movie_companies, $movie_info, $name, $role_type, $title) {
+    $result = [];
+    foreach ($aka_name as $an) {
+        foreach ($name as $n) {
+            if ($n['id'] == $an['person_id']) {
+                foreach ($cast_info as $ci) {
+                    if ($ci['person_id'] == $an['person_id']) {
+                        foreach ($char_name as $chn) {
+                            if ($chn['id'] == $ci['person_role_id']) {
+                                foreach ($role_type as $rt) {
+                                    if ($rt['id'] == $ci['role_id']) {
+                                        foreach ($title as $t) {
+                                            if ($t['id'] == $ci['movie_id']) {
+                                                foreach ($movie_companies as $mc) {
+                                                    if ($mc['movie_id'] == $t['id']) {
+                                                        foreach ($company_name as $cn) {
+                                                            if ($cn['id'] == $mc['company_id']) {
+                                                                foreach ($movie_info as $mi) {
+                                                                    if ($mi['movie_id'] == $t['id']) {
+                                                                        foreach ($info_type as $it) {
+                                                                            if ($it['id'] == $mi['info_type_id']) {
+                                                                                if (in_array($ci['note'], [
+    "(voice)",
+    "(voice: Japanese version)",
+    "(voice) (uncredited)",
+    "(voice: English version)"
+]) && $cn['country_code'] == "[us]" && $it['info'] == "release dates" && $mc['note'] != null && (strpos($mc['note'], "(USA)") !== false || strpos($mc['note'], "(worldwide)") !== false) && $mi['info'] != null && ((strpos($mi['info'], "Japan:") !== false && strpos($mi['info'], "200") !== false) || (strpos($mi['info'], "USA:") !== false && strpos($mi['info'], "200") !== false)) && $n['gender'] == "f" && strpos($n['name'], "Ang") !== false && $rt['role'] == "actress" && $t['production_year'] >= 2005 && $t['production_year'] <= 2009) {
+                                                                                    $result[] = [
+    "actress" => $n['name'],
+    "movie" => $t['title']
+];
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "voicing_actress" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['actress'];
+            }
+            return $result;
+        })()),
+        "voiced_movie" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q20.out
+++ b/tests/dataset/job/compiler/php/q20.out
@@ -1,0 +1,1 @@
+[{"complete_downey_ironman_movie":"Iron Man"}]

--- a/tests/dataset/job/compiler/php/q20.php
+++ b/tests/dataset/job/compiler/php/q20.php
@@ -1,0 +1,124 @@
+<?php
+$comp_cast_type = [
+    ["id" => 1, "kind" => "cast"],
+    ["id" => 2, "kind" => "complete cast"]
+];
+$char_name = [
+    ["id" => 1, "name" => "Tony Stark"],
+    ["id" => 2, "name" => "Sherlock Holmes"]
+];
+$complete_cast = [
+    [
+        "movie_id" => 1,
+        "subject_id" => 1,
+        "status_id" => 2
+    ],
+    [
+        "movie_id" => 2,
+        "subject_id" => 1,
+        "status_id" => 2
+    ]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Robert Downey Jr."
+    ],
+    ["id" => 2, "name" => "Another Actor"]
+];
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_role_id" => 1,
+        "person_id" => 1
+    ],
+    [
+        "movie_id" => 2,
+        "person_role_id" => 2,
+        "person_id" => 2
+    ]
+];
+$keyword = [
+    ["id" => 10, "keyword" => "superhero"],
+    ["id" => 20, "keyword" => "romance"]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 10],
+    ["movie_id" => 2, "keyword_id" => 20]
+];
+$kind_type = [["id" => 1, "kind" => "movie"]];
+$title = [
+    [
+        "id" => 1,
+        "kind_id" => 1,
+        "production_year" => 2008,
+        "title" => "Iron Man"
+    ],
+    [
+        "id" => 2,
+        "kind_id" => 1,
+        "production_year" => 1940,
+        "title" => "Old Hero"
+    ]
+];
+$matches = (function() use ($cast_info, $char_name, $comp_cast_type, $complete_cast, $keyword, $kind_type, $movie_keyword, $name, $title) {
+    $result = [];
+    foreach ($complete_cast as $cc) {
+        foreach ($comp_cast_type as $cct1) {
+            if ($cct1['id'] == $cc['subject_id']) {
+                foreach ($comp_cast_type as $cct2) {
+                    if ($cct2['id'] == $cc['status_id']) {
+                        foreach ($cast_info as $ci) {
+                            if ($ci['movie_id'] == $cc['movie_id']) {
+                                foreach ($char_name as $chn) {
+                                    if ($chn['id'] == $ci['person_role_id']) {
+                                        foreach ($name as $n) {
+                                            if ($n['id'] == $ci['person_id']) {
+                                                foreach ($movie_keyword as $mk) {
+                                                    if ($mk['movie_id'] == $cc['movie_id']) {
+                                                        foreach ($keyword as $k) {
+                                                            if ($k['id'] == $mk['keyword_id']) {
+                                                                foreach ($title as $t) {
+                                                                    if ($t['id'] == $cc['movie_id']) {
+                                                                        foreach ($kind_type as $kt) {
+                                                                            if ($kt['id'] == $t['kind_id']) {
+                                                                                if (in_array($cct1['kind'] == "cast" && strpos($cct2['kind'], "complete") !== false && (!strpos($chn['name'], "Sherlock") !== false) && (strpos($chn['name'], "Tony Stark") !== false || strpos($chn['name'], "Iron Man") !== false) && $k['keyword'], [
+    "superhero",
+    "sequel",
+    "second-part",
+    "marvel-comics",
+    "based-on-comic",
+    "tv-special",
+    "fight",
+    "violence"
+]) && $kt['kind'] == "movie" && $t['production_year'] > 1950) {
+                                                                                    $result[] = $t['title'];
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "complete_downey_ironman_movie" => min($matches)
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q7.php
+++ b/tests/dataset/job/compiler/php/q7.php
@@ -80,7 +80,7 @@ $rows = (function() use ($aka_name, $cast_info, $info_type, $link_type, $movie_l
                                                     if ($ml['linked_movie_id'] == $t['id']) {
                                                         foreach ($link_type as $lt) {
                                                             if ($lt['id'] == $ml['link_type_id']) {
-                                                                if ((strpos($an['name'], "a") !== false && $it['info'] == "mini biography" && $lt['link'] == "features" && $n['name_pcode_cf'] >= "A" && $n['name_pcode_cf'] <= "F" && ($n['gender'] == "m" || ($n['gender'] == "f" && $n['name']['starts_with']("B"))) && $pi['note'] == "Volker Boehm" && $t['production_year'] >= 1980 && $t['production_year'] <= 1995 && $pi['person_id'] == $an['person_id'] && $pi['person_id'] == $ci['person_id'] && $an['person_id'] == $ci['person_id'] && $ci['movie_id'] == $ml['linked_movie_id'])) {
+                                                                if ((strpos($an['name'], "a") !== false && $it['info'] == "mini biography" && $lt['link'] == "features" && $n['name_pcode_cf'] >= "A" && $n['name_pcode_cf'] <= "F" && ($n['gender'] == "m" || ($n['gender'] == "f" && str_starts_with($n['name'], "B"))) && $pi['note'] == "Volker Boehm" && $t['production_year'] >= 1980 && $t['production_year'] <= 1995 && $pi['person_id'] == $an['person_id'] && $pi['person_id'] == $ci['person_id'] && $an['person_id'] == $ci['person_id'] && $ci['movie_id'] == $ml['linked_movie_id'])) {
                                                                     $result[] = [
     "person_name" => $n['name'],
     "movie_title" => $t['title']


### PR DESCRIPTION
## Summary
- extend PHP JOB dataset tests to queries q11-q20
- support `starts_with` string method in PHP compiler
- add generated PHP sources/outputs for JOB q11-q20
- update q7 generated code after compiler change

## Testing
- `go test ./compiler/x/php -tags slow -run TestPHPCompiler_JOB_Golden/q7 -v`
- `go test ./compiler/x/php -tags slow -run JOB_Golden -v`
- `go test ./compiler/x/php -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6873aa504e3883209cf5d7fcfec61b50