### PR TITLE
Improve Go compiler struct inference

### DIFF
--- a/compiler/x/go/usage.go
+++ b/compiler/x/go/usage.go
@@ -211,7 +211,8 @@ func (c *Compiler) compileGlobalVarDecl(s *parser.Statement) error {
 					}
 				} else if qe := s.Let.Value.Binary.Left.Value.Target.Query; qe != nil {
 					if ml := mapLiteral(qe.Select); ml != nil {
-						if st, ok := c.inferStructFromMap(ml, s.Let.Name); ok {
+						qenv := c.queryEnv(qe)
+						if st, ok := c.inferStructFromMapEnv(ml, s.Let.Name, qenv); ok {
 							t = types.ListType{Elem: st}
 							c.env.SetStruct(st.Name, st)
 							c.compileStructType(st)
@@ -243,7 +244,8 @@ func (c *Compiler) compileGlobalVarDecl(s *parser.Statement) error {
 					}
 				} else if qe := s.Var.Value.Binary.Left.Value.Target.Query; qe != nil {
 					if ml := mapLiteral(qe.Select); ml != nil {
-						if st, ok := c.inferStructFromMap(ml, s.Var.Name); ok {
+						qenv := c.queryEnv(qe)
+						if st, ok := c.inferStructFromMapEnv(ml, s.Var.Name, qenv); ok {
 							t = types.ListType{Elem: st}
 							c.env.SetStruct(st.Name, st)
 							c.compileStructType(st)


### PR DESCRIPTION
## Summary
- support inferring struct types in query results
- add helper to build query environments for type inference
- update compiler and usage code to use the new helpers

## Testing
- `go run -tags slow /tmp/compile.go > /tmp/out.go`
- `go run -tags slow /tmp/compile_debug.go`

------
https://chatgpt.com/codex/tasks/task_e_687401471a7883209a6e6639010195c8