### PR TITLE
Improve Swift map key handling

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -5,6 +5,8 @@
 - 2025-07-13 07:03 – fixed nested selector handling and avoided unnecessary casts when grouping by built-in keys.
 - 2025-07-13 07:31 – added optional-aware struct generation for join queries.
 - 2025-07-13 08:07 – generated initial Swift code for `tpc-h/q1.mochi` but compilation still fails.
+- 2025-07-13 08:15 – added support for detecting map fields in group keys and removed
+  invalid `@dynamicMemberLookup` extension so query code now compiles.
 
 ## Remaining Work
 - [ ] Generate safer optional handling in join queries

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -3090,6 +3090,9 @@ func (c *compiler) elementFieldTypes(e *parser.Expr) map[string]string {
 			}
 		}
 	}
+	if p.Target.Map != nil {
+		return c.mapFieldsFromLiteral(p.Target.Map)
+	}
 	if p.Target.List != nil && len(p.Target.List.Elems) > 0 {
 		if m := mapLit(p.Target.List.Elems[0]); m != nil {
 			return c.mapFieldsFromLiteral(m)
@@ -3711,12 +3714,6 @@ const helperGroup = `class _Group {
     init(_ k: Any) { self.key = k }
 }
 
-@dynamicMemberLookup
-extension Dictionary where Key == String {
-    subscript(dynamicMember member: String) -> Any {
-        return self[member]!
-    }
-}
 
 func _keyStr(_ v: Any) -> String {
     if let data = try? JSONSerialization.data(withJSONObject: v, options: [.sortedKeys]),


### PR DESCRIPTION
## Summary
- support map literal field detection in Swift compiler
- remove unused dynamicMemberLookup extension
- update Swift TASKS

## Testing
- `go test ./compiler/x/swift -tags slow -run TestSwiftCompiler_TPCH_Golden_q1_q5/q4 -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6873de65ea1883208e61a760eab6a49c