### PR TITLE
Update Racket TPCH progress

### DIFF
--- a/compiler/x/racket/TASKS.md
+++ b/compiler/x/racket/TASKS.md
@@ -3,9 +3,9 @@
 Recent enhancements:
 
 - 2025-07-13 05:04 - Added string specialisation for `len` builtin. When the argument is a known string literal the compiler now emits `(string-length x)`.
+- 2025-07-20 05:04 - TPCH queries `q1`-`q22` compile and run in golden tests.
 
 ## Remaining Work
 
-- [ ] Investigate running `tests/dataset/tpc-h/q1.mochi` end-to-end.
 - [ ] Keep generated code aligned with manual translations under `tests/human/x/racket`.
 - [ ] Review query features such as `sort`, `skip`, and `take` for parity with other backends.


### PR DESCRIPTION
## Summary
- document TPCH support for q1-q22

## Testing
- `go test -tags slow ./compiler/x/racket -run TPCH -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6873de04d9e08320888cd9942b31c707