### PR TITLE
Fix build and passing tests

### DIFF
--- a/scripts/compile_tpch_java.go
+++ b/scripts/compile_tpch_java.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/scripts/compile_tpch_php.go
+++ b/scripts/compile_tpch_php.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- avoid importing slow packages by default
- run `go test ./...`
- run `make build`

## Testing
- `go test ./... --vet=off -count=1`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6873ea01bcb8832087fac334b903fe49