### PR TITLE
Expand Erlang TPCH golden tests

### DIFF
--- a/compiler/x/erlang/TASKS.md
+++ b/compiler/x/erlang/TASKS.md
@@ -7,6 +7,7 @@
 - [2025-07-13 05:22] Regenerated Erlang machine outputs with dynamic headers.
 - [2025-07-13 05:23] Added golden outputs for TPCH queries q16 through q21.
 - [2025-07-13 16:26] Added golden output for TPCH query q22.
+- [2025-07-13 16:48] Enabled golden tests for TPCH queries q1 and q16-q22.
 - [2025-07-13 05:02] Added support for `MOCHI_HEADER_TIME` and `MOCHI_HEADER_VERSION` environment variables in `meta.Header`.
 - [2025-07-13 05:02] Inline constants when calling `contains` to avoid unbound variable errors.
 

--- a/compiler/x/erlang/tpch_golden_test.go
+++ b/compiler/x/erlang/tpch_golden_test.go
@@ -30,7 +30,9 @@ func TestErlangCompiler_TPCHQueries(t *testing.T) {
 	os.Setenv("SOURCE_DATE_EPOCH", "1577977445")
 	defer os.Unsetenv("SOURCE_DATE_EPOCH")
 	root := repoRoot(t)
-	for _, i := range []int{22} {
+	// Extend coverage to compile additional TPCH queries. Running all
+	// queries can be slow so we enable a subset for now.
+	for _, i := range []int{1, 16, 17, 18, 19, 20, 21, 22} {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
 		codePath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "erlang", base+".erl")

--- a/scripts/compile_tpch_clj.go
+++ b/scripts/compile_tpch_clj.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/scripts/compile_tpch_java.go
+++ b/scripts/compile_tpch_java.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- enable compilation for a subset of TPCH queries
- log this progress in `compiler/x/erlang/TASKS.md`
- mark compilation scripts as ignored so they don't break `go test`

## Testing
- `go test ./...`
- `go test ./compiler/x/erlang -run TestErlangCompiler_TPCHQueries -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6873e2b22c0c8320ad69f9f14a078133