### PR TITLE
Run all Erlang TPCH tests

### DIFF
--- a/compiler/x/erlang/TASKS.md
+++ b/compiler/x/erlang/TASKS.md
@@ -7,6 +7,7 @@
 - [2025-07-13 05:22] Regenerated Erlang machine outputs with dynamic headers.
 - [2025-07-13 05:23] Added golden outputs for TPCH queries q16 through q21.
 - [2025-07-13 16:26] Added golden output for TPCH query q22.
+- [2025-07-13 17:40] Extended `tpch_golden_test` to run TPCH queries q1 through q22.
 - [2025-07-13 05:02] Added support for `MOCHI_HEADER_TIME` and `MOCHI_HEADER_VERSION` environment variables in `meta.Header`.
 - [2025-07-13 05:02] Inline constants when calling `contains` to avoid unbound variable errors.
 
@@ -15,4 +16,4 @@
 - [ ] Fix nested accumulation bug in `group_items_iteration`.
 - [ ] Support extern values for `python_math`.
 - [x] Compile TPC-H query `q1.mochi` successfully.
-- [x] Compile TPC-H query `q22.mochi` successfully.
+- [x] Compile TPC-H queries `q2` through `q22` successfully.

--- a/compiler/x/erlang/tpch_golden_test.go
+++ b/compiler/x/erlang/tpch_golden_test.go
@@ -30,7 +30,7 @@ func TestErlangCompiler_TPCHQueries(t *testing.T) {
 	os.Setenv("SOURCE_DATE_EPOCH", "1577977445")
 	defer os.Unsetenv("SOURCE_DATE_EPOCH")
 	root := repoRoot(t)
-	for _, i := range []int{22} {
+	for i := 1; i <= 22; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
 		codePath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "erlang", base+".erl")


### PR DESCRIPTION
## Summary
- run Erlang TPCH golden test for queries `q1` through `q22`
- record progress in `compiler/x/erlang/TASKS.md`

## Testing
- `go test ./compiler/x/erlang -run TestErlangCompiler_TPCHQueries -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6873def9feb48320afad016e08787840