### PR TITLE
Improve F# float literal handling

### DIFF
--- a/compiler/x/fs/compiler.go
+++ b/compiler/x/fs/compiler.go
@@ -5,9 +5,11 @@ package fscode
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	meta "mochi/compiler/meta"
@@ -1638,7 +1640,13 @@ func (c *Compiler) compileLiteral(l *parser.Literal) string {
 	case l.Str != nil:
 		return fmt.Sprintf("%q", *l.Str)
 	case l.Float != nil:
-		return fmt.Sprintf("%g", *l.Float)
+		f := *l.Float
+		// Ensure integral floats keep a decimal point so F# infers the
+		// correct type.
+		if math.Trunc(f) == f {
+			return fmt.Sprintf("%.1f", f)
+		}
+		return strconv.FormatFloat(f, 'f', -1, 64)
 	case l.Bool != nil:
 		if bool(*l.Bool) {
 			return "true"


### PR DESCRIPTION
## Summary
- update the F# compiler backend so integral float literals retain a decimal
- install dotnet runtime & mono to enable F# tests

## Testing
- `go test ./compiler/x/fs -tags slow -run TestFSCompiler_TPCH/q1 -v` *(fails: generated code mismatch & fsharpc errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873ac7708e4832095210f57395320cd