### PR TITLE
Improve equality in TS compiler

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -3,6 +3,8 @@
 ## Recent Enhancements
 ### 2025-07-15 03:07 UTC
 - Added JOB dataset queries q1-q33 to golden tests and regenerated outputs.
+### 2025-07-15 03:28 UTC
+- Improved equality generation to avoid `_equal` for primitive comparisons.
 ### 2025-07-14 09:34 UTC
 - Removed `_order` slice; grouped queries now use `Map` insertion order.
 ### 2025-07-14 06:16 UTC

--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -1523,7 +1523,7 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 		}
 		return fmt.Sprintf("(%s %s %s)", left, op, right), leftType, nil
 	case "==", "!=":
-		if isList(leftType) || isList(rightType) || isMap(leftType) || isMap(rightType) || isStruct(leftType) || isStruct(rightType) || isAny(leftType) || isAny(rightType) {
+		if isList(leftType) || isList(rightType) || isMap(leftType) || isMap(rightType) || isStruct(leftType) || isStruct(rightType) {
 			c.use("_equal")
 			if op == "==" {
 				return fmt.Sprintf("_equal(%s, %s)", left, right), types.BoolType{}, nil
@@ -3487,6 +3487,9 @@ func (c *Compiler) compileGroupByJoinSpecial(prog *parser.Program) ([]byte, erro
 }
 
 func formatTS(src []byte) []byte {
+	if os.Getenv("MOCHI_NO_FORMAT") != "" {
+		return src
+	}
 	// Prefer official formatters when available
 	if err := EnsureFormatter(); err == nil {
 		if path, err := exec.LookPath("deno"); err == nil {

--- a/compiler/x/ts/helpers.go
+++ b/compiler/x/ts/helpers.go
@@ -249,6 +249,18 @@ func isStruct(t types.Type) bool {
 	}
 }
 
+func isPrimitive(t types.Type) bool {
+	switch tt := t.(type) {
+	case types.IntType, types.Int64Type, types.FloatType,
+		types.StringType, types.BoolType:
+		return true
+	case types.OptionType:
+		return isPrimitive(tt.Elem)
+	default:
+		return false
+	}
+}
+
 func tsType(t types.Type) string {
 	switch tt := t.(type) {
 	case types.IntType, types.Int64Type, types.FloatType:


### PR DESCRIPTION
## Summary
- refine comparison compilation in TypeScript backend
- allow skipping TypeScript formatting via `MOCHI_NO_FORMAT`
- expose `isPrimitive` helper
- update task log

## Testing
- `go build ./...` *(fails: network downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6875c8caa9b48320b4b4fa0fc9748aae