### PR TITLE
Extend PHP JOB compiler to q33

### DIFF
--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -516,6 +516,15 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 		default:
 			leftType = types.AnyType{}
 		}
+		if (opStr == "==" || opStr == "!=") && (r == "true" || r == "false") {
+			if (opStr == "==" && r == "true") || (opStr == "!=" && r == "false") {
+				// no-op
+			} else {
+				res = "!(" + res + ")"
+			}
+			leftType = types.BoolType{}
+			continue
+		}
 		res = fmt.Sprintf("%s %s %s", res, opStr, r)
 		left = res
 	}

--- a/compiler/x/php/job_golden_test.go
+++ b/compiler/x/php/job_golden_test.go
@@ -20,7 +20,7 @@ func TestPHPCompiler_JOB_Golden(t *testing.T) {
 		t.Skip("php not installed")
 	}
 	root := repoRoot(t)
-	for i := 1; i <= 20; i++ {
+	for i := 1; i <= 33; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "job", base+".mochi")
 		codeWant := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", base+".php")

--- a/compiler/x/php/job_test.go
+++ b/compiler/x/php/job_test.go
@@ -17,7 +17,7 @@ func TestPHPCompiler_JOB(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not installed")
 	}
-	for i := 1; i <= 20; i++ {
+	for i := 1; i <= 33; i++ {
 		q := fmt.Sprintf("q%d", i)
 		testutil.CompileJOB(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
 			return phpcode.New(env).Compile(prog)

--- a/tests/dataset/job/compiler/php/q21.out
+++ b/tests/dataset/job/compiler/php/q21.out
@@ -1,0 +1,1 @@
+[{"company_name":"ACME Film Works","link_type":"is follow up","western_follow_up":"Western Return"}]

--- a/tests/dataset/job/compiler/php/q21.php
+++ b/tests/dataset/job/compiler/php/q21.php
@@ -1,0 +1,148 @@
+<?php
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "ACME Film Works",
+        "country_code" => "[us]"
+    ],
+    [
+        "id" => 2,
+        "name" => "Polish Warner",
+        "country_code" => "[pl]"
+    ]
+];
+$company_type = [
+    [
+        "id" => 1,
+        "kind" => "production companies"
+    ],
+    ["id" => 2, "kind" => "other"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "sequel"],
+    ["id" => 2, "keyword" => "drama"]
+];
+$link_type = [
+    ["id" => 1, "link" => "is follow up"],
+    ["id" => 2, "link" => "references"]
+];
+$title = [
+    [
+        "id" => 10,
+        "title" => "Western Return",
+        "production_year" => 1975
+    ],
+    [
+        "id" => 20,
+        "title" => "Other Movie",
+        "production_year" => 2015
+    ]
+];
+$movie_companies = [
+    [
+        "movie_id" => 10,
+        "company_id" => 1,
+        "company_type_id" => 1,
+        "note" => null
+    ],
+    [
+        "movie_id" => 20,
+        "company_id" => 2,
+        "company_type_id" => 1,
+        "note" => null
+    ]
+];
+$movie_info = [
+    ["movie_id" => 10, "info" => "Sweden"],
+    ["movie_id" => 20, "info" => "USA"]
+];
+$movie_keyword = [
+    ["movie_id" => 10, "keyword_id" => 1],
+    ["movie_id" => 20, "keyword_id" => 2]
+];
+$movie_link = [
+    ["movie_id" => 10, "link_type_id" => 1],
+    ["movie_id" => 20, "link_type_id" => 2]
+];
+$allowed_countries = [
+    "Sweden",
+    "Norway",
+    "Germany",
+    "Denmark",
+    "Swedish",
+    "Denish",
+    "Norwegian",
+    "German"
+];
+$rows = (function() use ($allowed_countries, $company_name, $company_type, $keyword, $link_type, $movie_companies, $movie_info, $movie_keyword, $movie_link, $title) {
+    $result = [];
+    foreach ($company_name as $cn) {
+        foreach ($movie_companies as $mc) {
+            if ($mc['company_id'] == $cn['id']) {
+                foreach ($company_type as $ct) {
+                    if ($ct['id'] == $mc['company_type_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $mc['movie_id']) {
+                                foreach ($movie_keyword as $mk) {
+                                    if ($mk['movie_id'] == $t['id']) {
+                                        foreach ($keyword as $k) {
+                                            if ($k['id'] == $mk['keyword_id']) {
+                                                foreach ($movie_link as $ml) {
+                                                    if ($ml['movie_id'] == $t['id']) {
+                                                        foreach ($link_type as $lt) {
+                                                            if ($lt['id'] == $ml['link_type_id']) {
+                                                                foreach ($movie_info as $mi) {
+                                                                    if ($mi['movie_id'] == $t['id']) {
+                                                                        if ($cn['country_code'] != "[pl]" && (strpos($cn['name'], "Film") !== false || strpos($cn['name'], "Warner") !== false) && $ct['kind'] == "production companies" && $k['keyword'] == "sequel" && strpos($lt['link'], "follow") !== false && $mc['note'] == null && (in_array($mi['info'], $allowed_countries)) && $t['production_year'] >= 1950 && $t['production_year'] <= 2000) {
+                                                                            $result[] = [
+    "company_name" => $cn['name'],
+    "link_type" => $lt['link'],
+    "western_follow_up" => $t['title']
+];
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "company_name" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['company_name'];
+            }
+            return $result;
+        })()),
+        "link_type" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['link_type'];
+            }
+            return $result;
+        })()),
+        "western_follow_up" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['western_follow_up'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q22.out
+++ b/tests/dataset/job/compiler/php/q22.out
@@ -1,0 +1,1 @@
+[{"movie_company":"Euro Films","rating":6.5,"western_violent_movie":"Violent Western"}]

--- a/tests/dataset/job/compiler/php/q22.php
+++ b/tests/dataset/job/compiler/php/q22.php
@@ -1,0 +1,162 @@
+<?php
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "Euro Films",
+        "country_code" => "[de]"
+    ],
+    [
+        "id" => 2,
+        "name" => "US Films",
+        "country_code" => "[us]"
+    ]
+];
+$company_type = [["id" => 1, "kind" => "production"]];
+$info_type = [
+    ["id" => 10, "info" => "countries"],
+    ["id" => 20, "info" => "rating"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "murder"],
+    ["id" => 2, "keyword" => "comedy"]
+];
+$kind_type = [
+    ["id" => 100, "kind" => "movie"],
+    ["id" => 200, "kind" => "episode"]
+];
+$movie_companies = [
+    [
+        "movie_id" => 10,
+        "company_id" => 1,
+        "company_type_id" => 1,
+        "note" => "release (2009) (worldwide)"
+    ],
+    [
+        "movie_id" => 20,
+        "company_id" => 2,
+        "company_type_id" => 1,
+        "note" => "release (2007) (USA)"
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 10,
+        "info_type_id" => 10,
+        "info" => "Germany"
+    ],
+    [
+        "movie_id" => 20,
+        "info_type_id" => 10,
+        "info" => "USA"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 10,
+        "info_type_id" => 20,
+        "info" => 6.5
+    ],
+    [
+        "movie_id" => 20,
+        "info_type_id" => 20,
+        "info" => 7.8
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 10, "keyword_id" => 1],
+    ["movie_id" => 20, "keyword_id" => 2]
+];
+$title = [
+    [
+        "id" => 10,
+        "kind_id" => 100,
+        "production_year" => 2009,
+        "title" => "Violent Western"
+    ],
+    [
+        "id" => 20,
+        "kind_id" => 100,
+        "production_year" => 2007,
+        "title" => "Old Western"
+    ]
+];
+$rows = (function() use ($company_name, $company_type, $info_type, $keyword, $kind_type, $movie_companies, $movie_info, $movie_info_idx, $movie_keyword, $title) {
+    $result = [];
+    foreach ($company_name as $cn) {
+        foreach ($movie_companies as $mc) {
+            if ($cn['id'] == $mc['company_id']) {
+                foreach ($company_type as $ct) {
+                    if ($ct['id'] == $mc['company_type_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $mc['movie_id']) {
+                                foreach ($movie_keyword as $mk) {
+                                    if ($mk['movie_id'] == $t['id']) {
+                                        foreach ($keyword as $k) {
+                                            if ($k['id'] == $mk['keyword_id']) {
+                                                foreach ($movie_info as $mi) {
+                                                    if ($mi['movie_id'] == $t['id']) {
+                                                        foreach ($info_type as $it1) {
+                                                            if ($it1['id'] == $mi['info_type_id']) {
+                                                                foreach ($movie_info_idx as $mi_idx) {
+                                                                    if ($mi_idx['movie_id'] == $t['id']) {
+                                                                        foreach ($info_type as $it2) {
+                                                                            if ($it2['id'] == $mi_idx['info_type_id']) {
+                                                                                foreach ($kind_type as $kt) {
+                                                                                    if ($kt['id'] == $t['kind_id']) {
+                                                                                        if ((!($cn['country_code'] != "[us]" && $it1['info'] == "countries" && $it2['info'] == "rating" && ($k['keyword'] == "murder" || $k['keyword'] == "murder-in-title" || $k['keyword'] == "blood" || $k['keyword'] == "violence") && ($kt['kind'] == "movie" || $kt['kind'] == "episode") && strpos($mc['note'], "(USA)") !== false) && strpos($mc['note'], "(200") !== false && ($mi['info'] == "Germany" || $mi['info'] == "German" || $mi['info'] == "USA" || $mi['info'] == "American") && $mi_idx['info'] < 7 && $t['production_year'] > 2008 && $kt['id'] == $t['kind_id'] && $t['id'] == $mi['movie_id'] && $t['id'] == $mk['movie_id'] && $t['id'] == $mi_idx['movie_id'] && $t['id'] == $mc['movie_id'] && $mk['movie_id'] == $mi['movie_id'] && $mk['movie_id'] == $mi_idx['movie_id'] && $mk['movie_id'] == $mc['movie_id'] && $mi['movie_id'] == $mi_idx['movie_id'] && $mi['movie_id'] == $mc['movie_id'] && $mc['movie_id'] == $mi_idx['movie_id'] && $k['id'] == $mk['keyword_id'] && $it1['id'] == $mi['info_type_id'] && $it2['id'] == $mi_idx['info_type_id'] && $ct['id'] == $mc['company_type_id'] && $cn['id'] == $mc['company_id'])) {
+                                                                                            $result[] = [
+    "company" => $cn['name'],
+    "rating" => $mi_idx['info'],
+    "title" => $t['title']
+];
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "movie_company" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['company'];
+            }
+            return $result;
+        })()),
+        "rating" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['rating'];
+            }
+            return $result;
+        })()),
+        "western_violent_movie" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['title'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q23.out
+++ b/tests/dataset/job/compiler/php/q23.out
@@ -1,0 +1,1 @@
+[{"movie_kind":"movie","complete_us_internet_movie":"Web Movie"}]

--- a/tests/dataset/job/compiler/php/q23.php
+++ b/tests/dataset/job/compiler/php/q23.php
@@ -1,0 +1,145 @@
+<?php
+$complete_cast = [
+    ["movie_id" => 1, "status_id" => 1],
+    ["movie_id" => 2, "status_id" => 2]
+];
+$comp_cast_type = [
+    [
+        "id" => 1,
+        "kind" => "complete+verified"
+    ],
+    ["id" => 2, "kind" => "partial"]
+];
+$company_name = [
+    ["id" => 1, "country_code" => "[us]"],
+    ["id" => 2, "country_code" => "[gb]"]
+];
+$company_type = [["id" => 1], ["id" => 2]];
+$info_type = [
+    ["id" => 1, "info" => "release dates"],
+    ["id" => 2, "info" => "other"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "internet"],
+    ["id" => 2, "keyword" => "other"]
+];
+$kind_type = [
+    ["id" => 1, "kind" => "movie"],
+    ["id" => 2, "kind" => "series"]
+];
+$movie_companies = [
+    [
+        "movie_id" => 1,
+        "company_id" => 1,
+        "company_type_id" => 1
+    ],
+    [
+        "movie_id" => 2,
+        "company_id" => 2,
+        "company_type_id" => 2
+    ]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "note" => "internet release",
+        "info" => "USA: May 2005"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 1,
+        "note" => "theater",
+        "info" => "USA: April 1998"
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2]
+];
+$title = [
+    [
+        "id" => 1,
+        "kind_id" => 1,
+        "production_year" => 2005,
+        "title" => "Web Movie"
+    ],
+    [
+        "id" => 2,
+        "kind_id" => 1,
+        "production_year" => 1998,
+        "title" => "Old Movie"
+    ]
+];
+$matches = (function() use ($comp_cast_type, $company_name, $company_type, $complete_cast, $info_type, $keyword, $kind_type, $movie_companies, $movie_info, $movie_keyword, $title) {
+    $result = [];
+    foreach ($complete_cast as $cc) {
+        foreach ($comp_cast_type as $cct1) {
+            if ($cct1['id'] == $cc['status_id']) {
+                foreach ($title as $t) {
+                    if ($t['id'] == $cc['movie_id']) {
+                        foreach ($kind_type as $kt) {
+                            if ($kt['id'] == $t['kind_id']) {
+                                foreach ($movie_info as $mi) {
+                                    if ($mi['movie_id'] == $t['id']) {
+                                        foreach ($info_type as $it1) {
+                                            if ($it1['id'] == $mi['info_type_id']) {
+                                                foreach ($movie_keyword as $mk) {
+                                                    if ($mk['movie_id'] == $t['id']) {
+                                                        foreach ($keyword as $k) {
+                                                            if ($k['id'] == $mk['keyword_id']) {
+                                                                foreach ($movie_companies as $mc) {
+                                                                    if ($mc['movie_id'] == $t['id']) {
+                                                                        foreach ($company_name as $cn) {
+                                                                            if ($cn['id'] == $mc['company_id']) {
+                                                                                foreach ($company_type as $ct) {
+                                                                                    if ($ct['id'] == $mc['company_type_id']) {
+                                                                                        if ($cct1['kind'] == "complete+verified" && $cn['country_code'] == "[us]" && $it1['info'] == "release dates" && $kt['kind'] == "movie" && strpos($mi['note'], "internet") !== false && (strpos($mi['info'], "USA:") !== false && (strpos($mi['info'], "199") !== false || strpos($mi['info'], "200") !== false)) && $t['production_year'] > 2000) {
+                                                                                            $result[] = [
+    "movie_kind" => $kt['kind'],
+    "complete_us_internet_movie" => $t['title']
+];
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "movie_kind" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['movie_kind'];
+            }
+            return $result;
+        })()),
+        "complete_us_internet_movie" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['complete_us_internet_movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q24.out
+++ b/tests/dataset/job/compiler/php/q24.out
@@ -1,0 +1,1 @@
+[{"voiced_char_name":"Hero Character","voicing_actress_name":"Ann Actress","voiced_action_movie_jap_eng":"Heroic Adventure"}]

--- a/tests/dataset/job/compiler/php/q24.php
+++ b/tests/dataset/job/compiler/php/q24.php
@@ -1,0 +1,112 @@
+<?php
+$aka_name = [["person_id" => 1]];
+$char_name = [
+    ["id" => 1, "name" => "Hero Character"]
+];
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_id" => 1,
+        "person_role_id" => 1,
+        "role_id" => 1,
+        "note" => "(voice)"
+    ]
+];
+$company_name = [["id" => 1, "country_code" => "[us]"]];
+$info_type = [["id" => 1, "info" => "release dates"]];
+$keyword = [["id" => 1, "keyword" => "hero"]];
+$movie_companies = [["movie_id" => 1, "company_id" => 1]];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "info" => "Japan: Feb 2015"
+    ]
+];
+$movie_keyword = [["movie_id" => 1, "keyword_id" => 1]];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Ann Actress",
+        "gender" => "f"
+    ]
+];
+$role_type = [["id" => 1, "role" => "actress"]];
+$title = [
+    [
+        "id" => 1,
+        "title" => "Heroic Adventure",
+        "production_year" => 2015
+    ]
+];
+$matches = (function() use ($aka_name, $cast_info, $char_name, $company_name, $info_type, $keyword, $movie_companies, $movie_info, $movie_keyword, $name, $role_type, $title) {
+    $result = [];
+    foreach ($aka_name as $an) {
+        foreach ($char_name as $chn) {
+            foreach ($cast_info as $ci) {
+                foreach ($company_name as $cn) {
+                    foreach ($info_type as $it) {
+                        foreach ($keyword as $k) {
+                            foreach ($movie_companies as $mc) {
+                                foreach ($movie_info as $mi) {
+                                    foreach ($movie_keyword as $mk) {
+                                        foreach ($name as $n) {
+                                            foreach ($role_type as $rt) {
+                                                foreach ($title as $t) {
+                                                    if ((in_array(in_array($ci['note'], [
+    "(voice)",
+    "(voice: Japanese version)",
+    "(voice) (uncredited)",
+    "(voice: English version)"
+]) && $cn['country_code'] == "[us]" && $it['info'] == "release dates" && $k['keyword'], [
+    "hero",
+    "martial-arts",
+    "hand-to-hand-combat"
+]) && $mi['info'] != null && (str_starts_with($mi['info'], "Japan:") && strpos($mi['info'], "201") !== false || str_starts_with($mi['info'], "USA:") && strpos($mi['info'], "201") !== false) && $n['gender'] == "f" && strpos($n['name'], "An") !== false && $rt['role'] == "actress" && $t['production_year'] > 2010 && $t['id'] == $mi['movie_id'] && $t['id'] == $mc['movie_id'] && $t['id'] == $ci['movie_id'] && $t['id'] == $mk['movie_id'] && $mc['movie_id'] == $ci['movie_id'] && $mc['movie_id'] == $mi['movie_id'] && $mc['movie_id'] == $mk['movie_id'] && $mi['movie_id'] == $ci['movie_id'] && $mi['movie_id'] == $mk['movie_id'] && $ci['movie_id'] == $mk['movie_id'] && $cn['id'] == $mc['company_id'] && $it['id'] == $mi['info_type_id'] && $n['id'] == $ci['person_id'] && $rt['id'] == $ci['role_id'] && $n['id'] == $an['person_id'] && $ci['person_id'] == $an['person_id'] && $chn['id'] == $ci['person_role_id'] && $k['id'] == $mk['keyword_id'])) {
+                                                        $result[] = [
+    "voiced_char_name" => $chn['name'],
+    "voicing_actress_name" => $n['name'],
+    "voiced_action_movie_jap_eng" => $t['title']
+];
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "voiced_char_name" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['voiced_char_name'];
+            }
+            return $result;
+        })()),
+        "voicing_actress_name" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['voicing_actress_name'];
+            }
+            return $result;
+        })()),
+        "voiced_action_movie_jap_eng" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['voiced_action_movie_jap_eng'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q25.out
+++ b/tests/dataset/job/compiler/php/q25.out
@@ -1,0 +1,1 @@
+[{"movie_budget":"Horror","movie_votes":100,"male_writer":"Mike","violent_movie_title":"Scary Movie"}]

--- a/tests/dataset/job/compiler/php/q25.php
+++ b/tests/dataset/job/compiler/php/q25.php
@@ -1,0 +1,143 @@
+<?php
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_id" => 1,
+        "note" => "(writer)"
+    ],
+    [
+        "movie_id" => 2,
+        "person_id" => 2,
+        "note" => "(writer)"
+    ]
+];
+$info_type = [
+    ["id" => 1, "info" => "genres"],
+    ["id" => 2, "info" => "votes"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "murder"],
+    ["id" => 2, "keyword" => "romance"]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "info" => "Horror"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 1,
+        "info" => "Comedy"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 2,
+        "info" => 100
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 2,
+        "info" => 50
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Mike",
+        "gender" => "m"
+    ],
+    [
+        "id" => 2,
+        "name" => "Sue",
+        "gender" => "f"
+    ]
+];
+$title = [
+    ["id" => 1, "title" => "Scary Movie"],
+    ["id" => 2, "title" => "Funny Movie"]
+];
+$allowed_notes = [
+    "(writer)",
+    "(head writer)",
+    "(written by)",
+    "(story)",
+    "(story editor)"
+];
+$allowed_keywords = [
+    "murder",
+    "blood",
+    "gore",
+    "death",
+    "female-nudity"
+];
+$matches = (function() use ($allowed_keywords, $allowed_notes, $cast_info, $info_type, $keyword, $movie_info, $movie_info_idx, $movie_keyword, $name, $title) {
+    $result = [];
+    foreach ($cast_info as $ci) {
+        foreach ($info_type as $it1) {
+            foreach ($info_type as $it2) {
+                foreach ($keyword as $k) {
+                    foreach ($movie_info as $mi) {
+                        foreach ($movie_info_idx as $mi_idx) {
+                            foreach ($movie_keyword as $mk) {
+                                foreach ($name as $n) {
+                                    foreach ($title as $t) {
+                                        if (((in_array($ci['note'], $allowed_notes)) && $it1['info'] == "genres" && $it2['info'] == "votes" && (in_array($k['keyword'], $allowed_keywords)) && $mi['info'] == "Horror" && $n['gender'] == "m" && $t['id'] == $mi['movie_id'] && $t['id'] == $mi_idx['movie_id'] && $t['id'] == $ci['movie_id'] && $t['id'] == $mk['movie_id'] && $ci['movie_id'] == $mi['movie_id'] && $ci['movie_id'] == $mi_idx['movie_id'] && $ci['movie_id'] == $mk['movie_id'] && $mi['movie_id'] == $mi_idx['movie_id'] && $mi['movie_id'] == $mk['movie_id'] && $mi_idx['movie_id'] == $mk['movie_id'] && $n['id'] == $ci['person_id'] && $it1['id'] == $mi['info_type_id'] && $it2['id'] == $mi_idx['info_type_id'] && $k['id'] == $mk['keyword_id'])) {
+                                            $result[] = [
+    "budget" => $mi['info'],
+    "votes" => $mi_idx['info'],
+    "writer" => $n['name'],
+    "title" => $t['title']
+];
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "movie_budget" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['budget'];
+            }
+            return $result;
+        })()),
+        "movie_votes" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['votes'];
+            }
+            return $result;
+        })()),
+        "male_writer" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['writer'];
+            }
+            return $result;
+        })()),
+        "violent_movie_title" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['title'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q26.out
+++ b/tests/dataset/job/compiler/php/q26.out
@@ -1,0 +1,1 @@
+[{"character_name":"Spider-Man","rating":8.5,"playing_actor":"Actor One","complete_hero_movie":"Hero Movie"}]

--- a/tests/dataset/job/compiler/php/q26.php
+++ b/tests/dataset/job/compiler/php/q26.php
@@ -1,0 +1,177 @@
+<?php
+$complete_cast = [
+    [
+        "movie_id" => 1,
+        "subject_id" => 1,
+        "status_id" => 2
+    ],
+    [
+        "movie_id" => 2,
+        "subject_id" => 1,
+        "status_id" => 2
+    ]
+];
+$comp_cast_type = [
+    ["id" => 1, "kind" => "cast"],
+    ["id" => 2, "kind" => "complete"]
+];
+$char_name = [
+    ["id" => 1, "name" => "Spider-Man"],
+    ["id" => 2, "name" => "Villain"]
+];
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_role_id" => 1,
+        "person_id" => 1
+    ],
+    [
+        "movie_id" => 2,
+        "person_role_id" => 2,
+        "person_id" => 2
+    ]
+];
+$info_type = [["id" => 1, "info" => "rating"]];
+$keyword = [
+    ["id" => 1, "keyword" => "superhero"],
+    ["id" => 2, "keyword" => "comedy"]
+];
+$kind_type = [["id" => 1, "kind" => "movie"]];
+$movie_info_idx = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "info" => 8.5
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 1,
+        "info" => 6.5
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2]
+];
+$name = [
+    ["id" => 1, "name" => "Actor One"],
+    ["id" => 2, "name" => "Actor Two"]
+];
+$title = [
+    [
+        "id" => 1,
+        "kind_id" => 1,
+        "production_year" => 2005,
+        "title" => "Hero Movie"
+    ],
+    [
+        "id" => 2,
+        "kind_id" => 1,
+        "production_year" => 1999,
+        "title" => "Old Film"
+    ]
+];
+$allowed_keywords = [
+    "superhero",
+    "marvel-comics",
+    "based-on-comic",
+    "tv-special",
+    "fight",
+    "violence",
+    "magnet",
+    "web",
+    "claw",
+    "laser"
+];
+$rows = (function() use ($allowed_keywords, $cast_info, $char_name, $comp_cast_type, $complete_cast, $info_type, $keyword, $kind_type, $movie_info_idx, $movie_keyword, $name, $title) {
+    $result = [];
+    foreach ($complete_cast as $cc) {
+        foreach ($comp_cast_type as $cct1) {
+            if ($cct1['id'] == $cc['subject_id']) {
+                foreach ($comp_cast_type as $cct2) {
+                    if ($cct2['id'] == $cc['status_id']) {
+                        foreach ($cast_info as $ci) {
+                            if ($ci['movie_id'] == $cc['movie_id']) {
+                                foreach ($char_name as $chn) {
+                                    if ($chn['id'] == $ci['person_role_id']) {
+                                        foreach ($name as $n) {
+                                            if ($n['id'] == $ci['person_id']) {
+                                                foreach ($title as $t) {
+                                                    if ($t['id'] == $ci['movie_id']) {
+                                                        foreach ($kind_type as $kt) {
+                                                            if ($kt['id'] == $t['kind_id']) {
+                                                                foreach ($movie_keyword as $mk) {
+                                                                    if ($mk['movie_id'] == $t['id']) {
+                                                                        foreach ($keyword as $k) {
+                                                                            if ($k['id'] == $mk['keyword_id']) {
+                                                                                foreach ($movie_info_idx as $mi_idx) {
+                                                                                    if ($mi_idx['movie_id'] == $t['id']) {
+                                                                                        foreach ($info_type as $it2) {
+                                                                                            if ($it2['id'] == $mi_idx['info_type_id']) {
+                                                                                                if ($cct1['kind'] == "cast" && strpos($cct2['kind'], "complete") !== false && $chn['name'] != null && (strpos($chn['name'], "man") !== false || strpos($chn['name'], "Man") !== false) && $it2['info'] == "rating" && (in_array($k['keyword'], $allowed_keywords)) && $kt['kind'] == "movie" && $mi_idx['info'] > 7 && $t['production_year'] > 2000) {
+                                                                                                    $result[] = [
+    "character" => $chn['name'],
+    "rating" => $mi_idx['info'],
+    "actor" => $n['name'],
+    "movie" => $t['title']
+];
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "character_name" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['character'];
+            }
+            return $result;
+        })()),
+        "rating" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['rating'];
+            }
+            return $result;
+        })()),
+        "playing_actor" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['actor'];
+            }
+            return $result;
+        })()),
+        "complete_hero_movie" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q27.out
+++ b/tests/dataset/job/compiler/php/q27.out
@@ -1,0 +1,1 @@
+{"producing_company":"Best Film","link_type":"follows","complete_western_sequel":"Western Sequel"}

--- a/tests/dataset/job/compiler/php/q27.php
+++ b/tests/dataset/job/compiler/php/q27.php
@@ -1,0 +1,165 @@
+<?php
+$comp_cast_type = [
+    ["id" => 1, "kind" => "cast"],
+    ["id" => 2, "kind" => "crew"],
+    ["id" => 3, "kind" => "complete"]
+];
+$complete_cast = [
+    [
+        "movie_id" => 1,
+        "subject_id" => 1,
+        "status_id" => 3
+    ],
+    [
+        "movie_id" => 2,
+        "subject_id" => 2,
+        "status_id" => 3
+    ]
+];
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "Best Film",
+        "country_code" => "[se]"
+    ],
+    [
+        "id" => 2,
+        "name" => "Polish Film",
+        "country_code" => "[pl]"
+    ]
+];
+$company_type = [
+    [
+        "id" => 1,
+        "kind" => "production companies"
+    ],
+    ["id" => 2, "kind" => "other"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "sequel"],
+    ["id" => 2, "keyword" => "remake"]
+];
+$link_type = [
+    ["id" => 1, "link" => "follows"],
+    ["id" => 2, "link" => "related"]
+];
+$movie_companies = [
+    [
+        "movie_id" => 1,
+        "company_id" => 1,
+        "company_type_id" => 1,
+        "note" => null
+    ],
+    [
+        "movie_id" => 2,
+        "company_id" => 2,
+        "company_type_id" => 1,
+        "note" => "extra"
+    ]
+];
+$movie_info = [
+    ["movie_id" => 1, "info" => "Sweden"],
+    ["movie_id" => 2, "info" => "USA"]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2]
+];
+$movie_link = [
+    ["movie_id" => 1, "link_type_id" => 1],
+    ["movie_id" => 2, "link_type_id" => 2]
+];
+$title = [
+    [
+        "id" => 1,
+        "production_year" => 1980,
+        "title" => "Western Sequel"
+    ],
+    [
+        "id" => 2,
+        "production_year" => 1999,
+        "title" => "Another Movie"
+    ]
+];
+$matches = (function() use ($comp_cast_type, $company_name, $company_type, $complete_cast, $keyword, $link_type, $movie_companies, $movie_info, $movie_keyword, $movie_link, $title) {
+    $result = [];
+    foreach ($complete_cast as $cc) {
+        foreach ($comp_cast_type as $cct1) {
+            if ($cct1['id'] == $cc['subject_id']) {
+                foreach ($comp_cast_type as $cct2) {
+                    if ($cct2['id'] == $cc['status_id']) {
+                        foreach ($title as $t) {
+                            if ($t['id'] == $cc['movie_id']) {
+                                foreach ($movie_link as $ml) {
+                                    if ($ml['movie_id'] == $t['id']) {
+                                        foreach ($link_type as $lt) {
+                                            if ($lt['id'] == $ml['link_type_id']) {
+                                                foreach ($movie_keyword as $mk) {
+                                                    if ($mk['movie_id'] == $t['id']) {
+                                                        foreach ($keyword as $k) {
+                                                            if ($k['id'] == $mk['keyword_id']) {
+                                                                foreach ($movie_companies as $mc) {
+                                                                    if ($mc['movie_id'] == $t['id']) {
+                                                                        foreach ($company_type as $ct) {
+                                                                            if ($ct['id'] == $mc['company_type_id']) {
+                                                                                foreach ($company_name as $cn) {
+                                                                                    if ($cn['id'] == $mc['company_id']) {
+                                                                                        foreach ($movie_info as $mi) {
+                                                                                            if ($mi['movie_id'] == $t['id']) {
+                                                                                                if ((($cct1['kind'] == "cast" || $cct1['kind'] == "crew") && $cct2['kind'] == "complete" && $cn['country_code'] != "[pl]" && (strpos($cn['name'], "Film") !== false || strpos($cn['name'], "Warner") !== false) && $ct['kind'] == "production companies" && $k['keyword'] == "sequel" && strpos($lt['link'], "follow") !== false && $mc['note'] == null && ($mi['info'] == "Sweden" || $mi['info'] == "Germany" || $mi['info'] == "Swedish" || $mi['info'] == "German") && $t['production_year'] >= 1950 && $t['production_year'] <= 2000 && $ml['movie_id'] == $mk['movie_id'] && $ml['movie_id'] == $mc['movie_id'] && $mk['movie_id'] == $mc['movie_id'] && $ml['movie_id'] == $mi['movie_id'] && $mk['movie_id'] == $mi['movie_id'] && $mc['movie_id'] == $mi['movie_id'] && $ml['movie_id'] == $cc['movie_id'] && $mk['movie_id'] == $cc['movie_id'] && $mc['movie_id'] == $cc['movie_id'] && $mi['movie_id'] == $cc['movie_id'])) {
+                                                                                                    $result[] = [
+    "company" => $cn['name'],
+    "link" => $lt['link'],
+    "title" => $t['title']
+];
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    "producing_company" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['company'];
+        }
+        return $result;
+    })()),
+    "link_type" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['link'];
+        }
+        return $result;
+    })()),
+    "complete_western_sequel" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['title'];
+        }
+        return $result;
+    })())
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q28.out
+++ b/tests/dataset/job/compiler/php/q28.out
@@ -1,0 +1,1 @@
+{"movie_company":"Euro Films Ltd.","rating":7.2,"complete_euro_dark_movie":"Dark Euro Film"}

--- a/tests/dataset/job/compiler/php/q28.php
+++ b/tests/dataset/job/compiler/php/q28.php
@@ -1,0 +1,210 @@
+<?php
+$comp_cast_type = [
+    ["id" => 1, "kind" => "crew"],
+    [
+        "id" => 2,
+        "kind" => "complete+verified"
+    ],
+    ["id" => 3, "kind" => "partial"]
+];
+$complete_cast = [
+    [
+        "movie_id" => 1,
+        "subject_id" => 1,
+        "status_id" => 3
+    ],
+    [
+        "movie_id" => 2,
+        "subject_id" => 1,
+        "status_id" => 2
+    ]
+];
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "Euro Films Ltd.",
+        "country_code" => "[gb]"
+    ],
+    [
+        "id" => 2,
+        "name" => "US Studios",
+        "country_code" => "[us]"
+    ]
+];
+$company_type = [["id" => 1], ["id" => 2]];
+$movie_companies = [
+    [
+        "movie_id" => 1,
+        "company_id" => 1,
+        "company_type_id" => 1,
+        "note" => "production (2005) (UK)"
+    ],
+    [
+        "movie_id" => 2,
+        "company_id" => 2,
+        "company_type_id" => 1,
+        "note" => "production (USA)"
+    ]
+];
+$info_type = [
+    ["id" => 1, "info" => "countries"],
+    ["id" => 2, "info" => "rating"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "blood"],
+    ["id" => 2, "keyword" => "romance"]
+];
+$kind_type = [
+    ["id" => 1, "kind" => "movie"],
+    ["id" => 2, "kind" => "episode"]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "info" => "Germany"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 1,
+        "info" => "USA"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 2,
+        "info" => 7.2
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 2,
+        "info" => 9
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2]
+];
+$title = [
+    [
+        "id" => 1,
+        "kind_id" => 1,
+        "production_year" => 2005,
+        "title" => "Dark Euro Film"
+    ],
+    [
+        "id" => 2,
+        "kind_id" => 1,
+        "production_year" => 2005,
+        "title" => "US Film"
+    ]
+];
+$allowed_keywords = [
+    "murder",
+    "murder-in-title",
+    "blood",
+    "violence"
+];
+$allowed_countries = [
+    "Sweden",
+    "Norway",
+    "Germany",
+    "Denmark",
+    "Swedish",
+    "Danish",
+    "Norwegian",
+    "German",
+    "USA",
+    "American"
+];
+$matches = (function() use ($allowed_countries, $allowed_keywords, $comp_cast_type, $company_name, $company_type, $complete_cast, $info_type, $keyword, $kind_type, $movie_companies, $movie_info, $movie_info_idx, $movie_keyword, $title) {
+    $result = [];
+    foreach ($complete_cast as $cc) {
+        foreach ($comp_cast_type as $cct1) {
+            if ($cct1['id'] == $cc['subject_id']) {
+                foreach ($comp_cast_type as $cct2) {
+                    if ($cct2['id'] == $cc['status_id']) {
+                        foreach ($movie_companies as $mc) {
+                            if ($mc['movie_id'] == $cc['movie_id']) {
+                                foreach ($company_name as $cn) {
+                                    if ($cn['id'] == $mc['company_id']) {
+                                        foreach ($company_type as $ct) {
+                                            if ($ct['id'] == $mc['company_type_id']) {
+                                                foreach ($movie_keyword as $mk) {
+                                                    if ($mk['movie_id'] == $cc['movie_id']) {
+                                                        foreach ($keyword as $k) {
+                                                            if ($k['id'] == $mk['keyword_id']) {
+                                                                foreach ($movie_info as $mi) {
+                                                                    if ($mi['movie_id'] == $cc['movie_id']) {
+                                                                        foreach ($info_type as $it1) {
+                                                                            if ($it1['id'] == $mi['info_type_id']) {
+                                                                                foreach ($movie_info_idx as $mi_idx) {
+                                                                                    if ($mi_idx['movie_id'] == $cc['movie_id']) {
+                                                                                        foreach ($info_type as $it2) {
+                                                                                            if ($it2['id'] == $mi_idx['info_type_id']) {
+                                                                                                foreach ($title as $t) {
+                                                                                                    if ($t['id'] == $cc['movie_id']) {
+                                                                                                        foreach ($kind_type as $kt) {
+                                                                                                            if ($kt['id'] == $t['kind_id']) {
+                                                                                                                if ((!($cct1['kind'] == "crew" && $cct2['kind'] != "complete+verified" && $cn['country_code'] != "[us]" && $it1['info'] == "countries" && $it2['info'] == "rating" && (in_array($k['keyword'], $allowed_keywords)) && (in_array($kt['kind'], ["movie", "episode"])) && strpos($mc['note'], "(USA)") !== false) && strpos($mc['note'], "(200") !== false && (in_array($mi['info'], $allowed_countries)) && $mi_idx['info'] < 8.5 && $t['production_year'] > 2000)) {
+                                                                                                                    $result[] = [
+    "company" => $cn['name'],
+    "rating" => $mi_idx['info'],
+    "title" => $t['title']
+];
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    "movie_company" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['company'];
+        }
+        return $result;
+    })()),
+    "rating" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['rating'];
+        }
+        return $result;
+    })()),
+    "complete_euro_dark_movie" => min((function() use ($matches) {
+        $result = [];
+        foreach ($matches as $x) {
+            $result[] = $x['title'];
+        }
+        return $result;
+    })())
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q29.out
+++ b/tests/dataset/job/compiler/php/q29.out
@@ -1,0 +1,1 @@
+[{"voiced_char":"Queen","voicing_actress":"Angela Aniston","voiced_animation":"Shrek 2"}]

--- a/tests/dataset/job/compiler/php/q29.php
+++ b/tests/dataset/job/compiler/php/q29.php
@@ -1,0 +1,182 @@
+<?php
+$aka_name = [["person_id" => 1], ["person_id" => 2]];
+$complete_cast = [
+    [
+        "movie_id" => 1,
+        "subject_id" => 1,
+        "status_id" => 2
+    ],
+    [
+        "movie_id" => 2,
+        "subject_id" => 1,
+        "status_id" => 2
+    ]
+];
+$comp_cast_type = [
+    ["id" => 1, "kind" => "cast"],
+    [
+        "id" => 2,
+        "kind" => "complete+verified"
+    ],
+    ["id" => 3, "kind" => "other"]
+];
+$char_name = [
+    ["id" => 1, "name" => "Queen"],
+    ["id" => 2, "name" => "Princess"]
+];
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_id" => 1,
+        "role_id" => 1,
+        "person_role_id" => 1,
+        "note" => "(voice)"
+    ],
+    [
+        "movie_id" => 2,
+        "person_id" => 2,
+        "role_id" => 1,
+        "person_role_id" => 2,
+        "note" => "(voice)"
+    ]
+];
+$company_name = [
+    ["id" => 1, "country_code" => "[us]"],
+    ["id" => 2, "country_code" => "[uk]"]
+];
+$info_type = [
+    ["id" => 1, "info" => "release dates"],
+    ["id" => 2, "info" => "trivia"],
+    ["id" => 3, "info" => "other"]
+];
+$keyword = [
+    [
+        "id" => 1,
+        "keyword" => "computer-animation"
+    ],
+    ["id" => 2, "keyword" => "action"]
+];
+$movie_companies = [
+    ["movie_id" => 1, "company_id" => 1],
+    ["movie_id" => 2, "company_id" => 2]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "info" => "USA:2004"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 1,
+        "info" => "USA:1995"
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Angela Aniston",
+        "gender" => "f"
+    ],
+    [
+        "id" => 2,
+        "name" => "Bob Brown",
+        "gender" => "m"
+    ]
+];
+$person_info = [
+    ["person_id" => 1, "info_type_id" => 2],
+    ["person_id" => 2, "info_type_id" => 2]
+];
+$role_type = [
+    ["id" => 1, "role" => "actress"],
+    ["id" => 2, "role" => "actor"]
+];
+$title = [
+    [
+        "id" => 1,
+        "title" => "Shrek 2",
+        "production_year" => 2004
+    ],
+    [
+        "id" => 2,
+        "title" => "Old Film",
+        "production_year" => 1999
+    ]
+];
+$matches = (function() use ($aka_name, $cast_info, $char_name, $comp_cast_type, $company_name, $complete_cast, $info_type, $keyword, $movie_companies, $movie_info, $movie_keyword, $name, $person_info, $role_type, $title) {
+    $result = [];
+    foreach ($aka_name as $an) {
+        foreach ($complete_cast as $cc) {
+            foreach ($comp_cast_type as $cct1) {
+                foreach ($comp_cast_type as $cct2) {
+                    foreach ($char_name as $chn) {
+                        foreach ($cast_info as $ci) {
+                            foreach ($company_name as $cn) {
+                                foreach ($info_type as $it) {
+                                    foreach ($info_type as $it3) {
+                                        foreach ($keyword as $k) {
+                                            foreach ($movie_companies as $mc) {
+                                                foreach ($movie_info as $mi) {
+                                                    foreach ($movie_keyword as $mk) {
+                                                        foreach ($name as $n) {
+                                                            foreach ($person_info as $pi) {
+                                                                foreach ($role_type as $rt) {
+                                                                    foreach ($title as $t) {
+                                                                        if (($cct1['kind'] == "cast" && $cct2['kind'] == "complete+verified" && $chn['name'] == "Queen" && ($ci['note'] == "(voice)" || $ci['note'] == "(voice) (uncredited)" || $ci['note'] == "(voice: English version)") && $cn['country_code'] == "[us]" && $it['info'] == "release dates" && $it3['info'] == "trivia" && $k['keyword'] == "computer-animation" && (str_starts_with($mi['info'], "Japan:200") || str_starts_with($mi['info'], "USA:200")) && $n['gender'] == "f" && strpos($n['name'], "An") !== false && $rt['role'] == "actress" && $t['title'] == "Shrek 2" && $t['production_year'] >= 2000 && $t['production_year'] <= 2010 && $t['id'] == $mi['movie_id'] && $t['id'] == $mc['movie_id'] && $t['id'] == $ci['movie_id'] && $t['id'] == $mk['movie_id'] && $t['id'] == $cc['movie_id'] && $mc['movie_id'] == $ci['movie_id'] && $mc['movie_id'] == $mi['movie_id'] && $mc['movie_id'] == $mk['movie_id'] && $mc['movie_id'] == $cc['movie_id'] && $mi['movie_id'] == $ci['movie_id'] && $mi['movie_id'] == $mk['movie_id'] && $mi['movie_id'] == $cc['movie_id'] && $ci['movie_id'] == $mk['movie_id'] && $ci['movie_id'] == $cc['movie_id'] && $mk['movie_id'] == $cc['movie_id'] && $cn['id'] == $mc['company_id'] && $it['id'] == $mi['info_type_id'] && $n['id'] == $ci['person_id'] && $rt['id'] == $ci['role_id'] && $n['id'] == $an['person_id'] && $ci['person_id'] == $an['person_id'] && $chn['id'] == $ci['person_role_id'] && $n['id'] == $pi['person_id'] && $ci['person_id'] == $pi['person_id'] && $it3['id'] == $pi['info_type_id'] && $k['id'] == $mk['keyword_id'] && $cct1['id'] == $cc['subject_id'] && $cct2['id'] == $cc['status_id'])) {
+                                                                            $result[] = [
+    "voiced_char" => $chn['name'],
+    "voicing_actress" => $n['name'],
+    "voiced_animation" => $t['title']
+];
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "voiced_char" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['voiced_char'];
+            }
+            return $result;
+        })()),
+        "voicing_actress" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['voicing_actress'];
+            }
+            return $result;
+        })()),
+        "voiced_animation" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['voiced_animation'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q30.out
+++ b/tests/dataset/job/compiler/php/q30.out
@@ -1,0 +1,1 @@
+[{"movie_budget":"Horror","movie_votes":2000,"writer":"John Writer","complete_violent_movie":"Violent Horror"}]

--- a/tests/dataset/job/compiler/php/q30.php
+++ b/tests/dataset/job/compiler/php/q30.php
@@ -1,0 +1,201 @@
+<?php
+$comp_cast_type = [
+    ["id" => 1, "kind" => "cast"],
+    [
+        "id" => 2,
+        "kind" => "complete+verified"
+    ],
+    ["id" => 3, "kind" => "crew"]
+];
+$complete_cast = [
+    [
+        "movie_id" => 1,
+        "subject_id" => 1,
+        "status_id" => 2
+    ],
+    [
+        "movie_id" => 2,
+        "subject_id" => 3,
+        "status_id" => 2
+    ]
+];
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_id" => 10,
+        "note" => "(writer)"
+    ],
+    [
+        "movie_id" => 2,
+        "person_id" => 11,
+        "note" => "(actor)"
+    ]
+];
+$info_type = [
+    ["id" => 1, "info" => "genres"],
+    ["id" => 2, "info" => "votes"]
+];
+$keyword = [
+    ["id" => 1, "keyword" => "murder"],
+    ["id" => 2, "keyword" => "comedy"]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 1,
+        "info" => "Horror"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 1,
+        "info" => "Comedy"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 2,
+        "info" => 2000
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 2,
+        "info" => 150
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 1],
+    ["movie_id" => 2, "keyword_id" => 2]
+];
+$name = [
+    [
+        "id" => 10,
+        "name" => "John Writer",
+        "gender" => "m"
+    ],
+    [
+        "id" => 11,
+        "name" => "Jane Actor",
+        "gender" => "f"
+    ]
+];
+$title = [
+    [
+        "id" => 1,
+        "title" => "Violent Horror",
+        "production_year" => 2005
+    ],
+    [
+        "id" => 2,
+        "title" => "Old Comedy",
+        "production_year" => 1995
+    ]
+];
+$violent_keywords = [
+    "murder",
+    "violence",
+    "blood",
+    "gore",
+    "death",
+    "female-nudity",
+    "hospital"
+];
+$writer_notes = [
+    "(writer)",
+    "(head writer)",
+    "(written by)",
+    "(story)",
+    "(story editor)"
+];
+$matches = (function() use ($cast_info, $comp_cast_type, $complete_cast, $info_type, $keyword, $movie_info, $movie_info_idx, $movie_keyword, $name, $title, $violent_keywords, $writer_notes) {
+    $result = [];
+    foreach ($complete_cast as $cc) {
+        foreach ($comp_cast_type as $cct1) {
+            if ($cct1['id'] == $cc['subject_id']) {
+                foreach ($comp_cast_type as $cct2) {
+                    if ($cct2['id'] == $cc['status_id']) {
+                        foreach ($cast_info as $ci) {
+                            if ($ci['movie_id'] == $cc['movie_id']) {
+                                foreach ($movie_info as $mi) {
+                                    if ($mi['movie_id'] == $cc['movie_id']) {
+                                        foreach ($movie_info_idx as $mi_idx) {
+                                            if ($mi_idx['movie_id'] == $cc['movie_id']) {
+                                                foreach ($movie_keyword as $mk) {
+                                                    if ($mk['movie_id'] == $cc['movie_id']) {
+                                                        foreach ($info_type as $it1) {
+                                                            if ($it1['id'] == $mi['info_type_id']) {
+                                                                foreach ($info_type as $it2) {
+                                                                    if ($it2['id'] == $mi_idx['info_type_id']) {
+                                                                        foreach ($keyword as $k) {
+                                                                            if ($k['id'] == $mk['keyword_id']) {
+                                                                                foreach ($name as $n) {
+                                                                                    if ($n['id'] == $ci['person_id']) {
+                                                                                        foreach ($title as $t) {
+                                                                                            if ($t['id'] == $cc['movie_id']) {
+                                                                                                if ((in_array($cct1['kind'], ["cast", "crew"])) && $cct2['kind'] == "complete+verified" && (in_array($ci['note'], $writer_notes)) && $it1['info'] == "genres" && $it2['info'] == "votes" && (in_array($k['keyword'], $violent_keywords)) && (in_array($mi['info'], ["Horror", "Thriller"])) && $n['gender'] == "m" && $t['production_year'] > 2000) {
+                                                                                                    $result[] = [
+    "budget" => $mi['info'],
+    "votes" => $mi_idx['info'],
+    "writer" => $n['name'],
+    "movie" => $t['title']
+];
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "movie_budget" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['budget'];
+            }
+            return $result;
+        })()),
+        "movie_votes" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['votes'];
+            }
+            return $result;
+        })()),
+        "writer" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['writer'];
+            }
+            return $result;
+        })()),
+        "complete_violent_movie" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $x) {
+                $result[] = $x['movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q31.out
+++ b/tests/dataset/job/compiler/php/q31.out
@@ -1,0 +1,1 @@
+[{"movie_budget":"Horror","movie_votes":800,"writer":"Arthur","violent_liongate_movie":"Alpha Horror"}]

--- a/tests/dataset/job/compiler/php/q31.php
+++ b/tests/dataset/job/compiler/php/q31.php
@@ -1,0 +1,201 @@
+<?php
+$cast_info = [
+    [
+        "movie_id" => 1,
+        "person_id" => 1,
+        "note" => "(writer)"
+    ],
+    [
+        "movie_id" => 2,
+        "person_id" => 2,
+        "note" => "(story)"
+    ],
+    [
+        "movie_id" => 3,
+        "person_id" => 3,
+        "note" => "(writer)"
+    ]
+];
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "Lionsgate Pictures"
+    ],
+    ["id" => 2, "name" => "Other Studio"]
+];
+$info_type = [
+    ["id" => 10, "info" => "genres"],
+    ["id" => 20, "info" => "votes"]
+];
+$keyword = [
+    ["id" => 100, "keyword" => "murder"],
+    ["id" => 200, "keyword" => "comedy"]
+];
+$movie_companies = [
+    ["movie_id" => 1, "company_id" => 1],
+    ["movie_id" => 2, "company_id" => 1],
+    ["movie_id" => 3, "company_id" => 2]
+];
+$movie_info = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 10,
+        "info" => "Horror"
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 10,
+        "info" => "Thriller"
+    ],
+    [
+        "movie_id" => 3,
+        "info_type_id" => 10,
+        "info" => "Comedy"
+    ]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 1,
+        "info_type_id" => 20,
+        "info" => 1000
+    ],
+    [
+        "movie_id" => 2,
+        "info_type_id" => 20,
+        "info" => 800
+    ],
+    [
+        "movie_id" => 3,
+        "info_type_id" => 20,
+        "info" => 500
+    ]
+];
+$movie_keyword = [
+    ["movie_id" => 1, "keyword_id" => 100],
+    ["movie_id" => 2, "keyword_id" => 100],
+    ["movie_id" => 3, "keyword_id" => 200]
+];
+$name = [
+    [
+        "id" => 1,
+        "name" => "Arthur",
+        "gender" => "m"
+    ],
+    [
+        "id" => 2,
+        "name" => "Bob",
+        "gender" => "m"
+    ],
+    [
+        "id" => 3,
+        "name" => "Carla",
+        "gender" => "f"
+    ]
+];
+$title = [
+    ["id" => 1, "title" => "Alpha Horror"],
+    ["id" => 2, "title" => "Beta Blood"],
+    ["id" => 3, "title" => "Gamma Comedy"]
+];
+$matches = (function() use ($cast_info, $company_name, $info_type, $keyword, $movie_companies, $movie_info, $movie_info_idx, $movie_keyword, $name, $title) {
+    $result = [];
+    foreach ($cast_info as $ci) {
+        foreach ($name as $n) {
+            if ($n['id'] == $ci['person_id']) {
+                foreach ($title as $t) {
+                    if ($t['id'] == $ci['movie_id']) {
+                        foreach ($movie_info as $mi) {
+                            if ($mi['movie_id'] == $t['id']) {
+                                foreach ($movie_info_idx as $mi_idx) {
+                                    if ($mi_idx['movie_id'] == $t['id']) {
+                                        foreach ($movie_keyword as $mk) {
+                                            if ($mk['movie_id'] == $t['id']) {
+                                                foreach ($keyword as $k) {
+                                                    if ($k['id'] == $mk['keyword_id']) {
+                                                        foreach ($movie_companies as $mc) {
+                                                            if ($mc['movie_id'] == $t['id']) {
+                                                                foreach ($company_name as $cn) {
+                                                                    if ($cn['id'] == $mc['company_id']) {
+                                                                        foreach ($info_type as $it1) {
+                                                                            if ($it1['id'] == $mi['info_type_id']) {
+                                                                                foreach ($info_type as $it2) {
+                                                                                    if ($it2['id'] == $mi_idx['info_type_id']) {
+                                                                                        if (in_array(in_array(in_array($ci['note'], [
+    "(writer)",
+    "(head writer)",
+    "(written by)",
+    "(story)",
+    "(story editor)"
+]) && str_starts_with($cn['name'], "Lionsgate") && $it1['info'] == "genres" && $it2['info'] == "votes" && $k['keyword'], [
+    "murder",
+    "violence",
+    "blood",
+    "gore",
+    "death",
+    "female-nudity",
+    "hospital"
+]) && $mi['info'], ["Horror", "Thriller"]) && $n['gender'] == "m") {
+                                                                                            $result[] = [
+    "movie_budget" => $mi['info'],
+    "movie_votes" => $mi_idx['info'],
+    "writer" => $n['name'],
+    "violent_liongate_movie" => $t['title']
+];
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "movie_budget" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['movie_budget'];
+            }
+            return $result;
+        })()),
+        "movie_votes" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['movie_votes'];
+            }
+            return $result;
+        })()),
+        "writer" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['writer'];
+            }
+            return $result;
+        })()),
+        "violent_liongate_movie" => min((function() use ($matches) {
+            $result = [];
+            foreach ($matches as $r) {
+                $result[] = $r['violent_liongate_movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q32.out
+++ b/tests/dataset/job/compiler/php/q32.out
@@ -1,0 +1,1 @@
+[{"link_type":"sequel","first_movie":"Movie A","second_movie":"Movie C"}]

--- a/tests/dataset/job/compiler/php/q32.php
+++ b/tests/dataset/job/compiler/php/q32.php
@@ -1,0 +1,95 @@
+<?php
+$keyword = [
+    [
+        "id" => 1,
+        "keyword" => "10,000-mile-club"
+    ],
+    [
+        "id" => 2,
+        "keyword" => "character-name-in-title"
+    ]
+];
+$link_type = [
+    ["id" => 1, "link" => "sequel"],
+    ["id" => 2, "link" => "remake"]
+];
+$movie_keyword = [
+    ["movie_id" => 100, "keyword_id" => 1],
+    ["movie_id" => 200, "keyword_id" => 2]
+];
+$movie_link = [
+    [
+        "movie_id" => 100,
+        "linked_movie_id" => 300,
+        "link_type_id" => 1
+    ],
+    [
+        "movie_id" => 200,
+        "linked_movie_id" => 400,
+        "link_type_id" => 2
+    ]
+];
+$title = [
+    ["id" => 100, "title" => "Movie A"],
+    ["id" => 200, "title" => "Movie B"],
+    ["id" => 300, "title" => "Movie C"],
+    ["id" => 400, "title" => "Movie D"]
+];
+$joined = (function() use ($keyword, $link_type, $movie_keyword, $movie_link, $title) {
+    $result = [];
+    foreach ($keyword as $k) {
+        foreach ($movie_keyword as $mk) {
+            if ($mk['keyword_id'] == $k['id']) {
+                foreach ($title as $t1) {
+                    if ($t1['id'] == $mk['movie_id']) {
+                        foreach ($movie_link as $ml) {
+                            if ($ml['movie_id'] == $t1['id']) {
+                                foreach ($title as $t2) {
+                                    if ($t2['id'] == $ml['linked_movie_id']) {
+                                        foreach ($link_type as $lt) {
+                                            if ($lt['id'] == $ml['link_type_id']) {
+                                                if ($k['keyword'] == "10,000-mile-club") {
+                                                    $result[] = [
+    "link_type" => $lt['link'],
+    "first_movie" => $t1['title'],
+    "second_movie" => $t2['title']
+];
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    "link_type" => min((function() use ($joined) {
+        $result = [];
+        foreach ($joined as $r) {
+            $result[] = $r['link_type'];
+        }
+        return $result;
+    })()),
+    "first_movie" => min((function() use ($joined) {
+        $result = [];
+        foreach ($joined as $r) {
+            $result[] = $r['first_movie'];
+        }
+        return $result;
+    })()),
+    "second_movie" => min((function() use ($joined) {
+        $result = [];
+        foreach ($joined as $r) {
+            $result[] = $r['second_movie'];
+        }
+        return $result;
+    })())
+];
+echo json_encode([$result]), PHP_EOL;
+?>

--- a/tests/dataset/job/compiler/php/q33.out
+++ b/tests/dataset/job/compiler/php/q33.out
@@ -1,0 +1,1 @@
+[{"first_company":"US Studio","second_company":"GB Studio","first_rating":"7.0","second_rating":"2.5","first_movie":"Series A","second_movie":"Series B"}]

--- a/tests/dataset/job/compiler/php/q33.php
+++ b/tests/dataset/job/compiler/php/q33.php
@@ -1,0 +1,178 @@
+<?php
+$company_name = [
+    [
+        "id" => 1,
+        "name" => "US Studio",
+        "country_code" => "[us]"
+    ],
+    [
+        "id" => 2,
+        "name" => "GB Studio",
+        "country_code" => "[gb]"
+    ]
+];
+$info_type = [
+    ["id" => 1, "info" => "rating"],
+    ["id" => 2, "info" => "other"]
+];
+$kind_type = [
+    ["id" => 1, "kind" => "tv series"],
+    ["id" => 2, "kind" => "movie"]
+];
+$link_type = [
+    ["id" => 1, "link" => "follows"],
+    ["id" => 2, "link" => "remake of"]
+];
+$movie_companies = [
+    ["movie_id" => 10, "company_id" => 1],
+    ["movie_id" => 20, "company_id" => 2]
+];
+$movie_info_idx = [
+    [
+        "movie_id" => 10,
+        "info_type_id" => 1,
+        "info" => "7.0"
+    ],
+    [
+        "movie_id" => 20,
+        "info_type_id" => 1,
+        "info" => "2.5"
+    ]
+];
+$movie_link = [
+    [
+        "movie_id" => 10,
+        "linked_movie_id" => 20,
+        "link_type_id" => 1
+    ]
+];
+$title = [
+    [
+        "id" => 10,
+        "title" => "Series A",
+        "kind_id" => 1,
+        "production_year" => 2004
+    ],
+    [
+        "id" => 20,
+        "title" => "Series B",
+        "kind_id" => 1,
+        "production_year" => 2006
+    ]
+];
+$rows = (function() use ($company_name, $info_type, $kind_type, $link_type, $movie_companies, $movie_info_idx, $movie_link, $title) {
+    $result = [];
+    foreach ($company_name as $cn1) {
+        foreach ($movie_companies as $mc1) {
+            if ($cn1['id'] == $mc1['company_id']) {
+                foreach ($title as $t1) {
+                    if ($t1['id'] == $mc1['movie_id']) {
+                        foreach ($movie_info_idx as $mi_idx1) {
+                            if ($mi_idx1['movie_id'] == $t1['id']) {
+                                foreach ($info_type as $it1) {
+                                    if ($it1['id'] == $mi_idx1['info_type_id']) {
+                                        foreach ($kind_type as $kt1) {
+                                            if ($kt1['id'] == $t1['kind_id']) {
+                                                foreach ($movie_link as $ml) {
+                                                    if ($ml['movie_id'] == $t1['id']) {
+                                                        foreach ($title as $t2) {
+                                                            if ($t2['id'] == $ml['linked_movie_id']) {
+                                                                foreach ($movie_info_idx as $mi_idx2) {
+                                                                    if ($mi_idx2['movie_id'] == $t2['id']) {
+                                                                        foreach ($info_type as $it2) {
+                                                                            if ($it2['id'] == $mi_idx2['info_type_id']) {
+                                                                                foreach ($kind_type as $kt2) {
+                                                                                    if ($kt2['id'] == $t2['kind_id']) {
+                                                                                        foreach ($movie_companies as $mc2) {
+                                                                                            if ($mc2['movie_id'] == $t2['id']) {
+                                                                                                foreach ($company_name as $cn2) {
+                                                                                                    if ($cn2['id'] == $mc2['company_id']) {
+                                                                                                        foreach ($link_type as $lt) {
+                                                                                                            if ($lt['id'] == $ml['link_type_id']) {
+                                                                                                                if ($cn1['country_code'] == "[us]" && $it1['info'] == "rating" && $it2['info'] == "rating" && $kt1['kind'] == "tv series" && $kt2['kind'] == "tv series" && ($lt['link'] == "sequel" || $lt['link'] == "follows" || $lt['link'] == "followed by") && $mi_idx2['info'] < "3.0" && $t2['production_year'] >= 2005 && $t2['production_year'] <= 2008) {
+                                                                                                                    $result[] = [
+    "first_company" => $cn1['name'],
+    "second_company" => $cn2['name'],
+    "first_rating" => $mi_idx1['info'],
+    "second_rating" => $mi_idx2['info'],
+    "first_movie" => $t1['title'],
+    "second_movie" => $t2['title']
+];
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$result = [
+    [
+        "first_company" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['first_company'];
+            }
+            return $result;
+        })()),
+        "second_company" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['second_company'];
+            }
+            return $result;
+        })()),
+        "first_rating" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['first_rating'];
+            }
+            return $result;
+        })()),
+        "second_rating" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['second_rating'];
+            }
+            return $result;
+        })()),
+        "first_movie" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['first_movie'];
+            }
+            return $result;
+        })()),
+        "second_movie" => min((function() use ($rows) {
+            $result = [];
+            foreach ($rows as $r) {
+                $result[] = $r['second_movie'];
+            }
+            return $result;
+        })())
+    ]
+];
+echo json_encode($result), PHP_EOL;
+?>


### PR DESCRIPTION
## Summary
- support JOB queries q21–q33 in the PHP backend
- regenerate golden PHP code and outputs for the new JOB queries
- run JOB compiler tests over all 33 queries

## Testing
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_JOB`
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_JOB_Golden`
- `go test ./... -tags slow` *(fails: package mochi/archived/... not in std)*

------
https://chatgpt.com/codex/tasks/task_e_6873ae8c33508320a9d920ad276aaee3