### PR TITLE
Add error-aware TPC‑DS generation

### DIFF
--- a/compiler/x/rust/TASKS.md
+++ b/compiler/x/rust/TASKS.md
@@ -8,6 +8,8 @@
 - 2025-07-13 17:46 - Attempted to generate Rust code for q8, q9 and q11 but compilation failed due to numeric type mismatches.
 - 2025-07-13 17:56 - Generated Rust code for TPC-H query q8 and added golden outputs.
 - 2025-07-13 18:18 - Generated Rust code for TPC-H query q17 and added golden outputs.
+- 2025-07-15 04:50 - Added golden tests for TPC-DS queries q1 through q19 and script to regenerate outputs.
+- 2025-07-15 05:45 - Improved TPC-DS Rust updater to capture errors and write `.rs.out` files
 
 ## Remaining Enhancements
 - [ ] Inline JSON printing for variables when values are known at compile time

--- a/scripts/compile_tpcds_rust.go
+++ b/scripts/compile_tpcds_rust.go
@@ -1,0 +1,105 @@
+//go:build archive
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	rustcode "mochi/compiler/x/rust"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func writeError(dir, name string, msg string) {
+	_ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(msg), 0o644)
+}
+
+func main() {
+	os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
+	defer os.Unsetenv("MOCHI_HEADER_TIME")
+
+	root, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			panic("go.mod not found")
+		}
+		root = parent
+	}
+
+	outDir := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "rust")
+	_ = os.MkdirAll(outDir, 0o755)
+
+	queries := []int{}
+	if env := os.Getenv("QUERIES"); env != "" {
+		for _, part := range strings.Split(env, ",") {
+			if n, err := strconv.Atoi(strings.TrimSpace(part)); err == nil {
+				queries = append(queries, n)
+			}
+		}
+	} else {
+		for i := 1; i <= 99; i++ {
+			queries = append(queries, i)
+		}
+	}
+
+	for _, i := range queries {
+		q := fmt.Sprintf("q%d", i)
+		src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		prog, err := parser.Parse(src)
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("parse error: %v", err))
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			writeError(outDir, q, fmt.Sprintf("type error: %v", errs[0]))
+			continue
+		}
+		code, err := rustcode.New(env).Compile(prog)
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("compile error: %v", err))
+			continue
+		}
+		codeOut := filepath.Join(outDir, q+".rs.out")
+		if err := os.WriteFile(codeOut, code, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write code", q, err)
+			continue
+		}
+		tmp := filepath.Join(os.TempDir(), q+".rs")
+		if err := os.WriteFile(tmp, code, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "tmp write", q, err)
+			continue
+		}
+		bin := filepath.Join(os.TempDir(), q)
+		if out, err := exec.Command("rustc", tmp, "-O", "-o", bin).CombinedOutput(); err != nil {
+			writeError(outDir, q, fmt.Sprintf("rustc: %v\n%s", err, out))
+			continue
+		}
+		cmd := exec.Command(bin)
+		var outBuf bytes.Buffer
+		cmd.Stdout = &outBuf
+		cmd.Stderr = &outBuf
+		if err := cmd.Run(); err != nil {
+			writeError(outDir, q, fmt.Sprintf("run: %v\n%s", err, outBuf.String()))
+			continue
+		}
+		cleaned := append(bytes.TrimSpace(outBuf.Bytes()), '\n')
+		if err := os.WriteFile(filepath.Join(outDir, q+".out"), cleaned, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write out", q, err)
+		}
+		os.Remove(filepath.Join(outDir, q+".error"))
+	}
+}


### PR DESCRIPTION
## Summary
- refine TPC-DS golden test by reusing stripHeader helper
- update compile script to emit `.rs.out` files and capture errors
- log the new script behavior in the Rust TASKS

## Testing
- `go test ./compiler/x/rust -run TestRustCompiler_TPCDSQueries/q1 -tags=slow -count=1` *(fails: generated code mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6875dcf81abc832098e4ea55aedd300e