### PR TITLE
Add plan subpackage

### DIFF
--- a/tests/types/queryplan/cross_join.mochi
+++ b/tests/types/queryplan/cross_join.mochi
@@ -1,0 +1,26 @@
+// cross_join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+let result = from o in orders
+             from c in customers
+             select {
+               orderId: o.id,
+               orderCustomerId: o.customerId,
+               pairedCustomerName: c.name,
+               orderTotal: o.total
+             }
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result {
+  print("Order", entry.orderId,
+        "(customerId:", entry.orderCustomerId,
+        ", total: $", entry.orderTotal,
+        ") paired with", entry.pairedCustomerName)
+}

--- a/tests/types/queryplan/cross_join.plan
+++ b/tests/types/queryplan/cross_join.plan
@@ -1,0 +1,24 @@
+(select
+  (map
+    (entry
+      (selector orderId)
+      (selector id (selector o))
+    )
+    (entry
+      (selector orderCustomerId)
+      (selector customerId (selector o))
+    )
+    (entry
+      (selector pairedCustomerName)
+      (selector name (selector c))
+    )
+    (entry
+      (selector orderTotal)
+      (selector total (selector o))
+    )
+  )
+  (join
+    (scan o (selector orders))
+    (scan c (selector customers))
+  )
+)

--- a/tests/types/queryplan/group_by.mochi
+++ b/tests/types/queryplan/group_by.mochi
@@ -1,0 +1,20 @@
+// group-by.mochi
+let people = [
+  { name: "Alice", age: 30, city: "Paris" },
+  { name: "Bob", age: 15, city: "Hanoi" },
+  { name: "Charlie", age: 65, city: "Paris" },
+  { name: "Diana", age: 45, city: "Hanoi" },
+  { name: "Eve", age: 70, city: "Paris" },
+  { name: "Frank", age: 22, city: "Hanoi" }
+]
+let stats = from person in people
+            group by person.city into g
+            select {
+              city: g.key,
+              count: count(g),
+              avg_age: avg(from p in g select p.age)
+            }
+print("--- People grouped by city ---")
+for s in stats {
+  print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}

--- a/tests/types/queryplan/group_by.plan
+++ b/tests/types/queryplan/group_by.plan
@@ -1,0 +1,27 @@
+(select
+  (map
+    (entry
+      (selector city)
+      (selector key (selector g))
+    )
+    (entry
+      (selector count)
+      (call count (selector g))
+    )
+    (entry
+      (selector avg_age)
+      (call avg
+        (query p
+          (source (selector g))
+          (select
+            (selector age (selector p))
+          )
+        )
+      )
+    )
+  )
+  (group g
+    (selector city (selector person))
+    (scan person (selector people))
+  )
+)

