### PR TITLE
Add Fortran tpc-ds skeleton

### DIFF
--- a/compiler/x/fortran/compiler.go
+++ b/compiler/x/fortran/compiler.go
@@ -3209,6 +3209,10 @@ func loadDatasetFortran(src string) ([]byte, error) {
 		path := filepath.Join(dir, "tests", "dataset", "tpc-h", "compiler", "fortran", name+".f90")
 		return os.ReadFile(path)
 	}
+	if strings.Contains(src, filepath.Join("dataset", "tpc-ds")) {
+		path := filepath.Join(dir, "tests", "dataset", "tpc-ds", "compiler", "fortran", name+".f90.out")
+		return os.ReadFile(path)
+	}
 	path := filepath.Join(dir, "tests", "dataset", "tpc-h", "compiler", "fortran", name+".f90")
 	if b, err := os.ReadFile(path); err == nil {
 		return b, nil

--- a/compiler/x/fortran/tpcds_golden_test.go
+++ b/compiler/x/fortran/tpcds_golden_test.go
@@ -1,0 +1,85 @@
+//go:build slow
+
+package ftncode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ftncode "mochi/compiler/x/fortran"
+	"mochi/compiler/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestFortranCompiler_TPCDSQueries(t *testing.T) {
+	gfortran := ensureFortran(t)
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 99; i++ {
+		base := fmt.Sprintf("q%d", i)
+		codeWant := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "fortran", base+".f90.out")
+		outWant := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "fortran", base+".out")
+		if _, err := os.Stat(codeWant); err != nil {
+			continue
+		}
+		if _, err := os.Stat(outWant); err != nil {
+			continue
+		}
+		t.Run(base, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-ds", base+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			os.Setenv("MOCHI_FORTRAN_NODATASET", "1")
+			code, err := ftncode.New(env).Compile(prog)
+			os.Unsetenv("MOCHI_FORTRAN_NODATASET")
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCode, err := os.ReadFile(codeWant)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			got := stripHeader(bytes.TrimSpace(code))
+			want := stripHeader(bytes.TrimSpace(wantCode))
+			if !bytes.Equal(got, want) {
+				t.Errorf("generated code mismatch for %s.f90.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, got, want)
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.f90")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			exe := filepath.Join(dir, "main")
+			if out, err := exec.Command(gfortran, file, "-static", "-o", exe).CombinedOutput(); err != nil {
+				t.Fatalf("gfortran error: %v\n%s", err, out)
+			}
+			cmd := exec.Command(exe)
+			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run error: %v\n%s", err, out)
+			}
+			gotOut := bytes.TrimSpace(out)
+			wantOut, err := os.ReadFile(outWant)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base, gotOut, bytes.TrimSpace(wantOut))
+			}
+		})
+	}
+}

--- a/scripts/compile_tpcds_fortran.go
+++ b/scripts/compile_tpcds_fortran.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	ftncode "mochi/compiler/x/fortran"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func writeError(dir, name string, msg string) {
+	_ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(msg), 0o644)
+}
+
+func main() {
+	os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
+	defer os.Unsetenv("MOCHI_HEADER_TIME")
+
+	gfortran, err := ftncode.EnsureFortran()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	root, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			panic("go.mod not found")
+		}
+		root = parent
+	}
+
+	outDir := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "fortran")
+	_ = os.MkdirAll(outDir, 0o755)
+
+	queries := []int{}
+	if env := os.Getenv("QUERIES"); env != "" {
+		for _, part := range strings.Split(env, ",") {
+			if n, err := strconv.Atoi(strings.TrimSpace(part)); err == nil {
+				queries = append(queries, n)
+			}
+		}
+	} else {
+		for i := 1; i <= 99; i++ {
+			queries = append(queries, i)
+		}
+	}
+
+	for _, i := range queries {
+		q := fmt.Sprintf("q%d", i)
+		src := filepath.Join(root, "tests", "dataset", "tpc-ds", q+".mochi")
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		prog, err := parser.Parse(src)
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("parse error: %v", err))
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			writeError(outDir, q, fmt.Sprintf("type error: %v", errs[0]))
+			continue
+		}
+		code, err := ftncode.New(env).Compile(prog)
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("compile error: %v", err))
+			continue
+		}
+		codePath := filepath.Join(outDir, q+".f90.out")
+		if err := os.WriteFile(codePath, code, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write code", q, err)
+			continue
+		}
+		tmp := filepath.Join(os.TempDir(), q+".f90")
+		if err := os.WriteFile(tmp, code, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "tmp write", q, err)
+			continue
+		}
+		exe := strings.TrimSuffix(tmp, ".f90")
+		if out, err := exec.Command(gfortran, tmp, "-static", "-o", exe).CombinedOutput(); err != nil {
+			writeError(outDir, q, fmt.Sprintf("gfortran: %v\n%s", err, out))
+			continue
+		}
+		cmd := exec.Command(exe)
+		if in, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(in)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("run: %v\n%s", err, out))
+			continue
+		}
+		_ = os.Remove(filepath.Join(outDir, q+".error"))
+		cleaned := append(bytes.TrimSpace(out), '\n')
+		if err := os.WriteFile(filepath.Join(outDir, q+".out"), cleaned, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write out", q, err)
+		}
+	}
+}

