### PR TITLE
Add v0.10.26 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # 📦 CHANGELOG.md
+## [0.10.26] – 2025-07-14T19:44:27+07:00
+
+### Added
+
+* JOB dataset queries compiled across languages with golden tests
+* `starts_with` builtin supported across Python, Prolog, PHP and Lua
+
+### Changed
+
+* Python dataclasses unify field types and provide iteration helpers
+* Go compiler prints typed lists and infers structs for query selects
+* TypeScript simplifies group-by logic with spread-based appends
+* C backend tracks stack arrays and emits static arrays for struct lists
+* C++ and Java refine struct references and dataclass types
+
+### Fixed
+
+* Numeric casts corrected for TPCH query 1 in Go
+* Cross join output and helper comments fixed in the C backend
+* Query loop formatting improved for TypeScript
+* Dataclass float handling updated for Python
+
 ## [0.10.25] – 2025-07-13T09:42:07+07:00
 
 ### Added

--- a/releases/v0.10.26.md
+++ b/releases/v0.10.26.md
@@ -1,0 +1,28 @@
+# Jul 2025 (v0.10.26)
+
+Released on Mon Jul 14 19:44:27 2025 +0700.
+
+Mochi v0.10.26 introduces JOB dataset examples and refines compiler output across
+languages while fixing several TPCH issues.
+
+## Examples
+
+- JOB dataset queries compiled across languages with golden tests
+- Updated TPCH outputs with improved struct names and dataclasses
+
+## Compilers
+
+- Python dataclasses unify field types, implement iteration and format lists
+- Go compiler inlines list printing and infers structs for query selects
+- TypeScript simplifies group-by logic and spreads values when appending
+- C backend tracks stack arrays and emits static arrays for struct lists
+- C++ and Java fix struct references with refined dataclass types
+
+## Runtime
+
+- C backend adds join grouping support with stack-based arrays
+- Go backend prints typed lists with single struct declarations
+
+## Documentation
+
+- Machine READMEs refreshed with dataset tasks and compiler notes


### PR DESCRIPTION
## Summary
- document v0.10.26 changes in CHANGELOG
- add release notes file for v0.10.26

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6875b7bfa8b08320910db779f5bc1873