--- a/types/plan/plan.go
+++ b/types/plan/plan.go
@@ -1,0 +1,111 @@
+package plan
+
+import (
+	"mochi/ast"
+	"mochi/parser"
+)
+
+// Node represents a typed logical query plan node.
+type Node interface{ isNode() }
+
+type Scan struct {
+	Src   *parser.Expr
+	Alias string
+	Elem  any
+}
+
+func (*Scan) isNode() {}
+
+type Select struct {
+	Expr  *parser.Expr
+	Input Node
+}
+
+func (*Select) isNode() {}
+
+type Where struct {
+	Cond  *parser.Expr
+	Input Node
+}
+
+func (*Where) isNode() {}
+
+type Join struct {
+	Left     Node
+	Right    Node
+	On       *parser.Expr
+	JoinType string
+}
+
+func (*Join) isNode() {}
+
+type Group struct {
+	By    []*parser.Expr
+	Name  string
+	Input Node
+}
+
+func (*Group) isNode() {}
+
+type Sort struct {
+	Key   *parser.Expr
+	Input Node
+}
+
+func (*Sort) isNode() {}
+
+type Limit struct {
+	Skip  *parser.Expr
+	Take  *parser.Expr
+	Input Node
+}
+
+func (*Limit) isNode() {}
+
+// nodeTree converts a plan Node to an AST node used for printing.
+func nodeTree(pl Node) *ast.Node {
+	switch p := pl.(type) {
+	case *Scan:
+		return &ast.Node{Kind: "scan", Value: p.Alias, Children: []*ast.Node{ast.FromExpr(p.Src)}}
+	case *Select:
+		return &ast.Node{Kind: "select", Children: []*ast.Node{ast.FromExpr(p.Expr), nodeTree(p.Input)}}
+	case *Where:
+		return &ast.Node{Kind: "where", Children: []*ast.Node{ast.FromExpr(p.Cond), nodeTree(p.Input)}}
+	case *Join:
+		kind := "join"
+		if p.JoinType != "inner" {
+			kind = p.JoinType + "_join"
+		}
+		n := &ast.Node{Kind: kind, Children: []*ast.Node{nodeTree(p.Left), nodeTree(p.Right)}}
+		if p.On != nil {
+			n.Children = append(n.Children, &ast.Node{Kind: "on", Children: []*ast.Node{ast.FromExpr(p.On)}})
+		}
+		return n
+	case *Group:
+		n := &ast.Node{Kind: "group", Value: p.Name}
+		for _, e := range p.By {
+			n.Children = append(n.Children, ast.FromExpr(e))
+		}
+		n.Children = append(n.Children, nodeTree(p.Input))
+		return n
+	case *Sort:
+		return &ast.Node{Kind: "sort", Children: []*ast.Node{ast.FromExpr(p.Key), nodeTree(p.Input)}}
+	case *Limit:
+		n := &ast.Node{Kind: "limit"}
+		if p.Skip != nil {
+			n.Children = append(n.Children, &ast.Node{Kind: "skip", Children: []*ast.Node{ast.FromExpr(p.Skip)}})
+		}
+		if p.Take != nil {
+			n.Children = append(n.Children, &ast.Node{Kind: "take", Children: []*ast.Node{ast.FromExpr(p.Take)}})
+		}
+		n.Children = append(n.Children, nodeTree(p.Input))
+		return n
+	default:
+		return &ast.Node{Kind: "unknown"}
+	}
+}
+
+// String pretty prints a plan Node as a Lisp-like tree.
+func String(pl Node) string {
+	return nodeTree(pl).String()
+}

