### PR TITLE
Improve smalltalk compiler unary handling

### DIFF
--- a/compiler/x/st/TASKS.md
+++ b/compiler/x/st/TASKS.md
@@ -3,6 +3,8 @@
 ## Recent Enhancements
 - 2025-07-13 05:03 - Added support for `else if` by recursively handling `IfStmt.ElseIf`.
 - 2025-07-13 05:07 - Fixed header comments so generated files run under GNU Smalltalk.
+- 2025-07-13 16:35 - Unary negation now parenthesizes expressions and grouping keys
+  with complex expressions are wrapped. Initial work on compiling TPCH `q11`.
 
 ## Remaining Work
 - [ ] Verify TPC-H `q1.mochi` output matches reference when compiled.

--- a/compiler/x/st/compiler.go
+++ b/compiler/x/st/compiler.go
@@ -507,7 +507,11 @@ func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
 	for i := len(u.Ops) - 1; i >= 0; i-- {
 		switch u.Ops[i] {
 		case "-":
-			val = "-" + val
+			if strings.ContainsAny(val, " :") {
+				val = "-(" + val + ")"
+			} else {
+				val = "-" + val
+			}
 		case "!":
 			val = val + " not"
 		}
@@ -633,6 +637,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			v, err := c.compileExpr(it.Value)
 			if err != nil {
 				return "", err
+			}
+			if strings.ContainsAny(v, " :") {
+				v = "(" + v + ")"
 			}
 			pairs[i] = fmt.Sprintf("%s->%s", k, v)
 		}
@@ -934,7 +941,11 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			}
 			if q.Group != nil {
 				b.WriteString(next + "| g |\n")
-				b.WriteString(next + "g := groups at: " + key + " ifAbsentPut:[OrderedCollection new].\n")
+				if strings.ContainsAny(key, " :") {
+					b.WriteString(next + "g := groups at: (" + key + ") ifAbsentPut:[OrderedCollection new].\n")
+				} else {
+					b.WriteString(next + "g := groups at: " + key + " ifAbsentPut:[OrderedCollection new].\n")
+				}
 				b.WriteString(next + "g add: " + row + ".\n")
 			} else {
 				b.WriteString(next + "tmp add: " + sel + ".\n")


### PR DESCRIPTION
## Summary
- wrap expressions with spaces or colons when applying unary minus
- wrap grouping keys when they contain complex expressions
- document progress in `TASKS.md`

## Testing
- `go test ./compiler/x/st -run TestSTCompiler_TPCHQueries -tags=slow` *(fails: generated code mismatch for q1.st.out)*
- `go test ./...` *(fails to build some packages)*

------
https://chatgpt.com/codex/tasks/task_e_6873de5a0dc88320ac0e47db7c2f86cb