### PR TITLE
Improve Python query inference

### DIFF
--- a/types/infer.go
+++ b/types/infer.go
@@ -561,6 +561,8 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 		var elemType Type = AnyType{}
 		if lt, ok := srcType.(ListType); ok {
 			elemType = lt.Elem
+		} else if gt, ok := srcType.(GroupType); ok {
+			elemType = gt.Elem
 		}
 		child := NewEnv(env)
 		child.SetVar(p.Query.Var, elemType, true)


### PR DESCRIPTION
## Summary
- handle `GroupType` sources in `types.ExprType` inference

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875c3df3fc88320997487c24fd1663d