### PR TITLE
Update zig tpc-ds tooling

### DIFF
--- a/compiler/x/zig/TASKS.md
+++ b/compiler/x/zig/TASKS.md
@@ -1,6 +1,7 @@
 # Zig Backend Progress
 
 ## Recent Enhancements
+- 2025-07-15 07:14 - Added `compile_tpcds_zig.go` script and fixed empty struct handling in `zigTypeOf`.
 - 2025-07-15 05:45 - Golden test captures build errors and verifies TPCDS outputs.
 - 2025-07-15 05:00 - Added TPCDS golden test running q1-q99 for zig backend.
 - 2025-07-13 05:12 - Added `ensureGroupSlice` helper to avoid repeated `.Items.items` chains when iterating grouped data.

--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -37,10 +37,14 @@ func zigTypeOf(t types.Type) string {
 			for i, f := range tt.Order {
 				fields[i] = fmt.Sprintf("%s: %s,", sanitizeName(f), zigTypeOf(tt.Fields[f]))
 			}
-			if len(fields) > 1 {
+			switch len(fields) {
+			case 0:
+				return "struct {}"
+			case 1:
+				return fmt.Sprintf("struct { %s }", fields[0])
+			default:
 				return "struct {\n    " + strings.Join(fields, "\n    ") + "\n}"
 			}
-			return fmt.Sprintf("struct { %s }", fields[0])
 		}
 		return sanitizeName(tt.Name)
 	case types.UnionType:

--- a/scripts/compile_tpcds_zig.go
+++ b/scripts/compile_tpcds_zig.go
@@ -1,0 +1,97 @@
+//go:build archive && slow
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	zigcode "mochi/compiler/x/zig"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func writeError(dir, name string, msg string) {
+	_ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(msg), 0o644)
+}
+
+func main() {
+	os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
+	defer os.Unsetenv("MOCHI_HEADER_TIME")
+
+	outDir := filepath.Join("tests", "dataset", "tpc-ds", "compiler", "zig")
+	_ = os.MkdirAll(outDir, 0o755)
+
+	var queries []int
+	if env := os.Getenv("QUERIES"); env != "" {
+		for _, part := range strings.Split(env, ",") {
+			if n, err := strconv.Atoi(strings.TrimSpace(part)); err == nil {
+				queries = append(queries, n)
+			}
+		}
+	} else {
+		for i := 1; i <= 99; i++ {
+			queries = append(queries, i)
+		}
+	}
+
+	zigc, err := zigcode.EnsureZig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "zig not installed:", err)
+		return
+	}
+
+	for _, i := range queries {
+		q := fmt.Sprintf("q%d", i)
+		src := filepath.Join("tests", "dataset", "tpc-ds", q+".mochi")
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		prog, err := parser.Parse(src)
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("parse error: %v", err))
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			writeError(outDir, q, fmt.Sprintf("type error: %v", errs[0]))
+			continue
+		}
+		code, err := zigcode.New(env).Compile(prog)
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("compile error: %v", err))
+			continue
+		}
+		codeOut := filepath.Join(outDir, q+".zig.out")
+		if err := os.WriteFile(codeOut, code, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write code", q, err)
+			continue
+		}
+		tmp := filepath.Join(os.TempDir(), q+".zig")
+		if err := os.WriteFile(tmp, code, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "tmp write", q, err)
+			continue
+		}
+		exe := filepath.Join(os.TempDir(), q)
+		buildOut, err := exec.Command(zigc, "build-exe", tmp, "-O", "ReleaseSafe", "-femit-bin="+exe).CombinedOutput()
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("zig build: %v\n%s", err, buildOut))
+			continue
+		}
+		runOut, err := exec.Command(exe).CombinedOutput()
+		if err != nil {
+			writeError(outDir, q, fmt.Sprintf("run: %v\n%s", err, runOut))
+			continue
+		}
+		cleaned := append(bytes.TrimSpace(runOut), '\n')
+		if err := os.WriteFile(filepath.Join(outDir, q+".out"), cleaned, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write out", q, err)
+		}
+		os.Remove(filepath.Join(outDir, q+".error"))
+	}
+}


### PR DESCRIPTION
## Summary
- fix Zig backend for structs with no fields
- add compile_tpcds_zig.go helper for generating TPC‑DS outputs
- document new script in zig TASKS

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875fe6b7c648320b064060981f648f6