### PR TITLE
Update TPCH Ruby tests

### DIFF
--- a/compiler/x/rb/TASKS.md
+++ b/compiler/x/rb/TASKS.md
@@ -6,6 +6,10 @@
 - Verified `tpc-h/q1.mochi` compiles and runs successfully.
 - Verified `tpc-h/q2.mochi` and `tpc-h/q3.mochi` compile and run successfully.
 
+## Progress (2025-07-13 16:48)
+- Recompiled `tpc-h` queries `q4`-`q22` using the updated compiler.
+- Confirmed `tpch_golden_test.go` generates code and matches expected output.
+
 ## Remaining Enhancements
 - [ ] Format output closer to the examples in `tests/human/x/rb`.
 - [ ] Extend dataset query support for additional TPC-H benchmarks.

--- a/scripts/compile_tpch_clj.go
+++ b/scripts/compile_tpch_clj.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- ensure TPCH CLJ compile script only builds with `slow` tag
- document TPCH progress for the Ruby compiler

## Testing
- `go test -tags slow ./compiler/x/rb -run TestRBCompiler_TPCHQueries -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6873e1b188548320a69b3083780d0232