### PR TITLE
Fix cross join list helper name

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -7,6 +7,8 @@ Initial work added support for generating C structs and list helpers when a prog
 
 - 2025-08-16 02:15 – Reviewed YAML and JSONL features; noted missing runtime helpers.
 - 2025-08-23 10:20 – Fixed relative path resolution in `compileLoadExpr` so `load_yaml.mochi` compiles.
+- 2025-08-24 11:00 – Updated cross join code generation to use snake_case struct
+  list helpers via `createListFuncName`.
 - 2025-07-13 10:45 – Added struct typing for group iteration so `group_items_iteration.mochi` compiles to C (still fails at runtime).
 - 2025-07-13 09:37 – Added experimental map-literal grouping for two string keys to begin TPC-H q1 support.
 

--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -2220,6 +2220,11 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 					}
 					retList := types.ListType{Elem: retT}
 					listC := cTypeFromType(retList)
+					listCreate := listC + "_create"
+					if st, ok := retT.(types.StructType); ok {
+						listC = sanitizeListName(st.Name)
+						listCreate = createListFuncName(st.Name)
+					}
 					if listC == "list_string" {
 						c.need(needListString)
 					} else if listC == "list_float" {
@@ -2950,6 +2955,11 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 		}
 		retList := types.ListType{Elem: retT}
 		listC := cTypeFromType(retList)
+		listCreate := listC + "_create"
+		if st, ok := retT.(types.StructType); ok {
+			listC = sanitizeListName(st.Name)
+			listCreate = createListFuncName(st.Name)
+		}
 		if listC == "list_string" {
 			c.need(needListString)
 		} else if listC == "list_float" {
@@ -2966,7 +2976,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 		for i := 1; i < len(sources); i++ {
 			lenExpr = fmt.Sprintf("%s * %s", lenExpr, c.listLenExpr(sources[i].expr))
 		}
-		c.writeln(fmt.Sprintf("%s %s = %s_create(%s);", listC, res, listC, lenExpr))
+		c.writeln(fmt.Sprintf("%s %s = %s(%s);", listC, res, listCreate, lenExpr))
 		c.writeln(fmt.Sprintf("int %s = 0;", idx))
 
 		var loop func(int)


### PR DESCRIPTION
## Summary
- rename generated list helper in cross join queries using `createListFuncName`
- note new progress item in `compiler/x/c/TASKS.md`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68745943fed883208262142d70d2c18f