### PR TITLE
Fix struct type comparison in Go compiler

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -19,6 +19,7 @@ TPC-H progress:
 
 ## Recent Updates
 - 2025-07-14 06:18 - Added helper `isPlainAnyList` for future printing logic
+- 2025-07-14 07:16 - Relaxed struct type comparison to match anonymous structs
 - 2025-07-14 05:56 - Used `_toAnySlice` when converting to `[]any` and simplified print detection
 - 2025-07-14 04:23 - Injected fallback struct generation to match human left join output
 - 2025-07-14 03:18 - Removed inline closure for left join print; always emit inferred structs

--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -4069,6 +4069,14 @@ func (c *Compiler) compileExprHint(e *parser.Expr, hint types.Type) (string, err
 		if e.Binary != nil && len(e.Binary.Right) == 0 {
 			if ml := e.Binary.Left.Value.Target.Map; ml != nil {
 				parts := make([]string, len(ml.Items))
+				if st.Name == "" {
+					for name, existing := range c.env.Structs() {
+						if structMatches(existing, st.Fields, st.Order) {
+							st.Name = name
+							break
+						}
+					}
+				}
 				if len(ml.Items) == len(st.Order) {
 					for i, item := range ml.Items {
 						key, ok2 := simpleStringKey(item.Key)

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -187,6 +187,15 @@ func equalTypes(a, b types.Type) bool {
 	if isInt(a) && isInt(b) {
 		return true
 	}
+	if sa, ok := a.(types.StructType); ok {
+		if sb, ok := b.(types.StructType); ok {
+			if sa.Name == "" || sb.Name == "" {
+				if structTypesMatch(sa, sb) {
+					return true
+				}
+			}
+		}
+	}
 	return reflect.DeepEqual(a, b)
 }
 
@@ -343,6 +352,24 @@ func structMatches(existing types.StructType, fields map[string]types.Type, orde
 			return false
 		}
 		if !equalTypes(existing.Fields[name], fields[name]) {
+			return false
+		}
+	}
+	return true
+}
+
+// structTypesMatch reports whether two struct types have the same set of fields
+// and ordering, ignoring their names. This is used for comparing inferred
+// anonymous structs with named ones.
+func structTypesMatch(a, b types.StructType) bool {
+	if len(a.Fields) != len(b.Fields) || len(a.Order) != len(b.Order) {
+		return false
+	}
+	for i, name := range a.Order {
+		if b.Order[i] != name {
+			return false
+		}
+		if !equalTypes(a.Fields[name], b.Fields[name]) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary
- allow anonymous structs to match named structs during type comparison
- document update in TASKS

## Testing
- `go test ./compiler/x/go -run '^TestGoCompiler_TPCH$/q1$' -tags slow -count=1` *(fails: generated code mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6874ab1361d0832080ebda7fdf855f86