### PR TITLE
Fix query var usage in Go backend

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -128,6 +128,13 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 
 	bodyBytes := c.buf.Bytes()
 
+	// Ensure inferred struct types are included even if none were written earlier
+	if c.decls.Len() == 0 && c.env != nil {
+		for _, st := range c.env.Structs() {
+			c.compileStructType(st)
+		}
+	}
+
 	// Restore buffer and write final output with updated imports.
 	c.buf = oldBuf
 	c.indent = 0

--- a/compiler/x/go/usage.go
+++ b/compiler/x/go/usage.go
@@ -552,6 +552,16 @@ func primaryUsesVar(p *parser.Primary, name string) bool {
 		if exprUsesVar(p.Query.Source, name) {
 			return true
 		}
+		for _, f := range p.Query.Froms {
+			if exprUsesVar(f.Src, name) {
+				return true
+			}
+		}
+		for _, j := range p.Query.Joins {
+			if exprUsesVar(j.Src, name) || exprUsesVar(j.On, name) {
+				return true
+			}
+		}
 		if p.Query.Where != nil && exprUsesVar(p.Query.Where, name) {
 			return true
 		}


### PR DESCRIPTION
## Summary
- track variables referenced in query `from`/`join` clauses
- retry emitting struct declarations when none were written

## Testing
- `go test ./compiler/x/go -tags slow -run TestGoCompiler_ValidPrograms/cross_join -v` *(fails: not enough arguments in call to os.WriteFile)*

------
https://chatgpt.com/codex/tasks/task_e_687406625c908320b6012ed1245833fd