--- a/types/query_plan_builder.go
+++ b/types/query_plan_builder.go
@@ -1,0 +1,197 @@
+package types
+
+import (
+	"fmt"
+	"mochi/ast"
+	"mochi/parser"
+	"mochi/types/plan"
+)
+
+// BuildQueryPlan converts a parsed QueryExpr into a typed logical plan.
+func BuildQueryPlan(q *parser.QueryExpr, env *Env) (plan.Node, error) {
+	if q == nil {
+		return nil, fmt.Errorf("nil query expression")
+	}
+
+	srcT, err := checkExpr(q.Source, env)
+	if err != nil {
+		return nil, err
+	}
+	var elemT Type
+	switch t := srcT.(type) {
+	case ListType:
+		elemT = t.Elem
+	case GroupType:
+		elemT = t.Elem
+	default:
+		return nil, errQuerySourceList(q.Pos)
+	}
+	child := NewEnv(env)
+	child.SetVar(q.Var, elemT, true)
+
+	cond := q.Where
+	pushAlias := ""
+	if cond != nil {
+		if aliases := usedAliases(cond); len(aliases) == 1 {
+			for a := range aliases {
+				pushAlias = a
+			}
+		}
+	}
+
+	var root plan.Node = &plan.Scan{Src: q.Source, Alias: q.Var, Elem: elemT}
+	if pushAlias == q.Var {
+		if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+			return nil, err
+		}
+		root = &plan.Where{Cond: cond, Input: root}
+		cond = nil
+	}
+
+	for _, f := range q.Froms {
+		ft, err := checkExpr(f.Src, child)
+		if err != nil {
+			return nil, err
+		}
+		var fe Type
+		switch t := ft.(type) {
+		case ListType:
+			fe = t.Elem
+		case GroupType:
+			fe = t.Elem
+		default:
+			return nil, errJoinSourceList(f.Pos)
+		}
+		child.SetVar(f.Var, fe, true)
+		var rhs plan.Node = &plan.Scan{Src: f.Src, Alias: f.Var, Elem: fe}
+		if pushAlias == f.Var {
+			if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+				return nil, err
+			}
+			rhs = &plan.Where{Cond: cond, Input: rhs}
+			cond = nil
+			pushAlias = ""
+		}
+		root = &plan.Join{Left: root, Right: rhs, JoinType: "inner"}
+	}
+
+	for _, j := range q.Joins {
+		jt, err := checkExpr(j.Src, child)
+		if err != nil {
+			return nil, err
+		}
+		var je Type
+		switch t := jt.(type) {
+		case ListType:
+			je = t.Elem
+		case GroupType:
+			je = t.Elem
+		default:
+			return nil, errJoinSourceList(j.Pos)
+		}
+		child.SetVar(j.Var, je, true)
+		if _, err := checkExprWithExpected(j.On, child, BoolType{}); err != nil {
+			return nil, err
+		}
+		joinType := "inner"
+		if j.Side != nil {
+			joinType = *j.Side
+		}
+		var rhs plan.Node = &plan.Scan{Src: j.Src, Alias: j.Var, Elem: je}
+		if joinType == "inner" && pushAlias == j.Var {
+			if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+				return nil, err
+			}
+			rhs = &plan.Where{Cond: cond, Input: rhs}
+			cond = nil
+			pushAlias = ""
+		}
+		root = &plan.Join{Left: root, Right: rhs, On: j.On, JoinType: joinType}
+	}
+
+	if cond != nil {
+		if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+			return nil, err
+		}
+		root = &plan.Where{Cond: cond, Input: root}
+	}
+
+	selEnv := child
+	if q.Group != nil {
+		for _, e := range q.Group.Exprs {
+			if _, err := checkExpr(e, child); err != nil {
+				return nil, err
+			}
+		}
+		genv := NewEnv(child)
+		genv.SetVar(q.Group.Name, GroupType{Key: AnyType{}, Elem: elemT}, true)
+		if q.Group.Having != nil {
+			if _, err := checkExprWithExpected(q.Group.Having, genv, BoolType{}); err != nil {
+				return nil, err
+			}
+		}
+		root = &plan.Group{By: q.Group.Exprs, Name: q.Group.Name, Input: root}
+		selEnv = genv
+	}
+
+	if q.Sort != nil {
+		if _, err := checkExpr(q.Sort, child); err != nil {
+			return nil, err
+		}
+		root = &plan.Sort{Key: q.Sort, Input: root}
+	}
+
+	if q.Skip != nil || q.Take != nil {
+		if q.Skip != nil {
+			if _, err := checkExprWithExpected(q.Skip, child, IntType{}); err != nil {
+				return nil, err
+			}
+		}
+		if q.Take != nil {
+			if _, err := checkExprWithExpected(q.Take, child, IntType{}); err != nil {
+				return nil, err
+			}
+		}
+		root = &plan.Limit{Skip: q.Skip, Take: q.Take, Input: root}
+	}
+
+	if q.Select != nil {
+		if _, err := checkExpr(q.Select, selEnv); err != nil {
+			return nil, err
+		}
+		root = &plan.Select{Expr: q.Select, Input: root}
+	}
+
+	return root, nil
+}
+
+// PlanString pretty prints a plan.Node as a Lisp-like tree.
+func PlanString(pl plan.Node) string {
+	return plan.String(pl)
+}
+
+// usedAliases returns the set of selector roots referenced in e.
+func usedAliases(e *parser.Expr) map[string]struct{} {
+	aliases := map[string]struct{}{}
+	if e == nil {
+		return aliases
+	}
+	node := ast.FromExpr(e)
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n.Kind == "selector" {
+			base := n
+			for len(base.Children) == 1 && base.Children[0].Kind == "selector" {
+				base = base.Children[0]
+			}
+			if s, ok := base.Value.(string); ok {
+				aliases[s] = struct{}{}
+			}
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(node)
+	return aliases
+}

--- a/types/query_plan_test.go
+++ b/types/query_plan_test.go
@@ -1,0 +1,44 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"mochi/golden"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func firstQuery(prog *parser.Program) *parser.QueryExpr {
+	for _, stmt := range prog.Statements {
+		if stmt.Let != nil && stmt.Let.Value != nil {
+			if q := stmt.Let.Value.Binary.Left.Value.Target.Query; q != nil {
+				return q
+			}
+		}
+	}
+	return nil
+}
+
+func TestQueryPlan(t *testing.T) {
+	golden.Run(t, "tests/types/queryplan", ".mochi", ".plan", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("type error: %v", errs[0])
+		}
+		q := firstQuery(prog)
+		if q == nil {
+			return nil, fmt.Errorf("no query expression found")
+		}
+		plan, err := types.BuildQueryPlan(q, env)
+		if err != nil {
+			return nil, err
+		}
+		out := types.PlanString(plan)
+		return []byte(out), nil
+	})
+}


### PR DESCRIPTION
## Summary
- introduce `types/plan` package containing public plan node structs
- keep query plan builder in `types` using new plan nodes
- update tests to work with new package

## Testing
- `go test ./types -run TestQueryPlan -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6875c563fbac8320b2121f25991d5a41