### PR TITLE
Add pair-string grouping scaffolding

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -93,5 +93,6 @@ should compile and run successfully.
 - [ ] Implement JSONL output helper for `save` statements
 
 - 2025-07-14 06:30 – Generated static arrays for list literals and cleaned join-group logic to match idiomatic C.
+- 2025-07-14 07:10 – Began adding pair-string grouping type inference for TPCH q1.
 
 - 2025-07-14 04:36 – Refactored group_by_join output to use simpler loops and static arrays.


### PR DESCRIPTION
## Summary
- add `equalListStructs` map to C compiler
- emit helper functions for list-of-struct equality
- expose `isListStructType` helper
- start implementing pair-string key inference for grouped queries
- document progress in TASKS

## Testing
- `go run -tags slow ./cmd/mochix buildx -t c tests/dataset/tpc-h/q1.mochi` *(fails: incompatible types)*

------
https://chatgpt.com/codex/tasks/task_e_6874aa39366c83208ebbf762f369e2c3