### PR TITLE
Fix compile_tpcds_c build tag

### DIFF
--- a/scripts/compile_tpcds_c.go
+++ b/scripts/compile_tpcds_c.go
@@ -1,3 +1,5 @@
+//go:build archive
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- fix missing `archive` build constraint in `scripts/compile_tpcds_c.go`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6875faa7df408320ad43c60732c26d49