--- a/tests/dataset/tpc-ds/compiler/fortran/q1.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q1.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q10.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q10.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 20

--- a/tests/dataset/tpc-ds/compiler/fortran/q11.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q11.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 7

--- a/tests/dataset/tpc-ds/compiler/fortran/q12.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q12.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 8

--- a/tests/dataset/tpc-ds/compiler/fortran/q13.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q13.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 13

--- a/tests/dataset/tpc-ds/compiler/fortran/q14.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q14.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 10

--- a/tests/dataset/tpc-ds/compiler/fortran/q15.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q15.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 8

--- a/tests/dataset/tpc-ds/compiler/fortran/q16.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q16.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 11

--- a/tests/dataset/tpc-ds/compiler/fortran/q17.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q17.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 10

--- a/tests/dataset/tpc-ds/compiler/fortran/q18.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q18.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 11

--- a/tests/dataset/tpc-ds/compiler/fortran/q19.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q19.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 10

--- a/tests/dataset/tpc-ds/compiler/fortran/q2.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q2.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 4

--- a/tests/dataset/tpc-ds/compiler/fortran/q20.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q20.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 21

--- a/tests/dataset/tpc-ds/compiler/fortran/q21.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q21.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 9

--- a/tests/dataset/tpc-ds/compiler/fortran/q22.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q22.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 14

--- a/tests/dataset/tpc-ds/compiler/fortran/q23.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q23.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 23

--- a/tests/dataset/tpc-ds/compiler/fortran/q24.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q24.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 12

--- a/tests/dataset/tpc-ds/compiler/fortran/q25.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q25.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 11

--- a/tests/dataset/tpc-ds/compiler/fortran/q26.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q26.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 20

--- a/tests/dataset/tpc-ds/compiler/fortran/q27.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q27.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 10

--- a/tests/dataset/tpc-ds/compiler/fortran/q28.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q28.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 6

--- a/tests/dataset/tpc-ds/compiler/fortran/q29.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q29.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 11

--- a/tests/dataset/tpc-ds/compiler/fortran/q3.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q3.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 1

--- a/tests/dataset/tpc-ds/compiler/fortran/q30.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q30.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q31.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q31.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q32.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q32.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q33.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q33.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q34.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q34.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q35.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q35.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q36.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q36.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q37.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q37.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q38.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q38.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q39.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q39.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 6

--- a/tests/dataset/tpc-ds/compiler/fortran/q4.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q4.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q40.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q40.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q41.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q41.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q42.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q42.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q43.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q43.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q44.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q44.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q45.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q45.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q46.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q46.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q47.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q47.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q48.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q48.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q49.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q49.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q5.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q5.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q50.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q50.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q51.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q51.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q52.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q52.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q53.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q53.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q54.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q54.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q55.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q55.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q56.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q56.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q57.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q57.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q58.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q58.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q59.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q59.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q6.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q6.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q60.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q60.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q61.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q61.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q62.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q62.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q63.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q63.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q64.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q64.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q65.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q65.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q66.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q66.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q67.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q67.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q68.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q68.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q69.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q69.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q7.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q7.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q70.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q70.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q71.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q71.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q72.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q72.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q73.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q73.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q74.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q74.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q75.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q75.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q76.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q76.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q77.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q77.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q78.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q78.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q79.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q79.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 2

--- a/tests/dataset/tpc-ds/compiler/fortran/q8.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q8.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 1

--- a/tests/dataset/tpc-ds/compiler/fortran/q80.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q80.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q81.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q81.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q82.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q82.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q83.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q83.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q84.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q84.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q85.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q85.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q86.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q86.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q87.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q87.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q88.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q88.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q89.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q89.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q9.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q9.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 3

--- a/tests/dataset/tpc-ds/compiler/fortran/q90.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q90.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 4

--- a/tests/dataset/tpc-ds/compiler/fortran/q91.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q91.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 11

--- a/tests/dataset/tpc-ds/compiler/fortran/q92.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q92.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 4

--- a/tests/dataset/tpc-ds/compiler/fortran/q93.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q93.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 7

--- a/tests/dataset/tpc-ds/compiler/fortran/q94.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q94.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 9

--- a/tests/dataset/tpc-ds/compiler/fortran/q95.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q95.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 19

--- a/tests/dataset/tpc-ds/compiler/fortran/q96.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q96.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 8

--- a/tests/dataset/tpc-ds/compiler/fortran/q97.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q97.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 6

--- a/tests/dataset/tpc-ds/compiler/fortran/q98.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q98.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 7

--- a/tests/dataset/tpc-ds/compiler/fortran/q99.error
+++ b/tests/dataset/tpc-ds/compiler/fortran/q99.error
@@ -1,0 +1,1 @@
+compile error: unsupported expression at line 8


### PR DESCRIPTION
## Summary
- extend `loadDatasetFortran` to read tpc-ds generated files
- script to try compiling all tpc-ds queries to Fortran
- basic golden test scaffold for tpc-ds queries
- update Fortran compiler tasks
- include results from running the script (error files)

## Testing
- `go test -tags slow ./compiler/x/fortran -run TestFortranCompiler_TPCDSQueries -count=1`
- `go test ./...` *(fails: `go test` run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6875f4e104348320a28aed624fce18a9