### PR TITLE
Fix zig avg builtin and add tpch output check

### DIFF
--- a/compiler/x/zig/builtins.go
+++ b/compiler/x/zig/builtins.go
@@ -5,12 +5,12 @@ package zigcode
 func (c *Compiler) writeBuiltins() {
 	c.writeErrorHandler()
 	if c.needsAvgInt {
-		c.writeln("fn _avg_int(v: []const i32) i32 {")
+		c.writeln("fn _avg_int(v: []const i32) f64 {")
 		c.indent++
 		c.writeln("if (v.len == 0) return 0;")
-		c.writeln("var sum: i32 = 0;")
-		c.writeln("for (v) |it| { sum += it; }")
-		c.writeln("return @divTrunc(sum, @as(i32, @intCast(v.len)));")
+		c.writeln("var sum: f64 = 0;")
+		c.writeln("for (v) |it| { sum += @floatFromInt(it); }")
+		c.writeln("return sum / @as(f64, @floatFromInt(v.len));")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")

--- a/compiler/x/zig/tpch_golden_test.go
+++ b/compiler/x/zig/tpch_golden_test.go
@@ -96,6 +96,15 @@ func TestZigCompiler_TPCH_Golden(t *testing.T) {
 			if !bytes.Equal(compiled, vmOut) {
 				t.Errorf("output mismatch for %s\n\n-- zig --\n%s\n\n-- vm --\n%s\n", q, compiled, vmOut)
 			}
+
+			wantOutPath := filepath.Join(root, "tests", "dataset", "tpc-h", "out", q+".out")
+			wantOut, err := os.ReadFile(wantOutPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if !bytes.Equal(compiled, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".out", compiled, bytes.TrimSpace(wantOut))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- adjust `_avg_int` builtin to return `f64`
- make TPCH golden tests validate against `.out` files

## Testing
- `go fmt`
- `go test ./compiler/x/zig -run TPCH -tags slow -count=1` *(fails: zig build error)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9d8276883209bdf6367a09171bd