### PR TITLE
Improve F# compiler sort handling

### DIFF
--- a/compiler/x/fs/TASKS.md
+++ b/compiler/x/fs/TASKS.md
@@ -19,3 +19,5 @@
   initial `tpcds_test.go` but compilation of generated code fails with numerous
   type errors.
 
+
+- 2025-07-15 06:37 - Implemented tuple-based sort key generation in `compileQuery` to allow sorting before dropping query variables. F# code for TPC-DS queries still fails to compile due to other type issues.


### PR DESCRIPTION
## Summary
- generate tuple-based sort keys in FS compiler
- document progress on F# compiler work

## Testing
- `go test ./... -tags slow -run TestFSCompiler_TPCDS/q1 -count=1` *(fails: fsharpc errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875f4de61288320ad755b553bcf18f2