### PR TITLE
Enable regeneration of Fortran TPCH golden code

### DIFF
--- a/compiler/x/fortran/update_flag_test.go
+++ b/compiler/x/fortran/update_flag_test.go
@@ -1,0 +1,10 @@
+package ftncode_test
+
+import "flag"
+
+var update = flag.Bool("update", false, "update golden files")
+
+func shouldUpdate() bool {
+	f := flag.Lookup("update")
+	return f != nil && f.Value.String() == "true"
+}


### PR DESCRIPTION
## Summary
- allow Fortran TPCH tests to write updated .f90 files when `-update` is used
- share update flag helpers across tests

## Testing
- `go test ./compiler/x/fortran -run TestFortranCompiler_TPCH_Dataset_Golden -tags slow -v`
- `go test ./compiler/x/fortran -run TestFortranCompiler_TPCH_Golden -tags slow -v`


------
https://chatgpt.com/codex/tasks/task_e_6873b821dfec8320943579550260fe20