### PR TITLE
Add golden update flag for JOB dataset tests

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -98,3 +98,4 @@ should compile and run successfully.
 - 2025-07-14 04:36 – Refactored group_by_join output to use simpler loops and static arrays.
 - 2025-07-14 12:25 – Updated TPCH q1 code generation to infer struct lists in tests
 - 2025-07-15 03:06 – Generated C code for JOB queries q1-q33 and extended golden tests
+- 2025-07-15 03:20 - Attempted JOB query compilation; added golden update flag in tests. Compilation still fails for many queries.


### PR DESCRIPTION
## Summary
- enable updating C golden files for JOB dataset tests
- log progress in `TASKS.md`

## Testing
- `go test ./compiler/x/c -run JOB_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6875c7b1eed08320adadf785f84014f2