### PR TITLE
Add JOB error golden files for C backend

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -99,3 +99,4 @@ should compile and run successfully.
 - 2025-07-14 12:25 – Updated TPCH q1 code generation to infer struct lists in tests
 - 2025-07-15 03:06 – Generated C code for JOB queries q1-q33 and extended golden tests
 - 2025-07-15 03:20 - Attempted JOB query compilation; added golden update flag in tests. Compilation still fails for many queries.
+- 2025-07-15 03:31 – Added error capture to JOB golden tests and re-ran q1-q33. Compilation still failing but .error files are recorded.

--- a/tests/dataset/job/compiler/c/q1.error
+++ b/tests/dataset/job/compiler/c/q1.error
@@ -1,0 +1,93 @@
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c: In function ‘test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production’:
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:283:86: error: invalid operands to binary == (have ‘int’ and ‘tmp_item_t’)
+  283 |   if (!(test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production_result ==
+      |                                                                                      ^~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:317:31: warning: implicit declaration of function ‘filtered_item_list_t_create’ [-Wimplicit-function-declaration]
+  317 |   filtered_item_list_t tmp1 = filtered_item_list_t_create(
+      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:318:19: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  318 |       company_type.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:318:41: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  318 |       company_type.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:318:53: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  318 |       company_type.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:318:74: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  318 |       company_type.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:319:16: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  319 |       info_type.len);
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:345:40: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  345 |                   ((!contains_string(mc.note,
+      |                                      ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:80:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:347:38: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  347 |                   (contains_string(mc.note, "(co-production)") ||
+      |                                    ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:80:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:348:38: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  348 |                    contains_string(mc.note, "(presents)")))) {
+      |                                    ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:80:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:361:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  361 |   int tmp8 = int_create(filtered.len);
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:365:9: error: request for member ‘data’ in something not a structure or union
+  365 |     tmp8.data[tmp9] = r.note;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:368:7: error: request for member ‘len’ in something not a structure or union
+  368 |   tmp8.len = tmp9;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:373:10: error: request for member ‘data’ in something not a structure or union
+  373 |     tmp11.data[tmp12] = r.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:376:8: error: request for member ‘len’ in something not a structure or union
+  376 |   tmp11.len = tmp12;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:385:73: error: incompatible type for argument 1 of ‘_min_string’
+  385 |   result_item_t result = (result_item_t){.production_note = _min_string(tmp8),
+      |                                                                         ^~~~
+      |                                                                         |
+      |                                                                         int
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:386:69: error: incompatible type for argument 1 of ‘_min_string’
+  386 |                                          .movie_title = _min_string(tmp11),
+      |                                                                     ^~~~~
+      |                                                                     |
+      |                                                                     int
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:389:19: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  389 |   tmp17.data[0] = result;
+      |                   ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:394:24: error: invalid initializer
+  394 |     result_item_t it = tmp17.data[i18];
+      |                        ^~~~~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:411:7: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  411 |       result;
+      |       ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:413:12: error: request for member ‘data’ in something not a structure or union
+  413 |   free(tmp8.data);
+      |            ^
+/tmp/TestCCompiler_JOB_Goldenq12875279128/001/prog.c:414:13: error: request for member ‘data’ in something not a structure or union
+  414 |   free(tmp11.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q10.error
+++ b/tests/dataset/job/compiler/c/q10.error
@@ -1,0 +1,106 @@
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c: In function ‘test_Q10_finds_uncredited_voice_actor_in_Russian_movie’:
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:313:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  313 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:320:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  320 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:366:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  366 |   matches_item_list_t tmp4 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:367:16: error: ‘(char_name_t *)&char_name’ is a pointer; did you mean to use ‘->’?
+  367 |       char_name.len * cast_info.len * role_type.len * title.len *
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:367:32: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  367 |       char_name.len * cast_info.len * role_type.len * title.len *
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:367:48: error: ‘(role_type_t *)&role_type’ is a pointer; did you mean to use ‘->’?
+  367 |       char_name.len * cast_info.len * role_type.len * title.len *
+      |                                                ^
+      |                                                ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:367:60: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  367 |       char_name.len * cast_info.len * role_type.len * title.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:368:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  368 |       movie_companies.len * company_name.len * company_type.len);
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:368:41: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  368 |       movie_companies.len * company_name.len * company_type.len);
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:368:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  368 |       movie_companies.len * company_name.len * company_type.len);
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:402:41: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  402 |                 if (!(contains_string(ci.note, "(voice)") &&
+      |                                       ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:403:41: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  403 |                       contains_string(ci.note, "(uncredited)") &&
+      |                                       ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:420:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  420 |   int tmp13 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:424:10: error: request for member ‘data’ in something not a structure or union
+  424 |     tmp13.data[tmp14] = x.character;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:427:8: error: request for member ‘len’ in something not a structure or union
+  427 |   tmp13.len = tmp14;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:432:10: error: request for member ‘data’ in something not a structure or union
+  432 |     tmp16.data[tmp17] = x.movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:435:8: error: request for member ‘len’ in something not a structure or union
+  435 |   tmp16.len = tmp17;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:437:61: error: incompatible type for argument 1 of ‘_min_string’
+  437 |       (result_t){.uncredited_voiced_character = _min_string(tmp13),
+      |                                                             ^~~~~
+      |                                                             |
+      |                                                             int
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:438:47: error: incompatible type for argument 1 of ‘_min_string’
+  438 |                  .russian_movie = _min_string(tmp16)}};
+      |                                               ^~~~~
+      |                                               |
+      |                                               int
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:448:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  448 |     _json_string(it.uncredited_voiced_character);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:452:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  452 |     _json_string(it.russian_movie);
+      |                  ~~^~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:456:67: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  456 |   test_Q10_finds_uncredited_voice_actor_in_Russian_movie_result = result;
+      |                                                                   ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:458:13: error: request for member ‘data’ in something not a structure or union
+  458 |   free(tmp13.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq103043615073/001/prog.c:459:13: error: request for member ‘data’ in something not a structure or union
+  459 |   free(tmp16.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q11.error
+++ b/tests/dataset/job/compiler/c/q11.error
@@ -1,0 +1,139 @@
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c: In function ‘test_Q11_returns_min_company__link_type_and_title’:
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:337:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  337 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:344:15: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  344 |           tmp1.data[i3]) {
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:400:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  400 |   matches_item_list_t tmp4 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:401:19: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:401:41: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:401:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:401:72: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                                        ^
+      |                                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:402:20: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  402 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len);
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:402:34: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  402 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len);
+      |                                  ^
+      |                                  ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:402:51: error: ‘(movie_link_t *)&movie_link’ is a pointer; did you mean to use ‘->’?
+  402 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len);
+      |                                                   ^
+      |                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:402:67: error: ‘(link_type_t *)&link_type’ is a pointer; did you mean to use ‘->’?
+  402 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len);
+      |                                                                   ^
+      |                                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:442:44: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  442 |                         (contains_string(cn.name, "Film") ||
+      |                                          ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:443:44: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  443 |                          contains_string(cn.name, "Warner")) &&
+      |                                          ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:446:43: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  446 |                         contains_string(lt.link, "follow") && mc.note == 0 &&
+      |                                         ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:467:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  467 |   int tmp14 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:471:10: error: request for member ‘data’ in something not a structure or union
+  471 |     tmp14.data[tmp15] = x.company;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:474:8: error: request for member ‘len’ in something not a structure or union
+  474 |   tmp14.len = tmp15;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:479:10: error: request for member ‘data’ in something not a structure or union
+  479 |     tmp17.data[tmp18] = x.link;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:482:8: error: request for member ‘len’ in something not a structure or union
+  482 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:487:10: error: request for member ‘data’ in something not a structure or union
+  487 |     tmp20.data[tmp21] = x.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:490:8: error: request for member ‘len’ in something not a structure or union
+  490 |   tmp20.len = tmp21;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:492:46: error: incompatible type for argument 1 of ‘_min_string’
+  492 |       (result_t){.from_company = _min_string(tmp14),
+      |                                              ^~~~~
+      |                                              |
+      |                                              int
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:493:49: error: incompatible type for argument 1 of ‘_min_string’
+  493 |                  .movie_link_type = _min_string(tmp17),
+      |                                                 ^~~~~
+      |                                                 |
+      |                                                 int
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:494:57: error: incompatible type for argument 1 of ‘_min_string’
+  494 |                  .non_polish_sequel_movie = _min_string(tmp20)}};
+      |                                                         ^~~~~
+      |                                                         |
+      |                                                         int
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:504:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  504 |     _json_string(it.from_company);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:508:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  508 |     _json_string(it.movie_link_type);
+      |                  ~~^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:512:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  512 |     _json_string(it.non_polish_sequel_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:516:62: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  516 |   test_Q11_returns_min_company__link_type_and_title_result = result;
+      |                                                              ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:518:13: error: request for member ‘data’ in something not a structure or union
+  518 |   free(tmp14.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:519:13: error: request for member ‘data’ in something not a structure or union
+  519 |   free(tmp17.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq11152704658/001/prog.c:520:13: error: request for member ‘data’ in something not a structure or union
+  520 |   free(tmp20.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q12.error
+++ b/tests/dataset/job/compiler/c/q12.error
@@ -1,0 +1,60 @@
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c: In function ‘test_Q12_finds_high_rated_US_drama_or_horror_with_company’:
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:288:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  288 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:296:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  296 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:341:29: warning: implicit declaration of function ‘result_item_list_t_create’ [-Wimplicit-function-declaration]
+  341 |   result_item_list_t tmp4 = result_item_list_t_create(
+      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:342:19: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  342 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:342:41: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  342 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:342:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  342 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:342:72: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  342 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                                        ^
+      |                                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:343:17: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  343 |       movie_info.len * info_type.len * movie_info_idx.len * info_type.len);
+      |                 ^
+      |                 ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:343:33: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  343 |       movie_info.len * info_type.len * movie_info_idx.len * info_type.len);
+      |                                 ^
+      |                                 ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:343:54: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  343 |       movie_info.len * info_type.len * movie_info_idx.len * info_type.len);
+      |                                                      ^
+      |                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:343:70: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  343 |       movie_info.len * info_type.len * movie_info_idx.len * info_type.len);
+      |                                                                      ^
+      |                                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:414:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  414 |     _json_string(it.movie_company);
+      |                  ~~^~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:64:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   64 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:422:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  422 |     _json_string(it.drama_horror_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:64:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   64 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq122788158615/001/prog.c:426:70: error: incompatible types when assigning to type ‘list_int’ from type ‘result_item_list_t’
+  426 |   test_Q12_finds_high_rated_US_drama_or_horror_with_company_result = result;
+      |                                                                      ^~~~~~

--- a/tests/dataset/job/compiler/c/q13.error
+++ b/tests/dataset/job/compiler/c/q13.error
@@ -1,0 +1,141 @@
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c: In function ‘test_Q13_finds_earliest_German_movie_info’:
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:319:58: error: invalid operands to binary == (have ‘int’ and ‘tmp_item_t’)
+  319 |   if (!(test_Q13_finds_earliest_German_movie_info_result ==
+      |                                                          ^~
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:364:33: warning: implicit declaration of function ‘candidates_item_list_t_create’ [-Wimplicit-function-declaration]
+  364 |   candidates_item_list_t tmp1 = candidates_item_list_t_create(
+      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:365:19: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  365 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:365:41: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  365 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:365:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  365 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:365:72: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  365 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                                        ^
+      |                                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:366:16: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  366 |       kind_type.len * movie_info.len * info_type.len * movie_info_idx.len *
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:366:33: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  366 |       kind_type.len * movie_info.len * info_type.len * movie_info_idx.len *
+      |                                 ^
+      |                                 ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:366:49: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  366 |       kind_type.len * movie_info.len * info_type.len * movie_info_idx.len *
+      |                                                 ^
+      |                                                 ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:366:70: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  366 |       kind_type.len * movie_info.len * info_type.len * movie_info_idx.len *
+      |                                                                      ^
+      |                                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:367:16: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  367 |       info_type.len);
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:433:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  433 |   int tmp12 = int_create(candidates.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:439:10: error: request for member ‘data’ in something not a structure or union
+  439 |     tmp12.data[tmp13] = x.release_date;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:443:8: error: request for member ‘len’ in something not a structure or union
+  443 |   tmp12.len = tmp13;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:450:34: error: request for member ‘data’ in something not a structure or union
+  450 |         const char *tmp17 = tmp12.data[i18];
+      |                                  ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:451:14: error: request for member ‘data’ in something not a structure or union
+  451 |         tmp12.data[i18] = tmp12.data[i19];
+      |              ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:451:32: error: request for member ‘data’ in something not a structure or union
+  451 |         tmp12.data[i18] = tmp12.data[i19];
+      |                                ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:452:14: error: request for member ‘data’ in something not a structure or union
+  452 |         tmp12.data[i19] = tmp17;
+      |              ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:462:10: error: request for member ‘data’ in something not a structure or union
+  462 |     tmp20.data[tmp21] = x.rating;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:466:8: error: request for member ‘len’ in something not a structure or union
+  466 |   tmp20.len = tmp21;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:473:34: error: request for member ‘data’ in something not a structure or union
+  473 |         const char *tmp25 = tmp20.data[i26];
+      |                                  ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:474:14: error: request for member ‘data’ in something not a structure or union
+  474 |         tmp20.data[i26] = tmp20.data[i27];
+      |              ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:474:32: error: request for member ‘data’ in something not a structure or union
+  474 |         tmp20.data[i26] = tmp20.data[i27];
+      |                                ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:475:14: error: request for member ‘data’ in something not a structure or union
+  475 |         tmp20.data[i27] = tmp25;
+      |              ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:485:10: error: request for member ‘data’ in something not a structure or union
+  485 |     tmp28.data[tmp29] = x.german_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:489:8: error: request for member ‘len’ in something not a structure or union
+  489 |   tmp28.len = tmp29;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:496:34: error: request for member ‘data’ in something not a structure or union
+  496 |         const char *tmp33 = tmp28.data[i34];
+      |                                  ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:497:14: error: request for member ‘data’ in something not a structure or union
+  497 |         tmp28.data[i34] = tmp28.data[i35];
+      |              ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:497:32: error: request for member ‘data’ in something not a structure or union
+  497 |         tmp28.data[i34] = tmp28.data[i35];
+      |                                ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:498:14: error: request for member ‘data’ in something not a structure or union
+  498 |         tmp28.data[i35] = tmp33;
+      |              ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:502:65: error: request for member ‘data’ in something not a structure or union
+  502 |   result_item_t result = (result_item_t){.release_date = (tmp12).data[0],
+      |                                                                 ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:503:59: error: request for member ‘data’ in something not a structure or union
+  503 |                                          .rating = (tmp20).data[0],
+      |                                                           ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:504:65: error: request for member ‘data’ in something not a structure or union
+  504 |                                          .german_movie = (tmp28).data[0]};
+      |                                                                 ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:508:22: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  508 |   _json_string(result.release_date);
+      |                ~~~~~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:64:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   64 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:512:22: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  512 |   _json_string(result.rating);
+      |                ~~~~~~^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:64:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   64 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:516:22: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  516 |   _json_string(result.german_movie);
+      |                ~~~~~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:64:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   64 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:518:54: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  518 |   test_Q13_finds_earliest_German_movie_info_result = result;
+      |                                                      ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:520:13: error: request for member ‘data’ in something not a structure or union
+  520 |   free(tmp12.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:521:13: error: request for member ‘data’ in something not a structure or union
+  521 |   free(tmp20.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq131053870555/001/prog.c:522:13: error: request for member ‘data’ in something not a structure or union
+  522 |   free(tmp28.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q14.error
+++ b/tests/dataset/job/compiler/c/q14.error
@@ -1,0 +1,53 @@
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c: In function ‘test_Q14_selects_minimal_rating_and_title_for_dark_movies’:
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:321:74: error: invalid operands to binary == (have ‘int’ and ‘tmp_item_t’)
+  321 |   if (!(test_Q14_selects_minimal_rating_and_title_for_dark_movies_result ==
+      |                                                                          ^~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:370:7: error: conflicting types for ‘allowed_keywords’; have ‘int’
+  370 |   int allowed_keywords = allowed_keywords;
+      |       ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:365:15: note: previous definition of ‘allowed_keywords’ with type ‘list_string’
+  365 |   list_string allowed_keywords = list_string_create(4);
+      |               ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:382:7: error: conflicting types for ‘allowed_countries’; have ‘int’
+  382 |   int allowed_countries = allowed_countries;
+      |       ^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:371:15: note: previous definition of ‘allowed_countries’ with type ‘list_string’
+  371 |   list_string allowed_countries = list_string_create(10);
+      |               ^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:406:67: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  406 |                          (contains_list_string(allowed_keywords, k.keyword)) &&
+      |                                                                  ~^~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:408:69: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  408 |                          (contains_list_string(allowed_countries, mi.info)) &&
+      |                                                                   ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:440:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  440 |   int tmp6 = int_create(matches.len);
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:444:9: error: request for member ‘data’ in something not a structure or union
+  444 |     tmp6.data[tmp7] = x.title;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:447:7: error: request for member ‘len’ in something not a structure or union
+  447 |   tmp6.len = tmp7;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:449:70: error: incompatible type for argument 1 of ‘_min_string’
+  449 |       .rating = _min_float(tmp3), .northern_dark_movie = _min_string(tmp6)};
+      |                                                                      ^~~~
+      |                                                                      |
+      |                                                                      int
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:459:70: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  459 |   test_Q14_selects_minimal_rating_and_title_for_dark_movies_result = result;
+      |                                                                      ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq144118064268/001/prog.c:463:12: error: request for member ‘data’ in something not a structure or union
+  463 |   free(tmp6.data);
+      |            ^

--- a/tests/dataset/job/compiler/c/q15.error
+++ b/tests/dataset/job/compiler/c/q15.error
@@ -1,0 +1,132 @@
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c: In function ‘test_Q15_finds_the_earliest_US_internet_movie_release_after_2000’:
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:351:23: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  351 |           .len != tmp1.len) {
+      |                       ^
+      |                       ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:360:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  360 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:416:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  416 |   rows_item_list_t tmp4 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:417:12: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  417 |       title.len * aka_title.len * movie_info.len * movie_keyword.len *
+      |            ^
+      |            ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:417:28: error: ‘(aka_title_t *)&aka_title’ is a pointer; did you mean to use ‘->’?
+  417 |       title.len * aka_title.len * movie_info.len * movie_keyword.len *
+      |                            ^
+      |                            ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:417:45: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  417 |       title.len * aka_title.len * movie_info.len * movie_keyword.len *
+      |                                             ^
+      |                                             ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:417:65: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  417 |       title.len * aka_title.len * movie_info.len * movie_keyword.len *
+      |                                                                 ^
+      |                                                                 ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:418:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  418 |       movie_companies.len * keyword.len * info_type.len * company_name.len *
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:418:36: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  418 |       movie_companies.len * keyword.len * info_type.len * company_name.len *
+      |                                    ^
+      |                                    ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:418:52: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  418 |       movie_companies.len * keyword.len * info_type.len * company_name.len *
+      |                                                    ^
+      |                                                    ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:418:71: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  418 |       movie_companies.len * keyword.len * info_type.len * company_name.len *
+      |                                                                       ^
+      |                                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:419:19: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  419 |       company_type.len);
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:465:45: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  465 |                           contains_string(mc.note, "200") &&
+      |                                           ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:466:45: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  466 |                           contains_string(mc.note, "worldwide") &&
+      |                                           ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:467:45: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  467 |                           contains_string(mi.note, "internet") &&
+      |                                           ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:468:45: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  468 |                           contains_string(mi.info, "USA:") &&
+      |                                           ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:469:45: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  469 |                           contains_string(mi.info, "200") &&
+      |                                           ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:487:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  487 |   int tmp15 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:491:10: error: request for member ‘data’ in something not a structure or union
+  491 |     tmp15.data[tmp16] = r.release_date;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:494:8: error: request for member ‘len’ in something not a structure or union
+  494 |   tmp15.len = tmp16;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:499:10: error: request for member ‘data’ in something not a structure or union
+  499 |     tmp18.data[tmp19] = r.internet_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:502:8: error: request for member ‘len’ in something not a structure or union
+  502 |   tmp18.len = tmp19;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:503:63: error: incompatible type for argument 1 of ‘_min_string’
+  503 |   result_t result[] = {(result_t){.release_date = _min_string(tmp15),
+      |                                                               ^~~~~
+      |                                                               |
+      |                                                               int
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:504:65: error: incompatible type for argument 1 of ‘_min_string’
+  504 |                                   .internet_movie = _min_string(tmp18)}};
+      |                                                                 ^~~~~
+      |                                                                 |
+      |                                                                 int
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:514:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  514 |     _json_string(it.release_date);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:518:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  518 |     _json_string(it.internet_movie);
+      |                  ~~^~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:523:7: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  523 |       result;
+      |       ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:525:13: error: request for member ‘data’ in something not a structure or union
+  525 |   free(tmp15.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq151783599852/001/prog.c:526:13: error: request for member ‘data’ in something not a structure or union
+  526 |   free(tmp18.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q16.error
+++ b/tests/dataset/job/compiler/c/q16.error
@@ -1,0 +1,98 @@
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c: In function ‘test_Q16_finds_series_named_after_a_character_between_episodes_50_and_99’:
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:328:23: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  328 |           .len != tmp1.len) {
+      |                       ^
+      |                       ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:338:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  338 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:380:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  380 |   rows_item_list_t tmp4 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:381:15: error: ‘(aka_name_t *)&aka_name’ is a pointer; did you mean to use ‘->’?
+  381 |       aka_name.len * name.len * cast_info.len * title.len * movie_keyword.len *
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:381:26: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  381 |       aka_name.len * name.len * cast_info.len * title.len * movie_keyword.len *
+      |                          ^
+      |                          ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:381:42: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  381 |       aka_name.len * name.len * cast_info.len * title.len * movie_keyword.len *
+      |                                          ^
+      |                                          ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:381:54: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  381 |       aka_name.len * name.len * cast_info.len * title.len * movie_keyword.len *
+      |                                                      ^
+      |                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:381:74: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  381 |       aka_name.len * name.len * cast_info.len * title.len * movie_keyword.len *
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:382:14: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  382 |       keyword.len * movie_companies.len * company_name.len);
+      |              ^
+      |              ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:382:36: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  382 |       keyword.len * movie_companies.len * company_name.len);
+      |                                    ^
+      |                                    ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:382:55: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  382 |       keyword.len * movie_companies.len * company_name.len);
+      |                                                       ^
+      |                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:439:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  439 |   int tmp14 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:443:10: error: request for member ‘data’ in something not a structure or union
+  443 |     tmp14.data[tmp15] = r.pseudonym;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:446:8: error: request for member ‘len’ in something not a structure or union
+  446 |   tmp14.len = tmp15;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:451:10: error: request for member ‘data’ in something not a structure or union
+  451 |     tmp17.data[tmp18] = r.series;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:454:8: error: request for member ‘len’ in something not a structure or union
+  454 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:456:54: error: incompatible type for argument 1 of ‘_min_string’
+  456 |       (result_t){.cool_actor_pseudonym = _min_string(tmp14),
+      |                                                      ^~~~~
+      |                                                      |
+      |                                                      int
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:457:57: error: incompatible type for argument 1 of ‘_min_string’
+  457 |                  .series_named_after_char = _min_string(tmp17)}};
+      |                                                         ^~~~~
+      |                                                         |
+      |                                                         int
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:467:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  467 |     _json_string(it.cool_actor_pseudonym);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:471:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  471 |     _json_string(it.series_named_after_char);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:476:7: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  476 |       result;
+      |       ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:478:13: error: request for member ‘data’ in something not a structure or union
+  478 |   free(tmp14.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq16555468053/001/prog.c:479:13: error: request for member ‘data’ in something not a structure or union
+  479 |   free(tmp17.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q17.error
+++ b/tests/dataset/job/compiler/c/q17.error
@@ -1,0 +1,70 @@
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c: In function ‘test_Q17_finds_US_character_name_movie_with_actor_starting_with_B’:
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:290:23: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  290 |           .len != tmp1.len) {
+      |                       ^
+      |                       ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:300:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  300 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:340:7: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  340 |       int_create(name.len * cast_info.len * title.len * movie_keyword.len *
+      |       ^~~~~~~~~~
+      |       list_int_create
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:340:22: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  340 |       int_create(name.len * cast_info.len * title.len * movie_keyword.len *
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:340:38: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  340 |       int_create(name.len * cast_info.len * title.len * movie_keyword.len *
+      |                                      ^
+      |                                      ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:340:50: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  340 |       int_create(name.len * cast_info.len * title.len * movie_keyword.len *
+      |                                                  ^
+      |                                                  ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:340:70: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  340 |       int_create(name.len * cast_info.len * title.len * movie_keyword.len *
+      |                                                                      ^
+      |                                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:341:25: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  341 |                  keyword.len * movie_companies.len * company_name.len);
+      |                         ^
+      |                         ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:341:47: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  341 |                  keyword.len * movie_companies.len * company_name.len);
+      |                                               ^
+      |                                               ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:341:66: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  341 |                  keyword.len * movie_companies.len * company_name.len);
+      |                                                                  ^
+      |                                                                  ->
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:377:29: error: request for member ‘starts_with’ in something not a structure or union
+  377 |                       n.name.starts_with("B") && ci.movie_id == mk.movie_id &&
+      |                             ^
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:382:21: error: request for member ‘data’ in something not a structure or union
+  382 |                 tmp4.data[tmp5] = n.name;
+      |                     ^
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:391:7: error: request for member ‘len’ in something not a structure or union
+  391 |   tmp4.len = tmp5;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:394:65: error: incompatible type for argument 1 of ‘_min_int’
+  394 |       (result_t){.member_in_charnamed_american_movie = _min_int(matches),
+      |                                                                 ^~~~~~~
+      |                                                                 |
+      |                                                                 int
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:62:30: note: expected ‘list_int’ but argument is of type ‘int’
+   62 | static int _min_int(list_int v) {
+      |                     ~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:395:33: error: incompatible type for argument 1 of ‘_min_int’
+  395 |                  .a1 = _min_int(matches)}};
+      |                                 ^~~~~~~
+      |                                 |
+      |                                 int
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:62:30: note: expected ‘list_int’ but argument is of type ‘int’
+   62 | static int _min_int(list_int v) {
+      |                     ~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq173814554275/001/prog.c:412:7: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  412 |       result;
+      |       ^~~~~~

--- a/tests/dataset/job/compiler/c/q18.error
+++ b/tests/dataset/job/compiler/c/q18.error
@@ -1,0 +1,78 @@
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c: In function ‘test_Q18_finds_minimal_budget__votes_and_title_for_Tim_productions’:
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:310:83: error: invalid operands to binary == (have ‘int’ and ‘tmp_item_t’)
+  310 |   if (!(test_Q18_finds_minimal_budget__votes_and_title_for_Tim_productions_result ==
+      |                                                                                   ^~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:350:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  350 |   rows_item_list_t tmp1 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:351:16: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  351 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:351:27: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  351 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                           ^
+      |                           ->
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:351:39: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  351 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                                       ^
+      |                                       ->
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:351:56: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  351 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                                                        ^
+      |                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:352:21: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  352 |       movie_info_idx.len * info_type.len * info_type.len);
+      |                     ^
+      |                     ->
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:352:37: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  352 |       movie_info_idx.len * info_type.len * info_type.len);
+      |                                     ^
+      |                                     ->
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:352:53: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  352 |       movie_info_idx.len * info_type.len * info_type.len);
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:386:53: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  386 |                 if (!((contains_list_string(rows, ci.note) &&
+      |                                                   ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:388:60: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  388 |                        n.gender == "m" && contains_string(n.name, "Tim") &&
+      |                                                           ~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:86:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   86 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:405:20: error: conflicting types for ‘rows’; have ‘rows_item_list_t’
+  405 |   rows_item_list_t rows = tmp1;
+      |                    ^~~~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:347:15: note: previous definition of ‘rows’ with type ‘list_string’
+  347 |   list_string rows = list_string_create(2);
+      |               ^~~~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:422:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  422 |   int tmp16 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:426:10: error: request for member ‘data’ in something not a structure or union
+  426 |     tmp16.data[tmp17] = r.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:429:8: error: request for member ‘len’ in something not a structure or union
+  429 |   tmp16.len = tmp17;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:432:69: error: incompatible type for argument 1 of ‘_min_string’
+  432 |                                          .movie_title = _min_string(tmp16)};
+      |                                                                     ^~~~~
+      |                                                                     |
+      |                                                                     int
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:447:7: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  447 |       result;
+      |       ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq182931055666/001/prog.c:451:13: error: request for member ‘data’ in something not a structure or union
+  451 |   free(tmp16.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q19.error
+++ b/tests/dataset/job/compiler/c/q19.error
@@ -1,0 +1,160 @@
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c: In function ‘test_Q19_finds_female_voice_actress_in_US_Japan_release_between_2005_and_2009’:
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:382:23: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  382 |           .len != tmp1.len) {
+      |                       ^
+      |                       ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:392:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  392 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:455:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  455 |   matches_item_list_t tmp4 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:456:15: error: ‘(aka_name_t *)&aka_name’ is a pointer; did you mean to use ‘->’?
+  456 |       aka_name.len * name.len * cast_info.len * char_name.len * role_type.len *
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:456:26: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  456 |       aka_name.len * name.len * cast_info.len * char_name.len * role_type.len *
+      |                          ^
+      |                          ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:456:42: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  456 |       aka_name.len * name.len * cast_info.len * char_name.len * role_type.len *
+      |                                          ^
+      |                                          ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:456:58: error: ‘(char_name_t *)&char_name’ is a pointer; did you mean to use ‘->’?
+  456 |       aka_name.len * name.len * cast_info.len * char_name.len * role_type.len *
+      |                                                          ^
+      |                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:456:74: error: ‘(role_type_t *)&role_type’ is a pointer; did you mean to use ‘->’?
+  456 |       aka_name.len * name.len * cast_info.len * char_name.len * role_type.len *
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:457:12: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  457 |       title.len * movie_companies.len * company_name.len * movie_info.len *
+      |            ^
+      |            ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:457:34: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  457 |       title.len * movie_companies.len * company_name.len * movie_info.len *
+      |                                  ^
+      |                                  ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:457:53: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  457 |       title.len * movie_companies.len * company_name.len * movie_info.len *
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:457:70: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  457 |       title.len * movie_companies.len * company_name.len * movie_info.len *
+      |                                                                      ^
+      |                                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:458:16: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  458 |       info_type.len);
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:507:61: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  507 |                       if (!(contains_list_string(matches, ci.note) &&
+      |                                                           ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:71:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:510:48: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  510 |                             (contains_string(mc.note, "(USA)") ||
+      |                                              ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:511:48: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  511 |                              contains_string(mc.note, "(worldwide)")) &&
+      |                                              ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:513:49: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  513 |                             ((contains_string(mi.info, "Japan:") &&
+      |                                               ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:514:49: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  514 |                               contains_string(mi.info, "200")) ||
+      |                                               ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:515:49: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  515 |                              (contains_string(mi.info, "USA:") &&
+      |                                               ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:516:49: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  516 |                               contains_string(mi.info, "200"))) &&
+      |                                               ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:517:65: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  517 |                             n.gender == "f" && contains_string(n.name, "Ang") &&
+      |                                                                ~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:536:23: error: conflicting types for ‘matches’; have ‘matches_item_list_t’
+  536 |   matches_item_list_t matches = tmp4;
+      |                       ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:450:15: note: previous definition of ‘matches’ with type ‘list_string’
+  450 |   list_string matches = list_string_create(4);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:537:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  537 |   int tmp16 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:541:10: error: request for member ‘data’ in something not a structure or union
+  541 |     tmp16.data[tmp17] = r.actress;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:544:8: error: request for member ‘len’ in something not a structure or union
+  544 |   tmp16.len = tmp17;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:549:10: error: request for member ‘data’ in something not a structure or union
+  549 |     tmp19.data[tmp20] = r.movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:552:8: error: request for member ‘len’ in something not a structure or union
+  552 |   tmp19.len = tmp20;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:553:66: error: incompatible type for argument 1 of ‘_min_string’
+  553 |   result_t result[] = {(result_t){.voicing_actress = _min_string(tmp16),
+      |                                                                  ^~~~~
+      |                                                                  |
+      |                                                                  int
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:554:63: error: incompatible type for argument 1 of ‘_min_string’
+  554 |                                   .voiced_movie = _min_string(tmp19)}};
+      |                                                               ^~~~~
+      |                                                               |
+      |                                                               int
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:564:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  564 |     _json_string(it.voicing_actress);
+      |                  ~~^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:568:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  568 |     _json_string(it.voiced_movie);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:573:7: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  573 |       result;
+      |       ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:575:13: error: request for member ‘data’ in something not a structure or union
+  575 |   free(tmp16.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq191033871898/001/prog.c:576:13: error: request for member ‘data’ in something not a structure or union
+  576 |   free(tmp19.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q2.error
+++ b/tests/dataset/job/compiler/c/q2.error
@@ -1,0 +1,43 @@
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c: In function ‘test_Q2_finds_earliest_title_for_German_companies_with_character_keyword’:
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:209:90: warning: comparison between pointer and integer
+  209 |   if (!((test_Q2_finds_earliest_title_for_German_companies_with_character_keyword_result ==
+      |                                                                                          ^~
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:237:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  237 |   int tmp1 = int_create(company_name.len * movie_companies.len * title.len *
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:237:37: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  237 |   int tmp1 = int_create(company_name.len * movie_companies.len * title.len *
+      |                                     ^
+      |                                     ->
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:237:59: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  237 |   int tmp1 = int_create(company_name.len * movie_companies.len * title.len *
+      |                                                           ^
+      |                                                           ->
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:237:71: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  237 |   int tmp1 = int_create(company_name.len * movie_companies.len * title.len *
+      |                                                                       ^
+      |                                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:238:38: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  238 |                         movie_keyword.len * keyword.len);
+      |                                      ^
+      |                                      ->
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:238:52: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  238 |                         movie_keyword.len * keyword.len);
+      |                                                    ^
+      |                                                    ->
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:267:17: error: request for member ‘data’ in something not a structure or union
+  267 |             tmp1.data[tmp2] = t.title;
+      |                 ^
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:274:7: error: request for member ‘len’ in something not a structure or union
+  274 |   tmp1.len = tmp2;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:276:28: error: incompatible type for argument 1 of ‘_min_string’
+  276 |   int result = _min_string(titles);
+      |                            ^~~~~~
+      |                            |
+      |                            int
+/tmp/TestCCompiler_JOB_Goldenq2837580288/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^

--- a/tests/dataset/job/compiler/c/q20.error
+++ b/tests/dataset/job/compiler/c/q20.error
@@ -1,0 +1,119 @@
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c: In function ‘test_Q20_finds_complete_cast_Iron_Man_movie’:
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:335:69: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  335 |   if (test_Q20_finds_complete_cast_Iron_Man_movie_result.len != tmp1.len) {
+      |                                                                     ^
+      |                                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:341:15: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  341 |           tmp1.data[i3]) {
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:397:7: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  397 |       int_create(complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |       ^~~~~~~~~~
+      |       list_int_create
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:397:31: error: ‘(complete_cast_t *)&complete_cast’ is a pointer; did you mean to use ‘->’?
+  397 |       int_create(complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                               ^
+      |                               ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:397:52: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  397 |       int_create(complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                                    ^
+      |                                                    ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:397:73: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  397 |       int_create(complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                                                         ^
+      |                                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:398:27: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  398 |                  cast_info.len * char_name.len * name.len * movie_keyword.len *
+      |                           ^
+      |                           ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:398:43: error: ‘(char_name_t *)&char_name’ is a pointer; did you mean to use ‘->’?
+  398 |                  cast_info.len * char_name.len * name.len * movie_keyword.len *
+      |                                           ^
+      |                                           ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:398:54: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  398 |                  cast_info.len * char_name.len * name.len * movie_keyword.len *
+      |                                                      ^
+      |                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:398:74: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  398 |                  cast_info.len * char_name.len * name.len * movie_keyword.len *
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:399:25: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  399 |                  keyword.len * title.len * kind_type.len);
+      |                         ^
+      |                         ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:399:37: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  399 |                  keyword.len * title.len * kind_type.len);
+      |                                     ^
+      |                                     ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:399:53: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  399 |                  keyword.len * title.len * kind_type.len);
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:451:57: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  451 |                                     contains_string(cct2.kind, "complete") &&
+      |                                                     ~~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:452:59: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  452 |                                     ((!contains_string(chn.name,
+      |                                                        ~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:454:57: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  454 |                                     (contains_string(chn.name, "Tony Stark") ||
+      |                                                      ~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:455:57: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  455 |                                      contains_string(chn.name, "Iron Man")) &&
+      |                                                      ~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:455:77: warning: passing argument 2 of ‘contains_list_string’ makes pointer from integer without a cast [-Wint-conversion]
+  450 |                                 (strcmp(cct1.kind, "cast") == 0) &&
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~          
+  451 |                                     contains_string(cct2.kind, "complete") &&
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  452 |                                     ((!contains_string(chn.name,
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~             
+  453 |                                                        "Sherlock"))) &&
+      |                                                        ~~~~~~~~~~~~~~~~      
+  454 |                                     (contains_string(chn.name, "Tony Stark") ||
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  455 |                                      contains_string(chn.name, "Iron Man")) &&
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+      |                                                                             |
+      |                                                                             int
+  456 |                                     k.keyword) &&
+      |                                     ~~~~~~~~~                                
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:71:54: note: expected ‘char *’ but argument is of type ‘int’
+   71 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:460:27: error: request for member ‘data’ in something not a structure or union
+  460 |                       tmp4.data[tmp5] = t.title;
+      |                           ^
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:472:7: error: request for member ‘len’ in something not a structure or union
+  472 |   tmp4.len = tmp5;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:473:7: error: conflicting types for ‘matches’; have ‘int’
+  473 |   int matches = tmp4;
+      |       ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:387:15: note: previous definition of ‘matches’ with type ‘list_string’
+  387 |   list_string matches = list_string_create(8);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:485:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  485 |     _json_string(it.complete_downey_ironman_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq203158356142/001/prog.c:489:56: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  489 |   test_Q20_finds_complete_cast_Iron_Man_movie_result = result;
+      |                                                        ^~~~~~

--- a/tests/dataset/job/compiler/c/q21.error
+++ b/tests/dataset/job/compiler/c/q21.error
@@ -1,0 +1,155 @@
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c: In function ‘test_Q21_finds_western_follow_up_sequels’:
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:361:66: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  361 |   if (test_Q21_finds_western_follow_up_sequels_result.len != tmp1.len) {
+      |                                                                  ^
+      |                                                                  ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:367:15: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  367 |           tmp1.data[i3]) {
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:427:7: error: conflicting types for ‘allowed_countries’; have ‘int’
+  427 |   int allowed_countries = allowed_countries;
+      |       ^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:418:15: note: previous definition of ‘allowed_countries’ with type ‘list_string’
+  418 |   list_string allowed_countries = list_string_create(8);
+      |               ^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:428:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  428 |   rows_item_list_t tmp4 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:429:19: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  429 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:429:41: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  429 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:429:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  429 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:429:72: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  429 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                                        ^
+      |                                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:430:20: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  430 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:430:34: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  430 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len *
+      |                                  ^
+      |                                  ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:430:51: error: ‘(movie_link_t *)&movie_link’ is a pointer; did you mean to use ‘->’?
+  430 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len *
+      |                                                   ^
+      |                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:430:67: error: ‘(link_type_t *)&link_type’ is a pointer; did you mean to use ‘->’?
+  430 |       movie_keyword.len * keyword.len * movie_link.len * link_type.len *
+      |                                                                   ^
+      |                                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:431:17: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  431 |       movie_info.len);
+      |                 ^
+      |                 ->
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:476:46: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  476 |                           (contains_string(cn.name, "Film") ||
+      |                                            ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:477:46: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  477 |                            contains_string(cn.name, "Warner")) &&
+      |                                            ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:480:45: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  480 |                           contains_string(lt.link, "follow") && mc.note == 0 &&
+      |                                           ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:481:70: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  481 |                           (contains_list_string(allowed_countries, mi.info)) &&
+      |                                                                    ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:71:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:502:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  502 |   int tmp15 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:506:10: error: request for member ‘data’ in something not a structure or union
+  506 |     tmp15.data[tmp16] = r.company_name;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:509:8: error: request for member ‘len’ in something not a structure or union
+  509 |   tmp15.len = tmp16;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:514:10: error: request for member ‘data’ in something not a structure or union
+  514 |     tmp18.data[tmp19] = r.link_type;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:517:8: error: request for member ‘len’ in something not a structure or union
+  517 |   tmp18.len = tmp19;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:522:10: error: request for member ‘data’ in something not a structure or union
+  522 |     tmp21.data[tmp22] = r.western_follow_up;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:525:8: error: request for member ‘len’ in something not a structure or union
+  525 |   tmp21.len = tmp22;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:526:63: error: incompatible type for argument 1 of ‘_min_string’
+  526 |   result_t result[] = {(result_t){.company_name = _min_string(tmp15),
+      |                                                               ^~~~~
+      |                                                               |
+      |                                                               int
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:527:60: error: incompatible type for argument 1 of ‘_min_string’
+  527 |                                   .link_type = _min_string(tmp18),
+      |                                                            ^~~~~
+      |                                                            |
+      |                                                            int
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:528:68: error: incompatible type for argument 1 of ‘_min_string’
+  528 |                                   .western_follow_up = _min_string(tmp21)}};
+      |                                                                    ^~~~~
+      |                                                                    |
+      |                                                                    int
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:538:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  538 |     _json_string(it.company_name);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:542:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  542 |     _json_string(it.link_type);
+      |                  ~~^~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:546:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  546 |     _json_string(it.western_follow_up);
+      |                  ~~^~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:550:53: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  550 |   test_Q21_finds_western_follow_up_sequels_result = result;
+      |                                                     ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:552:13: error: request for member ‘data’ in something not a structure or union
+  552 |   free(tmp15.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:553:13: error: request for member ‘data’ in something not a structure or union
+  553 |   free(tmp18.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq212326331234/001/prog.c:554:13: error: request for member ‘data’ in something not a structure or union
+  554 |   free(tmp21.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q22.error
+++ b/tests/dataset/job/compiler/c/q22.error
@@ -1,0 +1,122 @@
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c: In function ‘test_Q22_finds_western_violent_movie_with_low_rating’:
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:387:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  387 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:394:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  394 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:455:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  455 |   rows_item_list_t tmp4 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:456:19: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  456 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:456:41: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  456 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:456:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  456 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:456:72: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  456 |       company_name.len * movie_companies.len * company_type.len * title.len *
+      |                                                                        ^
+      |                                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:457:20: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  457 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:457:34: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  457 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                                  ^
+      |                                  ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:457:51: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  457 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                                                   ^
+      |                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:457:67: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  457 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                                                                   ^
+      |                                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:458:21: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  458 |       movie_info_idx.len * info_type.len * kind_type.len);
+      |                     ^
+      |                     ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:458:37: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  458 |       movie_info_idx.len * info_type.len * kind_type.len);
+      |                                     ^
+      |                                     ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:458:53: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  458 |       movie_info_idx.len * info_type.len * kind_type.len);
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:521:50: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  521 |                                contains_string(mc.note, "(USA)") == 0 &&
+      |                                                ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:80:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:522:50: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  522 |                                contains_string(mc.note, "(200") &&
+      |                                                ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:80:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:560:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  560 |   int tmp17 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:564:10: error: request for member ‘data’ in something not a structure or union
+  564 |     tmp17.data[tmp18] = r.company;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:567:8: error: request for member ‘len’ in something not a structure or union
+  567 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:580:10: error: request for member ‘data’ in something not a structure or union
+  580 |     tmp23.data[tmp24] = r.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:583:8: error: request for member ‘len’ in something not a structure or union
+  583 |   tmp23.len = tmp24;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:584:64: error: incompatible type for argument 1 of ‘_min_string’
+  584 |   result_t result[] = {(result_t){.movie_company = _min_string(tmp17),
+      |                                                                ^~~~~
+      |                                                                |
+      |                                                                int
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:586:72: error: incompatible type for argument 1 of ‘_min_string’
+  586 |                                   .western_violent_movie = _min_string(tmp23)}};
+      |                                                                        ^~~~~
+      |                                                                        |
+      |                                                                        int
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:596:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  596 |     _json_string(it.movie_company);
+      |                  ~~^~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:85:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   85 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:604:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  604 |     _json_string(it.western_violent_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:85:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   85 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:608:65: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  608 |   test_Q22_finds_western_violent_movie_with_low_rating_result = result;
+      |                                                                 ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:610:13: error: request for member ‘data’ in something not a structure or union
+  610 |   free(tmp17.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq22673836028/001/prog.c:612:13: error: request for member ‘data’ in something not a structure or union
+  612 |   free(tmp23.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q23.error
+++ b/tests/dataset/job/compiler/c/q23.error
@@ -1,0 +1,134 @@
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c: In function ‘test_Q23_finds_US_internet_movie_with_verified_cast’:
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:390:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  390 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:397:15: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  397 |           tmp1.data[i3]) {
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:460:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  460 |   matches_item_list_t tmp4 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:461:20: error: ‘(complete_cast_t *)&complete_cast’ is a pointer; did you mean to use ‘->’?
+  461 |       complete_cast.len * comp_cast_type.len * title.len * kind_type.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:461:41: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  461 |       complete_cast.len * comp_cast_type.len * title.len * kind_type.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:461:53: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  461 |       complete_cast.len * comp_cast_type.len * title.len * kind_type.len *
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:461:69: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  461 |       complete_cast.len * comp_cast_type.len * title.len * kind_type.len *
+      |                                                                     ^
+      |                                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:462:17: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  462 |       movie_info.len * info_type.len * movie_keyword.len * keyword.len *
+      |                 ^
+      |                 ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:462:33: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  462 |       movie_info.len * info_type.len * movie_keyword.len * keyword.len *
+      |                                 ^
+      |                                 ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:462:53: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  462 |       movie_info.len * info_type.len * movie_keyword.len * keyword.len *
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:462:67: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  462 |       movie_info.len * info_type.len * movie_keyword.len * keyword.len *
+      |                                                                   ^
+      |                                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:463:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  463 |       movie_companies.len * company_name.len * company_type.len);
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:463:41: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  463 |       movie_companies.len * company_name.len * company_type.len);
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:463:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  463 |       movie_companies.len * company_name.len * company_type.len);
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:521:49: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  521 |                               contains_string(mi.note, "internet") &&
+      |                                               ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:522:50: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  522 |                               (contains_string(mi.info, "USA:") &&
+      |                                                ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:523:51: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  523 |                                (contains_string(mi.info, "199") ||
+      |                                                 ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:524:51: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  524 |                                 contains_string(mi.info, "200"))) &&
+      |                                                 ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:545:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  545 |   int tmp17 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:549:10: error: request for member ‘data’ in something not a structure or union
+  549 |     tmp17.data[tmp18] = r.movie_kind;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:552:8: error: request for member ‘len’ in something not a structure or union
+  552 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:557:10: error: request for member ‘data’ in something not a structure or union
+  557 |     tmp20.data[tmp21] = r.complete_us_internet_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:560:8: error: request for member ‘len’ in something not a structure or union
+  560 |   tmp20.len = tmp21;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:562:44: error: incompatible type for argument 1 of ‘_min_string’
+  562 |       (result_t){.movie_kind = _min_string(tmp17),
+      |                                            ^~~~~
+      |                                            |
+      |                                            int
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:563:60: error: incompatible type for argument 1 of ‘_min_string’
+  563 |                  .complete_us_internet_movie = _min_string(tmp20)}};
+      |                                                            ^~~~~
+      |                                                            |
+      |                                                            int
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:573:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  573 |     _json_string(it.movie_kind);
+      |                  ~~^~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:577:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  577 |     _json_string(it.complete_us_internet_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:581:64: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  581 |   test_Q23_finds_US_internet_movie_with_verified_cast_result = result;
+      |                                                                ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:583:13: error: request for member ‘data’ in something not a structure or union
+  583 |   free(tmp17.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq232555305483/001/prog.c:584:13: error: request for member ‘data’ in something not a structure or union
+  584 |   free(tmp20.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q24.error
+++ b/tests/dataset/job/compiler/c/q24.error
@@ -1,0 +1,142 @@
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c: In function ‘test_Q24_finds_voiced_action_movie_with_actress_named_An’:
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:420:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  420 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:428:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  428 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:480:15: error: redefinition of ‘matches’
+  480 |   list_string matches = list_string_create(3);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:475:15: note: previous definition of ‘matches’ with type ‘list_string’
+  475 |   list_string matches = list_string_create(4);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:515:70: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  515 |                                      contains_list_string(matches, ci.note) &&
+      |                                                                    ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:71:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:517:69: warning: passing argument 2 of ‘contains_list_string’ makes pointer from integer without a cast [-Wint-conversion]
+  515 |                                      contains_list_string(matches, ci.note) &&
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  516 |                                          cn.country_code == "[us]" &&
+      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  517 |                                          it.info == "release dates" &&
+      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+      |                                                                     |
+      |                                                                     int
+  518 |                                          k.keyword) &&
+      |                                          ~~~~~~~~~                   
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:71:54: note: expected ‘char *’ but argument is of type ‘int’
+   71 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:520:42: error: request for member ‘starts_with’ in something not a structure or union
+  520 |                                  (mi.info.starts_with("Japan:") &&
+      |                                          ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:521:57: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  521 |                                       contains_string(mi.info, "201") ||
+      |                                                       ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:522:42: error: request for member ‘starts_with’ in something not a structure or union
+  522 |                                   mi.info.starts_with("USA:") &&
+      |                                          ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:523:57: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  523 |                                       contains_string(mi.info, "201")) &&
+      |                                                       ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:525:51: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  525 |                                  contains_string(n.name, "An") &&
+      |                                                  ~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:563:23: error: conflicting types for ‘matches’; have ‘matches_item_list_t’
+  563 |   matches_item_list_t matches = tmp4;
+      |                       ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:480:15: note: previous definition of ‘matches’ with type ‘list_string’
+  480 |   list_string matches = list_string_create(3);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:564:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  564 |   int tmp6 = int_create(matches.len);
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:568:9: error: request for member ‘data’ in something not a structure or union
+  568 |     tmp6.data[tmp7] = x.voiced_char_name;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:571:7: error: request for member ‘len’ in something not a structure or union
+  571 |   tmp6.len = tmp7;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:576:9: error: request for member ‘data’ in something not a structure or union
+  576 |     tmp9.data[tmp10] = x.voicing_actress_name;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:579:7: error: request for member ‘len’ in something not a structure or union
+  579 |   tmp9.len = tmp10;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:584:10: error: request for member ‘data’ in something not a structure or union
+  584 |     tmp12.data[tmp13] = x.voiced_action_movie_jap_eng;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:587:8: error: request for member ‘len’ in something not a structure or union
+  587 |   tmp12.len = tmp13;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:589:50: error: incompatible type for argument 1 of ‘_min_string’
+  589 |       (result_t){.voiced_char_name = _min_string(tmp6),
+      |                                                  ^~~~
+      |                                                  |
+      |                                                  int
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:590:54: error: incompatible type for argument 1 of ‘_min_string’
+  590 |                  .voicing_actress_name = _min_string(tmp9),
+      |                                                      ^~~~
+      |                                                      |
+      |                                                      int
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:591:61: error: incompatible type for argument 1 of ‘_min_string’
+  591 |                  .voiced_action_movie_jap_eng = _min_string(tmp12)}};
+      |                                                             ^~~~~
+      |                                                             |
+      |                                                             int
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:601:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  601 |     _json_string(it.voiced_char_name);
+      |                  ~~^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:605:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  605 |     _json_string(it.voicing_actress_name);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:609:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  609 |     _json_string(it.voiced_action_movie_jap_eng);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:613:69: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  613 |   test_Q24_finds_voiced_action_movie_with_actress_named_An_result = result;
+      |                                                                     ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:616:12: error: request for member ‘data’ in something not a structure or union
+  616 |   free(tmp6.data);
+      |            ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:617:12: error: request for member ‘data’ in something not a structure or union
+  617 |   free(tmp9.data);
+      |            ^
+/tmp/TestCCompiler_JOB_Goldenq24905173748/001/prog.c:618:13: error: request for member ‘data’ in something not a structure or union
+  618 |   free(tmp12.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q25.error
+++ b/tests/dataset/job/compiler/c/q25.error
@@ -1,0 +1,110 @@
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c: In function ‘test_Q25_finds_male_horror_writer_with_violent_keywords’:
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:353:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  353 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:361:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  361 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:408:7: error: conflicting types for ‘allowed_notes’; have ‘int’
+  408 |   int allowed_notes = allowed_notes;
+      |       ^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:402:15: note: previous definition of ‘allowed_notes’ with type ‘list_string’
+  402 |   list_string allowed_notes = list_string_create(5);
+      |               ^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:415:7: error: conflicting types for ‘allowed_keywords’; have ‘int’
+  415 |   int allowed_keywords = allowed_keywords;
+      |       ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:409:15: note: previous definition of ‘allowed_keywords’ with type ‘list_string’
+  409 |   list_string allowed_keywords = list_string_create(5);
+      |               ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:440:67: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  440 |                     if (!(((contains_list_string(allowed_notes, ci.note)) &&
+      |                                                                 ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:443:51: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  443 |                                                  k.keyword)) &&
+      |                                                  ~^~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:474:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  474 |   int tmp6 = int_create(matches.len);
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:478:9: error: request for member ‘data’ in something not a structure or union
+  478 |     tmp6.data[tmp7] = x.budget;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:481:7: error: request for member ‘len’ in something not a structure or union
+  481 |   tmp6.len = tmp7;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:494:10: error: request for member ‘data’ in something not a structure or union
+  494 |     tmp12.data[tmp13] = x.writer;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:497:8: error: request for member ‘len’ in something not a structure or union
+  497 |   tmp12.len = tmp13;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:502:10: error: request for member ‘data’ in something not a structure or union
+  502 |     tmp15.data[tmp16] = x.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:505:8: error: request for member ‘len’ in something not a structure or union
+  505 |   tmp15.len = tmp16;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:506:63: error: incompatible type for argument 1 of ‘_min_string’
+  506 |   result_t result[] = {(result_t){.movie_budget = _min_string(tmp6),
+      |                                                               ^~~~
+      |                                                               |
+      |                                                               int
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:508:62: error: incompatible type for argument 1 of ‘_min_string’
+  508 |                                   .male_writer = _min_string(tmp12),
+      |                                                              ^~~~~
+      |                                                              |
+      |                                                              int
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:509:70: error: incompatible type for argument 1 of ‘_min_string’
+  509 |                                   .violent_movie_title = _min_string(tmp15)}};
+      |                                                                      ^~~~~
+      |                                                                      |
+      |                                                                      int
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:519:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  519 |     _json_string(it.movie_budget);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:527:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  527 |     _json_string(it.male_writer);
+      |                  ~~^~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:531:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  531 |     _json_string(it.violent_movie_title);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:535:68: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  535 |   test_Q25_finds_male_horror_writer_with_violent_keywords_result = result;
+      |                                                                    ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:538:12: error: request for member ‘data’ in something not a structure or union
+  538 |   free(tmp6.data);
+      |            ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:540:13: error: request for member ‘data’ in something not a structure or union
+  540 |   free(tmp12.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq252505025950/001/prog.c:541:13: error: request for member ‘data’ in something not a structure or union
+  541 |   free(tmp15.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q26.error
+++ b/tests/dataset/job/compiler/c/q26.error
@@ -1,0 +1,167 @@
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c: In function ‘test_Q26_finds_hero_movies_with_rating_above_7’:
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:413:72: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  413 |   if (test_Q26_finds_hero_movies_with_rating_above_7_result.len != tmp1.len) {
+      |                                                                        ^
+      |                                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:419:15: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  419 |           tmp1.data[i3]) {
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:484:7: error: conflicting types for ‘allowed_keywords’; have ‘int’
+  484 |   int allowed_keywords = allowed_keywords;
+      |       ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:473:15: note: previous definition of ‘allowed_keywords’ with type ‘list_string’
+  473 |   list_string allowed_keywords = list_string_create(10);
+      |               ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:485:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  485 |   rows_item_list_t tmp4 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:486:20: error: ‘(complete_cast_t *)&complete_cast’ is a pointer; did you mean to use ‘->’?
+  486 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:486:41: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  486 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:486:62: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  486 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                                              ^
+      |                                                              ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:487:16: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  487 |       cast_info.len * char_name.len * name.len * title.len * kind_type.len *
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:487:32: error: ‘(char_name_t *)&char_name’ is a pointer; did you mean to use ‘->’?
+  487 |       cast_info.len * char_name.len * name.len * title.len * kind_type.len *
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:487:43: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  487 |       cast_info.len * char_name.len * name.len * title.len * kind_type.len *
+      |                                           ^
+      |                                           ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:487:55: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  487 |       cast_info.len * char_name.len * name.len * title.len * kind_type.len *
+      |                                                       ^
+      |                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:487:71: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  487 |       cast_info.len * char_name.len * name.len * title.len * kind_type.len *
+      |                                                                       ^
+      |                                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:488:20: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  488 |       movie_keyword.len * keyword.len * movie_info_idx.len * info_type.len);
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:488:34: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  488 |       movie_keyword.len * keyword.len * movie_info_idx.len * info_type.len);
+      |                                  ^
+      |                                  ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:488:55: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  488 |       movie_keyword.len * keyword.len * movie_info_idx.len * info_type.len);
+      |                                                       ^
+      |                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:488:71: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  488 |       movie_keyword.len * keyword.len * movie_info_idx.len * info_type.len);
+      |                                                                       ^
+      |                                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:548:53: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  548 |                                 contains_string(cct2.kind, "complete") &&
+      |                                                 ~~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:86:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   86 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:550:53: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  550 |                                 (contains_string(chn.name, "man") ||
+      |                                                  ~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:86:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   86 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:551:53: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  551 |                                  contains_string(chn.name, "Man")) &&
+      |                                                  ~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:86:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   86 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:554:56: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  554 |                                                       k.keyword)) &&
+      |                                                       ~^~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:578:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  578 |   int tmp18 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:582:10: error: request for member ‘data’ in something not a structure or union
+  582 |     tmp18.data[tmp19] = r.character;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:585:8: error: request for member ‘len’ in something not a structure or union
+  585 |   tmp18.len = tmp19;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:598:10: error: request for member ‘data’ in something not a structure or union
+  598 |     tmp24.data[tmp25] = r.actor;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:601:8: error: request for member ‘len’ in something not a structure or union
+  601 |   tmp24.len = tmp25;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:606:10: error: request for member ‘data’ in something not a structure or union
+  606 |     tmp27.data[tmp28] = r.movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:609:8: error: request for member ‘len’ in something not a structure or union
+  609 |   tmp27.len = tmp28;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:610:65: error: incompatible type for argument 1 of ‘_min_string’
+  610 |   result_t result[] = {(result_t){.character_name = _min_string(tmp18),
+      |                                                                 ^~~~~
+      |                                                                 |
+      |                                                                 int
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:612:64: error: incompatible type for argument 1 of ‘_min_string’
+  612 |                                   .playing_actor = _min_string(tmp24),
+      |                                                                ^~~~~
+      |                                                                |
+      |                                                                int
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:613:70: error: incompatible type for argument 1 of ‘_min_string’
+  613 |                                   .complete_hero_movie = _min_string(tmp27)}};
+      |                                                                      ^~~~~
+      |                                                                      |
+      |                                                                      int
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:623:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  623 |     _json_string(it.character_name);
+      |                  ~~^~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:91:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   91 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:631:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  631 |     _json_string(it.playing_actor);
+      |                  ~~^~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:91:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   91 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:635:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  635 |     _json_string(it.complete_hero_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:91:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   91 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:639:59: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  639 |   test_Q26_finds_hero_movies_with_rating_above_7_result = result;
+      |                                                           ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:641:13: error: request for member ‘data’ in something not a structure or union
+  641 |   free(tmp18.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:643:13: error: request for member ‘data’ in something not a structure or union
+  643 |   free(tmp24.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq261344245714/001/prog.c:644:13: error: request for member ‘data’ in something not a structure or union
+  644 |   free(tmp27.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q27.error
+++ b/tests/dataset/job/compiler/c/q27.error
@@ -1,0 +1,136 @@
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c: In function ‘test_Q27_selects_minimal_company__link_and_title’:
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:389:65: error: invalid operands to binary == (have ‘int’ and ‘tmp_item_t’)
+  389 |   if (!(test_Q27_selects_minimal_company__link_and_title_result ==
+      |                                                                 ^~
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:428:34: warning: initialization of ‘int’ from ‘char *’ makes integer from pointer without a cast [-Wint-conversion]
+  428 |                          .note = "extra"}};
+      |                                  ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:428:34: note: (near initialization for ‘(anonymous).note’)
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:446:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  446 |   matches_item_list_t tmp1 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:447:20: error: ‘(complete_cast_t *)&complete_cast’ is a pointer; did you mean to use ‘->’?
+  447 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len * title.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:447:41: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  447 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len * title.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:447:62: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  447 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len * title.len *
+      |                                                              ^
+      |                                                              ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:447:74: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  447 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len * title.len *
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:448:17: error: ‘(movie_link_t *)&movie_link’ is a pointer; did you mean to use ‘->’?
+  448 |       movie_link.len * link_type.len * movie_keyword.len * keyword.len *
+      |                 ^
+      |                 ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:448:33: error: ‘(link_type_t *)&link_type’ is a pointer; did you mean to use ‘->’?
+  448 |       movie_link.len * link_type.len * movie_keyword.len * keyword.len *
+      |                                 ^
+      |                                 ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:448:53: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  448 |       movie_link.len * link_type.len * movie_keyword.len * keyword.len *
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:448:67: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  448 |       movie_link.len * link_type.len * movie_keyword.len * keyword.len *
+      |                                                                   ^
+      |                                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:449:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  449 |       movie_companies.len * company_type.len * company_name.len *
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:449:41: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  449 |       movie_companies.len * company_type.len * company_name.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:449:60: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  449 |       movie_companies.len * company_type.len * company_name.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:450:17: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  450 |       movie_info.len);
+      |                 ^
+      |                 ->
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:513:53: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  513 |                                  (contains_string(cn.name, "Film") ||
+      |                                                   ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:514:53: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  514 |                                   contains_string(cn.name, "Warner")) &&
+      |                                                   ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:517:52: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  517 |                                  contains_string(lt.link, "follow") &&
+      |                                                  ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:555:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  555 |   int tmp15 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:559:10: error: request for member ‘data’ in something not a structure or union
+  559 |     tmp15.data[tmp16] = x.company;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:562:8: error: request for member ‘len’ in something not a structure or union
+  562 |   tmp15.len = tmp16;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:567:10: error: request for member ‘data’ in something not a structure or union
+  567 |     tmp18.data[tmp19] = x.link;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:570:8: error: request for member ‘len’ in something not a structure or union
+  570 |   tmp18.len = tmp19;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:575:10: error: request for member ‘data’ in something not a structure or union
+  575 |     tmp21.data[tmp22] = x.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:578:8: error: request for member ‘len’ in something not a structure or union
+  578 |   tmp21.len = tmp22;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:580:56: error: incompatible type for argument 1 of ‘_min_string’
+  580 |       (result_item_t){.producing_company = _min_string(tmp15),
+      |                                                        ^~~~~
+      |                                                        |
+      |                                                        int
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:581:48: error: incompatible type for argument 1 of ‘_min_string’
+  581 |                       .link_type = _min_string(tmp18),
+      |                                                ^~~~~
+      |                                                |
+      |                                                int
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:582:62: error: incompatible type for argument 1 of ‘_min_string’
+  582 |                       .complete_western_sequel = _min_string(tmp21)};
+      |                                                              ^~~~~
+      |                                                              |
+      |                                                              int
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:596:61: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  596 |   test_Q27_selects_minimal_company__link_and_title_result = result;
+      |                                                             ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:598:13: error: request for member ‘data’ in something not a structure or union
+  598 |   free(tmp15.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:599:13: error: request for member ‘data’ in something not a structure or union
+  599 |   free(tmp18.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq273881164585/001/prog.c:600:13: error: request for member ‘data’ in something not a structure or union
+  600 |   free(tmp21.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q28.error
+++ b/tests/dataset/job/compiler/c/q28.error
@@ -1,0 +1,153 @@
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c: In function ‘test_Q28_finds_euro_dark_movie_with_minimal_values’:
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:425:67: error: invalid operands to binary == (have ‘int’ and ‘tmp_item_t’)
+  425 |   if (!(test_Q28_finds_euro_dark_movie_with_minimal_values_result ==
+      |                                                                   ^~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:497:7: error: conflicting types for ‘allowed_keywords’; have ‘int’
+  497 |   int allowed_keywords = allowed_keywords;
+      |       ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:492:15: note: previous definition of ‘allowed_keywords’ with type ‘list_string’
+  492 |   list_string allowed_keywords = list_string_create(4);
+      |               ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:509:7: error: conflicting types for ‘allowed_countries’; have ‘int’
+  509 |   int allowed_countries = allowed_countries;
+      |       ^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:498:15: note: previous definition of ‘allowed_countries’ with type ‘list_string’
+  498 |   list_string allowed_countries = list_string_create(10);
+      |               ^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:513:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  513 |   matches_item_list_t tmp1 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:514:20: error: ‘(complete_cast_t *)&complete_cast’ is a pointer; did you mean to use ‘->’?
+  514 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:514:41: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  514 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:514:62: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  514 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                                              ^
+      |                                                              ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:515:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  515 |       movie_companies.len * company_name.len * company_type.len *
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:515:41: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  515 |       movie_companies.len * company_name.len * company_type.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:515:60: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  515 |       movie_companies.len * company_name.len * company_type.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:516:20: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  516 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:516:34: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  516 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                                  ^
+      |                                  ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:516:51: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  516 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                                                   ^
+      |                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:516:67: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  516 |       movie_keyword.len * keyword.len * movie_info.len * info_type.len *
+      |                                                                   ^
+      |                                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:517:21: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  517 |       movie_info_idx.len * info_type.len * title.len * kind_type.len);
+      |                     ^
+      |                     ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:517:37: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  517 |       movie_info_idx.len * info_type.len * title.len * kind_type.len);
+      |                                     ^
+      |                                     ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:517:49: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  517 |       movie_info_idx.len * info_type.len * title.len * kind_type.len);
+      |                                                 ^
+      |                                                 ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:517:65: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  517 |       movie_info_idx.len * info_type.len * title.len * kind_type.len);
+      |                                                                 ^
+      |                                                                 ->
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:593:61: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  593 |                                                            k.keyword)) &&
+      |                                                            ~^~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:594:71: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  594 |                                      (contains_list_string(matches, kt.kind)) &&
+      |                                                                     ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:595:56: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  595 |                                      contains_string(mc.note, "(USA)") == 0 &&
+      |                                                      ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:86:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   86 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:596:56: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  596 |                                      contains_string(mc.note, "(200") &&
+      |                                                      ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:86:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   86 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:598:62: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  598 |                                                            mi.info)) &&
+      |                                                            ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:623:23: error: conflicting types for ‘matches’; have ‘matches_item_list_t’
+  623 |   matches_item_list_t matches = tmp1;
+      |                       ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:510:15: note: previous definition of ‘matches’ with type ‘list_string’
+  510 |   list_string matches = list_string_create(2);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:624:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  624 |   int tmp17 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:628:10: error: request for member ‘data’ in something not a structure or union
+  628 |     tmp17.data[tmp18] = x.company;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:631:8: error: request for member ‘len’ in something not a structure or union
+  631 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:644:10: error: request for member ‘data’ in something not a structure or union
+  644 |     tmp23.data[tmp24] = x.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:647:8: error: request for member ‘len’ in something not a structure or union
+  647 |   tmp23.len = tmp24;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:649:52: error: incompatible type for argument 1 of ‘_min_string’
+  649 |       (result_item_t){.movie_company = _min_string(tmp17),
+      |                                                    ^~~~~
+      |                                                    |
+      |                                                    int
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:651:63: error: incompatible type for argument 1 of ‘_min_string’
+  651 |                       .complete_euro_dark_movie = _min_string(tmp23)};
+      |                                                               ^~~~~
+      |                                                               |
+      |                                                               int
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:665:63: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  665 |   test_Q28_finds_euro_dark_movie_with_minimal_values_result = result;
+      |                                                               ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:667:13: error: request for member ‘data’ in something not a structure or union
+  667 |   free(tmp17.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq28869535695/001/prog.c:669:13: error: request for member ‘data’ in something not a structure or union
+  669 |   free(tmp23.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q29.error
+++ b/tests/dataset/job/compiler/c/q29.error
@@ -1,0 +1,98 @@
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c: In function ‘test_Q29_finds_the_actress_voicing_the_Queen_in_Shrek_2’:
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:472:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  472 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:480:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  480 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:615:52: error: request for member ‘starts_with’ in something not a structure or union
+  615 |                                            (mi.info.starts_with("Japan:200") ||
+      |                                                    ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:616:52: error: request for member ‘starts_with’ in something not a structure or union
+  616 |                                             mi.info.starts_with("USA:200")) &&
+      |                                                    ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:618:61: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  618 |                                            contains_string(n.name, "An") &&
+      |                                                            ~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:677:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  677 |   int tmp6 = int_create(matches.len);
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:681:9: error: request for member ‘data’ in something not a structure or union
+  681 |     tmp6.data[tmp7] = x.voiced_char;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:684:7: error: request for member ‘len’ in something not a structure or union
+  684 |   tmp6.len = tmp7;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:689:9: error: request for member ‘data’ in something not a structure or union
+  689 |     tmp9.data[tmp10] = x.voicing_actress;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:692:7: error: request for member ‘len’ in something not a structure or union
+  692 |   tmp9.len = tmp10;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:697:10: error: request for member ‘data’ in something not a structure or union
+  697 |     tmp12.data[tmp13] = x.voiced_animation;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:700:8: error: request for member ‘len’ in something not a structure or union
+  700 |   tmp12.len = tmp13;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:701:62: error: incompatible type for argument 1 of ‘_min_string’
+  701 |   result_t result[] = {(result_t){.voiced_char = _min_string(tmp6),
+      |                                                              ^~~~
+      |                                                              |
+      |                                                              int
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:702:66: error: incompatible type for argument 1 of ‘_min_string’
+  702 |                                   .voicing_actress = _min_string(tmp9),
+      |                                                                  ^~~~
+      |                                                                  |
+      |                                                                  int
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:703:67: error: incompatible type for argument 1 of ‘_min_string’
+  703 |                                   .voiced_animation = _min_string(tmp12)}};
+      |                                                                   ^~~~~
+      |                                                                   |
+      |                                                                   int
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:713:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  713 |     _json_string(it.voiced_char);
+      |                  ~~^~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:717:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  717 |     _json_string(it.voicing_actress);
+      |                  ~~^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:721:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  721 |     _json_string(it.voiced_animation);
+      |                  ~~^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:725:68: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  725 |   test_Q29_finds_the_actress_voicing_the_Queen_in_Shrek_2_result = result;
+      |                                                                    ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:728:12: error: request for member ‘data’ in something not a structure or union
+  728 |   free(tmp6.data);
+      |            ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:729:12: error: request for member ‘data’ in something not a structure or union
+  729 |   free(tmp9.data);
+      |            ^
+/tmp/TestCCompiler_JOB_Goldenq291587136356/001/prog.c:730:13: error: request for member ‘data’ in something not a structure or union
+  730 |   free(tmp12.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q3.error
+++ b/tests/dataset/job/compiler/c/q3.error
@@ -1,0 +1,75 @@
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c: In function ‘test_Q3_returns_lexicographically_smallest_sequel_title’:
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:238:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  238 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:246:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  246 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:287:7: error: conflicting types for ‘allowed_infos’; have ‘int’
+  287 |   int allowed_infos = allowed_infos;
+      |       ^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:278:15: note: previous definition of ‘allowed_infos’ with type ‘list_string’
+  278 |   list_string allowed_infos = list_string_create(8);
+      |               ^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:289:7: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  289 |       int_create(keyword.len * movie_keyword.len * movie_info.len * title.len);
+      |       ^~~~~~~~~~
+      |       list_int_create
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:289:25: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  289 |       int_create(keyword.len * movie_keyword.len * movie_info.len * title.len);
+      |                         ^
+      |                         ->
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:289:45: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  289 |       int_create(keyword.len * movie_keyword.len * movie_info.len * title.len);
+      |                                             ^
+      |                                             ->
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:289:62: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  289 |       int_create(keyword.len * movie_keyword.len * movie_info.len * title.len);
+      |                                                              ^
+      |                                                              ->
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:289:74: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  289 |       int_create(keyword.len * movie_keyword.len * movie_info.len * title.len);
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:309:55: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  309 |                                      contains_string(k.keyword, "sequel") &&
+      |                                                      ~^~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:309:75: warning: passing argument 2 of ‘contains_list_string’ makes pointer from integer without a cast [-Wint-conversion]
+  309 |                                      contains_string(k.keyword, "sequel") &&
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+      |                                                                           |
+      |                                                                           int
+  310 |                                          mi.info) &&
+      |                                          ~~~~~~~                           
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:71:54: note: expected ‘char *’ but argument is of type ‘int’
+   71 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:314:15: error: request for member ‘data’ in something not a structure or union
+  314 |           tmp4.data[tmp5] = t.title;
+      |               ^
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:320:7: error: request for member ‘len’ in something not a structure or union
+  320 |   tmp4.len = tmp5;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:323:45: error: incompatible type for argument 1 of ‘_min_string’
+  323 |       (result_t){.movie_title = _min_string(candidate_titles)}};
+      |                                             ^~~~~~~~~~~~~~~~
+      |                                             |
+      |                                             int
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:333:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  333 |     _json_string(it.movie_title);
+      |                  ~~^~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq3347835022/001/prog.c:337:68: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  337 |   test_Q3_returns_lexicographically_smallest_sequel_title_result = result;
+      |                                                                    ^~~~~~

--- a/tests/dataset/job/compiler/c/q30.error
+++ b/tests/dataset/job/compiler/c/q30.error
@@ -1,0 +1,185 @@
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c: In function ‘test_Q30_finds_violent_horror_thriller_movies_with_male_writer’:
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:394:23: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  394 |           .len != tmp1.len) {
+      |                       ^
+      |                       ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:403:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  403 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:462:7: error: conflicting types for ‘violent_keywords’; have ‘int’
+  462 |   int violent_keywords = violent_keywords;
+      |       ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:454:15: note: previous definition of ‘violent_keywords’ with type ‘list_string’
+  454 |   list_string violent_keywords = list_string_create(7);
+      |               ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:469:7: error: conflicting types for ‘writer_notes’; have ‘int’
+  469 |   int writer_notes = writer_notes;
+      |       ^~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:463:15: note: previous definition of ‘writer_notes’ with type ‘list_string’
+  463 |   list_string writer_notes = list_string_create(5);
+      |               ^~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:473:15: error: redefinition of ‘matches’
+  473 |   list_string matches = list_string_create(2);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:470:15: note: previous definition of ‘matches’ with type ‘list_string’
+  470 |   list_string matches = list_string_create(2);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:476:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  476 |   matches_item_list_t tmp4 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:477:20: error: ‘(complete_cast_t *)&complete_cast’ is a pointer; did you mean to use ‘->’?
+  477 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                    ^
+      |                    ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:477:41: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  477 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:477:62: error: ‘(comp_cast_type_t *)&comp_cast_type’ is a pointer; did you mean to use ‘->’?
+  477 |       complete_cast.len * comp_cast_type.len * comp_cast_type.len *
+      |                                                              ^
+      |                                                              ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:478:16: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  478 |       cast_info.len * movie_info.len * movie_info_idx.len * movie_keyword.len *
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:478:33: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  478 |       cast_info.len * movie_info.len * movie_info_idx.len * movie_keyword.len *
+      |                                 ^
+      |                                 ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:478:54: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  478 |       cast_info.len * movie_info.len * movie_info_idx.len * movie_keyword.len *
+      |                                                      ^
+      |                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:478:74: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  478 |       cast_info.len * movie_info.len * movie_info_idx.len * movie_keyword.len *
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:479:16: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  479 |       info_type.len * info_type.len * keyword.len * name.len * title.len);
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:479:32: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  479 |       info_type.len * info_type.len * keyword.len * name.len * title.len);
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:479:46: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  479 |       info_type.len * info_type.len * keyword.len * name.len * title.len);
+      |                                              ^
+      |                                              ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:479:57: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  479 |       info_type.len * info_type.len * keyword.len * name.len * title.len);
+      |                                                         ^
+      |                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:479:69: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  479 |       info_type.len * info_type.len * keyword.len * name.len * title.len);
+      |                                                                     ^
+      |                                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:538:68: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  538 |                           if (!((contains_list_string(matches, cct1.kind)) &&
+      |                                                                ~~~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:540:71: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  540 |                                 (contains_list_string(writer_notes, ci.note)) &&
+      |                                                                     ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:543:56: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  543 |                                                       k.keyword)) &&
+      |                                                       ~^~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:544:66: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  544 |                                 (contains_list_string(matches, mi.info)) &&
+      |                                                                ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:567:23: error: conflicting types for ‘matches’; have ‘matches_item_list_t’
+  567 |   matches_item_list_t matches = tmp4;
+      |                       ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:473:15: note: previous definition of ‘matches’ with type ‘list_string’
+  473 |   list_string matches = list_string_create(2);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:568:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  568 |   int tmp18 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:572:10: error: request for member ‘data’ in something not a structure or union
+  572 |     tmp18.data[tmp19] = x.budget;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:575:8: error: request for member ‘len’ in something not a structure or union
+  575 |   tmp18.len = tmp19;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:588:10: error: request for member ‘data’ in something not a structure or union
+  588 |     tmp24.data[tmp25] = x.writer;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:591:8: error: request for member ‘len’ in something not a structure or union
+  591 |   tmp24.len = tmp25;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:596:10: error: request for member ‘data’ in something not a structure or union
+  596 |     tmp27.data[tmp28] = x.movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:599:8: error: request for member ‘len’ in something not a structure or union
+  599 |   tmp27.len = tmp28;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:601:46: error: incompatible type for argument 1 of ‘_min_string’
+  601 |       (result_t){.movie_budget = _min_string(tmp18),
+      |                                              ^~~~~
+      |                                              |
+      |                                              int
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:603:40: error: incompatible type for argument 1 of ‘_min_string’
+  603 |                  .writer = _min_string(tmp24),
+      |                                        ^~~~~
+      |                                        |
+      |                                        int
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:604:56: error: incompatible type for argument 1 of ‘_min_string’
+  604 |                  .complete_violent_movie = _min_string(tmp27)}};
+      |                                                        ^~~~~
+      |                                                        |
+      |                                                        int
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:614:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  614 |     _json_string(it.movie_budget);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:622:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  622 |     _json_string(it.writer);
+      |                  ~~^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:626:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  626 |     _json_string(it.complete_violent_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:631:7: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  631 |       result;
+      |       ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:633:13: error: request for member ‘data’ in something not a structure or union
+  633 |   free(tmp18.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:635:13: error: request for member ‘data’ in something not a structure or union
+  635 |   free(tmp24.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq302871716165/001/prog.c:636:13: error: request for member ‘data’ in something not a structure or union
+  636 |   free(tmp27.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q31.error
+++ b/tests/dataset/job/compiler/c/q31.error
@@ -1,0 +1,160 @@
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c: In function ‘test_Q31_finds_minimal_budget__votes__writer_and_title’:
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:391:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  391 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:398:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  398 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:461:15: error: redefinition of ‘matches’
+  461 |   list_string matches = list_string_create(7);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:455:15: note: previous definition of ‘matches’ with type ‘list_string’
+  455 |   list_string matches = list_string_create(5);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:469:15: error: redefinition of ‘matches’
+  469 |   list_string matches = list_string_create(2);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:461:15: note: previous definition of ‘matches’ with type ‘list_string’
+  461 |   list_string matches = list_string_create(7);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:472:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  472 |   matches_item_list_t tmp4 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:473:16: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  473 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:473:27: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  473 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                           ^
+      |                           ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:473:39: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  473 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                                       ^
+      |                                       ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:473:56: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  473 |       cast_info.len * name.len * title.len * movie_info.len *
+      |                                                        ^
+      |                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:474:21: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  474 |       movie_info_idx.len * movie_keyword.len * keyword.len *
+      |                     ^
+      |                     ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:474:41: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  474 |       movie_info_idx.len * movie_keyword.len * keyword.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:474:55: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  474 |       movie_info_idx.len * movie_keyword.len * keyword.len *
+      |                                                       ^
+      |                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:475:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  475 |       movie_companies.len * company_name.len * info_type.len * info_type.len);
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:475:41: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  475 |       movie_companies.len * company_name.len * info_type.len * info_type.len);
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:475:57: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  475 |       movie_companies.len * company_name.len * info_type.len * info_type.len);
+      |                                                         ^
+      |                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:475:73: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  475 |       movie_companies.len * company_name.len * info_type.len * info_type.len);
+      |                                                                         ^
+      |                                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:533:71: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  533 |                                       contains_list_string(matches, ci.note) &&
+      |                                                                     ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:80:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   80 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:534:50: error: request for member ‘starts_with’ in something not a structure or union
+  534 |                                           cn.name.starts_with("Lionsgate") &&
+      |                                                  ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:559:23: error: conflicting types for ‘matches’; have ‘matches_item_list_t’
+  559 |   matches_item_list_t matches = tmp4;
+      |                       ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:469:15: note: previous definition of ‘matches’ with type ‘list_string’
+  469 |   list_string matches = list_string_create(2);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:560:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  560 |   int tmp17 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:564:10: error: request for member ‘data’ in something not a structure or union
+  564 |     tmp17.data[tmp18] = r.movie_budget;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:567:8: error: request for member ‘len’ in something not a structure or union
+  567 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:580:10: error: request for member ‘data’ in something not a structure or union
+  580 |     tmp23.data[tmp24] = r.writer;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:583:8: error: request for member ‘len’ in something not a structure or union
+  583 |   tmp23.len = tmp24;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:588:10: error: request for member ‘data’ in something not a structure or union
+  588 |     tmp26.data[tmp27] = r.violent_liongate_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:591:8: error: request for member ‘len’ in something not a structure or union
+  591 |   tmp26.len = tmp27;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:593:46: error: incompatible type for argument 1 of ‘_min_string’
+  593 |       (result_t){.movie_budget = _min_string(tmp17),
+      |                                              ^~~~~
+      |                                              |
+      |                                              int
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:595:40: error: incompatible type for argument 1 of ‘_min_string’
+  595 |                  .writer = _min_string(tmp23),
+      |                                        ^~~~~
+      |                                        |
+      |                                        int
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:596:56: error: incompatible type for argument 1 of ‘_min_string’
+  596 |                  .violent_liongate_movie = _min_string(tmp26)}};
+      |                                                        ^~~~~
+      |                                                        |
+      |                                                        int
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:71:38: note: expected ‘list_string’ but argument is of type ‘int’
+   71 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:606:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  606 |     _json_string(it.movie_budget);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:614:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  614 |     _json_string(it.writer);
+      |                  ~~^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:618:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  618 |     _json_string(it.violent_liongate_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:88:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   88 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:622:67: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  622 |   test_Q31_finds_minimal_budget__votes__writer_and_title_result = result;
+      |                                                                   ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:624:13: error: request for member ‘data’ in something not a structure or union
+  624 |   free(tmp17.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:626:13: error: request for member ‘data’ in something not a structure or union
+  626 |   free(tmp23.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq312657623653/001/prog.c:627:13: error: request for member ‘data’ in something not a structure or union
+  627 |   free(tmp26.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q32.error
+++ b/tests/dataset/job/compiler/c/q32.error
@@ -1,0 +1,96 @@
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c: In function ‘test_Q32_finds_movie_link_for_10_000_mile_club’:
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:268:63: error: invalid operands to binary == (have ‘int’ and ‘tmp_item_t’)
+  268 |   if (!(test_Q32_finds_movie_link_for_10_000_mile_club_result ==
+      |                                                               ^~
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:301:7: warning: implicit declaration of function ‘joined_item_list_t_create’ [-Wimplicit-function-declaration]
+  301 |       joined_item_list_t_create(keyword.len * movie_keyword.len * title.len *
+      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:301:40: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  301 |       joined_item_list_t_create(keyword.len * movie_keyword.len * title.len *
+      |                                        ^
+      |                                        ->
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:301:60: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  301 |       joined_item_list_t_create(keyword.len * movie_keyword.len * title.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:301:72: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  301 |       joined_item_list_t_create(keyword.len * movie_keyword.len * title.len *
+      |                                                                        ^
+      |                                                                        ->
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:302:43: error: ‘(movie_link_t *)&movie_link’ is a pointer; did you mean to use ‘->’?
+  302 |                                 movie_link.len * title.len * link_type.len);
+      |                                           ^
+      |                                           ->
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:302:55: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  302 |                                 movie_link.len * title.len * link_type.len);
+      |                                                       ^
+      |                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:302:71: error: ‘(link_type_t *)&link_type’ is a pointer; did you mean to use ‘->’?
+  302 |                                 movie_link.len * title.len * link_type.len);
+      |                                                                       ^
+      |                                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:346:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  346 |   int tmp9 = int_create(joined.len);
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:350:9: error: request for member ‘data’ in something not a structure or union
+  350 |     tmp9.data[tmp10] = r.link_type;
+      |         ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:353:7: error: request for member ‘len’ in something not a structure or union
+  353 |   tmp9.len = tmp10;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:358:10: error: request for member ‘data’ in something not a structure or union
+  358 |     tmp12.data[tmp13] = r.first_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:361:8: error: request for member ‘len’ in something not a structure or union
+  361 |   tmp12.len = tmp13;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:366:10: error: request for member ‘data’ in something not a structure or union
+  366 |     tmp15.data[tmp16] = r.second_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:369:8: error: request for member ‘len’ in something not a structure or union
+  369 |   tmp15.len = tmp16;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:370:67: error: incompatible type for argument 1 of ‘_min_string’
+  370 |   result_item_t result = (result_item_t){.link_type = _min_string(tmp9),
+      |                                                                   ^~~~
+      |                                                                   |
+      |                                                                   int
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:371:69: error: incompatible type for argument 1 of ‘_min_string’
+  371 |                                          .first_movie = _min_string(tmp12),
+      |                                                                     ^~~~~
+      |                                                                     |
+      |                                                                     int
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:372:70: error: incompatible type for argument 1 of ‘_min_string’
+  372 |                                          .second_movie = _min_string(tmp15)};
+      |                                                                      ^~~~~
+      |                                                                      |
+      |                                                                      int
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:374:19: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  374 |   tmp18.data[0] = result;
+      |                   ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:379:24: error: invalid initializer
+  379 |     result_item_t it = tmp18.data[i19];
+      |                        ^~~~~
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:395:59: error: incompatible types when assigning to type ‘int’ from type ‘result_item_t’
+  395 |   test_Q32_finds_movie_link_for_10_000_mile_club_result = result;
+      |                                                           ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:397:12: error: request for member ‘data’ in something not a structure or union
+  397 |   free(tmp9.data);
+      |            ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:398:13: error: request for member ‘data’ in something not a structure or union
+  398 |   free(tmp12.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq322081034714/001/prog.c:399:13: error: request for member ‘data’ in something not a structure or union
+  399 |   free(tmp15.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q33.error
+++ b/tests/dataset/job/compiler/c/q33.error
@@ -1,0 +1,214 @@
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c: In function ‘test_Q33_finds_linked_TV_series_with_low_rated_sequel’:
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:347:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  347 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:354:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  354 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:400:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  400 |   rows_item_list_t tmp4 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:401:19: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:401:41: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:401:53: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:401:74: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  401 |       company_name.len * movie_companies.len * title.len * movie_info_idx.len *
+      |                                                                          ^
+      |                                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:402:16: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  402 |       info_type.len * kind_type.len * movie_link.len * title.len *
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:402:32: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  402 |       info_type.len * kind_type.len * movie_link.len * title.len *
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:402:49: error: ‘(movie_link_t *)&movie_link’ is a pointer; did you mean to use ‘->’?
+  402 |       info_type.len * kind_type.len * movie_link.len * title.len *
+      |                                                 ^
+      |                                                 ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:402:61: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  402 |       info_type.len * kind_type.len * movie_link.len * title.len *
+      |                                                             ^
+      |                                                             ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:403:21: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  403 |       movie_info_idx.len * info_type.len * kind_type.len * movie_companies.len *
+      |                     ^
+      |                     ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:403:37: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  403 |       movie_info_idx.len * info_type.len * kind_type.len * movie_companies.len *
+      |                                     ^
+      |                                     ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:403:53: error: ‘(kind_type_t *)&kind_type’ is a pointer; did you mean to use ‘->’?
+  403 |       movie_info_idx.len * info_type.len * kind_type.len * movie_companies.len *
+      |                                                     ^
+      |                                                     ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:403:75: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  403 |       movie_info_idx.len * info_type.len * kind_type.len * movie_companies.len *
+      |                                                                           ^
+      |                                                                           ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:404:19: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  404 |       company_name.len * link_type.len);
+      |                   ^
+      |                   ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:404:35: error: ‘(link_type_t *)&link_type’ is a pointer; did you mean to use ‘->’?
+  404 |       company_name.len * link_type.len);
+      |                                   ^
+      |                                   ->
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:513:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  513 |   int tmp20 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:517:10: error: request for member ‘data’ in something not a structure or union
+  517 |     tmp20.data[tmp21] = r.first_company;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:520:8: error: request for member ‘len’ in something not a structure or union
+  520 |   tmp20.len = tmp21;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:525:10: error: request for member ‘data’ in something not a structure or union
+  525 |     tmp23.data[tmp24] = r.second_company;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:528:8: error: request for member ‘len’ in something not a structure or union
+  528 |   tmp23.len = tmp24;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:533:10: error: request for member ‘data’ in something not a structure or union
+  533 |     tmp26.data[tmp27] = r.first_rating;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:536:8: error: request for member ‘len’ in something not a structure or union
+  536 |   tmp26.len = tmp27;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:541:10: error: request for member ‘data’ in something not a structure or union
+  541 |     tmp29.data[tmp30] = r.second_rating;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:544:8: error: request for member ‘len’ in something not a structure or union
+  544 |   tmp29.len = tmp30;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:549:10: error: request for member ‘data’ in something not a structure or union
+  549 |     tmp32.data[tmp33] = r.first_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:552:8: error: request for member ‘len’ in something not a structure or union
+  552 |   tmp32.len = tmp33;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:557:10: error: request for member ‘data’ in something not a structure or union
+  557 |     tmp35.data[tmp36] = r.second_movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:560:8: error: request for member ‘len’ in something not a structure or union
+  560 |   tmp35.len = tmp36;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:561:64: error: incompatible type for argument 1 of ‘_min_string’
+  561 |   result_t result[] = {(result_t){.first_company = _min_string(tmp20),
+      |                                                                ^~~~~
+      |                                                                |
+      |                                                                int
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:562:65: error: incompatible type for argument 1 of ‘_min_string’
+  562 |                                   .second_company = _min_string(tmp23),
+      |                                                                 ^~~~~
+      |                                                                 |
+      |                                                                 int
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:563:63: error: incompatible type for argument 1 of ‘_min_string’
+  563 |                                   .first_rating = _min_string(tmp26),
+      |                                                               ^~~~~
+      |                                                               |
+      |                                                               int
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:564:64: error: incompatible type for argument 1 of ‘_min_string’
+  564 |                                   .second_rating = _min_string(tmp29),
+      |                                                                ^~~~~
+      |                                                                |
+      |                                                                int
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:565:62: error: incompatible type for argument 1 of ‘_min_string’
+  565 |                                   .first_movie = _min_string(tmp32),
+      |                                                              ^~~~~
+      |                                                              |
+      |                                                              int
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:566:63: error: incompatible type for argument 1 of ‘_min_string’
+  566 |                                   .second_movie = _min_string(tmp35)}};
+      |                                                               ^~~~~
+      |                                                               |
+      |                                                               int
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:576:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  576 |     _json_string(it.first_company);
+      |                  ~~^~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:580:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  580 |     _json_string(it.second_company);
+      |                  ~~^~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:584:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  584 |     _json_string(it.first_rating);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:588:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  588 |     _json_string(it.second_rating);
+      |                  ~~^~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:592:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  592 |     _json_string(it.first_movie);
+      |                  ~~^~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:596:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  596 |     _json_string(it.second_movie);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:73:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   73 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:600:66: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  600 |   test_Q33_finds_linked_TV_series_with_low_rated_sequel_result = result;
+      |                                                                  ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:602:13: error: request for member ‘data’ in something not a structure or union
+  602 |   free(tmp20.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:603:13: error: request for member ‘data’ in something not a structure or union
+  603 |   free(tmp23.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:604:13: error: request for member ‘data’ in something not a structure or union
+  604 |   free(tmp26.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:605:13: error: request for member ‘data’ in something not a structure or union
+  605 |   free(tmp29.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:606:13: error: request for member ‘data’ in something not a structure or union
+  606 |   free(tmp32.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq333739683591/001/prog.c:607:13: error: request for member ‘data’ in something not a structure or union
+  607 |   free(tmp35.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q4.error
+++ b/tests/dataset/job/compiler/c/q4.error
@@ -1,0 +1,92 @@
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c: In function ‘test_Q4_returns_minimum_rating_and_title_for_sequels’:
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:273:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  273 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:280:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  280 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:315:7: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  315 |       rows_item_list_t_create(info_type.len * movie_info_idx.len * title.len *
+      |       ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:315:40: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  315 |       rows_item_list_t_create(info_type.len * movie_info_idx.len * title.len *
+      |                                        ^
+      |                                        ->
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:315:61: error: ‘(movie_info_idx_t *)&movie_info_idx’ is a pointer; did you mean to use ‘->’?
+  315 |       rows_item_list_t_create(info_type.len * movie_info_idx.len * title.len *
+      |                                                             ^
+      |                                                             ->
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:315:73: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  315 |       rows_item_list_t_create(info_type.len * movie_info_idx.len * title.len *
+      |                                                                         ^
+      |                                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:316:44: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  316 |                               movie_keyword.len * keyword.len);
+      |                                            ^
+      |                                            ->
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:316:58: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  316 |                               movie_keyword.len * keyword.len);
+      |                                                          ^
+      |                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:341:36: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  341 |                   contains_string(k.keyword, "sequel") && mi.info > "5.0" &&
+      |                                   ~^~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:355:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  355 |   int tmp11 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:359:10: error: request for member ‘data’ in something not a structure or union
+  359 |     tmp11.data[tmp12] = r.rating;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:362:8: error: request for member ‘len’ in something not a structure or union
+  362 |   tmp11.len = tmp12;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:367:10: error: request for member ‘data’ in something not a structure or union
+  367 |     tmp14.data[tmp15] = r.title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:370:8: error: request for member ‘len’ in something not a structure or union
+  370 |   tmp14.len = tmp15;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:371:57: error: incompatible type for argument 1 of ‘_min_string’
+  371 |   result_t result[] = {(result_t){.rating = _min_string(tmp11),
+      |                                                         ^~~~~
+      |                                                         |
+      |                                                         int
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:372:62: error: incompatible type for argument 1 of ‘_min_string’
+  372 |                                   .movie_title = _min_string(tmp14)}};
+      |                                                              ^~~~~
+      |                                                              |
+      |                                                              int
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:382:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  382 |     _json_string(it.rating);
+      |                  ~~^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:386:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  386 |     _json_string(it.movie_title);
+      |                  ~~^~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:390:65: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  390 |   test_Q4_returns_minimum_rating_and_title_for_sequels_result = result;
+      |                                                                 ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:392:13: error: request for member ‘data’ in something not a structure or union
+  392 |   free(tmp11.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq4163279872/001/prog.c:393:13: error: request for member ‘data’ in something not a structure or union
+  393 |   free(tmp14.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q5.error
+++ b/tests/dataset/job/compiler/c/q5.error
@@ -1,0 +1,62 @@
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c: In function ‘test_Q5_finds_the_lexicographically_first_qualifying_title’:
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:257:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  257 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:265:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  265 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:315:14: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  315 |   int tmp4 = int_create(company_type.len * movie_companies.len *
+      |              ^~~~~~~~~~
+      |              list_int_create
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:315:37: error: ‘(company_type_t *)&company_type’ is a pointer; did you mean to use ‘->’?
+  315 |   int tmp4 = int_create(company_type.len * movie_companies.len *
+      |                                     ^
+      |                                     ->
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:315:59: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  315 |   int tmp4 = int_create(company_type.len * movie_companies.len *
+      |                                                           ^
+      |                                                           ->
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:316:35: error: ‘(movie_info_t *)&movie_info’ is a pointer; did you mean to use ‘->’?
+  316 |                         movie_info.len * info_type.len * title.len);
+      |                                   ^
+      |                                   ->
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:316:51: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  316 |                         movie_info.len * info_type.len * title.len);
+      |                                                   ^
+      |                                                   ->
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:316:63: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  316 |                         movie_info.len * info_type.len * title.len);
+      |                                                               ^
+      |                                                               ->
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:341:33: error: expected ‘)’ before ‘in’
+  341 |                   "(theatrical)" in mc.note && "(France)" in mc.note &&
+      |                                 ^~~
+      |                                 )
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:340:18: note: to match this ‘(’
+  340 |             if (!((strcmp(ct.kind, "production companies") == 0) &&
+      |                  ^
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:346:17: error: request for member ‘data’ in something not a structure or union
+  346 |             tmp4.data[tmp5] = t.title;
+      |                 ^
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:353:7: error: request for member ‘len’ in something not a structure or union
+  353 |   tmp4.len = tmp5;
+      |       ^
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:354:7: error: conflicting types for ‘candidate_titles’; have ‘int’
+  354 |   int candidate_titles = tmp4;
+      |       ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:306:15: note: previous definition of ‘candidate_titles’ with type ‘list_string’
+  306 |   list_string candidate_titles = list_string_create(8);
+      |               ^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:366:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  366 |     _json_string(it.typical_european_movie);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:79:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   79 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq51014489900/001/prog.c:370:71: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  370 |   test_Q5_finds_the_lexicographically_first_qualifying_title_result = result;
+      |                                                                       ^~~~~~

--- a/tests/dataset/job/compiler/c/q6.error
+++ b/tests/dataset/job/compiler/c/q6.error
@@ -1,0 +1,66 @@
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c: In function ‘test_Q6_finds_marvel_movie_with_Robert_Downey’:
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:247:71: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  247 |   if (test_Q6_finds_marvel_movie_with_Robert_Downey_result.len != tmp1.len) {
+      |                                                                       ^
+      |                                                                       ->
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:253:15: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  253 |           tmp1.data[i3]) {
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:284:29: warning: implicit declaration of function ‘result_item_list_t_create’ [-Wimplicit-function-declaration]
+  284 |   result_item_list_t tmp4 = result_item_list_t_create(
+      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:285:16: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  285 |       cast_info.len * movie_keyword.len * keyword.len * name.len * title.len);
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:285:36: error: ‘(movie_keyword_t *)&movie_keyword’ is a pointer; did you mean to use ‘->’?
+  285 |       cast_info.len * movie_keyword.len * keyword.len * name.len * title.len);
+      |                                    ^
+      |                                    ->
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:285:50: error: ‘(keyword_t *)&keyword’ is a pointer; did you mean to use ‘->’?
+  285 |       cast_info.len * movie_keyword.len * keyword.len * name.len * title.len);
+      |                                                  ^
+      |                                                  ->
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:285:61: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  285 |       cast_info.len * movie_keyword.len * keyword.len * name.len * title.len);
+      |                                                             ^
+      |                                                             ->
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:285:73: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  285 |       cast_info.len * movie_keyword.len * keyword.len * name.len * title.len);
+      |                                                                         ^
+      |                                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:310:36: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  310 |                   contains_string(n.name, "Downey") &&
+      |                                   ~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:62:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   62 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:311:36: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  311 |                   contains_string(n.name, "Robert") &&
+      |                                   ~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:62:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   62 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:334:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  334 |     _json_string(it.movie_keyword);
+      |                  ~~^~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:67:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   67 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:338:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  338 |     _json_string(it.actor_name);
+      |                  ~~^~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:67:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   67 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:342:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  342 |     _json_string(it.marvel_movie);
+      |                  ~~^~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:67:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   67 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq63840949441/001/prog.c:346:58: error: incompatible types when assigning to type ‘list_int’ from type ‘result_item_list_t’
+  346 |   test_Q6_finds_marvel_movie_with_Robert_Downey_result = result;
+      |                                                          ^~~~~~

--- a/tests/dataset/job/compiler/c/q7.error
+++ b/tests/dataset/job/compiler/c/q7.error
@@ -1,0 +1,107 @@
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c: In function ‘test_Q7_finds_movie_features_biography_for_person’:
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:333:11: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  333 |       tmp1.len) {
+      |           ^
+      |           ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:340:15: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  340 |           tmp1.data[i3]) {
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:383:27: warning: implicit declaration of function ‘rows_item_list_t_create’ [-Wimplicit-function-declaration]
+  383 |   rows_item_list_t tmp4 = rows_item_list_t_create(
+      |                           ^~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:384:15: error: ‘(aka_name_t *)&aka_name’ is a pointer; did you mean to use ‘->’?
+  384 |       aka_name.len * name.len * person_info.len * info_type.len *
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:384:26: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  384 |       aka_name.len * name.len * person_info.len * info_type.len *
+      |                          ^
+      |                          ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:384:44: error: ‘(person_info_t *)&person_info’ is a pointer; did you mean to use ‘->’?
+  384 |       aka_name.len * name.len * person_info.len * info_type.len *
+      |                                            ^
+      |                                            ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:384:60: error: ‘(info_type_t *)&info_type’ is a pointer; did you mean to use ‘->’?
+  384 |       aka_name.len * name.len * person_info.len * info_type.len *
+      |                                                            ^
+      |                                                            ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:385:16: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  385 |       cast_info.len * title.len * movie_link.len * link_type.len);
+      |                ^
+      |                ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:385:28: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  385 |       cast_info.len * title.len * movie_link.len * link_type.len);
+      |                            ^
+      |                            ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:385:45: error: ‘(movie_link_t *)&movie_link’ is a pointer; did you mean to use ‘->’?
+  385 |       cast_info.len * title.len * movie_link.len * link_type.len);
+      |                                             ^
+      |                                             ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:385:61: error: ‘(link_type_t *)&link_type’ is a pointer; did you mean to use ‘->’?
+  385 |       cast_info.len * title.len * movie_link.len * link_type.len);
+      |                                                             ^
+      |                                                             ->
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:424:44: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  424 |                   if (!((contains_string(an.name, "a") &&
+      |                                          ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:429:34: error: request for member ‘starts_with’ in something not a structure or union
+  429 |                            n.name.starts_with("B"))) &&
+      |                                  ^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:452:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  452 |   int tmp14 = int_create(rows.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:456:10: error: request for member ‘data’ in something not a structure or union
+  456 |     tmp14.data[tmp15] = r.person_name;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:459:8: error: request for member ‘len’ in something not a structure or union
+  459 |   tmp14.len = tmp15;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:464:10: error: request for member ‘data’ in something not a structure or union
+  464 |     tmp17.data[tmp18] = r.movie_title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:467:8: error: request for member ‘len’ in something not a structure or union
+  467 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:468:60: error: incompatible type for argument 1 of ‘_min_string’
+  468 |   result_t result[] = {(result_t){.of_person = _min_string(tmp14),
+      |                                                            ^~~~~
+      |                                                            |
+      |                                                            int
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:469:66: error: incompatible type for argument 1 of ‘_min_string’
+  469 |                                   .biography_movie = _min_string(tmp17)}};
+      |                                                                  ^~~~~
+      |                                                                  |
+      |                                                                  int
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:479:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  479 |     _json_string(it.of_person);
+      |                  ~~^~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:483:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  483 |     _json_string(it.biography_movie);
+      |                  ~~^~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:487:62: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  487 |   test_Q7_finds_movie_features_biography_for_person_result = result;
+      |                                                              ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:489:13: error: request for member ‘data’ in something not a structure or union
+  489 |   free(tmp14.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq74293004155/001/prog.c:490:13: error: request for member ‘data’ in something not a structure or union
+  490 |   free(tmp17.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q8.error
+++ b/tests/dataset/job/compiler/c/q8.error
@@ -1,0 +1,118 @@
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c: In function ‘test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing’:
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:315:23: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  315 |           .len != tmp1.len) {
+      |                       ^
+      |                       ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:325:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  325 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:359:31: warning: implicit declaration of function ‘eligible_item_list_t_create’ [-Wimplicit-function-declaration]
+  359 |   eligible_item_list_t tmp4 = eligible_item_list_t_create(
+      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:360:15: error: ‘(aka_name_t *)&aka_name’ is a pointer; did you mean to use ‘->’?
+  360 |       aka_name.len * name.len * cast_info.len * title.len *
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:360:26: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  360 |       aka_name.len * name.len * cast_info.len * title.len *
+      |                          ^
+      |                          ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:360:42: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  360 |       aka_name.len * name.len * cast_info.len * title.len *
+      |                                          ^
+      |                                          ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:360:54: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  360 |       aka_name.len * name.len * cast_info.len * title.len *
+      |                                                      ^
+      |                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:361:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  361 |       movie_companies.len * company_name.len * role_type.len);
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:361:41: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  361 |       movie_companies.len * company_name.len * role_type.len);
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:361:57: error: ‘(role_type_t *)&role_type’ is a pointer; did you mean to use ‘->’?
+  361 |       movie_companies.len * company_name.len * role_type.len);
+      |                                                         ^
+      |                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:397:41: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  397 |                       contains_string(mc.note, "(Japan)") &&
+      |                                       ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:398:44: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  398 |                       ((!contains_string(mc.note, "(USA)"))) &&
+      |                                          ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:399:41: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  399 |                       contains_string(n1.name, "Yo") &&
+      |                                       ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:400:44: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  400 |                       ((!contains_string(n1.name, "Yu"))) &&
+      |                                          ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:71:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:416:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  416 |   int tmp13 = int_create(eligible.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:420:10: error: request for member ‘data’ in something not a structure or union
+  420 |     tmp13.data[tmp14] = x.pseudonym;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:423:8: error: request for member ‘len’ in something not a structure or union
+  423 |   tmp13.len = tmp14;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:428:10: error: request for member ‘data’ in something not a structure or union
+  428 |     tmp16.data[tmp17] = x.movie_title;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:431:8: error: request for member ‘len’ in something not a structure or union
+  431 |   tmp16.len = tmp17;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:432:68: error: incompatible type for argument 1 of ‘_min_string’
+  432 |   result_t result[] = {(result_t){.actress_pseudonym = _min_string(tmp13),
+      |                                                                    ^~~~~
+      |                                                                    |
+      |                                                                    int
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:433:72: error: incompatible type for argument 1 of ‘_min_string’
+  433 |                                   .japanese_movie_dubbed = _min_string(tmp16)}};
+      |                                                                        ^~~~~
+      |                                                                        |
+      |                                                                        int
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:443:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  443 |     _json_string(it.actress_pseudonym);
+      |                  ~~^~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:447:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  447 |     _json_string(it.japanese_movie_dubbed);
+      |                  ~~^~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:76:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   76 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:452:7: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  452 |       result;
+      |       ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:454:13: error: request for member ‘data’ in something not a structure or union
+  454 |   free(tmp13.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq83850686028/001/prog.c:455:13: error: request for member ‘data’ in something not a structure or union
+  455 |   free(tmp16.data);
+      |             ^

--- a/tests/dataset/job/compiler/c/q9.error
+++ b/tests/dataset/job/compiler/c/q9.error
@@ -1,0 +1,151 @@
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c: In function ‘test_Q9_selects_minimal_alternative_name__character_and_movie’:
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:346:23: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  346 |           .len != tmp1.len) {
+      |                       ^
+      |                       ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:355:32: error: ‘(tmp1_t *)&tmp1’ is a pointer; did you mean to use ‘->’?
+  355 |               .data[i3] != tmp1.data[i3]) {
+      |                                ^
+      |                                ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c: In function ‘main’:
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:411:30: warning: implicit declaration of function ‘matches_item_list_t_create’ [-Wimplicit-function-declaration]
+  411 |   matches_item_list_t tmp4 = matches_item_list_t_create(
+      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:412:15: error: ‘(aka_name_t *)&aka_name’ is a pointer; did you mean to use ‘->’?
+  412 |       aka_name.len * name.len * cast_info.len * char_name.len * title.len *
+      |               ^
+      |               ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:412:26: error: ‘(name_t *)&name’ is a pointer; did you mean to use ‘->’?
+  412 |       aka_name.len * name.len * cast_info.len * char_name.len * title.len *
+      |                          ^
+      |                          ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:412:42: error: ‘(cast_info_t *)&cast_info’ is a pointer; did you mean to use ‘->’?
+  412 |       aka_name.len * name.len * cast_info.len * char_name.len * title.len *
+      |                                          ^
+      |                                          ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:412:58: error: ‘(char_name_t *)&char_name’ is a pointer; did you mean to use ‘->’?
+  412 |       aka_name.len * name.len * cast_info.len * char_name.len * title.len *
+      |                                                          ^
+      |                                                          ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:412:70: error: ‘(title_t *)&title’ is a pointer; did you mean to use ‘->’?
+  412 |       aka_name.len * name.len * cast_info.len * char_name.len * title.len *
+      |                                                                      ^
+      |                                                                      ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:413:22: error: ‘(movie_companie_t *)&movie_companies’ is a pointer; did you mean to use ‘->’?
+  413 |       movie_companies.len * company_name.len * role_type.len);
+      |                      ^
+      |                      ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:413:41: error: ‘(company_name_t *)&company_name’ is a pointer; did you mean to use ‘->’?
+  413 |       movie_companies.len * company_name.len * role_type.len);
+      |                                         ^
+      |                                         ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:413:57: error: ‘(role_type_t *)&role_type’ is a pointer; did you mean to use ‘->’?
+  413 |       movie_companies.len * company_name.len * role_type.len);
+      |                                                         ^
+      |                                                         ->
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:452:58: warning: passing argument 2 of ‘contains_list_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  452 |                   if (!((contains_list_string(matches, ci.note)) &&
+      |                                                        ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:71:54: note: expected ‘char *’ but argument is of type ‘const char *’
+   71 | static int contains_list_string(list_string v, char *item) {
+      |                                                ~~~~~~^~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:454:44: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  454 |                         (contains_string(mc.note, "(USA)") ||
+      |                                          ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:455:44: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  455 |                          contains_string(mc.note, "(worldwide)")) &&
+      |                                          ~~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:456:61: warning: passing argument 1 of ‘contains_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  456 |                         n.gender == "f" && contains_string(n.name, "Ang") &&
+      |                                                            ~^~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:77:34: note: expected ‘char *’ but argument is of type ‘const char *’
+   77 | static int contains_string(char *s, char *sub) {
+      |                            ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:473:23: error: conflicting types for ‘matches’; have ‘matches_item_list_t’
+  473 |   matches_item_list_t matches = tmp4;
+      |                       ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:406:15: note: previous definition of ‘matches’ with type ‘list_string’
+  406 |   list_string matches = list_string_create(4);
+      |               ^~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:474:15: warning: implicit declaration of function ‘int_create’; did you mean ‘list_int_create’? [-Wimplicit-function-declaration]
+  474 |   int tmp14 = int_create(matches.len);
+      |               ^~~~~~~~~~
+      |               list_int_create
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:478:10: error: request for member ‘data’ in something not a structure or union
+  478 |     tmp14.data[tmp15] = x.alt;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:481:8: error: request for member ‘len’ in something not a structure or union
+  481 |   tmp14.len = tmp15;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:486:10: error: request for member ‘data’ in something not a structure or union
+  486 |     tmp17.data[tmp18] = x.character;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:489:8: error: request for member ‘len’ in something not a structure or union
+  489 |   tmp17.len = tmp18;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:494:10: error: request for member ‘data’ in something not a structure or union
+  494 |     tmp20.data[tmp21] = x.movie;
+      |          ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:497:8: error: request for member ‘len’ in something not a structure or union
+  497 |   tmp20.len = tmp21;
+      |        ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:498:67: error: incompatible type for argument 1 of ‘_min_string’
+  498 |   result_t result[] = {(result_t){.alternative_name = _min_string(tmp14),
+      |                                                                   ^~~~~
+      |                                                                   |
+      |                                                                   int
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:499:65: error: incompatible type for argument 1 of ‘_min_string’
+  499 |                                   .character_name = _min_string(tmp17),
+      |                                                                 ^~~~~
+      |                                                                 |
+      |                                                                 int
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:500:56: error: incompatible type for argument 1 of ‘_min_string’
+  500 |                                   .movie = _min_string(tmp20)}};
+      |                                                        ^~~~~
+      |                                                        |
+      |                                                        int
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:62:38: note: expected ‘list_string’ but argument is of type ‘int’
+   62 | static char *_min_string(list_string v) {
+      |                          ~~~~~~~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:510:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  510 |     _json_string(it.alternative_name);
+      |                  ~~^~~~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:514:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  514 |     _json_string(it.character_name);
+      |                  ~~^~~~~~~~~~~~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:518:20: warning: passing argument 1 of ‘_json_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
+  518 |     _json_string(it.movie);
+      |                  ~~^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:82:32: note: expected ‘char *’ but argument is of type ‘const char *’
+   82 | static void _json_string(char *s) { printf("\"%s\"", s); }
+      |                          ~~~~~~^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:522:74: error: incompatible types when assigning to type ‘list_int’ from type ‘result_t *’
+  522 |   test_Q9_selects_minimal_alternative_name__character_and_movie_result = result;
+      |                                                                          ^~~~~~
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:524:13: error: request for member ‘data’ in something not a structure or union
+  524 |   free(tmp14.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:525:13: error: request for member ‘data’ in something not a structure or union
+  525 |   free(tmp17.data);
+      |             ^
+/tmp/TestCCompiler_JOB_Goldenq93860209230/001/prog.c:526:13: error: request for member ‘data’ in something not a structure or union
+  526 |   free(tmp20.data);
+      |             ^


### PR DESCRIPTION
## Summary
- update C compiler tests to write error files instead of skipping
- keep existing golden output comparison when compilation succeeds
- record error messages for JOB dataset queries
- log progress in `TASKS.md`

## Testing
- `go test ./compiler/x/c -run TestCCompiler_JOB_Golden -tags slow -count=1 -short`


------
https://chatgpt.com/codex/tasks/task_e_6875ca02664883208604128e09c86a4b