### PR TITLE
Update ex compiler progress

### DIFF
--- a/compiler/x/ex/TASKS.md
+++ b/compiler/x/ex/TASKS.md
@@ -10,6 +10,8 @@ runs it through the `elixir` executable, and compares the printed result with
 the expected `.out` file. The generated sources live under
 `tests/dataset/tpc-h/compiler/ex`.
 
+## Progress Update (2025-07-13 23:00)
+- Re-ran TPCH golden tests; all 22 queries compile and execute successfully.
 ## Remaining Enhancements
 - [ ] Finish YAML loader support for `load_yaml.mochi`.
 - [ ] Improve formatting of generated code.


### PR DESCRIPTION
## Summary
- note TPCH golden test status for Elixir compiler

## Testing
- `go test ./compiler/x/ex -run TestExCompiler_TPCHQueries -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6873e2a89c248320aa45a00cdea3bd65