### PR TITLE
Extend PHP TPCH tests

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -5,6 +5,8 @@
 - 2025-07-13 05:25 - Compiler handles TPC-H Q1 grouping output.
 - 2025-07-13 15:53 - Compiler now supports TPC-H queries 6-8 with group key and
   match variable handling.
+- 2025-07-13 15:53 - Added support for TPC-H queries 9-12 and updated golden
+  tests.
 
 ## Remaining Work
 - [ ] Improve runtime helpers for grouping and aggregation

--- a/compiler/x/php/tpch_golden_test.go
+++ b/compiler/x/php/tpch_golden_test.go
@@ -39,7 +39,7 @@ func TestPHPCompiler_TPCH_Golden(t *testing.T) {
 		t.Skip("php not installed")
 	}
 	root := repoRoot(t)
-	for i := 1; i <= 8; i++ {
+	for i := 1; i <= 12; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
 		codeWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "php", base+".php")

--- a/compiler/x/php/tpch_test.go
+++ b/compiler/x/php/tpch_test.go
@@ -17,7 +17,7 @@ func TestPHPCompiler_TPCH(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not installed")
 	}
-	for i := 1; i <= 8; i++ {
+	for i := 1; i <= 12; i++ {
 		q := fmt.Sprintf("q%d", i)
 		testutil.CompileTPCH(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
 			return phpcode.New(env).Compile(prog)

--- a/tests/dataset/tpc-h/compiler/php/q10.out
+++ b/tests/dataset/tpc-h/compiler/php/q10.out
@@ -1,0 +1,1 @@
+[{"c_custkey":1,"c_name":"Alice","revenue":900,"c_acctbal":100,"n_name":"BRAZIL","c_address":"123 St","c_phone":"123-456","c_comment":"Loyal"}]

--- a/tests/dataset/tpc-h/compiler/php/q10.php
+++ b/tests/dataset/tpc-h/compiler/php/q10.php
@@ -1,0 +1,107 @@
+<?php
+$nation = [
+    [
+        "n_nationkey" => 1,
+        "n_name" => "BRAZIL"
+    ]
+];
+$customer = [
+    [
+        "c_custkey" => 1,
+        "c_name" => "Alice",
+        "c_acctbal" => 100,
+        "c_nationkey" => 1,
+        "c_address" => "123 St",
+        "c_phone" => "123-456",
+        "c_comment" => "Loyal"
+    ]
+];
+$orders = [
+    [
+        "o_orderkey" => 1000,
+        "o_custkey" => 1,
+        "o_orderdate" => "1993-10-15"
+    ],
+    [
+        "o_orderkey" => 2000,
+        "o_custkey" => 1,
+        "o_orderdate" => "1994-01-02"
+    ]
+];
+$lineitem = [
+    [
+        "l_orderkey" => 1000,
+        "l_returnflag" => "R",
+        "l_extendedprice" => 1000,
+        "l_discount" => 0.1
+    ],
+    [
+        "l_orderkey" => 2000,
+        "l_returnflag" => "N",
+        "l_extendedprice" => 500,
+        "l_discount" => 0
+    ]
+];
+$start_date = "1993-10-01";
+$end_date = "1994-01-01";
+$result = (function() use ($customer, $end_date, $lineitem, $nation, $orders, $start_date) {
+    $groups = [];
+    foreach ($customer as $c) {
+        foreach ($orders as $o) {
+            if ($o['o_custkey'] == $c['c_custkey']) {
+                foreach ($lineitem as $l) {
+                    if ($l['l_orderkey'] == $o['o_orderkey']) {
+                        foreach ($nation as $n) {
+                            if ($n['n_nationkey'] == $c['c_nationkey']) {
+                                if ($o['o_orderdate'] >= $start_date && $o['o_orderdate'] < $end_date && $l['l_returnflag'] == "R") {
+                                    $_k = json_encode([
+    "c_custkey" => $c['c_custkey'],
+    "c_name" => $c['c_name'],
+    "c_acctbal" => $c['c_acctbal'],
+    "c_address" => $c['c_address'],
+    "c_phone" => $c['c_phone'],
+    "c_comment" => $c['c_comment'],
+    "n_name" => $n['n_name']
+]);
+                                    $groups[$_k][] = ["c" => $c, "o" => $o, "l" => $l, "n" => $n];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    $result = [];
+    foreach ($groups as $_k => $__g) {
+        $_key = json_decode($_k, true);
+        $g = ['key'=>$_key,'items'=> $__g];
+        $result[] = [-array_sum((function() use ($g) {
+    $result = [];
+    foreach ($g['items'] as $x) {
+        $result[] = $x['l']['l_extendedprice'] * (1 - $x['l']['l_discount']);
+    }
+    return $result;
+})()), [
+    "c_custkey" => $g['key']['c_custkey'],
+    "c_name" => $g['key']['c_name'],
+    "revenue" => array_sum((function() use ($g) {
+        $result = [];
+        foreach ($g['items'] as $x) {
+            $result[] = $x['l']['l_extendedprice'] * (1 - $x['l']['l_discount']);
+        }
+        return $result;
+    })()),
+    "c_acctbal" => $g['key']['c_acctbal'],
+    "n_name" => $g['key']['n_name'],
+    "c_address" => $g['key']['c_address'],
+    "c_phone" => $g['key']['c_phone'],
+    "c_comment" => $g['key']['c_comment']
+]];
+    }
+    usort($result, function($a, $b) { return $a[0] <=> $b[0]; });
+    $result = array_map(fn($r) => $r[1], $result);
+    return $result;
+})();
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/tpc-h/compiler/php/q11.out
+++ b/tests/dataset/tpc-h/compiler/php/q11.out
@@ -1,0 +1,1 @@
+[{"ps_partkey":1000,"value":2000},{"ps_partkey":2000,"value":50}]

--- a/tests/dataset/tpc-h/compiler/php/q11.php
+++ b/tests/dataset/tpc-h/compiler/php/q11.php
@@ -1,0 +1,107 @@
+<?php
+$nation = [
+    [
+        "n_nationkey" => 1,
+        "n_name" => "GERMANY"
+    ],
+    [
+        "n_nationkey" => 2,
+        "n_name" => "FRANCE"
+    ]
+];
+$supplier = [
+    ["s_suppkey" => 100, "s_nationkey" => 1],
+    ["s_suppkey" => 200, "s_nationkey" => 1],
+    ["s_suppkey" => 300, "s_nationkey" => 2]
+];
+$partsupp = [
+    [
+        "ps_partkey" => 1000,
+        "ps_suppkey" => 100,
+        "ps_supplycost" => 10,
+        "ps_availqty" => 100
+    ],
+    [
+        "ps_partkey" => 1000,
+        "ps_suppkey" => 200,
+        "ps_supplycost" => 20,
+        "ps_availqty" => 50
+    ],
+    [
+        "ps_partkey" => 2000,
+        "ps_suppkey" => 100,
+        "ps_supplycost" => 5,
+        "ps_availqty" => 10
+    ],
+    [
+        "ps_partkey" => 3000,
+        "ps_suppkey" => 300,
+        "ps_supplycost" => 8,
+        "ps_availqty" => 500
+    ]
+];
+$target_nation = "GERMANY";
+$filtered = (function() use ($nation, $partsupp, $supplier, $target_nation) {
+    $result = [];
+    foreach ($partsupp as $ps) {
+        foreach ($supplier as $s) {
+            if ($s['s_suppkey'] == $ps['ps_suppkey']) {
+                foreach ($nation as $n) {
+                    if ($n['n_nationkey'] == $s['s_nationkey']) {
+                        if ($n['n_name'] == $target_nation) {
+                            $result[] = [
+    "ps_partkey" => $ps['ps_partkey'],
+    "value" => $ps['ps_supplycost'] * $ps['ps_availqty']
+];
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $result;
+})();
+$grouped = (function() use ($filtered) {
+    $groups = [];
+    foreach ($filtered as $x) {
+        $_k = json_encode($x['ps_partkey']);
+        $groups[$_k][] = $x;
+    }
+    $result = [];
+    foreach ($groups as $_k => $__g) {
+        $_key = json_decode($_k, true);
+        $g = ['key'=>$_key,'items'=> $__g];
+        $result[] = [
+    "ps_partkey" => $g['key'],
+    "value" => array_sum((function() use ($g) {
+        $result = [];
+        foreach ($g['items'] as $r) {
+            $result[] = $r['value'];
+        }
+        return $result;
+    })())
+];
+    }
+    return $result;
+})();
+$total = array_sum((function() use ($filtered) {
+    $result = [];
+    foreach ($filtered as $x) {
+        $result[] = $x['value'];
+    }
+    return $result;
+})());
+$threshold = $total * 0.0001;
+$result = (function() use ($grouped, $threshold) {
+    $result = [];
+    foreach ($grouped as $x) {
+        if ($x['value'] > $threshold) {
+            $result[] = [-$x['value'], $x];
+        }
+    }
+    usort($result, function($a, $b) { return $a[0] <=> $b[0]; });
+    $result = array_map(fn($r) => $r[1], $result);
+    return $result;
+})();
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/tpc-h/compiler/php/q12.out
+++ b/tests/dataset/tpc-h/compiler/php/q12.out
@@ -1,0 +1,1 @@
+[{"l_shipmode":"MAIL","high_line_count":1,"low_line_count":0}]

--- a/tests/dataset/tpc-h/compiler/php/q12.php
+++ b/tests/dataset/tpc-h/compiler/php/q12.php
@@ -1,0 +1,67 @@
+<?php
+$orders = [
+    [
+        "o_orderkey" => 1,
+        "o_orderpriority" => "1-URGENT"
+    ],
+    [
+        "o_orderkey" => 2,
+        "o_orderpriority" => "3-MEDIUM"
+    ]
+];
+$lineitem = [
+    [
+        "l_orderkey" => 1,
+        "l_shipmode" => "MAIL",
+        "l_commitdate" => "1994-02-10",
+        "l_receiptdate" => "1994-02-15",
+        "l_shipdate" => "1994-02-05"
+    ],
+    [
+        "l_orderkey" => 2,
+        "l_shipmode" => "SHIP",
+        "l_commitdate" => "1994-03-01",
+        "l_receiptdate" => "1994-02-28",
+        "l_shipdate" => "1994-02-27"
+    ]
+];
+$result = (function() use ($lineitem, $orders) {
+    $groups = [];
+    foreach ($lineitem as $l) {
+        foreach ($orders as $o) {
+            if ($o['o_orderkey'] == $l['l_orderkey']) {
+                if ((in_array($l['l_shipmode'], ["MAIL", "SHIP"])) && ($l['l_commitdate'] < $l['l_receiptdate']) && ($l['l_shipdate'] < $l['l_commitdate']) && ($l['l_receiptdate'] >= "1994-01-01") && ($l['l_receiptdate'] < "1995-01-01")) {
+                    $_k = json_encode($l['l_shipmode']);
+                    $groups[$_k][] = ["l" => $l, "o" => $o];
+                }
+            }
+        }
+    }
+    $result = [];
+    foreach ($groups as $_k => $__g) {
+        $_key = json_decode($_k, true);
+        $g = ['key'=>$_key,'items'=> $__g];
+        $result[] = [$g['key'], [
+    "l_shipmode" => $g['key'],
+    "high_line_count" => array_sum((function() use ($g) {
+        $result = [];
+        foreach ($g['items'] as $x) {
+            $result[] = (in_array($x['o']['o_orderpriority'], ["1-URGENT", "2-HIGH"]) ? 1 : 0);
+        }
+        return $result;
+    })()),
+    "low_line_count" => array_sum((function() use ($g) {
+        $result = [];
+        foreach ($g['items'] as $x) {
+            $result[] = (!(in_array($x['o']['o_orderpriority'], ["1-URGENT", "2-HIGH"])) ? 1 : 0);
+        }
+        return $result;
+    })())
+]];
+    }
+    usort($result, function($a, $b) { return $a[0] <=> $b[0]; });
+    $result = array_map(fn($r) => $r[1], $result);
+    return $result;
+})();
+echo json_encode($result), PHP_EOL;
+?>

--- a/tests/dataset/tpc-h/compiler/php/q9.out
+++ b/tests/dataset/tpc-h/compiler/php/q9.out
@@ -1,0 +1,1 @@
+[{"nation":"BRAZIL","o_year":"1995","profit":850}]

--- a/tests/dataset/tpc-h/compiler/php/q9.php
+++ b/tests/dataset/tpc-h/compiler/php/q9.php
@@ -1,0 +1,126 @@
+<?php
+$nation = [
+    [
+        "n_nationkey" => 1,
+        "n_name" => "BRAZIL"
+    ],
+    [
+        "n_nationkey" => 2,
+        "n_name" => "CANADA"
+    ]
+];
+$supplier = [
+    ["s_suppkey" => 100, "s_nationkey" => 1],
+    ["s_suppkey" => 200, "s_nationkey" => 2]
+];
+$part = [
+    [
+        "p_partkey" => 1000,
+        "p_name" => "green metal box"
+    ],
+    [
+        "p_partkey" => 2000,
+        "p_name" => "red plastic crate"
+    ]
+];
+$partsupp = [
+    [
+        "ps_partkey" => 1000,
+        "ps_suppkey" => 100,
+        "ps_supplycost" => 10
+    ],
+    [
+        "ps_partkey" => 1000,
+        "ps_suppkey" => 200,
+        "ps_supplycost" => 8
+    ]
+];
+$orders = [
+    [
+        "o_orderkey" => 1,
+        "o_orderdate" => "1995-02-10"
+    ],
+    [
+        "o_orderkey" => 2,
+        "o_orderdate" => "1997-01-01"
+    ]
+];
+$lineitem = [
+    [
+        "l_orderkey" => 1,
+        "l_partkey" => 1000,
+        "l_suppkey" => 100,
+        "l_quantity" => 5,
+        "l_extendedprice" => 1000,
+        "l_discount" => 0.1
+    ],
+    [
+        "l_orderkey" => 2,
+        "l_partkey" => 1000,
+        "l_suppkey" => 200,
+        "l_quantity" => 10,
+        "l_extendedprice" => 800,
+        "l_discount" => 0.05
+    ]
+];
+$prefix = "green";
+$start_date = "1995-01-01";
+$end_date = "1996-12-31";
+$result = (function() use ($end_date, $lineitem, $nation, $orders, $part, $partsupp, $prefix, $start_date, $supplier) {
+    $groups = [];
+    foreach ($lineitem as $l) {
+        foreach ($part as $p) {
+            if ($p['p_partkey'] == $l['l_partkey']) {
+                foreach ($supplier as $s) {
+                    if ($s['s_suppkey'] == $l['l_suppkey']) {
+                        foreach ($partsupp as $ps) {
+                            if ($ps['ps_partkey'] == $l['l_partkey'] && $ps['ps_suppkey'] == $l['l_suppkey']) {
+                                foreach ($orders as $o) {
+                                    if ($o['o_orderkey'] == $l['l_orderkey']) {
+                                        foreach ($nation as $n) {
+                                            if ($n['n_nationkey'] == $s['s_nationkey']) {
+                                                if (substr($p['p_name'], 0, strlen($prefix)) == $prefix && $o['o_orderdate'] >= $start_date && $o['o_orderdate'] <= $end_date) {
+                                                    $_k = json_encode([
+    "nation" => $n['n_name'],
+    "o_year" => (int)(substr($o['o_orderdate'], 0, 4))
+]);
+                                                    $groups[$_k][] = ["l" => $l, "p" => $p, "s" => $s, "ps" => $ps, "o" => $o, "n" => $n];
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    $result = [];
+    foreach ($groups as $_k => $__g) {
+        $_key = json_decode($_k, true);
+        $g = ['key'=>$_key,'items'=> $__g];
+        $result[] = [[
+    $g['key']['nation'],
+    -$g['key']['o_year']
+], [
+    "nation" => $g['key']['nation'],
+    "o_year" => strval($g['key']['o_year']),
+    "profit" => array_sum((function() use ($g) {
+        $result = [];
+        foreach ($g['items'] as $x) {
+            $result[] = ($x['l']['l_extendedprice'] * (1 - $x['l']['l_discount'])) - ($x['ps']['ps_supplycost'] * $x['l']['l_quantity']);
+        }
+        return $result;
+    })())
+]];
+    }
+    usort($result, function($a, $b) { return $a[0] <=> $b[0]; });
+    $result = array_map(fn($r) => $r[1], $result);
+    return $result;
+})();
+echo json_encode($result), PHP_EOL;
+$revenue = 1000 * 0.9;
+$cost = 5 * 10;
+?>


### PR DESCRIPTION
## Summary
- update PHP backend progress log
- generate golden PHP code and output for TPCH q9–q12
- run TPCH golden tests for queries 1–12

## Testing
- `go test ./compiler/x/php -tags=slow -run TPCH_Golden -count=1 -v`
- `go test ./compiler/x/php -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6873dda378108320872a509611d0827c