### PR TITLE
Add plan subpackage

### DIFF
--- a/tests/dataset/tpc-h/q1.plan
+++ b/tests/dataset/tpc-h/q1.plan
@@ -1,0 +1,140 @@
+(select
+  (map
+    (entry
+      (selector returnflag)
+      (selector returnflag
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector linestatus)
+      (selector linestatus
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector sum_qty)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (selector l_quantity (selector x))
+          )
+        )
+      )
+    )
+    (entry
+      (selector sum_base_price)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (selector l_extendedprice (selector x))
+          )
+        )
+      )
+    )
+    (entry
+      (selector sum_disc_price)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (selector l_extendedprice (selector x))
+              (group
+                (binary -
+                  (int 1)
+                  (selector l_discount (selector x))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (entry
+      (selector sum_charge)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (binary *
+                (selector l_extendedprice (selector x))
+                (group
+                  (binary -
+                    (int 1)
+                    (selector l_discount (selector x))
+                  )
+                )
+              )
+              (group
+                (binary +
+                  (int 1)
+                  (selector l_tax (selector x))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (entry
+      (selector avg_qty)
+      (call avg
+        (query x
+          (source (selector g))
+          (select
+            (selector l_quantity (selector x))
+          )
+        )
+      )
+    )
+    (entry
+      (selector avg_price)
+      (call avg
+        (query x
+          (source (selector g))
+          (select
+            (selector l_extendedprice (selector x))
+          )
+        )
+      )
+    )
+    (entry
+      (selector avg_disc)
+      (call avg
+        (query x
+          (source (selector g))
+          (select
+            (selector l_discount (selector x))
+          )
+        )
+      )
+    )
+    (entry
+      (selector count_order)
+      (call count (selector g))
+    )
+  )
+  (group g
+    (map
+      (entry
+        (selector returnflag)
+        (selector l_returnflag (selector row))
+      )
+      (entry
+        (selector linestatus)
+        (selector l_linestatus (selector row))
+      )
+    )
+    (where
+      (binary <=
+        (selector l_shipdate (selector row))
+        (string 1998-09-02)
+      )
+      (scan row (selector lineitem))
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q10.plan
+++ b/tests/dataset/tpc-h/q10.plan
@@ -1,0 +1,171 @@
+(select
+  (map
+    (entry
+      (selector c_custkey)
+      (selector c_custkey
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_name)
+      (selector c_name
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector revenue)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (selector l_extendedprice
+                (selector l (selector x))
+              )
+              (group
+                (binary -
+                  (int 1)
+                  (selector l_discount
+                    (selector l (selector x))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (entry
+      (selector c_acctbal)
+      (selector c_acctbal
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector n_name)
+      (selector n_name
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_address)
+      (selector c_address
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_phone)
+      (selector c_phone
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_comment)
+      (selector c_comment
+        (selector key (selector g))
+      )
+    )
+  )
+  (sort
+    (unary -
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (selector l_extendedprice
+                (selector l (selector x))
+              )
+              (group
+                (binary -
+                  (int 1)
+                  (selector l_discount
+                    (selector l (selector x))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (group g
+      (map
+        (entry
+          (selector c_custkey)
+          (selector c_custkey (selector c))
+        )
+        (entry
+          (selector c_name)
+          (selector c_name (selector c))
+        )
+        (entry
+          (selector c_acctbal)
+          (selector c_acctbal (selector c))
+        )
+        (entry
+          (selector c_address)
+          (selector c_address (selector c))
+        )
+        (entry
+          (selector c_phone)
+          (selector c_phone (selector c))
+        )
+        (entry
+          (selector c_comment)
+          (selector c_comment (selector c))
+        )
+        (entry
+          (selector n_name)
+          (selector n_name (selector n))
+        )
+      )
+      (where
+        (binary ==
+          (binary &&
+            (binary <
+              (binary &&
+                (binary >=
+                  (selector o_orderdate (selector o))
+                  (selector start_date)
+                )
+                (selector o_orderdate (selector o))
+              )
+              (selector end_date)
+            )
+            (selector l_returnflag (selector l))
+          )
+          (string R)
+        )
+        (join
+          (join
+            (join
+              (scan c (selector customer))
+              (scan o (selector orders))
+              (on
+                (binary ==
+                  (selector o_custkey (selector o))
+                  (selector c_custkey (selector c))
+                )
+              )
+            )
+            (scan l (selector lineitem))
+            (on
+              (binary ==
+                (selector l_orderkey (selector l))
+                (selector o_orderkey (selector o))
+              )
+            )
+          )
+          (scan n (selector nation))
+          (on
+            (binary ==
+              (selector n_nationkey (selector n))
+              (selector c_nationkey (selector c))
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q11.plan
+++ b/tests/dataset/tpc-h/q11.plan
@@ -1,0 +1,40 @@
+(select
+  (map
+    (entry
+      (selector ps_partkey)
+      (selector ps_partkey (selector ps))
+    )
+    (entry
+      (selector value)
+      (binary *
+        (selector ps_supplycost (selector ps))
+        (selector ps_availqty (selector ps))
+      )
+    )
+  )
+  (where
+    (binary ==
+      (selector n_name (selector n))
+      (selector target_nation)
+    )
+    (join
+      (join
+        (scan ps (selector partsupp))
+        (scan s (selector supplier))
+        (on
+          (binary ==
+            (selector s_suppkey (selector s))
+            (selector ps_suppkey (selector ps))
+          )
+        )
+      )
+      (scan n (selector nation))
+      (on
+        (binary ==
+          (selector n_nationkey (selector n))
+          (selector s_nationkey (selector s))
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q12.plan
+++ b/tests/dataset/tpc-h/q12.plan
@@ -1,0 +1,108 @@
+(select
+  (map
+    (entry
+      (selector l_shipmode)
+      (selector key (selector g))
+    )
+    (entry
+      (selector high_line_count)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (if_expr
+              (binary in
+                (selector o_orderpriority
+                  (selector o (selector x))
+                )
+                (list (string 1-URGENT) (string 2-HIGH))
+              )
+              (int 1)
+              (int 0)
+            )
+          )
+        )
+      )
+    )
+    (entry
+      (selector low_line_count)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (if_expr
+              (unary !
+                (group
+                  (binary in
+                    (selector o_orderpriority
+                      (selector o (selector x))
+                    )
+                    (list (string 1-URGENT) (string 2-HIGH))
+                  )
+                )
+              )
+              (int 1)
+              (int 0)
+            )
+          )
+        )
+      )
+    )
+  )
+  (sort
+    (selector key (selector g))
+    (group g
+      (selector l_shipmode (selector l))
+      (join
+        (where
+          (binary &&
+            (binary &&
+              (binary &&
+                (binary &&
+                  (group
+                    (binary in
+                      (selector l_shipmode (selector l))
+                      (list (string MAIL) (string SHIP))
+                    )
+                  )
+                  (group
+                    (binary <
+                      (selector l_commitdate (selector l))
+                      (selector l_receiptdate (selector l))
+                    )
+                  )
+                )
+                (group
+                  (binary <
+                    (selector l_shipdate (selector l))
+                    (selector l_commitdate (selector l))
+                  )
+                )
+              )
+              (group
+                (binary >=
+                  (selector l_receiptdate (selector l))
+                  (string 1994-01-01)
+                )
+              )
+            )
+            (group
+              (binary <
+                (selector l_receiptdate (selector l))
+                (string 1995-01-01)
+              )
+            )
+          )
+          (scan l (selector lineitem))
+        )
+        (scan o (selector orders))
+        (on
+          (binary ==
+            (selector o_orderkey (selector o))
+            (selector l_orderkey (selector l))
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q13.plan
+++ b/tests/dataset/tpc-h/q13.plan
@@ -1,0 +1,46 @@
+(select
+  (map
+    (entry
+      (selector c_count)
+      (call count
+        (query o
+          (source (selector orders))
+          (where
+            (group
+              (binary &&
+                (binary &&
+                  (binary ==
+                    (selector o_custkey (selector o))
+                    (selector c_custkey (selector c))
+                  )
+                  (group
+                    (unary !
+                      (group
+                        (binary in
+                          (string special)
+                          (selector o_comment (selector o))
+                        )
+                      )
+                    )
+                  )
+                )
+                (group
+                  (unary !
+                    (group
+                      (binary in
+                        (string requests)
+                        (selector o_comment (selector o))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          (select (selector o))
+        )
+      )
+    )
+  )
+  (scan c (selector customer))
+)

--- a/tests/dataset/tpc-h/q14.plan
+++ b/tests/dataset/tpc-h/q14.plan
@@ -1,0 +1,45 @@
+(select
+  (map
+    (entry
+      (selector is_promo)
+      (binary in
+        (string PROMO)
+        (selector p_type (selector p))
+      )
+    )
+    (entry
+      (selector revenue)
+      (binary *
+        (selector l_extendedprice (selector l))
+        (group
+          (binary -
+            (int 1)
+            (selector l_discount (selector l))
+          )
+        )
+      )
+    )
+  )
+  (where
+    (binary <
+      (binary &&
+        (binary >=
+          (selector l_shipdate (selector l))
+          (selector start_date)
+        )
+        (selector l_shipdate (selector l))
+      )
+      (selector end_date)
+    )
+    (join
+      (scan l (selector lineitem))
+      (scan p (selector part))
+      (on
+        (binary ==
+          (selector p_partkey (selector p))
+          (selector l_partkey (selector l))
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q15.plan
+++ b/tests/dataset/tpc-h/q15.plan
@@ -1,0 +1,43 @@
+(select
+  (map
+    (entry
+      (selector supplier_no)
+      (selector key (selector g))
+    )
+    (entry
+      (selector total_revenue)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (selector l_extendedprice (selector x))
+              (group
+                (binary -
+                  (int 1)
+                  (selector l_discount (selector x))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (group g
+    (selector l_suppkey (selector l))
+    (where
+      (binary <
+        (binary &&
+          (binary >=
+            (selector l_shipdate (selector l))
+            (selector start_date)
+          )
+          (selector l_shipdate (selector l))
+        )
+        (selector end_date)
+      )
+      (scan l (selector lineitem))
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q16.plan
+++ b/tests/dataset/tpc-h/q16.plan
@@ -1,0 +1,33 @@
+(select
+  (selector ps_suppkey (selector ps))
+  (join
+    (scan ps (selector partsupp))
+    (where
+      (binary ==
+        (binary &&
+          (binary &&
+            (binary ==
+              (selector p_brand (selector p))
+              (string "Brand#12")
+            )
+            (call
+              (selector contains
+                (selector p_type (selector p))
+              )
+              (string SMALL)
+            )
+          )
+          (selector p_size (selector p))
+        )
+        (int 5)
+      )
+      (scan p (selector part))
+    )
+    (on
+      (binary ==
+        (selector p_partkey (selector p))
+        (selector ps_partkey (selector ps))
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q17.plan
+++ b/tests/dataset/tpc-h/q17.plan
@@ -1,0 +1,57 @@
+(select
+  (selector l_extendedprice (selector l))
+  (where
+    (group
+      (binary &&
+        (binary &&
+          (group
+            (binary ==
+              (selector p_brand (selector p))
+              (selector brand)
+            )
+          )
+          (group
+            (binary ==
+              (selector p_container (selector p))
+              (selector container)
+            )
+          )
+        )
+        (group
+          (binary <
+            (selector l_quantity (selector l))
+            (group
+              (binary *
+                (float 0.2)
+                (call avg
+                  (query x
+                    (source (selector lineitem))
+                    (where
+                      (binary ==
+                        (selector l_partkey (selector x))
+                        (selector p_partkey (selector p))
+                      )
+                    )
+                    (select
+                      (selector l_quantity (selector x))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (join
+      (scan l (selector lineitem))
+      (scan p (selector part))
+      (on
+        (binary ==
+          (selector p_partkey (selector p))
+          (selector l_partkey (selector l))
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q18.plan
+++ b/tests/dataset/tpc-h/q18.plan
@@ -1,0 +1,153 @@
+(select
+  (map
+    (entry
+      (selector c_name)
+      (selector c_name
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_custkey)
+      (selector c_custkey
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector revenue)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (selector l_extendedprice
+                (selector l (selector x))
+              )
+              (group
+                (binary -
+                  (int 1)
+                  (selector l_discount
+                    (selector l (selector x))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (entry
+      (selector c_acctbal)
+      (selector c_acctbal
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector n_name)
+      (selector n_name
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_address)
+      (selector c_address
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_phone)
+      (selector c_phone
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector c_comment)
+      (selector c_comment
+        (selector key (selector g))
+      )
+    )
+  )
+  (sort
+    (unary -
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (selector l_extendedprice
+                (selector l (selector x))
+              )
+              (group
+                (binary -
+                  (int 1)
+                  (selector l_discount
+                    (selector l (selector x))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (group g
+      (map
+        (entry
+          (selector c_name)
+          (selector c_name (selector c))
+        )
+        (entry
+          (selector c_custkey)
+          (selector c_custkey (selector c))
+        )
+        (entry
+          (selector c_acctbal)
+          (selector c_acctbal (selector c))
+        )
+        (entry
+          (selector c_address)
+          (selector c_address (selector c))
+        )
+        (entry
+          (selector c_phone)
+          (selector c_phone (selector c))
+        )
+        (entry
+          (selector c_comment)
+          (selector c_comment (selector c))
+        )
+        (entry
+          (selector n_name)
+          (selector n_name (selector n))
+        )
+      )
+      (join
+        (join
+          (join
+            (scan c (selector customer))
+            (scan o (selector orders))
+            (on
+              (binary ==
+                (selector o_custkey (selector o))
+                (selector c_custkey (selector c))
+              )
+            )
+          )
+          (scan l (selector lineitem))
+          (on
+            (binary ==
+              (selector l_orderkey (selector l))
+              (selector o_orderkey (selector o))
+            )
+          )
+        )
+        (scan n (selector nation))
+        (on
+          (binary ==
+            (selector n_nationkey (selector n))
+            (selector c_nationkey (selector c))
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q19.plan
+++ b/tests/dataset/tpc-h/q19.plan
@@ -1,0 +1,173 @@
+(select
+  (binary *
+    (selector l_extendedprice (selector l))
+    (group
+      (binary -
+        (int 1)
+        (selector l_discount (selector l))
+      )
+    )
+  )
+  (where
+    (binary ==
+      (binary &&
+        (binary in
+          (binary &&
+            (group
+              (binary ||
+                (binary ||
+                  (group
+                    (binary &&
+                      (binary &&
+                        (binary &&
+                          (group
+                            (binary ==
+                              (selector p_brand (selector p))
+                              (string "Brand#12")
+                            )
+                          )
+                          (group
+                            (binary in
+                              (selector p_container (selector p))
+                              (list (string "SM CASE") (string "SM BOX") (string "SM PACK") (string "SM PKG"))
+                            )
+                          )
+                        )
+                        (group
+                          (binary <=
+                            (binary &&
+                              (binary >=
+                                (selector l_quantity (selector l))
+                                (int 1)
+                              )
+                              (selector l_quantity (selector l))
+                            )
+                            (int 11)
+                          )
+                        )
+                      )
+                      (group
+                        (binary <=
+                          (binary &&
+                            (binary >=
+                              (selector p_size (selector p))
+                              (int 1)
+                            )
+                            (selector p_size (selector p))
+                          )
+                          (int 5)
+                        )
+                      )
+                    )
+                  )
+                  (group
+                    (binary &&
+                      (binary &&
+                        (binary &&
+                          (group
+                            (binary ==
+                              (selector p_brand (selector p))
+                              (string "Brand#23")
+                            )
+                          )
+                          (group
+                            (binary in
+                              (selector p_container (selector p))
+                              (list (string "MED BAG") (string "MED BOX") (string "MED PKG") (string "MED PACK"))
+                            )
+                          )
+                        )
+                        (group
+                          (binary <=
+                            (binary &&
+                              (binary >=
+                                (selector l_quantity (selector l))
+                                (int 10)
+                              )
+                              (selector l_quantity (selector l))
+                            )
+                            (int 20)
+                          )
+                        )
+                      )
+                      (group
+                        (binary <=
+                          (binary &&
+                            (binary >=
+                              (selector p_size (selector p))
+                              (int 1)
+                            )
+                            (selector p_size (selector p))
+                          )
+                          (int 10)
+                        )
+                      )
+                    )
+                  )
+                )
+                (group
+                  (binary &&
+                    (binary &&
+                      (binary &&
+                        (group
+                          (binary ==
+                            (selector p_brand (selector p))
+                            (string "Brand#34")
+                          )
+                        )
+                        (group
+                          (binary in
+                            (selector p_container (selector p))
+                            (list (string "LG CASE") (string "LG BOX") (string "LG PACK") (string "LG PKG"))
+                          )
+                        )
+                      )
+                      (group
+                        (binary <=
+                          (binary &&
+                            (binary >=
+                              (selector l_quantity (selector l))
+                              (int 20)
+                            )
+                            (selector l_quantity (selector l))
+                          )
+                          (int 30)
+                        )
+                      )
+                    )
+                    (group
+                      (binary <=
+                        (binary &&
+                          (binary >=
+                            (selector p_size (selector p))
+                            (int 1)
+                          )
+                          (selector p_size (selector p))
+                        )
+                        (int 15)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+            (selector l_shipmode (selector l))
+          )
+          (list (string AIR) (string "AIR REG"))
+        )
+        (selector l_shipinstruct (selector l))
+      )
+      (string "DELIVER IN PERSON")
+    )
+    (join
+      (scan l (selector lineitem))
+      (scan p (selector part))
+      (on
+        (binary ==
+          (selector p_partkey (selector p))
+          (selector l_partkey (selector l))
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q2.plan
+++ b/tests/dataset/tpc-h/q2.plan
@@ -1,0 +1,19 @@
+(select
+  (selector n)
+  (join
+    (where
+      (binary ==
+        (selector r_name (selector r))
+        (string EUROPE)
+      )
+      (scan r (selector region))
+    )
+    (scan n (selector nation))
+    (on
+      (binary ==
+        (selector n_regionkey (selector n))
+        (selector r_regionkey (selector r))
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q20.plan
+++ b/tests/dataset/tpc-h/q20.plan
@@ -1,0 +1,52 @@
+(select
+  (map
+    (entry
+      (selector partkey)
+      (selector partkey
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector suppkey)
+      (selector suppkey
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector qty)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (selector l_quantity (selector x))
+          )
+        )
+      )
+    )
+  )
+  (group g
+    (map
+      (entry
+        (selector partkey)
+        (selector l_partkey (selector l))
+      )
+      (entry
+        (selector suppkey)
+        (selector l_suppkey (selector l))
+      )
+    )
+    (where
+      (binary <
+        (binary &&
+          (binary >=
+            (selector l_shipdate (selector l))
+            (string 1994-01-01)
+          )
+          (selector l_shipdate (selector l))
+        )
+        (string 1995-01-01)
+      )
+      (scan l (selector lineitem))
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q21.plan
+++ b/tests/dataset/tpc-h/q21.plan
@@ -1,0 +1,99 @@
+(select
+  (map
+    (entry
+      (selector s_name)
+      (selector key (selector g))
+    )
+    (entry
+      (selector numwait)
+      (call count (selector g))
+    )
+  )
+  (sort
+    (list
+      (unary -
+        (call count (selector g))
+      )
+      (selector key (selector g))
+    )
+    (group g
+      (selector s_name (selector s))
+      (where
+        (binary &&
+          (binary ==
+            (binary &&
+              (binary >
+                (binary &&
+                  (binary ==
+                    (selector o_orderstatus (selector o))
+                    (string F)
+                  )
+                  (selector l_receiptdate (selector l1))
+                )
+                (selector l_commitdate (selector l1))
+              )
+              (selector n_name (selector n))
+            )
+            (string "SAUDI ARABIA")
+          )
+          (group
+            (unary !
+              (call exists
+                (query x
+                  (source (selector lineitem))
+                  (where
+                    (binary >
+                      (binary &&
+                        (binary !=
+                          (binary &&
+                            (binary ==
+                              (selector l_orderkey (selector x))
+                              (selector l_orderkey (selector l1))
+                            )
+                            (selector l_suppkey (selector x))
+                          )
+                          (selector l_suppkey (selector l1))
+                        )
+                        (selector l_receiptdate (selector x))
+                      )
+                      (selector l_commitdate (selector x))
+                    )
+                  )
+                  (select (selector x))
+                )
+              )
+            )
+          )
+        )
+        (join
+          (join
+            (join
+              (scan s (selector supplier))
+              (scan l1 (selector lineitem))
+              (on
+                (binary ==
+                  (selector s_suppkey (selector s))
+                  (selector l_suppkey (selector l1))
+                )
+              )
+            )
+            (scan o (selector orders))
+            (on
+              (binary ==
+                (selector o_orderkey (selector o))
+                (selector l_orderkey (selector l1))
+              )
+            )
+          )
+          (scan n (selector nation))
+          (on
+            (binary ==
+              (selector n_nationkey (selector n))
+              (selector s_nationkey (selector s))
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q22.plan
+++ b/tests/dataset/tpc-h/q22.plan
@@ -1,0 +1,51 @@
+(select
+  (map
+    (entry
+      (selector cntrycode)
+      (call substring
+        (selector c_phone (selector c))
+        (int 0)
+        (int 2)
+      )
+    )
+    (entry
+      (selector c_acctbal)
+      (selector c_acctbal (selector c))
+    )
+  )
+  (where
+    (binary &&
+      (binary >
+        (binary &&
+          (binary in
+            (call substring
+              (selector c_phone (selector c))
+              (int 0)
+              (int 2)
+            )
+            (selector valid_codes)
+          )
+          (selector c_acctbal (selector c))
+        )
+        (selector avg_balance)
+      )
+      (group
+        (unary !
+          (call exists
+            (query o
+              (source (selector orders))
+              (where
+                (binary ==
+                  (selector o_custkey (selector o))
+                  (selector c_custkey (selector c))
+                )
+              )
+              (select (selector o))
+            )
+          )
+        )
+      )
+    )
+    (scan c (selector customer))
+  )
+)

--- a/tests/dataset/tpc-h/q3.plan
+++ b/tests/dataset/tpc-h/q3.plan
@@ -1,0 +1,10 @@
+(select
+  (selector c)
+  (where
+    (binary ==
+      (selector c_mktsegment (selector c))
+      (selector segment)
+    )
+    (scan c (selector customer))
+  )
+)

--- a/tests/dataset/tpc-h/q4.plan
+++ b/tests/dataset/tpc-h/q4.plan
@@ -1,0 +1,16 @@
+(select
+  (selector o)
+  (where
+    (binary <
+      (binary &&
+        (binary >=
+          (selector o_orderdate (selector o))
+          (selector start_date)
+        )
+        (selector o_orderdate (selector o))
+      )
+      (selector end_date)
+    )
+    (scan o (selector orders))
+  )
+)

--- a/tests/dataset/tpc-h/q5.plan
+++ b/tests/dataset/tpc-h/q5.plan
@@ -1,0 +1,19 @@
+(select
+  (selector n)
+  (join
+    (where
+      (binary ==
+        (selector r_name (selector r))
+        (string ASIA)
+      )
+      (scan r (selector region))
+    )
+    (scan n (selector nation))
+    (on
+      (binary ==
+        (selector n_regionkey (selector n))
+        (selector r_regionkey (selector r))
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q6.plan
+++ b/tests/dataset/tpc-h/q6.plan
@@ -1,0 +1,49 @@
+(select
+  (call sum
+    (binary *
+      (selector l_extendedprice (selector l))
+      (selector l_discount (selector l))
+    )
+  )
+  (where
+    (binary &&
+      (binary &&
+        (binary &&
+          (binary &&
+            (group
+              (binary >=
+                (selector l_shipdate (selector l))
+                (string 1994-01-01)
+              )
+            )
+            (group
+              (binary <
+                (selector l_shipdate (selector l))
+                (string 1995-01-01)
+              )
+            )
+          )
+          (group
+            (binary >=
+              (selector l_discount (selector l))
+              (float 0.05)
+            )
+          )
+        )
+        (group
+          (binary <=
+            (selector l_discount (selector l))
+            (float 0.07)
+          )
+        )
+      )
+      (group
+        (binary <
+          (selector l_quantity (selector l))
+          (int 24)
+        )
+      )
+    )
+    (scan l (selector lineitem))
+  )
+)

--- a/tests/dataset/tpc-h/q7.plan
+++ b/tests/dataset/tpc-h/q7.plan
@@ -1,0 +1,156 @@
+(select
+  (map
+    (entry
+      (selector supp_nation)
+      (selector supp_nation
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector cust_nation)
+      (selector cust_nation
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector l_year)
+      (selector l_year
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector revenue)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary *
+              (selector l_extendedprice
+                (selector l (selector x))
+              )
+              (group
+                (binary -
+                  (int 1)
+                  (selector l_discount
+                    (selector l (selector x))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (sort
+    (list (selector supp_nation) (selector cust_nation) (selector l_year))
+    (group g
+      (map
+        (entry
+          (selector supp_nation)
+          (selector n_name (selector n1))
+        )
+        (entry
+          (selector cust_nation)
+          (selector n_name (selector n2))
+        )
+        (entry
+          (selector l_year)
+          (call substring
+            (selector l_shipdate (selector l))
+            (int 0)
+            (int 4)
+          )
+        )
+      )
+      (where
+        (group
+          (binary ||
+            (binary &&
+              (binary <=
+                (binary &&
+                  (binary >=
+                    (selector l_shipdate (selector l))
+                    (selector start_date)
+                  )
+                  (selector l_shipdate (selector l))
+                )
+                (selector end_date)
+              )
+              (group
+                (binary ==
+                  (binary &&
+                    (binary ==
+                      (selector n_name (selector n1))
+                      (selector nation1)
+                    )
+                    (selector n_name (selector n2))
+                  )
+                  (selector nation2)
+                )
+              )
+            )
+            (group
+              (binary ==
+                (binary &&
+                  (binary ==
+                    (selector n_name (selector n1))
+                    (selector nation2)
+                  )
+                  (selector n_name (selector n2))
+                )
+                (selector nation1)
+              )
+            )
+          )
+        )
+        (join
+          (join
+            (join
+              (join
+                (join
+                  (scan l (selector lineitem))
+                  (scan o (selector orders))
+                  (on
+                    (binary ==
+                      (selector o_orderkey (selector o))
+                      (selector l_orderkey (selector l))
+                    )
+                  )
+                )
+                (scan c (selector customer))
+                (on
+                  (binary ==
+                    (selector c_custkey (selector c))
+                    (selector o_custkey (selector o))
+                  )
+                )
+              )
+              (scan s (selector supplier))
+              (on
+                (binary ==
+                  (selector s_suppkey (selector s))
+                  (selector l_suppkey (selector l))
+                )
+              )
+            )
+            (scan n1 (selector nation))
+            (on
+              (binary ==
+                (selector n_nationkey (selector n1))
+                (selector s_nationkey (selector s))
+              )
+            )
+          )
+          (scan n2 (selector nation))
+          (on
+            (binary ==
+              (selector n_nationkey (selector n2))
+              (selector c_nationkey (selector c))
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q8.plan
+++ b/tests/dataset/tpc-h/q8.plan
@@ -1,0 +1,156 @@
+(select
+  (map
+    (entry
+      (selector o_year)
+      (selector key (selector year))
+    )
+    (entry
+      (selector mkt_share)
+      (binary /
+        (call sum
+          (query x
+            (source (selector year))
+            (select
+              (match
+                (binary ==
+                  (selector n_name
+                    (selector n (selector x))
+                  )
+                  (selector target_nation)
+                )
+                (case
+                  (bool true)
+                  (binary *
+                    (selector l_extendedprice
+                      (selector l (selector x))
+                    )
+                    (group
+                      (binary -
+                        (int 1)
+                        (selector l_discount
+                          (selector l (selector x))
+                        )
+                      )
+                    )
+                  )
+                )
+                (case (_) (float 0))
+              )
+            )
+          )
+        )
+        (call sum
+          (query x
+            (source (selector year))
+            (select
+              (binary *
+                (selector l_extendedprice
+                  (selector l (selector x))
+                )
+                (group
+                  (binary -
+                    (int 1)
+                    (selector l_discount
+                      (selector l (selector x))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (sort
+    (selector key (selector year))
+    (group year
+      (call substring
+        (selector o_orderdate (selector o))
+        (int 0)
+        (int 4)
+      )
+      (where
+        (group
+          (binary ==
+            (binary &&
+              (binary <=
+                (binary &&
+                  (binary >=
+                    (binary &&
+                      (binary ==
+                        (selector p_type (selector p))
+                        (selector target_type)
+                      )
+                      (selector o_orderdate (selector o))
+                    )
+                    (selector start_date)
+                  )
+                  (selector o_orderdate (selector o))
+                )
+                (selector end_date)
+              )
+              (selector r_name (selector r))
+            )
+            (string AMERICA)
+          )
+        )
+        (join
+          (join
+            (join
+              (join
+                (join
+                  (join
+                    (scan l (selector lineitem))
+                    (scan p (selector part))
+                    (on
+                      (binary ==
+                        (selector p_partkey (selector p))
+                        (selector l_partkey (selector l))
+                      )
+                    )
+                  )
+                  (scan s (selector supplier))
+                  (on
+                    (binary ==
+                      (selector s_suppkey (selector s))
+                      (selector l_suppkey (selector l))
+                    )
+                  )
+                )
+                (scan o (selector orders))
+                (on
+                  (binary ==
+                    (selector o_orderkey (selector o))
+                    (selector l_orderkey (selector l))
+                  )
+                )
+              )
+              (scan c (selector customer))
+              (on
+                (binary ==
+                  (selector c_custkey (selector c))
+                  (selector o_custkey (selector o))
+                )
+              )
+            )
+            (scan n (selector nation))
+            (on
+              (binary ==
+                (selector n_nationkey (selector n))
+                (selector c_nationkey (selector c))
+              )
+            )
+          )
+          (scan r (selector region))
+          (on
+            (binary ==
+              (selector r_regionkey (selector r))
+              (selector n_regionkey (selector n))
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/dataset/tpc-h/q9.plan
+++ b/tests/dataset/tpc-h/q9.plan
@@ -1,0 +1,160 @@
+(select
+  (map
+    (entry
+      (selector nation)
+      (selector nation
+        (selector key (selector g))
+      )
+    )
+    (entry
+      (selector o_year)
+      (call str
+        (selector o_year
+          (selector key (selector g))
+        )
+      )
+    )
+    (entry
+      (selector profit)
+      (call sum
+        (query x
+          (source (selector g))
+          (select
+            (binary -
+              (group
+                (binary *
+                  (selector l_extendedprice
+                    (selector l (selector x))
+                  )
+                  (group
+                    (binary -
+                      (int 1)
+                      (selector l_discount
+                        (selector l (selector x))
+                      )
+                    )
+                  )
+                )
+              )
+              (group
+                (binary *
+                  (selector ps_supplycost
+                    (selector ps (selector x))
+                  )
+                  (selector l_quantity
+                    (selector l (selector x))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (sort
+    (list
+      (selector nation
+        (selector key (selector g))
+      )
+      (unary -
+        (selector o_year
+          (selector key (selector g))
+        )
+      )
+    )
+    (group g
+      (map
+        (entry
+          (selector nation)
+          (selector n_name (selector n))
+        )
+        (entry
+          (selector o_year)
+          (cast
+            (call substring
+              (selector o_orderdate (selector o))
+              (int 0)
+              (int 4)
+            )
+            (type int)
+          )
+        )
+      )
+      (where
+        (binary <=
+          (binary &&
+            (binary >=
+              (binary &&
+                (binary ==
+                  (call substring
+                    (selector p_name (selector p))
+                    (int 0)
+                    (call len (selector prefix))
+                  )
+                  (selector prefix)
+                )
+                (selector o_orderdate (selector o))
+              )
+              (selector start_date)
+            )
+            (selector o_orderdate (selector o))
+          )
+          (selector end_date)
+        )
+        (join
+          (join
+            (join
+              (join
+                (join
+                  (scan l (selector lineitem))
+                  (scan p (selector part))
+                  (on
+                    (binary ==
+                      (selector p_partkey (selector p))
+                      (selector l_partkey (selector l))
+                    )
+                  )
+                )
+                (scan s (selector supplier))
+                (on
+                  (binary ==
+                    (selector s_suppkey (selector s))
+                    (selector l_suppkey (selector l))
+                  )
+                )
+              )
+              (scan ps (selector partsupp))
+              (on
+                (binary ==
+                  (binary &&
+                    (binary ==
+                      (selector ps_partkey (selector ps))
+                      (selector l_partkey (selector l))
+                    )
+                    (selector ps_suppkey (selector ps))
+                  )
+                  (selector l_suppkey (selector l))
+                )
+              )
+            )
+            (scan o (selector orders))
+            (on
+              (binary ==
+                (selector o_orderkey (selector o))
+                (selector l_orderkey (selector l))
+              )
+            )
+          )
+          (scan n (selector nation))
+          (on
+            (binary ==
+              (selector n_nationkey (selector n))
+              (selector s_nationkey (selector s))
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/types/queryplan/cross_join.mochi
+++ b/tests/types/queryplan/cross_join.mochi
@@ -1,0 +1,26 @@
+// cross_join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+let result = from o in orders
+             from c in customers
+             select {
+               orderId: o.id,
+               orderCustomerId: o.customerId,
+               pairedCustomerName: c.name,
+               orderTotal: o.total
+             }
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result {
+  print("Order", entry.orderId,
+        "(customerId:", entry.orderCustomerId,
+        ", total: $", entry.orderTotal,
+        ") paired with", entry.pairedCustomerName)
+}

--- a/tests/types/queryplan/cross_join.plan
+++ b/tests/types/queryplan/cross_join.plan
@@ -1,0 +1,24 @@
+(select
+  (map
+    (entry
+      (selector orderId)
+      (selector id (selector o))
+    )
+    (entry
+      (selector orderCustomerId)
+      (selector customerId (selector o))
+    )
+    (entry
+      (selector pairedCustomerName)
+      (selector name (selector c))
+    )
+    (entry
+      (selector orderTotal)
+      (selector total (selector o))
+    )
+  )
+  (join
+    (scan o (selector orders))
+    (scan c (selector customers))
+  )
+)

--- a/tests/types/queryplan/group_by.mochi
+++ b/tests/types/queryplan/group_by.mochi
@@ -1,0 +1,20 @@
+// group-by.mochi
+let people = [
+  { name: "Alice", age: 30, city: "Paris" },
+  { name: "Bob", age: 15, city: "Hanoi" },
+  { name: "Charlie", age: 65, city: "Paris" },
+  { name: "Diana", age: 45, city: "Hanoi" },
+  { name: "Eve", age: 70, city: "Paris" },
+  { name: "Frank", age: 22, city: "Hanoi" }
+]
+let stats = from person in people
+            group by person.city into g
+            select {
+              city: g.key,
+              count: count(g),
+              avg_age: avg(from p in g select p.age)
+            }
+print("--- People grouped by city ---")
+for s in stats {
+  print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}

--- a/tests/types/queryplan/group_by.plan
+++ b/tests/types/queryplan/group_by.plan
@@ -1,0 +1,27 @@
+(select
+  (map
+    (entry
+      (selector city)
+      (selector key (selector g))
+    )
+    (entry
+      (selector count)
+      (call count (selector g))
+    )
+    (entry
+      (selector avg_age)
+      (call avg
+        (query p
+          (source (selector g))
+          (select
+            (selector age (selector p))
+          )
+        )
+      )
+    )
+  )
+  (group g
+    (selector city (selector person))
+    (scan person (selector people))
+  )
+)

--- a/types/plan/plan.go
+++ b/types/plan/plan.go
@@ -1,0 +1,111 @@
+package plan
+
+import (
+	"mochi/ast"
+	"mochi/parser"
+)
+
+// Node represents a typed logical query plan node.
+type Node interface{ isNode() }
+
+type Scan struct {
+	Src   *parser.Expr
+	Alias string
+	Elem  any
+}
+
+func (*Scan) isNode() {}
+
+type Select struct {
+	Expr  *parser.Expr
+	Input Node
+}
+
+func (*Select) isNode() {}
+
+type Where struct {
+	Cond  *parser.Expr
+	Input Node
+}
+
+func (*Where) isNode() {}
+
+type Join struct {
+	Left     Node
+	Right    Node
+	On       *parser.Expr
+	JoinType string
+}
+
+func (*Join) isNode() {}
+
+type Group struct {
+	By    []*parser.Expr
+	Name  string
+	Input Node
+}
+
+func (*Group) isNode() {}
+
+type Sort struct {
+	Key   *parser.Expr
+	Input Node
+}
+
+func (*Sort) isNode() {}
+
+type Limit struct {
+	Skip  *parser.Expr
+	Take  *parser.Expr
+	Input Node
+}
+
+func (*Limit) isNode() {}
+
+// nodeTree converts a plan Node to an AST node used for printing.
+func nodeTree(pl Node) *ast.Node {
+	switch p := pl.(type) {
+	case *Scan:
+		return &ast.Node{Kind: "scan", Value: p.Alias, Children: []*ast.Node{ast.FromExpr(p.Src)}}
+	case *Select:
+		return &ast.Node{Kind: "select", Children: []*ast.Node{ast.FromExpr(p.Expr), nodeTree(p.Input)}}
+	case *Where:
+		return &ast.Node{Kind: "where", Children: []*ast.Node{ast.FromExpr(p.Cond), nodeTree(p.Input)}}
+	case *Join:
+		kind := "join"
+		if p.JoinType != "inner" {
+			kind = p.JoinType + "_join"
+		}
+		n := &ast.Node{Kind: kind, Children: []*ast.Node{nodeTree(p.Left), nodeTree(p.Right)}}
+		if p.On != nil {
+			n.Children = append(n.Children, &ast.Node{Kind: "on", Children: []*ast.Node{ast.FromExpr(p.On)}})
+		}
+		return n
+	case *Group:
+		n := &ast.Node{Kind: "group", Value: p.Name}
+		for _, e := range p.By {
+			n.Children = append(n.Children, ast.FromExpr(e))
+		}
+		n.Children = append(n.Children, nodeTree(p.Input))
+		return n
+	case *Sort:
+		return &ast.Node{Kind: "sort", Children: []*ast.Node{ast.FromExpr(p.Key), nodeTree(p.Input)}}
+	case *Limit:
+		n := &ast.Node{Kind: "limit"}
+		if p.Skip != nil {
+			n.Children = append(n.Children, &ast.Node{Kind: "skip", Children: []*ast.Node{ast.FromExpr(p.Skip)}})
+		}
+		if p.Take != nil {
+			n.Children = append(n.Children, &ast.Node{Kind: "take", Children: []*ast.Node{ast.FromExpr(p.Take)}})
+		}
+		n.Children = append(n.Children, nodeTree(p.Input))
+		return n
+	default:
+		return &ast.Node{Kind: "unknown"}
+	}
+}
+
+// String pretty prints a plan Node as a Lisp-like tree.
+func String(pl Node) string {
+	return nodeTree(pl).String()
+}

--- a/types/query_plan_builder.go
+++ b/types/query_plan_builder.go
@@ -1,0 +1,206 @@
+package types
+
+import (
+	"fmt"
+	"mochi/ast"
+	"mochi/parser"
+	"mochi/types/plan"
+)
+
+// BuildQueryPlan converts a parsed QueryExpr into a typed logical plan.
+func BuildQueryPlan(q *parser.QueryExpr, env *Env) (plan.Node, error) {
+	if q == nil {
+		return nil, fmt.Errorf("nil query expression")
+	}
+
+	srcT, err := checkExpr(q.Source, env)
+	if err != nil {
+		return nil, err
+	}
+	var elemT Type
+	switch t := srcT.(type) {
+	case ListType:
+		elemT = t.Elem
+	case GroupType:
+		elemT = t.Elem
+	default:
+		return nil, errQuerySourceList(q.Pos)
+	}
+	child := NewEnv(env)
+	child.SetVar(q.Var, elemT, true)
+
+	cond := q.Where
+	pushAlias := ""
+	if cond != nil {
+		if aliases := usedAliases(cond); len(aliases) == 1 {
+			for a := range aliases {
+				pushAlias = a
+			}
+		}
+	}
+
+	var root plan.Node = &plan.Scan{Src: q.Source, Alias: q.Var, Elem: elemT}
+	if pushAlias == q.Var {
+		if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+			return nil, err
+		}
+		root = &plan.Where{Cond: cond, Input: root}
+		cond = nil
+	}
+
+	for _, f := range q.Froms {
+		ft, err := checkExpr(f.Src, child)
+		if err != nil {
+			return nil, err
+		}
+		var fe Type
+		switch t := ft.(type) {
+		case ListType:
+			fe = t.Elem
+		case GroupType:
+			fe = t.Elem
+		default:
+			return nil, errJoinSourceList(f.Pos)
+		}
+		child.SetVar(f.Var, fe, true)
+		var rhs plan.Node = &plan.Scan{Src: f.Src, Alias: f.Var, Elem: fe}
+		if pushAlias == f.Var {
+			if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+				return nil, err
+			}
+			rhs = &plan.Where{Cond: cond, Input: rhs}
+			cond = nil
+			pushAlias = ""
+		}
+		root = &plan.Join{Left: root, Right: rhs, JoinType: "inner"}
+	}
+
+	for _, j := range q.Joins {
+		jt, err := checkExpr(j.Src, child)
+		if err != nil {
+			return nil, err
+		}
+		var je Type
+		switch t := jt.(type) {
+		case ListType:
+			je = t.Elem
+		case GroupType:
+			je = t.Elem
+		default:
+			return nil, errJoinSourceList(j.Pos)
+		}
+		child.SetVar(j.Var, je, true)
+		if _, err := checkExprWithExpected(j.On, child, BoolType{}); err != nil {
+			return nil, err
+		}
+		joinType := "inner"
+		if j.Side != nil {
+			joinType = *j.Side
+		}
+		var rhs plan.Node = &plan.Scan{Src: j.Src, Alias: j.Var, Elem: je}
+		if joinType == "inner" && pushAlias == j.Var {
+			if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+				return nil, err
+			}
+			rhs = &plan.Where{Cond: cond, Input: rhs}
+			cond = nil
+			pushAlias = ""
+		}
+		root = &plan.Join{Left: root, Right: rhs, On: j.On, JoinType: joinType}
+	}
+
+	if cond != nil {
+		if _, err := checkExprWithExpected(cond, child, BoolType{}); err != nil {
+			return nil, err
+		}
+		root = &plan.Where{Cond: cond, Input: root}
+	}
+
+	selEnv := child
+	if q.Group != nil {
+		for _, e := range q.Group.Exprs {
+			if _, err := checkExpr(e, child); err != nil {
+				return nil, err
+			}
+		}
+		genv := NewEnv(child)
+		genv.SetVar(q.Group.Name, GroupType{Key: AnyType{}, Elem: elemT}, true)
+		if len(q.Group.Exprs) == 1 {
+			if ml := q.Group.Exprs[0].Binary.Left.Value.Target.Map; ml != nil {
+				for _, it := range ml.Items {
+					if name, ok := identName(it.Key); ok {
+						genv.SetVar(name, AnyType{}, true)
+					}
+				}
+			}
+		}
+		if q.Group.Having != nil {
+			if _, err := checkExprWithExpected(q.Group.Having, genv, BoolType{}); err != nil {
+				return nil, err
+			}
+		}
+		root = &plan.Group{By: q.Group.Exprs, Name: q.Group.Name, Input: root}
+		selEnv = genv
+	}
+
+	if q.Sort != nil {
+		if _, err := checkExpr(q.Sort, selEnv); err != nil {
+			return nil, err
+		}
+		root = &plan.Sort{Key: q.Sort, Input: root}
+	}
+
+	if q.Skip != nil || q.Take != nil {
+		if q.Skip != nil {
+			if _, err := checkExprWithExpected(q.Skip, selEnv, IntType{}); err != nil {
+				return nil, err
+			}
+		}
+		if q.Take != nil {
+			if _, err := checkExprWithExpected(q.Take, selEnv, IntType{}); err != nil {
+				return nil, err
+			}
+		}
+		root = &plan.Limit{Skip: q.Skip, Take: q.Take, Input: root}
+	}
+
+	if q.Select != nil {
+		if _, err := checkExpr(q.Select, selEnv); err != nil {
+			return nil, err
+		}
+		root = &plan.Select{Expr: q.Select, Input: root}
+	}
+
+	return root, nil
+}
+
+// PlanString pretty prints a plan.Node as a Lisp-like tree.
+func PlanString(pl plan.Node) string {
+	return plan.String(pl)
+}
+
+// usedAliases returns the set of selector roots referenced in e.
+func usedAliases(e *parser.Expr) map[string]struct{} {
+	aliases := map[string]struct{}{}
+	if e == nil {
+		return aliases
+	}
+	node := ast.FromExpr(e)
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n.Kind == "selector" {
+			base := n
+			for len(base.Children) == 1 && base.Children[0].Kind == "selector" {
+				base = base.Children[0]
+			}
+			if s, ok := base.Value.(string); ok {
+				aliases[s] = struct{}{}
+			}
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(node)
+	return aliases
+}

--- a/types/query_plan_test.go
+++ b/types/query_plan_test.go
@@ -1,0 +1,67 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"mochi/golden"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func firstQuery(prog *parser.Program) *parser.QueryExpr {
+	for _, stmt := range prog.Statements {
+		if stmt.Let != nil && stmt.Let.Value != nil {
+			if q := stmt.Let.Value.Binary.Left.Value.Target.Query; q != nil {
+				return q
+			}
+		}
+	}
+	return nil
+}
+
+func TestQueryPlan(t *testing.T) {
+	golden.Run(t, "tests/types/queryplan", ".mochi", ".plan", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("type error: %v", errs[0])
+		}
+		q := firstQuery(prog)
+		if q == nil {
+			return nil, fmt.Errorf("no query expression found")
+		}
+		plan, err := types.BuildQueryPlan(q, env)
+		if err != nil {
+			return nil, err
+		}
+		out := types.PlanString(plan)
+		return []byte(out), nil
+	})
+}
+
+func TestQueryPlanTPCH(t *testing.T) {
+	golden.Run(t, "tests/dataset/tpc-h", ".mochi", ".plan", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("type error: %v", errs[0])
+		}
+		q := firstQuery(prog)
+		if q == nil {
+			return nil, fmt.Errorf("no query expression found")
+		}
+		plan, err := types.BuildQueryPlan(q, env)
+		if err != nil {
+			return nil, err
+		}
+		out := types.PlanString(plan)
+		return []byte(out), nil
+	})
+}


### PR DESCRIPTION
## Summary
- introduce `types/plan` package containing public plan node structs
- keep query plan builder in `types` using new plan nodes
- update tests to work with new package
- add golden tests parsing TPC-H query plans

## Testing
- `go test ./types`


------
https://chatgpt.com/codex/tasks/task_e_6875c563fbac8320b2121f25991d5a41