### PR TITLE
Fix tests

### DIFF
--- a/scripts/compile_tpcds_dart.go
+++ b/scripts/compile_tpcds_dart.go
@@ -1,3 +1,5 @@
+//go:build archive
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- fix build tag for tpcds Dart build script so standard tests compile

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875ea87fc908320aec3c564bed8063f