### PR TITLE
Document TPC-H coverage for Elixir backend

### DIFF
--- a/compiler/x/ex/TASKS.md
+++ b/compiler/x/ex/TASKS.md
@@ -3,6 +3,13 @@
 ## Recent Enhancements (2025-07-13 05:12)
 - Documented machine output checklist and TPCH progress.
 
+## TPC-H Progress (2025-07-13 22:45)
+All twenty-two queries (`q1` to `q22`) now compile and execute correctly. The
+golden test `TestExCompiler_TPCHQueries` generates Elixir code for each query,
+runs it through the `elixir` executable, and compares the printed result with
+the expected `.out` file. The generated sources live under
+`tests/dataset/tpc-h/compiler/ex`.
+
 ## Remaining Enhancements
 - [ ] Finish YAML loader support for `load_yaml.mochi`.
 - [ ] Improve formatting of generated code.


### PR DESCRIPTION
## Summary
- note that all TPC‑H queries q1..q22 compile and run
- explain that the golden test verifies generated code output

## Testing
- `go test ./compiler/x/ex -run TestExCompiler_TPCHQueries -tags=slow -v`

------
https://chatgpt.com/codex/tasks/task_e_6873d1c284d8832083fee71a48e151da